### PR TITLE
fix(plane): carry Plane context through A2A hop via pending map

### DIFF
--- a/lib/plugins/plane.ts
+++ b/lib/plugins/plane.ts
@@ -243,6 +243,9 @@ export class PlanePlugin implements Plugin {
 
   private server: ReturnType<typeof Bun.serve> | null = null;
   private workspaceDir: string;
+  // Maps correlationId → {planeIssueId, planeProjectId} so outbound handler can
+  // resolve Plane context even when the A2A reply payload doesn't carry it.
+  private pendingIssues = new Map<string, { planeIssueId: string; planeProjectId: string }>();
 
   constructor(workspaceDir: string) {
     this.workspaceDir = workspaceDir;
@@ -268,14 +271,23 @@ export class PlanePlugin implements Plugin {
       // ── Outbound: update Plane issues on reply ────────────────────────────
       bus.subscribe("plane.reply.#", "plane-outbound", async (msg: BusMessage) => {
         const payload = msg.payload as Record<string, unknown>;
-        const planeIssueId = String(payload.planeIssueId ?? "");
-        const planeProjectId = String(payload.planeProjectId ?? "");
         const status = String(payload.status ?? "");
         const summary = String(payload.summary ?? payload.content ?? "");
 
+        // Resolve Plane context: prefer explicit payload fields, fall back to
+        // the pending map keyed by correlationId (set when the inbound was published).
+        const pending = msg.correlationId ? this.pendingIssues.get(msg.correlationId) : undefined;
+        const planeIssueId = String(payload.planeIssueId ?? pending?.planeIssueId ?? "");
+        const planeProjectId = String(payload.planeProjectId ?? pending?.planeProjectId ?? "");
+
         if (!planeIssueId || !planeProjectId) {
-          console.warn("[plane] outbound reply missing planeIssueId or planeProjectId");
+          console.warn("[plane] outbound reply missing planeIssueId or planeProjectId — skipping Plane sync");
           return;
+        }
+
+        // Clean up pending entry on final status
+        if (status === "completed" || status === "done" || status === "rejected") {
+          this.pendingIssues.delete(msg.correlationId ?? "");
         }
 
         // Resolve state UUIDs for this project
@@ -392,9 +404,12 @@ export class PlanePlugin implements Plugin {
       return;
     }
 
+    const correlationId = `plane-${issue.id}`;
+    this.pendingIssues.set(correlationId, { planeIssueId: issue.id, planeProjectId: issue.project });
+
     bus.publish(topic, {
       id: crypto.randomUUID(),
-      correlationId: `plane-${issue.id}`,
+      correlationId,
       topic,
       timestamp: Date.now(),
       payload: {


### PR DESCRIPTION
## Summary

- Adds `pendingIssues` Map to `PlanePlugin` — stores `{planeIssueId, planeProjectId}` keyed by `correlationId` when the inbound bus event is published
- Outbound `plane.reply.#` handler resolves Plane context from payload first, falls back to the pending map
- Cleans up pending entries on terminal statuses (completed, done, rejected)
- Fixes the "outbound reply missing planeIssueId" warning seen during E2E testing

## Also (homelab-iac, separate commit)

`general_settings.drop_params: true` added to LiteLLM config — fixes `top_p: -1` error when LangChain's ChatOpenAI forwards unsupported params to the Claude fallback model.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved issue synchronization reliability with better fallback mechanisms when issue identifiers are missing.
  * Enhanced error logging for sync failures to provide clearer visibility into synchronization issues.

* **Improvements**
  * Optimized issue tracking to ensure proper cleanup of pending items upon completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->