### PR TITLE
Milestone 1: OnboardingPlugin Core + Config Hot-Reload

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,0 +1,5 @@
+{
+  "pid": 7,
+  "featureId": "feature-1775548716277-5dj6q1qw3",
+  "startedAt": "2026-04-07T07:59:09.935Z"
+}

--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,0 +1,10 @@
+{
+  "pid": 7,
+<<<<<<< HEAD
+  "featureId": "feature-1775548716277-5dj6q1qw3",
+  "startedAt": "2026-04-07T07:59:09.935Z"
+=======
+  "featureId": "feature-1775553242924-ztpmkoq9i",
+  "startedAt": "2026-04-07T09:14:38.656Z"
+>>>>>>> origin/dev
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 node_modules
 .env
 data/
-models.json
 
 # Agent workspace — registry files are tracked; runtime state is ignored
 workspace/crons/

--- a/lib/plane-client.ts
+++ b/lib/plane-client.ts
@@ -1,0 +1,279 @@
+/**
+ * PlaneClient — REST API client for Plane project management.
+ *
+ * Extracted from lib/plugins/plane.ts so both PlanePlugin (issue state sync)
+ * and OnboardingPlugin (project creation, webhook registration) can share it.
+ *
+ * Env vars used by callers:
+ *   PLANE_API_KEY         API key for outbound calls to Plane
+ *   PLANE_BASE_URL        default: http://ava:3002
+ *   PLANE_WORKSPACE_SLUG  default: protolabsai
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface PlaneLabel {
+  id: string;
+  name: string;
+}
+
+export interface PlaneState {
+  id: string;
+  name: string;
+  group: string;
+}
+
+export interface PlanePlaneProject {
+  id: string;
+  identifier: string;
+  name: string;
+  [key: string]: unknown;
+}
+
+export interface PlaneWebhook {
+  id: string;
+  url: string;
+  [key: string]: unknown;
+}
+
+// ── PlaneClient ───────────────────────────────────────────────────────────────
+
+export class PlaneClient {
+  private baseUrl: string;
+  private workspaceSlug: string;
+  private apiKey: string;
+
+  // projectId → label UUID → label name
+  private labelCache = new Map<string, Map<string, string>>();
+  // projectId → state group/name → state UUID
+  private stateCache = new Map<string, Map<string, string>>();
+
+  constructor(baseUrl: string, workspaceSlug: string, apiKey: string) {
+    this.baseUrl = baseUrl;
+    this.workspaceSlug = workspaceSlug;
+    this.apiKey = apiKey;
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      "X-Api-Key": this.apiKey,
+      "Content-Type": "application/json",
+    };
+  }
+
+  // ── Label/state cache (used by PlanePlugin for issue state sync) ──────────
+
+  async fetchLabels(projectId: string): Promise<Map<string, string>> {
+    if (this.labelCache.has(projectId)) return this.labelCache.get(projectId)!;
+
+    const map = new Map<string, string>();
+    try {
+      const url = `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/projects/${projectId}/labels/`;
+      const resp = await fetch(url, { headers: this.headers(), signal: AbortSignal.timeout(10_000) });
+      if (resp.ok) {
+        const data = (await resp.json()) as { results?: PlaneLabel[] };
+        for (const label of data.results ?? []) {
+          map.set(label.id, label.name.toLowerCase());
+        }
+      } else {
+        console.warn(`[plane-client] Failed to fetch labels for project ${projectId}: ${resp.status}`);
+      }
+    } catch (err) {
+      console.error("[plane-client] Error fetching labels:", err);
+    }
+    this.labelCache.set(projectId, map);
+    return map;
+  }
+
+  async fetchStates(projectId: string): Promise<Map<string, string>> {
+    if (this.stateCache.has(projectId)) return this.stateCache.get(projectId)!;
+
+    const map = new Map<string, string>();
+    try {
+      const url = `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/projects/${projectId}/states/`;
+      const resp = await fetch(url, { headers: this.headers(), signal: AbortSignal.timeout(10_000) });
+      if (resp.ok) {
+        const data = (await resp.json()) as { results?: PlaneState[] };
+        for (const state of data.results ?? []) {
+          map.set(state.group, state.id);
+          map.set(state.name.toLowerCase(), state.id);
+        }
+      } else {
+        console.warn(`[plane-client] Failed to fetch states for project ${projectId}: ${resp.status}`);
+      }
+    } catch (err) {
+      console.error("[plane-client] Error fetching states:", err);
+    }
+    this.stateCache.set(projectId, map);
+    return map;
+  }
+
+  async hasLabel(projectId: string, labelUUIDs: string[], targetName: string): Promise<boolean> {
+    const labels = await this.fetchLabels(projectId);
+    return labelUUIDs.some(uuid => labels.get(uuid) === targetName.toLowerCase());
+  }
+
+  async patchIssueState(projectId: string, issueId: string, stateUUID: string): Promise<boolean> {
+    try {
+      const url = `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/projects/${projectId}/work-items/${issueId}/`;
+      const resp = await fetch(url, {
+        method: "PATCH",
+        headers: this.headers(),
+        body: JSON.stringify({ state: stateUUID }),
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!resp.ok) {
+        console.error(`[plane-client] PATCH issue state failed: ${resp.status} ${await resp.text()}`);
+        return false;
+      }
+      return true;
+    } catch (err) {
+      console.error("[plane-client] Error patching issue state:", err);
+      return false;
+    }
+  }
+
+  async addIssueComment(projectId: string, issueId: string, comment: string): Promise<boolean> {
+    try {
+      const url = `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/projects/${projectId}/issues/${issueId}/comments/`;
+      const resp = await fetch(url, {
+        method: "POST",
+        headers: this.headers(),
+        body: JSON.stringify({ comment_html: `<p>${comment}</p>` }),
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!resp.ok) {
+        console.error(`[plane-client] POST issue comment failed: ${resp.status} ${await resp.text()}`);
+        return false;
+      }
+      return true;
+    } catch (err) {
+      console.error("[plane-client] Error adding issue comment:", err);
+      return false;
+    }
+  }
+
+  /** Invalidate cached labels/states for a project so they're re-fetched next time. */
+  invalidate(projectId: string): void {
+    this.labelCache.delete(projectId);
+    this.stateCache.delete(projectId);
+  }
+
+  // ── Project management (used by OnboardingPlugin) ─────────────────────────
+
+  /** List all projects in the workspace. */
+  async listProjects(): Promise<PlanePlaneProject[]> {
+    try {
+      const url = `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/projects/`;
+      const resp = await fetch(url, { headers: this.headers(), signal: AbortSignal.timeout(10_000) });
+      if (!resp.ok) {
+        console.warn(`[plane-client] Failed to list projects: ${resp.status}`);
+        return [];
+      }
+      const data = (await resp.json()) as { results?: PlanePlaneProject[] } | PlanePlaneProject[];
+      return Array.isArray(data) ? data : (data.results ?? []);
+    } catch (err) {
+      console.error("[plane-client] Error listing projects:", err);
+      return [];
+    }
+  }
+
+  /**
+   * Create a new project in the workspace.
+   * Returns the created project or null on failure.
+   * Idempotent: returns existing project if identifier already taken.
+   */
+  async createProject(
+    name: string,
+    identifier: string,
+    description?: string,
+  ): Promise<PlanePlaneProject | null> {
+    // Idempotency: check if project with this identifier already exists
+    const existing = await this.listProjects();
+    const found = existing.find(p => p.identifier === identifier || p.name === name);
+    if (found) {
+      console.log(`[plane-client] Project "${identifier}" already exists (${found.id}) — skipping creation`);
+      return found;
+    }
+
+    try {
+      const url = `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/projects/`;
+      const body: Record<string, unknown> = { name, identifier };
+      if (description) body.description = description;
+
+      const resp = await fetch(url, {
+        method: "POST",
+        headers: this.headers(),
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(15_000),
+      });
+
+      if (!resp.ok) {
+        const text = await resp.text();
+        console.error(`[plane-client] Failed to create project: ${resp.status} ${text}`);
+        return null;
+      }
+      return (await resp.json()) as PlanePlaneProject;
+    } catch (err) {
+      console.error("[plane-client] Error creating project:", err);
+      return null;
+    }
+  }
+
+  /** List workspace-level webhooks. */
+  async listWebhooks(): Promise<PlaneWebhook[]> {
+    try {
+      const url = `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/webhooks/`;
+      const resp = await fetch(url, { headers: this.headers(), signal: AbortSignal.timeout(10_000) });
+      if (!resp.ok) return [];
+      const data = (await resp.json()) as { results?: PlaneWebhook[] } | PlaneWebhook[];
+      return Array.isArray(data) ? data : (data.results ?? []);
+    } catch (err) {
+      console.error("[plane-client] Error listing webhooks:", err);
+      return [];
+    }
+  }
+
+  /**
+   * Register a workspace-level webhook (Plane webhooks are workspace-scoped).
+   * Idempotent: skips if a webhook with the same URL already exists.
+   */
+  async registerWebhook(webhookUrl: string, secret?: string): Promise<boolean> {
+    try {
+      const existing = await this.listWebhooks();
+      if (existing.some(wh => wh.url === webhookUrl)) {
+        console.log("[plane-client] Webhook already registered — skipping");
+        return true;
+      }
+
+      const url = `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/webhooks/`;
+      const body: Record<string, unknown> = {
+        url: webhookUrl,
+        is_active: true,
+        issue: true,
+        issue_comment: true,
+        project: false,
+        cycle: false,
+        module: false,
+      };
+      if (secret) body.secret = secret;
+
+      const resp = await fetch(url, {
+        method: "POST",
+        headers: this.headers(),
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(15_000),
+      });
+
+      if (!resp.ok) {
+        const text = await resp.text();
+        console.error(`[plane-client] Failed to register webhook: ${resp.status} ${text}`);
+        return false;
+      }
+      return true;
+    } catch (err) {
+      console.error("[plane-client] Error registering webhook:", err);
+      return false;
+    }
+  }
+}

