### PR TITLE
fix: Quinn responds in first person, no relay acknowledgments

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,0 +1,5 @@
+{
+  "pid": 7,
+  "featureId": "feature-1775549383974-m3ziha9v0",
+  "startedAt": "2026-04-07T08:10:17.120Z"
+}


### PR DESCRIPTION
## Summary

**Bug:** When a Discord message is routed to Quinn via the A2A bus, the bot posts a relay acknowledgment ('Sure — sending that over to Quinn now.') before Quinn responds, and error fallbacks are written in system-speak rather than Quinn's voice. The result feels like the bus is narrating about Quinn rather than Quinn speaking directly.

**Root cause (workspace/plugins/a2a.ts):**
1. Before dispatching to Quinn's A2A endpoint, the handler posts an immediate 'relay' acknowledgment to the Discord ch...

---
*Recovered automatically by Automaker post-agent hook*