### PR TITLE
fix: agents.yaml — port conflicts, endpoint mismatch, chain rules, Matt/Kai/Researcher wiring

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1775549531884-6ds1gptbf",
-  "startedAt": "2026-04-07T08:16:30.755Z"
+  "featureId": "feature-1775553242924-ztpmkoq9i",
+  "startedAt": "2026-04-07T09:14:38.656Z"
 }

--- a/.env.dist
+++ b/.env.dist
@@ -23,12 +23,3 @@ DATA_DIR=./data
 
 # Model configuration is in models.json (in repo root)
 # Pi SDK uses in-memory auth configured via models.json and OPENAI_API_KEY
-
-# Per-agent Discord bot tokens (optional — falls back to DISCORD_BOT_TOKEN)
-# Create a bot per agent in the Discord Developer Portal.
-# DISCORD_BOT_TOKEN_AVA=
-# DISCORD_BOT_TOKEN_QUINN=
-# DISCORD_BOT_TOKEN_JON=
-# DISCORD_BOT_TOKEN_CINDI=
-# DISCORD_BOT_TOKEN_RESEARCHER=
-# DISCORD_BOT_TOKEN_FRANK=

--- a/workspace/agents.yaml
+++ b/workspace/agents.yaml
@@ -9,27 +9,58 @@ agents:
     apiKeyEnv: AVA_API_KEY
     discordBotTokenEnvKey: DISCORD_BOT_TOKEN_AVA
     skills:
-      - plan
-      - plan_resume
-      - sitrep
-      - manage_feature
-      - auto_mode
-      - board_health
-      - onboard_project
-      - memory_recall
-      - memory_store
+      - name: plan
+        description: Break down a PRD or feature request into an actionable implementation plan
+      - name: plan_resume
+        description: Resume a paused plan after HITL approval
+      - name: sitrep
+        description: Generate a status report across active projects
+      - name: manage_feature
+        description: Manage a feature from backlog through implementation
+      - name: auto_mode
+        description: Fully autonomous issue-to-PR execution
+      - name: board_health
+        description: Audit project board health and flag stale or blocked items
+      - name: onboard_project
+        description: Register a new project and configure agents for it
+      - name: memory_recall
+        description: Recall relevant memories from the agent memory store
+      - name: memory_store
+        description: Store new memories into the agent memory store
+    chains:
+      plan:
+        - agent: researcher
+          trigger: before
+          prompt: "Research the codebase for patterns relevant to this PRD. Identify existing similar work, potential conflicts, and relevant file paths."
+        - agent: jon
+          trigger: parallel
+          prompt: "Review this PRD from a market/GTM lens. Is this worth building? What's the user value? What's missing from a go-to-market perspective?"
+      plan_resume:
+        - agent: ava
+          trigger: after
+          prompt: "Resume plan after HITL approval."
+    subscribesTo:
+      - message.inbound.#
+      - hitl.response.#
+      - agent.escalation.#
 
   - name: quinn
     url: http://quinn:7870/a2a
     apiKeyEnv: QUINN_API_KEY
     discordBotTokenEnvKey: DISCORD_BOT_TOKEN_QUINN
     skills:
-      - qa_report
-      - board_audit
-      - bug_triage
-      - pr_review
-      - memory_recall
-      - memory_store
+      - name: qa_report
+        description: Generate a QA report for a project or PR
+      - name: board_audit
+        description: Audit the project board for stale, duplicate, or broken items
+      - name: bug_triage
+        description: Triage a bug report and recommend next steps
+      - name: pr_review
+        description: Review a pull request for quality, patterns, and correctness
+      - name: memory_recall
+        description: Recall relevant memories from the agent memory store
+      - name: memory_store
+        description: Store new memories into the agent memory store
     chain:
       bug_triage:
         agent: ava
@@ -37,40 +68,126 @@ agents:
           If this is an actionable bug Quinn filed on the board, use auto_mode to kick off
           work on it immediately. If stale, duplicate, or already fixed, recommend closing
           the GitHub issue and explain why.
+    subscribesTo:
+      - message.inbound.discord.#
+      - message.inbound.github.#
 
   - name: jon
     url: http://jon:3010/a2a
     apiKeyEnv: JON_API_KEY
     discordBotTokenEnvKey: DISCORD_BOT_TOKEN_JON
     skills:
-      - content_strategy
-      - gtm_review
-      - competitive_research
-      - memory_recall
-      - memory_store
+      - name: content_strategy
+        description: Develop content strategy for a product or feature
+      - name: gtm_review
+        description: Review a feature or product from a go-to-market perspective
+      - name: competitive_research
+        description: Research competitors and market positioning
+      - name: memory_recall
+        description: Recall relevant memories from the agent memory store
+      - name: memory_store
+        description: Store new memories into the agent memory store
+    chains:
+      gtm_review:
+        - agent: ava
+          trigger: after
+          prompt: "Jon's GTM review complete. Merge his feedback with mine. If both approve → proceed to project creation. If either rejects → HITL gate with combined feedback."
+    subscribesTo:
+      - message.inbound.discord.#
+      - content.strategy.request
+      - gtm.review.request
 
   - name: cindi
     url: http://cindi:3011/a2a
     apiKeyEnv: CINDI_API_KEY
     discordBotTokenEnvKey: DISCORD_BOT_TOKEN_CINDI
     skills:
-      - write_content
-      - blog_post
-      - social_post
+      - name: write_content
+        description: Write long-form content for a blog post or article
+      - name: blog_post
+        description: Draft a blog post from a brief or outline
+      - name: social_post
+        description: Write social media posts for Twitter/LinkedIn
+    subscribesTo:
+      - content.write.request
+      - blog.post.request
+      - social.post.request
 
   - name: researcher
-    url: http://researcher:3012/a2a
+    url: http://researcher:7873/a2a
     apiKeyEnv: RESEARCHER_API_KEY
     discordBotTokenEnvKey: DISCORD_BOT_TOKEN_RESEARCHER
     skills:
-      - deep_research
-      - summarize
+      - name: deep_research
+        description: Perform deep research on a topic using web search and synthesis
+      - name: summarize
+        description: Summarize a document, article, or set of search results
+      - name: entity_extract
+        description: Extract named entities, concepts, and relationships from text
+      - name: pattern_analysis
+        description: Identify patterns and trends across a corpus of data or documents
+      - name: knowledge_synthesis
+        description: Synthesize knowledge from multiple sources into a coherent summary
+    projects:
+      - protolabsai-protomaker
+      - protolabsai-protoworkstacean
+      - protolabsai-protoui
+      - protolabsai-quinn
+    subscribesTo:
+      - research.request.#
 
   - name: frank
     url: http://frank:3013/a2a
     apiKeyEnv: FRANK_API_KEY
     discordBotTokenEnvKey: DISCORD_BOT_TOKEN_FRANK
     skills:
-      - deploy
-      - infra_health
-      - ci_debug
+      - name: deploy
+        description: Trigger and monitor deployments across environments
+      - name: infra_health
+        description: Check infrastructure health and surface alerts
+      - name: ci_debug
+        description: Diagnose and fix CI/CD pipeline failures
+      - name: docker_ops
+        description: Manage Docker containers, images, and compose stacks
+      - name: github_actions_debug
+        description: Debug failing GitHub Actions workflows and surface root causes
+      - name: resource_optimization
+        description: Identify and recommend resource usage optimizations across infra
+    subscribesTo:
+      - infra.alert.#
+      - deploy.request.#
+
+  - name: matt
+    url: http://matt:7874/a2a
+    apiKeyEnv: MATT_API_KEY
+    skills:
+      - name: frontend_impl
+        description: React component implementation, Tailwind CSS, design system work
+      - name: component_design
+        description: UI component architecture, Storybook, accessibility
+      - name: ui_review
+        description: Review frontend PRs for patterns, performance, design consistency
+    projects:
+      - protolabsai-protoui
+      - protolabsai-protomaker
+    subscribesTo:
+      - frontend.impl.request
+      - ui.review.request
+
+  - name: kai
+    url: http://kai:7875/a2a
+    apiKeyEnv: KAI_API_KEY
+    skills:
+      - name: backend_impl
+        description: Express routes, service layer, API design, Zod validation
+      - name: api_design
+        description: REST API contracts, OpenAPI spec, endpoint design
+      - name: backend_review
+        description: Review backend PRs for security, performance, patterns
+    projects:
+      - protolabsai-protomaker
+      - protolabsai-protoworkstacean
+      - protolabsai-protoui
+    subscribesTo:
+      - backend.impl.request
+      - api.review.request

--- a/workspace/projects.yaml
+++ b/workspace/projects.yaml
@@ -9,7 +9,7 @@ projects:
     github: protoLabsAI/protoMaker
     defaultBranch: main
     status: active
-    agents: [ava, quinn, frank]
+    agents: [ava, quinn, frank, matt, kai]
     discord:
       general: ""
       updates: ""
@@ -32,7 +32,7 @@ projects:
     github: protoLabsAI/protoUI
     defaultBranch: main
     status: active
-    agents: [ava, quinn]
+    agents: [ava, quinn, matt]
     discord:
       general: "1490601617567912050"
       updates: "1490601619300286525"
@@ -55,7 +55,7 @@ projects:
     github: protoLabsAI/protoWorkstacean
     defaultBranch: main
     status: active
-    agents: [ava, quinn, frank]
+    agents: [ava, quinn, frank, kai]
     discord:
       general: ""
       dev: ""


### PR DESCRIPTION
## Summary

Comprehensive agents.yaml cleanup: fix all endpoint conflicts, add missing agents, document all chain rules, define bus topic subscriptions.

**1. Fix port conflicts (BREAKING if left unfixed)**
- Researcher is `:7870` — same as Quinn. Assign Researcher a unique port: `http://researcher:7873/a2a`
- Frank registry says `:3013` but fleet-architecture.md says `:7880`. Audit actual deployment and reconcile. Use the correct port in agents.yaml, update fleet-architecture.md to match.

**2. Add Matt + ...

---
*Recovered automatically by Automaker post-agent hook*