--- a/lib/plane-client.ts
+++ b/lib/plane-client.ts
@@ -150,7 +150,7 @@ export class PlaneClient {
 
   async addIssueComment(projectId: string, issueId: string, comment: string): Promise<boolean> {
     try {
-      const url = `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/projects/${projectId}/issues/${issueId}/comments/`;
+      const url = `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/projects/${projectId}/work-items/${issueId}/comments/`;
       const resp = await fetch(url, {
         method: "POST",
         headers: this.headers(),

--- a/lib/plugins/discord.ts
+++ b/lib/plugins/discord.ts
@@ -18,7 +18,7 @@
  *   DISCORD_DIGEST_CHANNEL  fallback channel ID for cron-triggered posts
  */
 
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, watchFile, unwatchFile } from "node:fs";
 import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
 import {
@@ -347,11 +347,37 @@ export class DiscordPlugin implements Plugin {
       }
     });
 
+    // ── Hot-reload discord.yaml ───────────────────────────────────────────────
+    const configPath = join(this.workspaceDir, "discord.yaml");
+    if (existsSync(configPath)) {
+      watchFile(configPath, { interval: 5_000 }, async () => {
+        const prev = this.config;
+        this.config = loadConfig(this.workspaceDir);
+
+        // Apply updated moderation config
+        const { rateLimit, spamPatterns } = this.config.moderation;
+        this.rateMaxMessages = rateLimit.maxMessages;
+        this.rateWindowMs = rateLimit.windowSeconds * 1_000;
+        this.spamPatterns = spamPatterns.map(p => new RegExp(p, "i"));
+
+        // Re-register slash commands if command list changed
+        const prevCmds = JSON.stringify(prev.commands ?? []);
+        const newCmds = JSON.stringify(this.config.commands ?? []);
+        if (prevCmds !== newCmds && this.client?.isReady()) {
+          console.log("[discord] discord.yaml changed — re-registering slash commands");
+          await this._registerSlashCommands().catch(console.error);
+        } else {
+          console.log("[discord] discord.yaml reloaded");
+        }
+      });
+    }
+
     this.client.login(process.env.DISCORD_BOT_TOKEN);
   }
 
   uninstall(): void {
     this.client?.destroy();
+    unwatchFile(join(this.workspaceDir, "discord.yaml"));
   }
 
   // ── Private helpers ─────────────────────────────────────────────────────────

--- a/lib/plugins/event-viewer.ts
+++ b/lib/plugins/event-viewer.ts
@@ -14,7 +14,7 @@ export class EventViewerPlugin implements Plugin {
 
   private bus: EventBus | null = null;
   private server: ReturnType<typeof Bun.serve> | null = null;
-  private wsClients: Set<ServerWebSocket<{ id: string }>> = new Set();
+  private wsClients: Set<ServerWebSocket<unknown>> = new Set();
   private subscriptionId: string | null = null;
   private port: number;
   private viewerDir: string;

--- a/lib/plugins/event-viewer.ts
+++ b/lib/plugins/event-viewer.ts
@@ -2,6 +2,7 @@ import { resolve, dirname, join } from "node:path";
 import { readFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
+import type { ServerWebSocket } from "bun";
 import type { Plugin, EventBus, BusMessage } from "../types";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -38,7 +39,7 @@ export class EventViewerPlugin implements Plugin {
         const url = new URL(req.url);
 
         if (url.pathname === "/ws") {
-          const upgraded = server.upgrade<{ id: string }>(req, {
+          const upgraded = server.upgrade(req, {
             data: { id: crypto.randomUUID() },
           });
           if (upgraded) return undefined;

--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -19,7 +19,7 @@
  *   GITHUB_WEBHOOK_PORT     webhook HTTP server port (default: 8082)
  */
 
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, watchFile, unwatchFile } from "node:fs";
 import { join } from "node:path";
 import { createSign } from "node:crypto";
 import { parse as parseYaml } from "yaml";
@@ -102,6 +102,7 @@ interface AutoTriageConfig {
   orgName: string;
   events: string[];
   skillHint: string;
+  /** Derived at runtime from projects.yaml — not read from github.yaml. */
   monitoredRepos: string[];
   sanitization: SanitizationConfig;
 }
@@ -113,10 +114,30 @@ interface GitHubConfig {
   autoTriage?: AutoTriageConfig;
 }
 
+/**
+ * Derive monitoredRepos from projects.yaml (all active projects with a github field).
+ * Called each time config is loaded so hot-reloads of projects.yaml are reflected.
+ */
+function deriveMonitoredRepos(workspaceDir: string): string[] {
+  const projectsPath = join(workspaceDir, "projects.yaml");
+  if (!existsSync(projectsPath)) return [];
+  try {
+    const raw = readFileSync(projectsPath, "utf8");
+    const data = parseYaml(raw) as { projects?: { github?: string; status?: string }[] };
+    return (data.projects ?? [])
+      .filter(p => p.github && p.status !== "archived" && p.status !== "suspended")
+      .map(p => p.github as string);
+  } catch {
+    return [];
+  }
+}
+
 function loadConfig(workspaceDir: string): GitHubConfig {
   const configPath = join(workspaceDir, "github.yaml");
+  let config: GitHubConfig;
+
   if (!existsSync(configPath)) {
-    return {
+    config = {
       mentionHandle: "@quinn",
       skillHints: {
         issue_comment: "bug_triage",
@@ -125,8 +146,17 @@ function loadConfig(workspaceDir: string): GitHubConfig {
         pull_request: "pr_review",
       },
     };
+  } else {
+    config = parseYaml(readFileSync(configPath, "utf8")) as GitHubConfig;
   }
-  return parseYaml(readFileSync(configPath, "utf8")) as GitHubConfig;
+
+  // monitoredRepos is always derived from projects.yaml at runtime
+  // (never read from github.yaml) so that onboarding new projects takes effect immediately.
+  if (config.autoTriage) {
+    config.autoTriage.monitoredRepos = deriveMonitoredRepos(workspaceDir);
+  }
+
+  return config;
 }
 
 // ── Pending comment context ───────────────────────────────────────────────────
@@ -244,6 +274,7 @@ export class GitHubPlugin implements Plugin {
 
   private server: ReturnType<typeof Bun.serve> | null = null;
   private workspaceDir: string;
+  private config!: GitHubConfig;
 
   constructor(workspaceDir: string) {
     this.workspaceDir = workspaceDir;
@@ -259,9 +290,27 @@ export class GitHubPlugin implements Plugin {
     const usingApp = !!(process.env.QUINN_APP_ID && process.env.QUINN_APP_PRIVATE_KEY);
     console.log(`[github] Auth: ${usingApp ? "GitHub App (quinn[bot])" : "PAT (GITHUB_TOKEN)"}`);
 
-    const config = loadConfig(this.workspaceDir);
+    this.config = loadConfig(this.workspaceDir);
     const webhookSecret = process.env.GITHUB_WEBHOOK_SECRET ?? "";
     const port = parseInt(process.env.GITHUB_WEBHOOK_PORT ?? "8082", 10);
+
+    // ── Hot-reload github.yaml and projects.yaml ──────────────────────────────
+    const configPath = join(this.workspaceDir, "github.yaml");
+    const projectsPath = join(this.workspaceDir, "projects.yaml");
+
+    const reloadConfig = () => {
+      this.config = loadConfig(this.workspaceDir);
+      const repoCount = this.config.autoTriage?.monitoredRepos?.length ?? 0;
+      console.log(`[github] Config reloaded — ${repoCount} monitored repo(s)`);
+    };
+
+    if (existsSync(configPath)) {
+      watchFile(configPath, { interval: 5_000 }, reloadConfig);
+    }
+    // Also watch projects.yaml so monitoredRepos updates when projects are onboarded
+    if (existsSync(projectsPath)) {
+      watchFile(projectsPath, { interval: 5_000 }, reloadConfig);
+    }
 
     // ── Outbound: post comment back to GitHub ────────────────────────────────
     bus.subscribe("message.outbound.github.#", "github-outbound", async (msg: BusMessage) => {
@@ -304,7 +353,7 @@ export class GitHubPlugin implements Plugin {
           return new Response("Bad request", { status: 400 });
         }
 
-        this._handleEvent(event, payload, config, bus, getToken);
+        this._handleEvent(event, payload, this.config, bus, getToken);
         return new Response("OK", { status: 200 });
       },
     });
@@ -314,6 +363,8 @@ export class GitHubPlugin implements Plugin {
 
   uninstall(): void {
     this.server?.stop();
+    unwatchFile(join(this.workspaceDir, "github.yaml"));
+    unwatchFile(join(this.workspaceDir, "projects.yaml"));
   }
 
   private _handleEvent(

--- a/lib/plugins/onboarding.ts
+++ b/lib/plugins/onboarding.ts
@@ -1,0 +1,607 @@
+/**
+ * OnboardingPlugin — deterministic 8-step project onboarding pipeline.
+ *
+ * Each step is idempotent: re-running for the same project slug is safe.
+ *
+ * Steps:
+ *   1. validate       — check required fields, validate github format
+ *   2. idempotency    — skip if project slug already in projects.yaml
+ *   3. plane_project  — create Plane project (no-op if no PLANE_API_KEY)
+ *   4. plane_webhook  — register Plane webhook (no-op if no PLANE_API_KEY)
+ *   5. github_webhook — register GitHub webhook (no-op if no GitHub auth)
+ *   6. projects_yaml  — upsert project entry into workspace/projects.yaml
+ *   7. bus_notify     — publish message.inbound.onboard.complete for downstream consumers
+ *   8. reply          — send confirmation to reply topic / Discord
+ *
+ * Inbound triggers:
+ *   message.inbound.onboard   (from POST /api/onboard or Discord /onboard command)
+ *
+ * Outbound topics:
+ *   message.inbound.onboard.complete — project metadata after successful onboarding
+ *   msg.reply.topic                  — confirmation text back to caller
+ *
+ * Env vars:
+ *   PLANE_API_KEY, PLANE_BASE_URL, PLANE_WORKSPACE_SLUG, PLANE_WEBHOOK_SECRET
+ *   QUINN_APP_ID, QUINN_APP_PRIVATE_KEY, GITHUB_TOKEN
+ *   GITHUB_WEBHOOK_SECRET
+ *   WORKSTACEAN_PUBLIC_URL  base URL for webhook registration (e.g. https://ws.example.com)
+ */
+
+import { readFileSync, existsSync, writeFileSync } from "node:fs";
+import { createSign } from "node:crypto";
+import { join } from "node:path";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import type { EventBus, BusMessage, Plugin } from "../types.ts";
+import { PlaneClient } from "../plane-client.ts";
+
+// ── Request / response types ──────────────────────────────────────────────────
+
+interface OnboardRequest {
+  slug: string;              // e.g. "protolabsai-myproject"
+  title: string;             // human-readable project name
+  github: string;            // "owner/repo"
+  defaultBranch?: string;    // default: "main"
+  team?: string;             // "dev" | "gtm" | etc.
+  agents?: string[];         // ["ava", "quinn", "frank"]
+  discord?: {
+    general?: string;
+    updates?: string;
+    dev?: string;
+    alerts?: string;
+    releases?: string;
+  };
+}
+
+interface StepResult {
+  status: "ok" | "skip" | "error";
+  detail?: string;
+  data?: Record<string, unknown>;
+}
+
+interface OnboardSteps {
+  planeProject?: StepResult & { projectId?: string };
+  planeWebhook?: StepResult;
+  githubWebhook?: StepResult;
+  projectsYaml?: StepResult;
+}
+
+// ── GitHub App auth (for webhook registration) ────────────────────────────────
+
+class GitHubAppAuth {
+  private cache = new Map<string, { token: string; exp: number }>();
+
+  constructor(private appId: string, private privateKey: string) {}
+
+  async getToken(owner: string, repo: string): Promise<string> {
+    const key = `${owner}/${repo}`;
+    const cached = this.cache.get(key);
+    if (cached && cached.exp > Date.now() + 60_000) return cached.token;
+
+    const jwt = this.makeJWT();
+    const headers = this.appHeaders(jwt);
+
+    const installResp = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/installation`,
+      { headers },
+    );
+    if (!installResp.ok) {
+      throw new Error(`App not installed on ${owner}/${repo}: ${installResp.status}`);
+    }
+    const { id: installId } = await installResp.json() as { id: number };
+
+    const tokenResp = await fetch(
+      `https://api.github.com/app/installations/${installId}/access_tokens`,
+      { method: "POST", headers },
+    );
+    if (!tokenResp.ok) {
+      throw new Error(`Token fetch failed: ${tokenResp.status} ${await tokenResp.text()}`);
+    }
+    const { token, expires_at } = await tokenResp.json() as { token: string; expires_at: string };
+
+    this.cache.set(key, { token, exp: new Date(expires_at).getTime() });
+    return token;
+  }
+
+  private makeJWT(): string {
+    const now = Math.floor(Date.now() / 1000);
+    const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+    const payload = Buffer.from(JSON.stringify({ iat: now - 60, exp: now + 600, iss: this.appId })).toString("base64url");
+    const data = `${header}.${payload}`;
+    const sig = createSign("RSA-SHA256").update(data).sign(this.privateKey, "base64url");
+    return `${data}.${sig}`;
+  }
+
+  private appHeaders(jwt: string): Record<string, string> {
+    return {
+      Authorization: `Bearer ${jwt}`,
+      Accept: "application/vnd.github+json",
+      "User-Agent": "protoWorkstacean/1.0",
+      "X-GitHub-Api-Version": "2022-11-28",
+    };
+  }
+}
+
+function makeGitHubGetToken(): ((owner: string, repo: string) => Promise<string>) | null {
+  const appId = process.env.QUINN_APP_ID;
+  const privateKey = process.env.QUINN_APP_PRIVATE_KEY;
+  if (appId && privateKey) {
+    const app = new GitHubAppAuth(appId, privateKey);
+    return (owner, repo) => app.getToken(owner, repo);
+  }
+  const pat = process.env.GITHUB_TOKEN;
+  if (pat) return () => Promise.resolve(pat);
+  return null;
+}
+
+// ── GitHub webhook helpers ────────────────────────────────────────────────────
+
+async function listGitHubWebhooks(
+  owner: string,
+  repo: string,
+  token: string,
+): Promise<{ id: number; config: { url?: string } }[]> {
+  const resp = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/hooks`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "User-Agent": "protoWorkstacean/1.0",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      signal: AbortSignal.timeout(10_000),
+    },
+  );
+  if (!resp.ok) return [];
+  return (await resp.json()) as { id: number; config: { url?: string } }[];
+}
+
+async function createGitHubWebhook(
+  owner: string,
+  repo: string,
+  webhookUrl: string,
+  token: string,
+  secret?: string,
+): Promise<boolean> {
+  const body: Record<string, unknown> = {
+    name: "web",
+    active: true,
+    events: ["issues", "issue_comment", "pull_request", "pull_request_review_comment"],
+    config: {
+      url: webhookUrl,
+      content_type: "json",
+      insecure_ssl: "0",
+      ...(secret ? { secret } : {}),
+    },
+  };
+
+  const resp = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/hooks`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "User-Agent": "protoWorkstacean/1.0",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(15_000),
+    },
+  );
+
+  return resp.ok;
+}
+
+// ── projects.yaml helpers ─────────────────────────────────────────────────────
+
+interface ProjectsYaml {
+  projects: Record<string, unknown>[];
+}
+
+function readProjectsYaml(projectsPath: string): ProjectsYaml {
+  if (!existsSync(projectsPath)) return { projects: [] };
+  try {
+    const raw = readFileSync(projectsPath, "utf8");
+    const parsed = parseYaml(raw) as ProjectsYaml;
+    return { projects: parsed.projects ?? [] };
+  } catch {
+    return { projects: [] };
+  }
+}
+
+function projectSlugExists(projectsPath: string, slug: string): boolean {
+  const { projects } = readProjectsYaml(projectsPath);
+  return projects.some(p => (p as Record<string, unknown>).slug === slug);
+}
+
+// ── Plugin ────────────────────────────────────────────────────────────────────
+
+export class OnboardingPlugin implements Plugin {
+  readonly name = "onboarding";
+  readonly description = "Deterministic project onboarding pipeline — 8 idempotent steps";
+  readonly capabilities = ["onboarding"];
+
+  private workspaceDir: string;
+  // Prevent duplicate concurrent runs for the same slug
+  private inFlight = new Set<string>();
+
+  constructor(workspaceDir: string) {
+    this.workspaceDir = workspaceDir;
+  }
+
+  install(bus: EventBus): void {
+    bus.subscribe("message.inbound.onboard", "onboarding", async (msg: BusMessage) => {
+      await this._run(bus, msg).catch(err => {
+        console.error("[onboarding] Unhandled pipeline error:", err);
+      });
+    });
+    console.log("[onboarding] Plugin installed — listening on message.inbound.onboard");
+  }
+
+  uninstall(): void {}
+
+  // ── Pipeline entry point ───────────────────────────────────────────────────
+
+  private async _run(bus: EventBus, msg: BusMessage): Promise<void> {
+    const payload = msg.payload as Record<string, unknown>;
+
+    // ── Step 1: Validate ────────────────────────────────────────────────────
+    const req = this._parseRequest(payload);
+    if (!req) {
+      console.warn("[onboarding] Step 1 validate: missing required fields (slug, title, github)");
+      this._reply(bus, msg, {
+        success: false,
+        step: "validate",
+        error: "Missing required fields: slug, title, github (owner/repo)",
+      });
+      return;
+    }
+    if (!/^[^/]+\/[^/]+$/.test(req.github)) {
+      console.warn(`[onboarding] Step 1 validate: invalid github format "${req.github}"`);
+      this._reply(bus, msg, {
+        success: false,
+        step: "validate",
+        error: `Invalid github format "${req.github}" — expected "owner/repo"`,
+      });
+      return;
+    }
+
+    // Prevent concurrent runs for same slug
+    if (this.inFlight.has(req.slug)) {
+      console.log(`[onboarding] ${req.slug}: already in-flight — skipping duplicate`);
+      this._reply(bus, msg, {
+        success: false,
+        step: "validate",
+        error: `Onboarding for "${req.slug}" is already in progress`,
+      });
+      return;
+    }
+    this.inFlight.add(req.slug);
+
+    try {
+      await this._pipeline(bus, msg, req);
+    } finally {
+      this.inFlight.delete(req.slug);
+    }
+  }
+
+  private async _pipeline(bus: EventBus, msg: BusMessage, req: OnboardRequest): Promise<void> {
+    const projectsPath = join(this.workspaceDir, "projects.yaml");
+
+    // ── Step 2: Idempotency check ────────────────────────────────────────────
+    if (projectSlugExists(projectsPath, req.slug)) {
+      console.log(`[onboarding] ${req.slug}: already onboarded — skipping`);
+      this._reply(bus, msg, {
+        success: true,
+        step: "idempotency",
+        status: "already_onboarded",
+        slug: req.slug,
+        message: `Project "${req.slug}" is already registered in projects.yaml`,
+      });
+      return;
+    }
+
+    console.log(`[onboarding] Starting pipeline for "${req.slug}" (${req.github})`);
+    const steps: OnboardSteps = {};
+
+    // ── Step 3: Plane project ────────────────────────────────────────────────
+    steps.planeProject = await this._stepPlaneProject(req);
+    console.log(`[onboarding] Step 3 plane_project: ${steps.planeProject.status} — ${steps.planeProject.detail ?? ""}`);
+
+    // ── Step 4: Plane webhook ────────────────────────────────────────────────
+    steps.planeWebhook = await this._stepPlaneWebhook(req);
+    console.log(`[onboarding] Step 4 plane_webhook: ${steps.planeWebhook.status} — ${steps.planeWebhook.detail ?? ""}`);
+
+    // ── Step 5: GitHub webhook ───────────────────────────────────────────────
+    steps.githubWebhook = await this._stepGitHubWebhook(req);
+    console.log(`[onboarding] Step 5 github_webhook: ${steps.githubWebhook.status} — ${steps.githubWebhook.detail ?? ""}`);
+
+    // ── Step 6: Update projects.yaml ─────────────────────────────────────────
+    steps.projectsYaml = this._stepUpdateProjectsYaml(req, projectsPath, steps.planeProject.data?.projectId as string | undefined);
+    console.log(`[onboarding] Step 6 projects_yaml: ${steps.projectsYaml.status} — ${steps.projectsYaml.detail ?? ""}`);
+
+    if (steps.projectsYaml.status === "error") {
+      this._reply(bus, msg, {
+        success: false,
+        step: "projects_yaml",
+        error: steps.projectsYaml.detail ?? "Failed to write projects.yaml",
+      });
+      return;
+    }
+
+    // ── Step 7: Bus notify ───────────────────────────────────────────────────
+    this._stepBusNotify(bus, req, steps, msg.correlationId);
+    console.log(`[onboarding] Step 7 bus_notify: ok — published message.inbound.onboard.complete`);
+
+    // ── Step 8: Reply ────────────────────────────────────────────────────────
+    const summary = this._buildSummary(req, steps);
+    console.log(`[onboarding] Step 8 reply: ok — ${req.slug} onboarded`);
+    this._reply(bus, msg, {
+      success: true,
+      step: "complete",
+      status: "onboarded",
+      slug: req.slug,
+      github: req.github,
+      summary,
+      steps: {
+        planeProject: steps.planeProject.status,
+        planeWebhook: steps.planeWebhook.status,
+        githubWebhook: steps.githubWebhook.status,
+        projectsYaml: steps.projectsYaml.status,
+      },
+    });
+  }
+
+  // ── Step implementations ───────────────────────────────────────────────────
+
+  /** Step 3: Create Plane project. */
+  private async _stepPlaneProject(req: OnboardRequest): Promise<StepResult & { projectId?: string }> {
+    const apiKey = process.env.PLANE_API_KEY;
+    if (!apiKey) {
+      return { status: "skip", detail: "PLANE_API_KEY not set" };
+    }
+
+    const baseUrl = process.env.PLANE_BASE_URL ?? "http://ava:3002";
+    const workspaceSlug = process.env.PLANE_WORKSPACE_SLUG ?? "protolabsai";
+    const client = new PlaneClient(baseUrl, workspaceSlug, apiKey);
+
+    // Derive a short Plane identifier from the slug (max 12 chars, uppercase, alphanumeric)
+    const identifier = req.slug
+      .replace(/[^a-zA-Z0-9]/g, "")
+      .slice(0, 12)
+      .toUpperCase() || "PROJECT";
+
+    try {
+      const project = await client.createProject(req.title, identifier, `GitHub: ${req.github}`);
+      if (!project) {
+        return { status: "error", detail: "Plane project creation returned null" };
+      }
+      return {
+        status: "ok",
+        detail: `Created Plane project "${project.name}" (${project.id})`,
+        data: { projectId: project.id, identifier: project.identifier },
+        projectId: project.id,
+      };
+    } catch (err) {
+      return {
+        status: "error",
+        detail: `Plane project creation failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+
+  /** Step 4: Register Plane webhook. */
+  private async _stepPlaneWebhook(req: OnboardRequest): Promise<StepResult> {
+    const apiKey = process.env.PLANE_API_KEY;
+    if (!apiKey) {
+      return { status: "skip", detail: "PLANE_API_KEY not set" };
+    }
+
+    const baseUrl = process.env.PLANE_BASE_URL ?? "http://ava:3002";
+    const workspaceSlug = process.env.PLANE_WORKSPACE_SLUG ?? "protolabsai";
+    const publicUrl = process.env.WORKSTACEAN_PUBLIC_URL;
+
+    if (!publicUrl) {
+      return { status: "skip", detail: "WORKSTACEAN_PUBLIC_URL not set — skipping Plane webhook registration" };
+    }
+
+    const webhookUrl = `${publicUrl}/webhooks/plane`;
+    const secret = process.env.PLANE_WEBHOOK_SECRET;
+    const client = new PlaneClient(baseUrl, workspaceSlug, apiKey);
+
+    try {
+      const ok = await client.registerWebhook(webhookUrl, secret);
+      if (!ok) {
+        return { status: "error", detail: `Failed to register Plane webhook for ${req.github}` };
+      }
+      return { status: "ok", detail: `Plane webhook registered → ${webhookUrl}` };
+    } catch (err) {
+      return {
+        status: "error",
+        detail: `Plane webhook registration failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+
+  /** Step 5: Register GitHub webhook. */
+  private async _stepGitHubWebhook(req: OnboardRequest): Promise<StepResult> {
+    const getToken = makeGitHubGetToken();
+    if (!getToken) {
+      return { status: "skip", detail: "No GitHub auth configured (QUINN_APP_ID or GITHUB_TOKEN required)" };
+    }
+
+    const publicUrl = process.env.WORKSTACEAN_PUBLIC_URL;
+    if (!publicUrl) {
+      return { status: "skip", detail: "WORKSTACEAN_PUBLIC_URL not set — skipping GitHub webhook registration" };
+    }
+
+    const webhookUrl = `${publicUrl}/webhook/github`;
+    const [owner, repo] = req.github.split("/");
+    const secret = process.env.GITHUB_WEBHOOK_SECRET;
+
+    try {
+      const token = await getToken(owner, repo);
+
+      // Idempotency: check if webhook pointing to our URL already exists
+      const existing = await listGitHubWebhooks(owner, repo, token);
+      if (existing.some(wh => wh.config.url === webhookUrl)) {
+        return { status: "skip", detail: `GitHub webhook already registered for ${req.github}` };
+      }
+
+      const ok = await createGitHubWebhook(owner, repo, webhookUrl, token, secret);
+      if (!ok) {
+        return { status: "error", detail: `Failed to create GitHub webhook on ${req.github}` };
+      }
+      return { status: "ok", detail: `GitHub webhook registered on ${req.github} → ${webhookUrl}` };
+    } catch (err) {
+      return {
+        status: "error",
+        detail: `GitHub webhook registration failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+
+  /** Step 6: Upsert project entry into workspace/projects.yaml. */
+  private _stepUpdateProjectsYaml(
+    req: OnboardRequest,
+    projectsPath: string,
+    planeProjectId?: string,
+  ): StepResult {
+    try {
+      // Double-check idempotency (guard against race between two concurrent runs)
+      if (projectSlugExists(projectsPath, req.slug)) {
+        return { status: "skip", detail: `Slug "${req.slug}" already present — skipping write` };
+      }
+
+      const { projects } = readProjectsYaml(projectsPath);
+
+      const entry: Record<string, unknown> = {
+        slug: req.slug,
+        title: req.title,
+        team: req.team ?? "dev",
+        github: req.github,
+        defaultBranch: req.defaultBranch ?? "main",
+        status: "active",
+        onboardedAt: new Date().toISOString(),
+        agents: req.agents ?? ["ava", "quinn"],
+      };
+
+      if (req.discord) {
+        entry.discord = req.discord;
+      }
+
+      if (planeProjectId) {
+        entry.planeProjectId = planeProjectId;
+      }
+
+      projects.push(entry);
+
+      // Preserve header comment if present
+      let existingContent = "";
+      if (existsSync(projectsPath)) {
+        existingContent = readFileSync(projectsPath, "utf8");
+      }
+      const headerMatch = existingContent.match(/^(#[^\n]*\n)*/);
+      const header = headerMatch ? headerMatch[0] : "";
+
+      const newContent = header + stringifyYaml({ projects }, { lineWidth: 120 });
+      writeFileSync(projectsPath, newContent, "utf8");
+
+      return { status: "ok", detail: `Appended "${req.slug}" to projects.yaml` };
+    } catch (err) {
+      return {
+        status: "error",
+        detail: `Failed to write projects.yaml: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+
+  /** Step 7: Publish completion event to bus. */
+  private _stepBusNotify(
+    bus: EventBus,
+    req: OnboardRequest,
+    steps: OnboardSteps,
+    correlationId: string,
+  ): void {
+    const topic = "message.inbound.onboard.complete";
+    bus.publish(topic, {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic,
+      timestamp: Date.now(),
+      payload: {
+        slug: req.slug,
+        title: req.title,
+        github: req.github,
+        defaultBranch: req.defaultBranch ?? "main",
+        team: req.team ?? "dev",
+        agents: req.agents ?? ["ava", "quinn"],
+        discord: req.discord ?? {},
+        planeProjectId: steps.planeProject?.data?.projectId,
+        steps: {
+          planeProject: steps.planeProject?.status,
+          planeWebhook: steps.planeWebhook?.status,
+          githubWebhook: steps.githubWebhook?.status,
+        },
+      },
+    });
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  private _parseRequest(payload: Record<string, unknown>): OnboardRequest | null {
+    const slug = typeof payload.slug === "string" ? payload.slug.trim() : "";
+    const title = typeof payload.title === "string" ? payload.title.trim() : "";
+    const github = typeof payload.github === "string" ? payload.github.trim() : "";
+
+    if (!slug || !title || !github) return null;
+
+    return {
+      slug,
+      title,
+      github,
+      defaultBranch: typeof payload.defaultBranch === "string" ? payload.defaultBranch : "main",
+      team: typeof payload.team === "string" ? payload.team : undefined,
+      agents: Array.isArray(payload.agents) ? payload.agents as string[] : undefined,
+      discord: payload.discord as OnboardRequest["discord"] | undefined,
+    };
+  }
+
+  private _reply(bus: EventBus, msg: BusMessage, result: Record<string, unknown>): void {
+    const replyTopic = msg.reply?.topic;
+    if (!replyTopic) return;
+
+    const content = result.success
+      ? `✅ Project onboarding ${result.status === "already_onboarded" ? "already complete" : "complete"}: **${result.slug}**\n${result.summary ?? ""}`
+      : `❌ Onboarding failed at step \`${result.step}\`: ${result.error}`;
+
+    bus.publish(replyTopic, {
+      id: crypto.randomUUID(),
+      correlationId: msg.correlationId,
+      topic: replyTopic,
+      timestamp: Date.now(),
+      payload: { ...result, content },
+    });
+  }
+
+  private _buildSummary(req: OnboardRequest, steps: OnboardSteps): string {
+    const lines = [
+      `**${req.title}** (\`${req.slug}\`)`,
+      `GitHub: \`${req.github}\``,
+      "",
+      "Steps:",
+      `  • Plane project: ${this._statusEmoji(steps.planeProject?.status)} ${steps.planeProject?.detail ?? ""}`,
+      `  • Plane webhook: ${this._statusEmoji(steps.planeWebhook?.status)} ${steps.planeWebhook?.detail ?? ""}`,
+      `  • GitHub webhook: ${this._statusEmoji(steps.githubWebhook?.status)} ${steps.githubWebhook?.detail ?? ""}`,
+      `  • projects.yaml: ${this._statusEmoji(steps.projectsYaml?.status)} ${steps.projectsYaml?.detail ?? ""}`,
+    ];
+    return lines.join("\n");
+  }
+
+  private _statusEmoji(status?: string): string {
+    if (status === "ok") return "✅";
+    if (status === "skip") return "⏭️";
+    if (status === "error") return "⚠️";
+    return "❓";
+  }
+}

--- a/lib/plugins/plane.ts
+++ b/lib/plugins/plane.ts
@@ -18,6 +18,7 @@
 
 import { createHmac, timingSafeEqual } from "node:crypto";
 import type { EventBus, BusMessage, Plugin } from "../types.ts";
+import { PlaneClient } from "../plane-client.ts";
 
 // ── Plane webhook types ──────────────────────────────────────────────────────
 
@@ -97,143 +98,6 @@ class DeliveryDedup {
   }
 }
 
-// ── Label resolution cache ───────────────────────────────────────────────────
-
-interface PlaneLabel {
-  id: string;
-  name: string;
-}
-
-interface PlaneState {
-  id: string;
-  name: string;
-  group: string;
-}
-
-class PlaneAPICache {
-  private baseUrl: string;
-  private workspaceSlug: string;
-  private apiKey: string;
-
-  // projectId → label UUID → label name
-  private labelCache = new Map<string, Map<string, string>>();
-  // projectId → state group → state UUID
-  private stateCache = new Map<string, Map<string, string>>();
-
-  constructor(baseUrl: string, workspaceSlug: string, apiKey: string) {
-    this.baseUrl = baseUrl;
-    this.workspaceSlug = workspaceSlug;
-    this.apiKey = apiKey;
-  }
-
-  private headers(): Record<string, string> {
-    return {
-      "X-Api-Key": this.apiKey,
-      "Content-Type": "application/json",
-    };
-  }
-
-  async fetchLabels(projectId: string): Promise<Map<string, string>> {
-    if (this.labelCache.has(projectId)) return this.labelCache.get(projectId)!;
-
-    const map = new Map<string, string>();
-    try {
-      const url = `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/projects/${projectId}/labels/`;
-      const resp = await fetch(url, { headers: this.headers(), signal: AbortSignal.timeout(10_000) });
-      if (resp.ok) {
-        const data = (await resp.json()) as { results?: PlaneLabel[] };
-        for (const label of data.results ?? []) {
-          map.set(label.id, label.name.toLowerCase());
-        }
-      } else {
-        console.warn(`[plane] Failed to fetch labels for project ${projectId}: ${resp.status}`);
-      }
-    } catch (err) {
-      console.error("[plane] Error fetching labels:", err);
-    }
-
-    this.labelCache.set(projectId, map);
-    return map;
-  }
-
-  async fetchStates(projectId: string): Promise<Map<string, string>> {
-    if (this.stateCache.has(projectId)) return this.stateCache.get(projectId)!;
-
-    const map = new Map<string, string>();
-    try {
-      const url = `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/projects/${projectId}/states/`;
-      const resp = await fetch(url, { headers: this.headers(), signal: AbortSignal.timeout(10_000) });
-      if (resp.ok) {
-        const data = (await resp.json()) as { results?: PlaneState[] };
-        for (const state of data.results ?? []) {
-          // Map group names like "started", "completed" to their state UUIDs
-          map.set(state.group, state.id);
-          // Also map by lowercased name for exact matches
-          map.set(state.name.toLowerCase(), state.id);
-        }
-      } else {
-        console.warn(`[plane] Failed to fetch states for project ${projectId}: ${resp.status}`);
-      }
-    } catch (err) {
-      console.error("[plane] Error fetching states:", err);
-    }
-
-    this.stateCache.set(projectId, map);
-    return map;
-  }
-
-  async hasLabel(projectId: string, labelUUIDs: string[], targetName: string): Promise<boolean> {
-    const labels = await this.fetchLabels(projectId);
-    return labelUUIDs.some(uuid => labels.get(uuid) === targetName.toLowerCase());
-  }
-
-  async patchIssueState(projectId: string, issueId: string, stateUUID: string): Promise<boolean> {
-    try {
-      const url = `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/projects/${projectId}/work-items/${issueId}/`;
-      const resp = await fetch(url, {
-        method: "PATCH",
-        headers: this.headers(),
-        body: JSON.stringify({ state: stateUUID }),
-        signal: AbortSignal.timeout(10_000),
-      });
-      if (!resp.ok) {
-        console.error(`[plane] PATCH issue state failed: ${resp.status} ${await resp.text()}`);
-        return false;
-      }
-      return true;
-    } catch (err) {
-      console.error("[plane] Error patching issue state:", err);
-      return false;
-    }
-  }
-
-  async addIssueComment(projectId: string, issueId: string, comment: string): Promise<boolean> {
-    try {
-      const url = `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/projects/${projectId}/issues/${issueId}/comments/`;
-      const resp = await fetch(url, {
-        method: "POST",
-        headers: this.headers(),
-        body: JSON.stringify({ comment_html: `<p>${comment}</p>` }),
-        signal: AbortSignal.timeout(10_000),
-      });
-      if (!resp.ok) {
-        console.error(`[plane] POST issue comment failed: ${resp.status} ${await resp.text()}`);
-        return false;
-      }
-      return true;
-    } catch (err) {
-      console.error("[plane] Error adding issue comment:", err);
-      return false;
-    }
-  }
-
-  /** Invalidate cached labels/states for a project so they're re-fetched next time. */
-  invalidate(projectId: string): void {
-    this.labelCache.delete(projectId);
-    this.stateCache.delete(projectId);
-  }
-}
-
 // ── Plugin ────────────────────────────────────────────────────────────────────
 
 export class PlanePlugin implements Plugin {
@@ -263,10 +127,10 @@ export class PlanePlugin implements Plugin {
     }
 
     const dedup = new DeliveryDedup();
-    let apiCache: PlaneAPICache | null = null;
+    let apiCache: PlaneClient | null = null;
 
     if (apiKey) {
-      apiCache = new PlaneAPICache(baseUrl, workspaceSlug, apiKey);
+      apiCache = new PlaneClient(baseUrl, workspaceSlug, apiKey);
 
       // ── Outbound: update Plane issues on reply ────────────────────────────
       bus.subscribe("plane.reply.#", "plane-outbound", async (msg: BusMessage) => {
@@ -367,7 +231,7 @@ export class PlanePlugin implements Plugin {
   private async _handleWebhook(
     payload: PlaneWebhookPayload,
     bus: EventBus,
-    apiCache: PlaneAPICache | null,
+    apiCache: PlaneClient | null,
   ): Promise<void> {
     const { event, action, data } = payload;
 

--- a/models.json
+++ b/models.json
@@ -1,0 +1,24 @@
+{
+  "providers": {
+    "local-llm": {
+      "baseUrl": "http://gateway:4000/v1",
+      "api": "openai-completions",
+      "apiKey": "OPENAI_API_KEY",
+      "compat": {
+        "supportsUsageInStreaming": true,
+        "maxTokensField": "max_tokens"
+      },
+      "models": [
+        {
+          "id": "default",
+          "name": "Gateway Default",
+          "reasoning": false,
+          "input": ["text"],
+          "contextWindow": 131072,
+          "maxTokens": 16384,
+          "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+        }
+      ]
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,14 @@ const pluginRegistry: PluginRegistryEntry[] = [
     },
   },
   {
+    name: "onboarding",
+    condition: () => true,
+    factory: async () => {
+      const { OnboardingPlugin } = await import("../lib/plugins/onboarding");
+      return new OnboardingPlugin(workspaceDir);
+    },
+  },
+  {
     name: "hitl",
     condition: () => true,
     factory: async () => {
@@ -245,11 +253,70 @@ async function handlePublish(req: Request): Promise<Response> {
   return Response.json({ success: true, id: message.id });
 }
 
+async function handleOnboard(req: Request): Promise<Response> {
+  if (API_KEY && req.headers.get("X-API-Key") !== API_KEY) {
+    return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return Response.json({ success: false, error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.slug || !body.title || !body.github) {
+    return Response.json(
+      { success: false, error: "Missing required fields: slug, title, github (owner/repo)" },
+      { status: 400 },
+    );
+  }
+
+  const correlationId = crypto.randomUUID();
+  const topic = "message.inbound.onboard";
+
+  // Wait up to 30s for the pipeline to complete and reply
+  const result = await new Promise<Record<string, unknown>>((resolve) => {
+    const replyTopic = `onboard.result.${correlationId}`;
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout>;
+
+    const subId = bus.subscribe(replyTopic, "onboard-http", (msg: BusMessage) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      bus.unsubscribe(subId);
+      resolve(msg.payload as Record<string, unknown>);
+    });
+
+    timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      bus.unsubscribe(subId);
+      resolve({ success: true, status: "accepted", correlationId, message: "Onboarding started (no response within 30s)" });
+    }, 30_000);
+
+    bus.publish(topic, {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic,
+      timestamp: Date.now(),
+      payload: body,
+      source: { interface: "api" as const },
+      reply: { topic: replyTopic },
+    });
+  });
+
+  const statusCode = result.success ? 200 : 422;
+  return Response.json(result, { status: statusCode });
+}
+
 type RouteHandler = (req: Request) => Response | Promise<Response>;
 
 const routes = new Map<string, RouteHandler>([
   ["GET /health",        () => Response.json({ status: "ok", timestamp: Date.now() })],
   ["POST /publish",      handlePublish],
+  ["POST /api/onboard",  handleOnboard],
   ["GET /api/projects",  () => serveWorkspaceYaml("projects.yaml", "projects")],
   ["GET /api/agents",    () => serveWorkspaceYaml("agents.yaml", "agents")],
 ]);

--- a/workspace/plugins/a2a.ts
+++ b/workspace/plugins/a2a.ts
@@ -13,7 +13,7 @@
  *   GITHUB_TOKEN   posts chained agent responses as GitHub comments
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, watchFile, unwatchFile } from "node:fs";
 import { createSign } from "node:crypto";
 import { parse } from "yaml";
 
@@ -404,6 +404,10 @@ async function runChain(
   }
 }
 
+// ── Skills handled locally (never forwarded to an external agent) ────────────
+
+const LOCAL_SKILLS = new Set(["memory_recall", "memory_store", "onboard_project"]);
+
 // ── Plugin ──────────────────────────────────────────────────────────────────
 
 export default {
@@ -412,7 +416,7 @@ export default {
   capabilities: ["a2a-routing"],
 
   install(bus: EventBus) {
-    const agents = loadAgents();
+    let agents = loadAgents();
 
     if (!agents.length) {
       console.error("[a2a] No agents loaded — check workspace/agents.yaml");
@@ -421,6 +425,18 @@ export default {
 
     console.log(`[a2a] Loaded ${agents.length} agents: ${agents.map(a => a.name).join(", ")}`);
     refreshSkills(agents).catch(console.error);
+
+    // ── Hot-reload agents.yaml ─────────────────────────────────────────────
+    watchFile(AGENTS_YAML, { interval: 5_000 }, () => {
+      const updated = loadAgents();
+      if (updated.length) {
+        agents = updated;
+        console.log(`[a2a] agents.yaml reloaded — ${agents.length} agent(s): ${agents.map(a => a.name).join(", ")}`);
+        refreshSkills(agents).catch(console.error);
+      } else {
+        console.warn("[a2a] agents.yaml reload produced no agents — keeping previous registry");
+      }
+    });
 
     // ── Inbound messages ──────────────────────────────────────────────────
     bus.subscribe("message.inbound.#", "a2a", async (msg: BusMessage) => {
@@ -438,6 +454,18 @@ export default {
       if (skill && MEMORY_SKILLS.has(skill)) {
         console.log(`[a2a] "${content.slice(0, 60)}" → memory (local, skill: ${skill})`);
         await handleMemorySkill(bus, skill, content, msg, outboundTopic, p);
+        return;
+      }
+
+      // onboard_project: route to OnboardingPlugin via message.inbound.onboard
+      if (skill === "onboard_project") {
+        console.log(`[a2a] "${content.slice(0, 60)}" → onboarding (local, skill: onboard_project)`);
+        const onboardTopic = "message.inbound.onboard";
+        bus.publish(onboardTopic, {
+          ...msg,
+          id: crypto.randomUUID(),
+          topic: onboardTopic,
+        });
         return;
       }
 
@@ -493,5 +521,7 @@ export default {
     });
   },
 
-  uninstall(_bus: EventBus) {},
+  uninstall(_bus: EventBus) {
+    unwatchFile(AGENTS_YAML);
+  },
 };

--- a/workspace/plugins/a2a.ts
+++ b/workspace/plugins/a2a.ts
@@ -462,14 +462,52 @@ export default {
         return;
       }
 
-      // onboard_project: route to OnboardingPlugin via message.inbound.onboard
+      // onboard_project: route to OnboardingPlugin via message.inbound.onboard.
+      // The Discord payload has { content, channel, sender } but OnboardingPlugin
+      // expects { slug, title, github }.  Normalise here by parsing the content
+      // string for an "owner/repo" token, then building the structured payload.
+      // If the format is unrecognisable, reply with a usage error instead of
+      // silently dropping — a no-op is worse than a visible failure.
       if (skill === "onboard_project") {
         console.log(`[a2a] "${content.slice(0, 60)}" → onboarding (local, skill: onboard_project)`);
+
+        // Extract the first "owner/repo" token from the raw content string.
+        const githubMatch = content.match(/([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)/);
+        if (!githubMatch) {
+          console.warn(`[a2a] onboard_project: no owner/repo found in "${content.slice(0, 80)}"`);
+          publishResponse(
+            bus,
+            outboundTopic,
+            msg.correlationId,
+            "Usage: `/onboard <owner>/<repo> [slug] [title]`\nExample: `/onboard protolabsai/my-project`",
+            p.channel,
+            "a2a",
+          );
+          return;
+        }
+
+        const github = githubMatch[1];
+        // Derive slug from owner/repo: replace "/" and non-alphanumeric chars with "-"
+        const derivedSlug = github.replace(/\//g, "-").replace(/[^A-Za-z0-9-]/g, "-").toLowerCase();
+        // Optional explicit slug/title tokens after the repo: "owner/repo my-slug My Title"
+        const rest = content.slice(content.indexOf(github) + github.length).trim();
+        const restTokens = rest.split(/\s+/).filter(Boolean);
+        const slug = restTokens[0] && !restTokens[0].includes("/") ? restTokens[0] : derivedSlug;
+        const title = restTokens.length > 1
+          ? restTokens.slice(restTokens[0] === slug ? 1 : 0).join(" ")
+          : github.split("/")[1].replace(/[-_]/g, " ");
+
         const onboardTopic = "message.inbound.onboard";
         bus.publish(onboardTopic, {
           ...msg,
           id: crypto.randomUUID(),
           topic: onboardTopic,
+          payload: {
+            ...p,
+            slug,
+            title,
+            github,
+          },
         });
         return;
       }


### PR DESCRIPTION
## Summary

Phase 1 — OnboardingPlugin deterministic pipeline: new lib/plugins/onboarding.ts (~450 lines), lib/plane-client.ts (extracted from plane.ts), HTTP endpoint POST /api/onboard, bus trigger message.inbound.onboard, Discord /onboard slash command. All 8 steps with idempotency. Phase 2 — Config hot-reload: watchFile for github.yaml (github.ts), discord.yaml with slash command re-registration (discord.ts), agents.yaml (workspace/plugins/a2a.ts). Remove monitoredRepos from github.yaml — derive from pro...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated project onboarding pipeline with idempotent project/webhook setup and a POST /api/onboard endpoint
  * Centralized Plane client and GitHub auth for safer project and webhook operations
  * Config hot-reload for Discord, GitHub, and agents; improved local routing for onboarding skills

* **Bug Fixes**
  * Safer spam-pattern handling that skips invalid regexes and reduces ReDoS risk

* **Chores**
  * Updated workspace ignore rules; lock file now contains merge conflict markers needing resolution
<!-- end of auto-generated comment: release notes by coderabbit.ai -->