### PR TITLE
M2: Goal Registry + Evaluator — goals.yaml loader, diff engine, violation events

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,10 +1,5 @@
 {
   "pid": 7,
-<<<<<<< HEAD
-  "featureId": "feature-1775548716277-5dj6q1qw3",
-  "startedAt": "2026-04-07T07:59:09.935Z"
-=======
-  "featureId": "feature-1775553242924-ztpmkoq9i",
-  "startedAt": "2026-04-07T09:14:38.656Z"
->>>>>>> origin/dev
+  "featureId": "feature-1775585786112-mhhpqkaf",
+  "startedAt": "2026-04-07T18:52:51.496Z"
 }

--- a/__tests__/distribution_goal_evaluator.test.ts
+++ b/__tests__/distribution_goal_evaluator.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect } from "bun:test";
+import { DistributionGoalEvaluator } from "../src/evaluators/distribution_goal_evaluator.ts";
+import type { DistributionGoal } from "../src/types/goals.ts";
+
+const evaluator = new DistributionGoalEvaluator();
+
+function makeGoal(overrides: Partial<DistributionGoal>): DistributionGoal {
+  return {
+    id: "test-distribution",
+    type: "Distribution",
+    description: "Test distribution",
+    selector: "items",
+    ...overrides,
+  };
+}
+
+describe("DistributionGoalEvaluator", () => {
+  test("returns null when all values match pattern", () => {
+    const goal = makeGoal({ pattern: "^[a-z]+$" });
+    const result = evaluator.evaluate(goal, { items: ["foo", "bar", "baz"] });
+    expect(result).toBeNull();
+  });
+
+  test("returns violation when values do not match pattern", () => {
+    const goal = makeGoal({ pattern: "^[a-z]+$" });
+    const result = evaluator.evaluate(goal, { items: ["foo", "BAR", "123"] });
+    expect(result).not.toBeNull();
+    expect(result!.message).toContain("pattern");
+  });
+
+  test("returns null when distribution matches within tolerance", () => {
+    const goal = makeGoal({
+      distribution: { active: 0.8, idle: 0.2 },
+      tolerance: 0.1,
+    });
+    // 8 active, 2 idle out of 10 = exactly 80/20
+    const result = evaluator.evaluate(goal, {
+      items: ["active", "active", "active", "active", "active", "active", "active", "active", "idle", "idle"],
+    });
+    expect(result).toBeNull();
+  });
+
+  test("returns violation when distribution deviates beyond tolerance", () => {
+    const goal = makeGoal({
+      distribution: { active: 0.9, idle: 0.1 },
+      tolerance: 0.05,
+    });
+    // 5 active, 5 idle = 50/50 — violates 90/10 expectation
+    const result = evaluator.evaluate(goal, {
+      items: ["active", "active", "active", "active", "active", "idle", "idle", "idle", "idle", "idle"],
+    });
+    expect(result).not.toBeNull();
+    expect(result!.message).toContain("Distribution violation");
+  });
+
+  test("handles object values (converted to array)", () => {
+    const goal = makeGoal({ pattern: "^\\d+$" });
+    const result = evaluator.evaluate(goal, { items: { a: "123", b: "456" } });
+    expect(result).toBeNull();
+  });
+
+  test("returns violation when selector is missing", () => {
+    const goal = makeGoal({ pattern: ".*" });
+    const result = evaluator.evaluate(goal, {});
+    expect(result).not.toBeNull();
+    expect(result!.message).toContain("not found");
+  });
+
+  test("returns violation for non-array/non-object value", () => {
+    const goal = makeGoal({ pattern: ".*" });
+    const result = evaluator.evaluate(goal, { items: 42 });
+    expect(result).not.toBeNull();
+    expect(result!.message).toContain("array");
+  });
+
+  test("skips disabled goals", () => {
+    const goal = makeGoal({ pattern: "^never$", enabled: false });
+    const result = evaluator.evaluate(goal, { items: ["anything"] });
+    expect(result).toBeNull();
+  });
+});

--- a/__tests__/goal_evaluator_plugin.test.ts
+++ b/__tests__/goal_evaluator_plugin.test.ts
@@ -1,0 +1,231 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { writeFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { InMemoryEventBus } from "../lib/bus.ts";
+import { GoalEvaluatorPlugin } from "../src/plugins/goal_evaluator_plugin.ts";
+import type { BusMessage } from "../lib/types.ts";
+import type { GoalViolatedEventPayload } from "../src/types/events.ts";
+
+const TMP_DIR = join(process.cwd(), "tmp", "test-goal-evaluator-plugin");
+
+function setup() {
+  mkdirSync(join(TMP_DIR, "workspace"), { recursive: true });
+}
+
+function teardown() {
+  if (existsSync(TMP_DIR)) {
+    rmSync(TMP_DIR, { recursive: true, force: true });
+  }
+}
+
+function writeGoals(goals: string) {
+  writeFileSync(join(TMP_DIR, "workspace", "goals.yaml"), goals);
+}
+
+describe("GoalEvaluatorPlugin", () => {
+  let bus: InMemoryEventBus;
+  let plugin: GoalEvaluatorPlugin;
+
+  beforeEach(() => {
+    setup();
+    bus = new InMemoryEventBus();
+  });
+
+  afterEach(() => {
+    plugin?.uninstall();
+    teardown();
+  });
+
+  test("installs and subscribes to world.state.#", () => {
+    plugin = new GoalEvaluatorPlugin({ workspaceDir: join(TMP_DIR, "workspace") });
+    plugin.install(bus);
+
+    const topics = bus.topics();
+    const worldStateTopic = topics.find(t => t.pattern === "world.state.#");
+    expect(worldStateTopic).toBeDefined();
+  });
+
+  test("diffs state — emits violation event on goal violation", () => {
+    writeGoals(`
+goals:
+  - id: status-must-be-ok
+    type: Invariant
+    description: Status must be ok
+    selector: status
+    operator: eq
+    expected: "ok"
+`);
+
+    plugin = new GoalEvaluatorPlugin({ workspaceDir: join(TMP_DIR, "workspace") });
+    plugin.install(bus);
+
+    const violationEvents: BusMessage[] = [];
+    bus.subscribe("world.goal.violated", "test", msg => {
+      violationEvents.push(msg);
+    });
+
+    bus.publish("world.state.update", {
+      id: "1",
+      correlationId: "1",
+      topic: "world.state.update",
+      timestamp: Date.now(),
+      payload: { status: "degraded" },
+    });
+
+    expect(violationEvents).toHaveLength(1);
+    const payload = violationEvents[0].payload as GoalViolatedEventPayload;
+    expect(payload.type).toBe("world.goal.violated");
+    expect(payload.violation.goalId).toBe("status-must-be-ok");
+  });
+
+  test("emits violation event for each violated goal", () => {
+    writeGoals(`
+goals:
+  - id: goal-1
+    type: Invariant
+    description: Goal 1
+    selector: a
+    operator: truthy
+  - id: goal-2
+    type: Threshold
+    description: Goal 2
+    selector: cpu
+    max: 80
+`);
+
+    plugin = new GoalEvaluatorPlugin({ workspaceDir: join(TMP_DIR, "workspace") });
+    plugin.install(bus);
+
+    const violationEvents: BusMessage[] = [];
+    bus.subscribe("world.goal.violated", "test", msg => {
+      violationEvents.push(msg);
+    });
+
+    bus.publish("world.state.update", {
+      id: "2",
+      correlationId: "2",
+      topic: "world.state.update",
+      timestamp: Date.now(),
+      payload: { a: null, cpu: 95 },
+    });
+
+    expect(violationEvents).toHaveLength(2);
+  });
+
+  test("evaluates Invariant goal — no violation when goal is satisfied", () => {
+    writeGoals(`
+goals:
+  - id: status-ok
+    type: Invariant
+    description: Status must be ok
+    selector: status
+    operator: eq
+    expected: "ok"
+`);
+
+    plugin = new GoalEvaluatorPlugin({ workspaceDir: join(TMP_DIR, "workspace") });
+    plugin.install(bus);
+
+    const violationEvents: BusMessage[] = [];
+    bus.subscribe("world.goal.violated", "test", msg => {
+      violationEvents.push(msg);
+    });
+
+    bus.publish("world.state.update", {
+      id: "3",
+      correlationId: "3",
+      topic: "world.state.update",
+      timestamp: Date.now(),
+      payload: { status: "ok" },
+    });
+
+    expect(violationEvents).toHaveLength(0);
+  });
+
+  test("emits violation event with correct payload structure", () => {
+    writeGoals(`
+goals:
+  - id: cpu-ok
+    type: Threshold
+    description: CPU below 80
+    severity: high
+    selector: metrics.cpu
+    max: 80
+`);
+
+    plugin = new GoalEvaluatorPlugin({ workspaceDir: join(TMP_DIR, "workspace") });
+    plugin.install(bus);
+
+    let violationMsg: BusMessage | null = null;
+    bus.subscribe("world.goal.violated", "test", msg => {
+      violationMsg = msg;
+    });
+
+    bus.publish("world.state.update", {
+      id: "4",
+      correlationId: "4",
+      topic: "world.state.update",
+      timestamp: Date.now(),
+      payload: { metrics: { cpu: 92 } },
+    });
+
+    expect(violationMsg).not.toBeNull();
+    const payload = violationMsg!.payload as GoalViolatedEventPayload;
+    expect(payload.violation.goalId).toBe("cpu-ok");
+    expect(payload.violation.goalType).toBe("Threshold");
+    expect(payload.violation.severity).toBe("high");
+    expect(payload.violation.actual).toBe(92);
+  });
+
+  test("evaluateState returns violations directly", () => {
+    writeGoals(`
+goals:
+  - id: status-check
+    type: Invariant
+    description: Status must be active
+    selector: status
+    operator: eq
+    expected: "active"
+`);
+
+    plugin = new GoalEvaluatorPlugin({ workspaceDir: join(TMP_DIR, "workspace") });
+    plugin.install(bus);
+
+    const violations = plugin.evaluateState({ status: "inactive" });
+    expect(violations).toHaveLength(1);
+    expect(violations[0].goalId).toBe("status-check");
+
+    const noViolations = plugin.evaluateState({ status: "active" });
+    expect(noViolations).toHaveLength(0);
+  });
+
+  test("uninstalls cleanly and stops receiving events", () => {
+    writeGoals(`
+goals:
+  - id: always-violated
+    type: Invariant
+    description: Always violated
+    selector: missing
+    operator: truthy
+`);
+
+    plugin = new GoalEvaluatorPlugin({ workspaceDir: join(TMP_DIR, "workspace") });
+    plugin.install(bus);
+    plugin.uninstall();
+
+    const violationEvents: BusMessage[] = [];
+    bus.subscribe("world.goal.violated", "test", msg => {
+      violationEvents.push(msg);
+    });
+
+    bus.publish("world.state.update", {
+      id: "5",
+      correlationId: "5",
+      topic: "world.state.update",
+      timestamp: Date.now(),
+      payload: {},
+    });
+
+    expect(violationEvents).toHaveLength(0);
+  });
+});

--- a/__tests__/goals_loader.test.ts
+++ b/__tests__/goals_loader.test.ts
@@ -1,0 +1,150 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { writeFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { GoalsLoader } from "../src/loaders/goals_loader.ts";
+
+const TMP_DIR = join(process.cwd(), "tmp", "test-goals-loader");
+
+function setup() {
+  mkdirSync(TMP_DIR, { recursive: true });
+  mkdirSync(join(TMP_DIR, "workspace"), { recursive: true });
+}
+
+function teardown() {
+  if (existsSync(TMP_DIR)) {
+    rmSync(TMP_DIR, { recursive: true, force: true });
+  }
+}
+
+describe("GoalsLoader", () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  test("loads global goals from workspace/goals.yaml", () => {
+    const goalsYaml = `
+version: "1.0"
+goals:
+  - id: test-invariant
+    type: Invariant
+    description: Test invariant goal
+    selector: status
+    operator: truthy
+  - id: test-threshold
+    type: Threshold
+    description: Test threshold goal
+    selector: metrics.cpu
+    max: 80
+`;
+    writeFileSync(join(TMP_DIR, "workspace", "goals.yaml"), goalsYaml);
+    const loader = new GoalsLoader(join(TMP_DIR, "workspace"));
+    const goals = loader.loadGlobal();
+
+    expect(goals).toHaveLength(2);
+    expect(goals[0].id).toBe("test-invariant");
+    expect(goals[0].type).toBe("Invariant");
+    expect(goals[1].id).toBe("test-threshold");
+    expect(goals[1].type).toBe("Threshold");
+  });
+
+  test("returns empty array when global goals.yaml is missing", () => {
+    const loader = new GoalsLoader(join(TMP_DIR, "workspace"));
+    const goals = loader.loadGlobal();
+    expect(goals).toHaveLength(0);
+  });
+
+  test("skips invalid goals and continues with valid ones", () => {
+    const goalsYaml = `
+goals:
+  - id: valid-goal
+    type: Invariant
+    description: Valid goal
+    selector: status
+  - type: Invariant
+    description: Missing ID — invalid
+    selector: foo
+  - id: no-type-goal
+    description: Missing type — invalid
+    selector: bar
+`;
+    writeFileSync(join(TMP_DIR, "workspace", "goals.yaml"), goalsYaml);
+    const loader = new GoalsLoader(join(TMP_DIR, "workspace"));
+    const goals = loader.loadGlobal();
+
+    expect(goals).toHaveLength(1);
+    expect(goals[0].id).toBe("valid-goal");
+  });
+
+  test("applies project overrides to global goals", () => {
+    const globalYaml = `
+goals:
+  - id: shared-goal
+    type: Invariant
+    description: Global version
+    selector: status
+    operator: truthy
+  - id: global-only
+    type: Threshold
+    description: Only in global
+    selector: cpu
+    max: 80
+`;
+    const projectYaml = `
+goals:
+  - id: shared-goal
+    type: Invariant
+    description: Project override version
+    selector: status
+    operator: eq
+    expected: "healthy"
+  - id: project-only
+    type: Threshold
+    description: Only in project
+    selector: memory
+    max: 90
+`;
+    writeFileSync(join(TMP_DIR, "workspace", "goals.yaml"), globalYaml);
+    const projectDir = join(TMP_DIR, "projects", "my-project");
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(join(projectDir, "goals.yaml"), projectYaml);
+
+    const loader = new GoalsLoader(join(TMP_DIR, "workspace"), join(TMP_DIR, "projects"));
+    const result = loader.loadMerged("my-project");
+
+    expect(result.source).toBe("merged");
+    expect(result.projectSlug).toBe("my-project");
+
+    const sharedGoal = result.goals.find(g => g.id === "shared-goal");
+    expect(sharedGoal).toBeDefined();
+    expect(sharedGoal!.description).toBe("Project override version");
+
+    const globalOnly = result.goals.find(g => g.id === "global-only");
+    expect(globalOnly).toBeDefined();
+
+    const projectOnly = result.goals.find(g => g.id === "project-only");
+    expect(projectOnly).toBeDefined();
+  });
+
+  test("returns global goals when project has no goals.yaml", () => {
+    const globalYaml = `
+goals:
+  - id: global-goal
+    type: Invariant
+    description: Global goal
+    selector: status
+`;
+    writeFileSync(join(TMP_DIR, "workspace", "goals.yaml"), globalYaml);
+
+    const loader = new GoalsLoader(join(TMP_DIR, "workspace"), join(TMP_DIR, "projects"));
+    const result = loader.loadMerged("nonexistent-project");
+
+    expect(result.source).toBe("global");
+    expect(result.goals).toHaveLength(1);
+  });
+
+  test("handles malformed YAML gracefully", () => {
+    writeFileSync(join(TMP_DIR, "workspace", "goals.yaml"), "{ invalid yaml: [[[");
+    const loader = new GoalsLoader(join(TMP_DIR, "workspace"));
+    const goals = loader.loadGlobal();
+    expect(goals).toHaveLength(0);
+  });
+});

--- a/__tests__/integrations/discord_integration.test.ts
+++ b/__tests__/integrations/discord_integration.test.ts
@@ -1,0 +1,76 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import type { GoalViolation } from "../../src/types/goals.ts";
+
+function makeViolation(overrides?: Partial<GoalViolation>): GoalViolation {
+  return {
+    goalId: "test-goal",
+    goalType: "Threshold",
+    severity: "critical",
+    description: "Test threshold violation",
+    message: "CPU exceeded max threshold",
+    actual: 95,
+    expected: { max: 80 },
+    timestamp: Date.now(),
+    projectSlug: "my-project",
+    ...overrides,
+  };
+}
+
+describe("DiscordLogger", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    if ("DISCORD_GOALS_WEBHOOK_URL" in originalEnv) {
+      process.env.DISCORD_GOALS_WEBHOOK_URL = originalEnv.DISCORD_GOALS_WEBHOOK_URL;
+    } else {
+      delete process.env.DISCORD_GOALS_WEBHOOK_URL;
+    }
+  });
+
+  test("logs violations to console fallback when no webhook URL is configured", async () => {
+    delete process.env.DISCORD_GOALS_WEBHOOK_URL;
+
+    const { DiscordLogger } = await import("../../src/integrations/discord_logger.ts");
+    const logger = new DiscordLogger();
+
+    const result = await logger.logViolation(makeViolation());
+    expect(result).toBe(false);
+  });
+
+  test("uses webhook URL passed to constructor", async () => {
+    const { DiscordLogger } = await import("../../src/integrations/discord_logger.ts");
+    // Invalid URL — should fail gracefully
+    const logger = new DiscordLogger("https://discord.invalid/webhook/test");
+
+    const result = await logger.logViolation(makeViolation());
+    // Network failure → fallback
+    expect(result).toBe(false);
+  });
+
+  test("logs violations to console when webhook URL is set but invalid", async () => {
+    process.env.DISCORD_GOALS_WEBHOOK_URL = "https://discord.invalid/webhook";
+
+    const { DiscordLogger } = await import("../../src/integrations/discord_logger.ts");
+    const logger = new DiscordLogger();
+
+    const result = await logger.logViolation(makeViolation());
+    expect(result).toBe(false);
+  });
+
+  test("builds correct embed structure", async () => {
+    delete process.env.DISCORD_GOALS_WEBHOOK_URL;
+
+    const { DiscordLogger } = await import("../../src/integrations/discord_logger.ts");
+
+    // Access private method via any cast for structural test
+    const logger = new DiscordLogger() as unknown as { _buildEmbed: (v: GoalViolation) => Record<string, unknown> };
+
+    const violation = makeViolation({ severity: "critical", goalId: "cpu-check" });
+    const embed = logger._buildEmbed(violation);
+
+    expect(embed.title).toContain("Goal Violation");
+    expect(typeof embed.color).toBe("number");
+    expect(Array.isArray(embed.fields)).toBe(true);
+    expect(embed.timestamp).toBeDefined();
+  });
+});

--- a/__tests__/integrations/langfuse_integration.test.ts
+++ b/__tests__/integrations/langfuse_integration.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import type { GoalViolation } from "../../src/types/goals.ts";
+
+function makeViolation(overrides?: Partial<GoalViolation>): GoalViolation {
+  return {
+    goalId: "test-goal",
+    goalType: "Invariant",
+    severity: "high",
+    description: "Test violation",
+    message: "Test message",
+    actual: "bad",
+    expected: "good",
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("LangfuseLogger", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    // Restore env
+    for (const key of ["LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY", "LANGFUSE_HOST"]) {
+      if (key in originalEnv) {
+        process.env[key] = originalEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  test("logs violations to console when credentials are missing", async () => {
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+
+    const { LangfuseLogger } = await import("../../src/integrations/langfuse_logger.ts");
+    const logger = new LangfuseLogger();
+
+    const violation = makeViolation();
+    const result = await logger.logViolation(violation);
+
+    // Falls back to console — returns false
+    expect(result).toBe(false);
+  });
+
+  test("buffers violations and flushes", async () => {
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+
+    const { LangfuseLogger } = await import("../../src/integrations/langfuse_logger.ts");
+    const logger = new LangfuseLogger();
+
+    logger.bufferViolation(makeViolation({ goalId: "v1" }));
+    logger.bufferViolation(makeViolation({ goalId: "v2" }));
+
+    const result = await logger.flush();
+    // No credentials — returns false but doesn't throw
+    expect(result).toBe(false);
+  });
+
+  test("attempts HTTP request when credentials are present", async () => {
+    process.env.LANGFUSE_PUBLIC_KEY = "pk-test";
+    process.env.LANGFUSE_SECRET_KEY = "sk-test";
+    process.env.LANGFUSE_HOST = "https://test.langfuse.invalid";
+
+    const { LangfuseLogger } = await import("../../src/integrations/langfuse_logger.ts");
+    const logger = new LangfuseLogger();
+
+    const violation = makeViolation();
+    // Network will fail (invalid host) — should fall back gracefully
+    const result = await logger.logViolation(violation);
+    expect(result).toBe(false); // network failure → fallback
+  });
+
+  test("flush with empty buffer returns true", async () => {
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+
+    const { LangfuseLogger } = await import("../../src/integrations/langfuse_logger.ts");
+    const logger = new LangfuseLogger();
+
+    const result = await logger.flush();
+    expect(result).toBe(true);
+  });
+});

--- a/__tests__/invariant_goal_evaluator.test.ts
+++ b/__tests__/invariant_goal_evaluator.test.ts
@@ -1,0 +1,101 @@
+import { describe, test, expect } from "bun:test";
+import { InvariantGoalEvaluator } from "../src/evaluators/invariant_goal_evaluator.ts";
+import type { InvariantGoal } from "../src/types/goals.ts";
+
+const evaluator = new InvariantGoalEvaluator();
+
+function makeGoal(overrides: Partial<InvariantGoal>): InvariantGoal {
+  return {
+    id: "test-goal",
+    type: "Invariant",
+    description: "Test invariant",
+    selector: "status",
+    ...overrides,
+  };
+}
+
+describe("InvariantGoalEvaluator", () => {
+  test("returns null when truthy condition is satisfied", () => {
+    const goal = makeGoal({ operator: "truthy" });
+    const result = evaluator.evaluate(goal, { status: "ok" });
+    expect(result).toBeNull();
+  });
+
+  test("returns violation when truthy condition fails", () => {
+    const goal = makeGoal({ operator: "truthy" });
+    const result = evaluator.evaluate(goal, { status: null });
+    expect(result).not.toBeNull();
+    expect(result!.goalId).toBe("test-goal");
+    expect(result!.goalType).toBe("Invariant");
+  });
+
+  test("returns null for falsy operator when value is falsy", () => {
+    const goal = makeGoal({ operator: "falsy" });
+    const result = evaluator.evaluate(goal, { status: false });
+    expect(result).toBeNull();
+  });
+
+  test("returns violation for falsy operator when value is truthy", () => {
+    const goal = makeGoal({ operator: "falsy" });
+    const result = evaluator.evaluate(goal, { status: "active" });
+    expect(result).not.toBeNull();
+  });
+
+  test("evaluates Invariant goal — eq operator match", () => {
+    const goal = makeGoal({ operator: "eq", expected: "healthy" });
+    const result = evaluator.evaluate(goal, { status: "healthy" });
+    expect(result).toBeNull();
+  });
+
+  test("evaluates Invariant goal — eq operator violation", () => {
+    const goal = makeGoal({ operator: "eq", expected: "healthy" });
+    const result = evaluator.evaluate(goal, { status: "degraded" });
+    expect(result).not.toBeNull();
+    expect(result!.actual).toBe("degraded");
+    expect(result!.expected).toBe("healthy");
+  });
+
+  test("evaluates Invariant goal — neq operator", () => {
+    const goal = makeGoal({ operator: "neq", expected: "error" });
+    expect(evaluator.evaluate(goal, { status: "ok" })).toBeNull();
+    expect(evaluator.evaluate(goal, { status: "error" })).not.toBeNull();
+  });
+
+  test("evaluates Invariant goal — in operator", () => {
+    const goal = makeGoal({ operator: "in", expected: ["active", "idle"] });
+    expect(evaluator.evaluate(goal, { status: "active" })).toBeNull();
+    expect(evaluator.evaluate(goal, { status: "error" })).not.toBeNull();
+  });
+
+  test("evaluates Invariant goal — not_in operator", () => {
+    const goal = makeGoal({ operator: "not_in", expected: ["error", "fatal"] });
+    expect(evaluator.evaluate(goal, { status: "ok" })).toBeNull();
+    expect(evaluator.evaluate(goal, { status: "error" })).not.toBeNull();
+  });
+
+  test("returns violation when selector is missing from state", () => {
+    const goal = makeGoal({ selector: "missing.path" });
+    const result = evaluator.evaluate(goal, {});
+    expect(result).not.toBeNull();
+    expect(result!.message).toContain("not found");
+  });
+
+  test("skips disabled goals", () => {
+    const goal = makeGoal({ enabled: false, operator: "truthy" });
+    const result = evaluator.evaluate(goal, { status: null });
+    expect(result).toBeNull();
+  });
+
+  test("includes projectSlug in violation", () => {
+    const goal = makeGoal({ operator: "truthy" });
+    const result = evaluator.evaluate(goal, { status: null }, "my-project");
+    expect(result).not.toBeNull();
+    expect(result!.projectSlug).toBe("my-project");
+  });
+
+  test("defaults severity to medium", () => {
+    const goal = makeGoal({ operator: "truthy" });
+    const result = evaluator.evaluate(goal, { status: null });
+    expect(result!.severity).toBe("medium");
+  });
+});

--- a/__tests__/state_diff_engine.test.ts
+++ b/__tests__/state_diff_engine.test.ts
@@ -1,0 +1,109 @@
+import { describe, test, expect } from "bun:test";
+import { StateDiffEngine, resolvePath } from "../src/engines/state_diff_engine.ts";
+
+describe("resolvePath", () => {
+  test("resolves top-level key", () => {
+    const result = resolvePath({ status: "ok" }, "status");
+    expect(result.found).toBe(true);
+    expect(result.value).toBe("ok");
+  });
+
+  test("resolves nested key", () => {
+    const result = resolvePath({ a: { b: { c: 42 } } }, "a.b.c");
+    expect(result.found).toBe(true);
+    expect(result.value).toBe(42);
+  });
+
+  test("returns not found for missing key", () => {
+    const result = resolvePath({ a: 1 }, "a.b.c");
+    expect(result.found).toBe(false);
+  });
+
+  test("returns not found for null intermediate", () => {
+    const result = resolvePath({ a: null }, "a.b");
+    expect(result.found).toBe(false);
+  });
+
+  test("resolves empty path returning whole object", () => {
+    const obj = { x: 1 };
+    const result = resolvePath(obj, "");
+    expect(result.found).toBe(true);
+    expect(result.value).toBe(obj);
+  });
+});
+
+describe("StateDiffEngine", () => {
+  const engine = new StateDiffEngine();
+
+  test("returns no diff for identical states", () => {
+    const state = { a: 1, b: "hello" };
+    const diff = engine.diff(state, state);
+    expect(diff.hasChanges).toBe(false);
+    expect(diff.entries).toHaveLength(0);
+  });
+
+  test("diffs state — detects changed value", () => {
+    const expected = { status: "ok" };
+    const actual = { status: "error" };
+    const diff = engine.diff(expected, actual);
+
+    expect(diff.hasChanges).toBe(true);
+    const entry = diff.entries.find(e => e.path === "status");
+    expect(entry).toBeDefined();
+    expect(entry!.type).toBe("changed");
+    expect(entry!.expected).toBe("ok");
+    expect(entry!.actual).toBe("error");
+  });
+
+  test("detects missing field", () => {
+    const expected = { a: 1, b: 2 };
+    const actual = { a: 1 };
+    const diff = engine.diff(expected, actual);
+
+    expect(diff.hasChanges).toBe(true);
+    const entry = diff.entries.find(e => e.path === "b");
+    expect(entry).toBeDefined();
+    expect(entry!.type).toBe("missing");
+  });
+
+  test("detects extra field", () => {
+    const expected = { a: 1 };
+    const actual = { a: 1, b: 2 };
+    const diff = engine.diff(expected, actual);
+
+    expect(diff.hasChanges).toBe(true);
+    const entry = diff.entries.find(e => e.path === "b");
+    expect(entry).toBeDefined();
+    expect(entry!.type).toBe("extra");
+  });
+
+  test("detects type mismatch", () => {
+    const expected = { count: 5 };
+    const actual = { count: "5" };
+    const diff = engine.diff(expected, actual);
+
+    expect(diff.hasChanges).toBe(true);
+    const entry = diff.entries.find(e => e.path === "count");
+    expect(entry).toBeDefined();
+    expect(entry!.type).toBe("type_mismatch");
+  });
+
+  test("recursively diffs nested objects", () => {
+    const expected = { a: { b: { c: 1 } } };
+    const actual = { a: { b: { c: 2 } } };
+    const diff = engine.diff(expected, actual);
+
+    expect(diff.hasChanges).toBe(true);
+    const entry = diff.entries.find(e => e.path === "a.b.c");
+    expect(entry).toBeDefined();
+    expect(entry!.type).toBe("changed");
+  });
+
+  test("detects array changes", () => {
+    const expected = { items: [1, 2, 3] };
+    const actual = { items: [1, 2, 4] };
+    const diff = engine.diff(expected, actual);
+
+    expect(diff.hasChanges).toBe(true);
+  });
+});

--- a/__tests__/threshold_goal_evaluator.test.ts
+++ b/__tests__/threshold_goal_evaluator.test.ts
@@ -1,0 +1,69 @@
+import { describe, test, expect } from "bun:test";
+import { ThresholdGoalEvaluator } from "../src/evaluators/threshold_goal_evaluator.ts";
+import type { ThresholdGoal } from "../src/types/goals.ts";
+
+const evaluator = new ThresholdGoalEvaluator();
+
+function makeGoal(overrides: Partial<ThresholdGoal>): ThresholdGoal {
+  return {
+    id: "test-threshold",
+    type: "Threshold",
+    description: "Test threshold",
+    selector: "metrics.cpu",
+    ...overrides,
+  };
+}
+
+describe("ThresholdGoalEvaluator", () => {
+  test("evaluates Threshold goal — value within bounds", () => {
+    const goal = makeGoal({ min: 0, max: 80 });
+    expect(evaluator.evaluate(goal, { metrics: { cpu: 50 } })).toBeNull();
+  });
+
+  test("evaluates Threshold goal — max exceeded", () => {
+    const goal = makeGoal({ max: 80 });
+    const result = evaluator.evaluate(goal, { metrics: { cpu: 92 } });
+    expect(result).not.toBeNull();
+    expect(result!.actual).toBe(92);
+    expect(result!.message).toContain("exceeds maximum");
+  });
+
+  test("evaluates Threshold goal — below min", () => {
+    const goal = makeGoal({ min: 10 });
+    const result = evaluator.evaluate(goal, { metrics: { cpu: 3 } });
+    expect(result).not.toBeNull();
+    expect(result!.actual).toBe(3);
+    expect(result!.message).toContain("below minimum");
+  });
+
+  test("evaluates Threshold goal — exactly at boundary (no violation)", () => {
+    const goal = makeGoal({ min: 10, max: 80 });
+    expect(evaluator.evaluate(goal, { metrics: { cpu: 10 } })).toBeNull();
+    expect(evaluator.evaluate(goal, { metrics: { cpu: 80 } })).toBeNull();
+  });
+
+  test("returns violation for non-numeric value", () => {
+    const goal = makeGoal({ max: 80 });
+    const result = evaluator.evaluate(goal, { metrics: { cpu: "high" } });
+    expect(result).not.toBeNull();
+    expect(result!.message).toContain("number");
+  });
+
+  test("returns violation when selector is missing", () => {
+    const goal = makeGoal({ max: 80 });
+    const result = evaluator.evaluate(goal, {});
+    expect(result).not.toBeNull();
+    expect(result!.message).toContain("not found");
+  });
+
+  test("skips disabled goals", () => {
+    const goal = makeGoal({ max: 80, enabled: false });
+    expect(evaluator.evaluate(goal, { metrics: { cpu: 99 } })).toBeNull();
+  });
+
+  test("includes projectSlug in violation", () => {
+    const goal = makeGoal({ max: 80 });
+    const result = evaluator.evaluate(goal, { metrics: { cpu: 95 } }, "proj-1");
+    expect(result!.projectSlug).toBe("proj-1");
+  });
+});

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,65 @@
+# Event Catalog
+
+This document describes events published by the GoalEvaluatorPlugin.
+
+## world.goal.violated
+
+Emitted when a goal evaluation detects a violation.
+
+**Topic:** `world.goal.violated`
+
+**Payload:**
+
+```typescript
+{
+  type: "world.goal.violated";
+  violation: {
+    goalId: string;          // Goal identifier from goals.yaml
+    goalType: "Invariant" | "Threshold" | "Distribution";
+    severity: "low" | "medium" | "high" | "critical";
+    description: string;     // Human-readable goal description
+    message: string;         // Specific violation message
+    actual: unknown;         // Actual value observed in world state
+    expected: unknown;       // Expected value/bounds
+    timestamp: number;       // Unix milliseconds
+    projectSlug?: string;    // Project context (if scoped)
+  };
+}
+```
+
+**Example:**
+
+```json
+{
+  "topic": "world.goal.violated",
+  "payload": {
+    "type": "world.goal.violated",
+    "violation": {
+      "goalId": "cpu-ok",
+      "goalType": "Threshold",
+      "severity": "high",
+      "description": "CPU must stay below 80%",
+      "message": "\"metrics.cpu.usage\" value 92 exceeds maximum threshold 80",
+      "actual": 92,
+      "expected": { "max": 80 },
+      "timestamp": 1712345678000,
+      "projectSlug": "protoworkstacean"
+    }
+  }
+}
+```
+
+## world.state.# (input)
+
+The plugin subscribes to `world.state.#` for incoming world state.
+
+**Expected payload:**
+
+```typescript
+{
+  state: Record<string, unknown>;  // The world state to evaluate against
+  projectSlug?: string;            // Optional project scope
+}
+```
+
+Or the entire payload is treated as the world state if no `state` key is present.

--- a/docs/goals-examples.yaml
+++ b/docs/goals-examples.yaml
@@ -1,0 +1,100 @@
+version: "1.0"
+
+goals:
+  # ── Invariant examples ────────────────────────────────────────────────────
+
+  - id: auth-service-healthy
+    type: Invariant
+    description: Auth service must always be in a healthy state
+    severity: critical
+    selector: services.auth.status
+    operator: eq
+    expected: "healthy"
+
+  - id: database-connected
+    type: Invariant
+    description: Database connection must be established
+    severity: critical
+    selector: database.connected
+    operator: truthy
+
+  - id: feature-flag-enabled
+    type: Invariant
+    description: New checkout feature flag must be enabled in production
+    severity: medium
+    selector: featureFlags.newCheckout
+    operator: truthy
+    tags: [feature-flags, checkout]
+
+  - id: environment-is-production
+    type: Invariant
+    description: Environment must be one of the expected values
+    severity: high
+    selector: system.environment
+    operator: in
+    expected: ["production", "staging"]
+
+  # ── Threshold examples ────────────────────────────────────────────────────
+
+  - id: cpu-usage-under-80
+    type: Threshold
+    description: CPU usage must stay below 80%
+    severity: high
+    selector: metrics.cpu.usagePercent
+    max: 80
+    tags: [performance, infrastructure]
+
+  - id: memory-within-bounds
+    type: Threshold
+    description: Memory usage must stay between 10% and 90%
+    severity: high
+    selector: metrics.memory.usagePercent
+    min: 10
+    max: 90
+
+  - id: error-rate-low
+    type: Threshold
+    description: API error rate must stay below 5%
+    severity: critical
+    selector: metrics.api.errorRatePercent
+    max: 5
+    tags: [reliability, api]
+
+  - id: active-agents-minimum
+    type: Threshold
+    description: At least 2 agents must be active at all times
+    severity: high
+    selector: agents.activeCount
+    min: 2
+
+  # ── Distribution examples ─────────────────────────────────────────────────
+
+  - id: agent-status-distribution
+    type: Distribution
+    description: Agent statuses should follow expected distribution
+    severity: medium
+    selector: agents.allStatuses
+    distribution:
+      active: 0.7
+      idle: 0.2
+      error: 0.1
+    tolerance: 0.15
+    tags: [agents, health]
+
+  - id: all-ids-are-uuids
+    type: Distribution
+    description: All resource IDs must be valid UUIDs
+    severity: high
+    selector: resources.ids
+    pattern: "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+
+  - id: log-levels-distribution
+    type: Distribution
+    description: Log level distribution should not be dominated by errors
+    severity: high
+    selector: logs.levelCounts
+    distribution:
+      info: 0.7
+      warn: 0.2
+      error: 0.1
+    tolerance: 0.2

--- a/docs/goals-schema.md
+++ b/docs/goals-schema.md
@@ -1,0 +1,119 @@
+# goals.yaml Schema Reference
+
+The `goals.yaml` file defines observable goals for the GoalEvaluatorPlugin.
+Goals are evaluated against incoming world state events. Violations are emitted
+as `world.goal.violated` events and logged to Langfuse and Discord.
+
+## File Locations
+
+| Scope | Path |
+|-------|------|
+| Global | `workspace/goals.yaml` |
+| Per-project override | `.automaker/projects/{slug}/goals.yaml` |
+
+Project-level goals override global goals with the same `id`.
+
+## Top-Level Structure
+
+```yaml
+version: "1.0"  # optional
+goals:
+  - id: unique-goal-id
+    type: Invariant | Threshold | Distribution
+    description: Human-readable description
+    severity: low | medium | high | critical  # default: medium
+    enabled: true  # default: true
+    tags: [optional, labels]
+    # ... type-specific fields
+```
+
+## Goal Types
+
+### Invariant
+
+Checks a boolean condition against a world state value.
+
+```yaml
+- id: auth-service-healthy
+  type: Invariant
+  description: Auth service must be healthy
+  severity: critical
+  selector: services.auth.status
+  operator: eq
+  expected: "healthy"
+```
+
+**Fields:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `selector` | Yes | Dot-notation path into world state |
+| `operator` | No | `eq`, `neq`, `truthy`, `falsy`, `in`, `not_in` (default: `truthy`) |
+| `expected` | No | Expected value for comparison |
+
+**Operators:**
+- `truthy` — value must be truthy (non-null, non-false, non-zero, non-empty)
+- `falsy` — value must be falsy
+- `eq` — value must equal `expected`
+- `neq` — value must not equal `expected`
+- `in` — value must be in `expected` array
+- `not_in` — value must not be in `expected` array
+
+### Threshold
+
+Checks a numeric metric against min/max bounds.
+
+```yaml
+- id: cpu-usage-ok
+  type: Threshold
+  description: CPU usage must stay below 80%
+  severity: high
+  selector: metrics.cpu.usage
+  max: 80
+```
+
+**Fields:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `selector` | Yes | Dot-notation path resolving to a number |
+| `min` | Conditional | Minimum allowed value (at least one of min/max required) |
+| `max` | Conditional | Maximum allowed value |
+
+### Distribution
+
+Checks patterns or value proportions in an array/map.
+
+```yaml
+- id: agent-status-distribution
+  type: Distribution
+  description: Most agents should be active
+  severity: medium
+  selector: agents.statuses
+  distribution:
+    active: 0.8
+    idle: 0.2
+  tolerance: 0.1
+```
+
+**Fields:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `selector` | Yes | Dot-notation path resolving to an array or object |
+| `pattern` | No | Regex — all values must match |
+| `distribution` | No | Expected value proportions `{ value: fraction }` |
+| `tolerance` | No | Allowed deviation from expected fraction (default: `0.1`) |
+
+## Severity Levels
+
+| Level | Color | Use case |
+|-------|-------|----------|
+| `low` | Blue | Informational, non-urgent |
+| `medium` | Orange | Should investigate soon |
+| `high` | Red | Requires prompt attention |
+| `critical` | Purple | System-breaking condition |
+
+## JSON Schema
+
+The full JSON schema is at `schema/goals.yaml.schema.json`.

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -1,0 +1,127 @@
+# Goal Registry & Evaluator (Milestone 2)
+
+The Goal Evaluator is an observe-only plugin that continuously monitors world state
+against declared goals and emits violation events when deviations are detected.
+
+## Architecture
+
+```
+world.state.# ──► GoalEvaluatorPlugin
+                        │
+                        ├── GoalsLoader (workspace/goals.yaml + per-project overrides)
+                        ├── InvariantGoalEvaluator
+                        ├── ThresholdGoalEvaluator
+                        ├── DistributionGoalEvaluator
+                        │
+                        ├── EventBus.publish("world.goal.violated", ...)
+                        ├── LangfuseLogger (HTTP ingestion API)
+                        └── DiscordLogger (webhook)
+```
+
+## Configuration
+
+The plugin is configured via `GoalsConfig`:
+
+```typescript
+import { GoalEvaluatorPlugin } from "./src/plugins/goal_evaluator_plugin.ts";
+
+const plugin = new GoalEvaluatorPlugin({
+  workspaceDir: "workspace",
+  observeOnly: true,  // always true — no planner in this milestone
+});
+plugin.install(bus);
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `LANGFUSE_PUBLIC_KEY` | Langfuse public API key |
+| `LANGFUSE_SECRET_KEY` | Langfuse secret API key |
+| `LANGFUSE_HOST` | Langfuse host (default: `https://cloud.langfuse.com`) |
+| `DISCORD_GOALS_WEBHOOK_URL` | Discord webhook URL for violation notifications |
+
+## Goals File Format
+
+See [goals-schema.md](./goals-schema.md) for the full schema reference.
+
+Example `workspace/goals.yaml`:
+
+```yaml
+version: "1.0"
+goals:
+  - id: auth-healthy
+    type: Invariant
+    description: Auth service must be healthy
+    severity: critical
+    selector: services.auth.status
+    operator: eq
+    expected: "healthy"
+
+  - id: cpu-ok
+    type: Threshold
+    description: CPU must stay below 80%
+    severity: high
+    selector: metrics.cpu.usage
+    max: 80
+```
+
+## World State Topic Convention
+
+The plugin subscribes to `world.state.#`. Publish world state updates with:
+
+```typescript
+bus.publish("world.state.update", {
+  id: crypto.randomUUID(),
+  correlationId: crypto.randomUUID(),
+  topic: "world.state.update",
+  timestamp: Date.now(),
+  payload: {
+    projectSlug: "my-project",  // optional
+    state: {
+      services: { auth: { status: "healthy" } },
+      metrics: { cpu: { usage: 45 } },
+    },
+  },
+});
+```
+
+## Violation Events
+
+When a goal is violated, the plugin emits a `world.goal.violated` event:
+
+```typescript
+{
+  topic: "world.goal.violated",
+  payload: {
+    type: "world.goal.violated",
+    violation: {
+      goalId: "auth-healthy",
+      goalType: "Invariant",
+      severity: "critical",
+      description: "Auth service must be healthy",
+      message: "Expected \"services.auth.status\" to equal \"healthy\", got \"degraded\"",
+      actual: "degraded",
+      expected: "healthy",
+      timestamp: 1712345678000,
+      projectSlug: "my-project",
+    },
+  },
+}
+```
+
+See [events.md](./events.md) for the full event catalog.
+
+## Observe-Only Mode
+
+The plugin **never triggers planner actions**. It only:
+1. Evaluates goals against world state
+2. Emits `world.goal.violated` events
+3. Logs violations to Langfuse and Discord
+
+Planner integration is deferred to a future milestone.
+
+## Per-Project Goal Overrides
+
+Place a `goals.yaml` file at `.automaker/projects/{slug}/goals.yaml`.
+Project goals with the same `id` override global goals. New IDs are additive.

--- a/schema/goals.yaml.schema.json
+++ b/schema/goals.yaml.schema.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://protoworkstacean/schemas/goals.yaml.schema.json",
+  "title": "GoalsConfig",
+  "description": "Schema for goals.yaml configuration files used by GoalEvaluatorPlugin",
+  "type": "object",
+  "required": ["goals"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Schema version (e.g. '1.0')"
+    },
+    "goals": {
+      "type": "array",
+      "description": "List of goal definitions — supports Invariant, Threshold, and Distribution types",
+      "items": {
+        "oneOf": [
+          { "$ref": "#/definitions/InvariantGoal" },
+          { "$ref": "#/definitions/ThresholdGoal" },
+          { "$ref": "#/definitions/DistributionGoal" }
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "Severity": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "critical"],
+      "description": "Violation severity level"
+    },
+    "BaseGoal": {
+      "type": "object",
+      "required": ["id", "type", "description"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique goal identifier",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "enum": ["Invariant", "Threshold", "Distribution"],
+          "description": "Goal evaluation type"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what this goal enforces",
+          "minLength": 1
+        },
+        "severity": {
+          "$ref": "#/definitions/Severity"
+        },
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether this goal is active (default: true)"
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Optional labels for filtering/grouping goals"
+        }
+      }
+    },
+    "InvariantGoal": {
+      "allOf": [
+        { "$ref": "#/definitions/BaseGoal" },
+        {
+          "type": "object",
+          "required": ["selector"],
+          "properties": {
+            "type": { "const": "Invariant" },
+            "selector": {
+              "type": "string",
+              "description": "Dot-notation path into world state (e.g. 'services.auth.status')"
+            },
+            "expected": {
+              "description": "Expected value (used with operator)"
+            },
+            "operator": {
+              "type": "string",
+              "enum": ["eq", "neq", "truthy", "falsy", "in", "not_in"],
+              "default": "truthy",
+              "description": "Comparison operator (default: truthy)"
+            }
+          }
+        }
+      ]
+    },
+    "ThresholdGoal": {
+      "allOf": [
+        { "$ref": "#/definitions/BaseGoal" },
+        {
+          "type": "object",
+          "required": ["selector"],
+          "properties": {
+            "type": { "const": "Threshold" },
+            "selector": {
+              "type": "string",
+              "description": "Dot-notation path resolving to a numeric value"
+            },
+            "min": {
+              "type": "number",
+              "description": "Minimum allowed value (inclusive)"
+            },
+            "max": {
+              "type": "number",
+              "description": "Maximum allowed value (inclusive)"
+            }
+          },
+          "anyOf": [
+            { "required": ["min"] },
+            { "required": ["max"] }
+          ]
+        }
+      ]
+    },
+    "DistributionGoal": {
+      "allOf": [
+        { "$ref": "#/definitions/BaseGoal" },
+        {
+          "type": "object",
+          "required": ["selector"],
+          "properties": {
+            "type": { "const": "Distribution" },
+            "selector": {
+              "type": "string",
+              "description": "Dot-notation path resolving to an array or object of values"
+            },
+            "pattern": {
+              "type": "string",
+              "description": "Regex pattern — all values must match"
+            },
+            "distribution": {
+              "type": "object",
+              "description": "Expected distribution as { value: fraction } e.g. { 'active': 0.8 }",
+              "additionalProperties": { "type": "number", "minimum": 0, "maximum": 1 }
+            },
+            "tolerance": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "default": 0.1,
+              "description": "Allowed deviation from expected distribution fraction (default: 0.1)"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/config/goals_config.ts
+++ b/src/config/goals_config.ts
@@ -1,0 +1,16 @@
+export interface GoalsConfig {
+  /** When true, evaluator only observes and logs — no planner actions triggered */
+  observeOnly: boolean;
+  /** Workspace directory for finding goals.yaml */
+  workspaceDir: string;
+  /** Base directory for per-project goals.yaml overrides */
+  projectsBaseDir?: string;
+  /** Evaluation interval in milliseconds (0 = event-driven only) */
+  evaluationIntervalMs?: number;
+}
+
+export const DEFAULT_GOALS_CONFIG: GoalsConfig = {
+  observeOnly: true,
+  workspaceDir: "workspace",
+  evaluationIntervalMs: 0,
+};

--- a/src/engines/state_diff_engine.ts
+++ b/src/engines/state_diff_engine.ts
@@ -1,0 +1,95 @@
+import type { StateDiff, StateDiffEntry, WorldState } from "../types/state_diff.ts";
+
+/**
+ * Resolves a dot-notation path into an object.
+ * e.g. resolvePath({ a: { b: 1 } }, "a.b") => 1
+ */
+export function resolvePath(obj: unknown, path: string): { found: boolean; value: unknown } {
+  if (!path) return { found: true, value: obj };
+
+  const parts = path.split(".");
+  let current: unknown = obj;
+
+  for (const part of parts) {
+    if (current === null || current === undefined) {
+      return { found: false, value: undefined };
+    }
+    if (typeof current !== "object") {
+      return { found: false, value: undefined };
+    }
+    const record = current as Record<string, unknown>;
+    if (!(part in record)) {
+      return { found: false, value: undefined };
+    }
+    current = record[part];
+  }
+
+  return { found: true, value: current };
+}
+
+/**
+ * Diffs two world states field-by-field.
+ * Returns all entries where actual differs from expected.
+ */
+export class StateDiffEngine {
+  diff(expected: WorldState, actual: WorldState): StateDiff {
+    const entries: StateDiffEntry[] = [];
+
+    this._diffObjects(expected, actual, "", entries);
+
+    return {
+      entries,
+      hasChanges: entries.length > 0,
+    };
+  }
+
+  private _diffObjects(
+    expected: Record<string, unknown>,
+    actual: Record<string, unknown>,
+    prefix: string,
+    entries: StateDiffEntry[],
+  ): void {
+    const allKeys = new Set([...Object.keys(expected), ...Object.keys(actual)]);
+
+    for (const key of allKeys) {
+      const path = prefix ? `${prefix}.${key}` : key;
+      const hasExpected = key in expected;
+      const hasActual = key in actual;
+
+      if (hasExpected && !hasActual) {
+        entries.push({ path, type: "missing", expected: expected[key], actual: undefined });
+      } else if (!hasExpected && hasActual) {
+        entries.push({ path, type: "extra", expected: undefined, actual: actual[key] });
+      } else {
+        const expVal = expected[key];
+        const actVal = actual[key];
+
+        if (this._isPlainObject(expVal) && this._isPlainObject(actVal)) {
+          this._diffObjects(
+            expVal as Record<string, unknown>,
+            actVal as Record<string, unknown>,
+            path,
+            entries,
+          );
+        } else if (Array.isArray(expVal) && Array.isArray(actVal)) {
+          if (!this._arraysEqual(expVal, actVal)) {
+            entries.push({ path, type: "changed", expected: expVal, actual: actVal });
+          }
+        } else if (typeof expVal !== typeof actVal) {
+          entries.push({ path, type: "type_mismatch", expected: expVal, actual: actVal });
+        } else if (expVal !== actVal) {
+          entries.push({ path, type: "changed", expected: expVal, actual: actVal });
+        }
+      }
+    }
+  }
+
+  private _isPlainObject(val: unknown): boolean {
+    return val !== null && typeof val === "object" && !Array.isArray(val);
+  }
+
+  private _arraysEqual(a: unknown[], b: unknown[]): boolean {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => v === b[i]);
+  }
+}

--- a/src/evaluators/distribution_goal_evaluator.ts
+++ b/src/evaluators/distribution_goal_evaluator.ts
@@ -1,0 +1,145 @@
+import type { DistributionGoal, GoalViolation, Severity } from "../types/goals.ts";
+import type { WorldState } from "../types/state_diff.ts";
+import { resolvePath } from "../engines/state_diff_engine.ts";
+
+export class DistributionGoalEvaluator {
+  evaluate(goal: DistributionGoal, state: WorldState, projectSlug?: string): GoalViolation | null {
+    if (goal.enabled === false) return null;
+
+    const { found, value } = resolvePath(state, goal.selector);
+
+    if (!found) {
+      return {
+        goalId: goal.id,
+        goalType: "Distribution",
+        severity: (goal.severity ?? "medium") as Severity,
+        description: goal.description,
+        message: `Selector "${goal.selector}" not found in world state`,
+        actual: undefined,
+        expected: { pattern: goal.pattern, distribution: goal.distribution },
+        timestamp: Date.now(),
+        projectSlug,
+      };
+    }
+
+    // Check pattern: all values in array must match regex
+    if (goal.pattern) {
+      const violation = this._checkPattern(goal, value, projectSlug);
+      if (violation) return violation;
+    }
+
+    // Check distribution: value proportions must match expected distribution within tolerance
+    if (goal.distribution) {
+      const violation = this._checkDistribution(goal, value, projectSlug);
+      if (violation) return violation;
+    }
+
+    return null;
+  }
+
+  private _checkPattern(
+    goal: DistributionGoal,
+    value: unknown,
+    projectSlug?: string,
+  ): GoalViolation | null {
+    const values = this._toArray(value);
+    if (values === null) {
+      return {
+        goalId: goal.id,
+        goalType: "Distribution",
+        severity: (goal.severity ?? "medium") as Severity,
+        description: goal.description,
+        message: `Selector "${goal.selector}" must resolve to an array for pattern check, got ${typeof value}`,
+        actual: value,
+        expected: { pattern: goal.pattern },
+        timestamp: Date.now(),
+        projectSlug,
+      };
+    }
+
+    const regex = new RegExp(goal.pattern!);
+    const nonMatching = values.filter(v => !regex.test(String(v)));
+
+    if (nonMatching.length === 0) return null;
+
+    return {
+      goalId: goal.id,
+      goalType: "Distribution",
+      severity: (goal.severity ?? "medium") as Severity,
+      description: goal.description,
+      message: `${nonMatching.length} value(s) in "${goal.selector}" do not match pattern "${goal.pattern}": ${JSON.stringify(nonMatching.slice(0, 5))}`,
+      actual: values,
+      expected: { pattern: goal.pattern },
+      timestamp: Date.now(),
+      projectSlug,
+    };
+  }
+
+  private _checkDistribution(
+    goal: DistributionGoal,
+    value: unknown,
+    projectSlug?: string,
+  ): GoalViolation | null {
+    const values = this._toArray(value);
+    if (values === null || values.length === 0) {
+      return {
+        goalId: goal.id,
+        goalType: "Distribution",
+        severity: (goal.severity ?? "medium") as Severity,
+        description: goal.description,
+        message: `Selector "${goal.selector}" must resolve to a non-empty array for distribution check`,
+        actual: value,
+        expected: goal.distribution,
+        timestamp: Date.now(),
+        projectSlug,
+      };
+    }
+
+    const tolerance = goal.tolerance ?? 0.1;
+    const total = values.length;
+    const counts: Record<string, number> = {};
+
+    for (const v of values) {
+      const key = String(v);
+      counts[key] = (counts[key] ?? 0) + 1;
+    }
+
+    const actualDistribution: Record<string, number> = {};
+    for (const [key, count] of Object.entries(counts)) {
+      actualDistribution[key] = count / total;
+    }
+
+    const deviations: string[] = [];
+    for (const [key, expectedPct] of Object.entries(goal.distribution!)) {
+      const actualPct = actualDistribution[key] ?? 0;
+      const deviation = Math.abs(actualPct - expectedPct);
+      if (deviation > tolerance) {
+        deviations.push(
+          `"${key}": expected ${(expectedPct * 100).toFixed(1)}%, got ${(actualPct * 100).toFixed(1)}% (deviation ${(deviation * 100).toFixed(1)}% > tolerance ${(tolerance * 100).toFixed(1)}%)`,
+        );
+      }
+    }
+
+    if (deviations.length === 0) return null;
+
+    return {
+      goalId: goal.id,
+      goalType: "Distribution",
+      severity: (goal.severity ?? "medium") as Severity,
+      description: goal.description,
+      message: `Distribution violation in "${goal.selector}": ${deviations.join("; ")}`,
+      actual: actualDistribution,
+      expected: goal.distribution,
+      timestamp: Date.now(),
+      projectSlug,
+    };
+  }
+
+  private _toArray(value: unknown): unknown[] | null {
+    if (Array.isArray(value)) return value;
+    if (value !== null && typeof value === "object") {
+      return Object.values(value as Record<string, unknown>);
+    }
+    return null;
+  }
+}

--- a/src/evaluators/invariant_goal_evaluator.ts
+++ b/src/evaluators/invariant_goal_evaluator.ts
@@ -1,0 +1,83 @@
+import type { InvariantGoal, GoalViolation, Severity } from "../types/goals.ts";
+import type { WorldState } from "../types/state_diff.ts";
+import { resolvePath } from "../engines/state_diff_engine.ts";
+
+export class InvariantGoalEvaluator {
+  evaluate(goal: InvariantGoal, state: WorldState, projectSlug?: string): GoalViolation | null {
+    if (goal.enabled === false) return null;
+
+    const { found, value } = resolvePath(state, goal.selector);
+    const operator = goal.operator ?? "truthy";
+
+    let violated = false;
+    let message = "";
+
+    if (!found && operator !== "falsy") {
+      violated = true;
+      message = `Selector "${goal.selector}" not found in world state`;
+    } else {
+      switch (operator) {
+        case "truthy":
+          violated = !value;
+          message = violated
+            ? `Expected "${goal.selector}" to be truthy, got ${JSON.stringify(value)}`
+            : "";
+          break;
+        case "falsy":
+          violated = !!value;
+          message = violated
+            ? `Expected "${goal.selector}" to be falsy, got ${JSON.stringify(value)}`
+            : "";
+          break;
+        case "eq":
+          violated = value !== goal.expected;
+          message = violated
+            ? `Expected "${goal.selector}" to equal ${JSON.stringify(goal.expected)}, got ${JSON.stringify(value)}`
+            : "";
+          break;
+        case "neq":
+          violated = value === goal.expected;
+          message = violated
+            ? `Expected "${goal.selector}" to not equal ${JSON.stringify(goal.expected)}, got ${JSON.stringify(value)}`
+            : "";
+          break;
+        case "in":
+          if (!Array.isArray(goal.expected)) {
+            violated = true;
+            message = `Goal "${goal.id}" operator "in" requires expected to be an array`;
+          } else {
+            violated = !(goal.expected as unknown[]).includes(value);
+            message = violated
+              ? `Expected "${goal.selector}" to be one of ${JSON.stringify(goal.expected)}, got ${JSON.stringify(value)}`
+              : "";
+          }
+          break;
+        case "not_in":
+          if (!Array.isArray(goal.expected)) {
+            violated = true;
+            message = `Goal "${goal.id}" operator "not_in" requires expected to be an array`;
+          } else {
+            violated = (goal.expected as unknown[]).includes(value);
+            message = violated
+              ? `Expected "${goal.selector}" to not be in ${JSON.stringify(goal.expected)}, got ${JSON.stringify(value)}`
+              : "";
+          }
+          break;
+      }
+    }
+
+    if (!violated) return null;
+
+    return {
+      goalId: goal.id,
+      goalType: "Invariant",
+      severity: (goal.severity ?? "medium") as Severity,
+      description: goal.description,
+      message,
+      actual: value,
+      expected: goal.expected,
+      timestamp: Date.now(),
+      projectSlug,
+    };
+  }
+}

--- a/src/evaluators/threshold_goal_evaluator.ts
+++ b/src/evaluators/threshold_goal_evaluator.ts
@@ -1,0 +1,65 @@
+import type { ThresholdGoal, GoalViolation, Severity } from "../types/goals.ts";
+import type { WorldState } from "../types/state_diff.ts";
+import { resolvePath } from "../engines/state_diff_engine.ts";
+
+export class ThresholdGoalEvaluator {
+  evaluate(goal: ThresholdGoal, state: WorldState, projectSlug?: string): GoalViolation | null {
+    if (goal.enabled === false) return null;
+
+    const { found, value } = resolvePath(state, goal.selector);
+
+    if (!found) {
+      return {
+        goalId: goal.id,
+        goalType: "Threshold",
+        severity: (goal.severity ?? "medium") as Severity,
+        description: goal.description,
+        message: `Selector "${goal.selector}" not found in world state`,
+        actual: undefined,
+        expected: { min: goal.min, max: goal.max },
+        timestamp: Date.now(),
+        projectSlug,
+      };
+    }
+
+    if (typeof value !== "number") {
+      return {
+        goalId: goal.id,
+        goalType: "Threshold",
+        severity: (goal.severity ?? "medium") as Severity,
+        description: goal.description,
+        message: `Selector "${goal.selector}" must resolve to a number, got ${typeof value}`,
+        actual: value,
+        expected: { min: goal.min, max: goal.max },
+        timestamp: Date.now(),
+        projectSlug,
+      };
+    }
+
+    const belowMin = goal.min !== undefined && value < goal.min;
+    const aboveMax = goal.max !== undefined && value > goal.max;
+
+    if (!belowMin && !aboveMax) return null;
+
+    let message: string;
+    if (belowMin && aboveMax) {
+      message = `"${goal.selector}" value ${value} is below min ${goal.min} and above max ${goal.max}`;
+    } else if (belowMin) {
+      message = `"${goal.selector}" value ${value} is below minimum threshold ${goal.min}`;
+    } else {
+      message = `"${goal.selector}" value ${value} exceeds maximum threshold ${goal.max}`;
+    }
+
+    return {
+      goalId: goal.id,
+      goalType: "Threshold",
+      severity: (goal.severity ?? "medium") as Severity,
+      description: goal.description,
+      message,
+      actual: value,
+      expected: { min: goal.min, max: goal.max },
+      timestamp: Date.now(),
+      projectSlug,
+    };
+  }
+}

--- a/src/integrations/discord_logger.ts
+++ b/src/integrations/discord_logger.ts
@@ -1,0 +1,94 @@
+import type { GoalViolation } from "../types/goals.ts";
+
+const SEVERITY_COLORS: Record<string, number> = {
+  low: 0x3498db,      // blue
+  medium: 0xf39c12,   // orange
+  high: 0xe74c3c,     // red
+  critical: 0x8e44ad, // purple
+};
+
+/**
+ * Discord webhook integration for goal violation logging.
+ * Uses the DISCORD_GOALS_WEBHOOK_URL environment variable.
+ * Falls back to console logging on missing config or network error.
+ */
+export class DiscordLogger {
+  private webhookUrl: string | null;
+
+  constructor(webhookUrl?: string) {
+    this.webhookUrl = webhookUrl ?? process.env.DISCORD_GOALS_WEBHOOK_URL ?? null;
+    if (!this.webhookUrl) {
+      console.info("[discord-logger] DISCORD_GOALS_WEBHOOK_URL not set — using console fallback");
+    }
+  }
+
+  /** Send a goal violation message to Discord. Returns true on success. */
+  async logViolation(violation: GoalViolation): Promise<boolean> {
+    if (!this.webhookUrl) {
+      console.log(`[discord-logger:fallback] Goal violation: [${violation.severity.toUpperCase()}] ${violation.goalId} — ${violation.message}`);
+      return false;
+    }
+
+    const embed = this._buildEmbed(violation);
+
+    try {
+      const resp = await fetch(this.webhookUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ embeds: [embed] }),
+        signal: AbortSignal.timeout(10_000),
+      });
+
+      if (!resp.ok) {
+        const body = await resp.text().catch(() => "");
+        throw new Error(`Discord webhook error ${resp.status}: ${body}`);
+      }
+
+      return true;
+    } catch (err) {
+      console.error("[discord-logger] Discord integration error:", err);
+      console.log(`[discord-logger:fallback] Goal violation: [${violation.severity.toUpperCase()}] ${violation.goalId} — ${violation.message}`);
+      return false;
+    }
+  }
+
+  private _buildEmbed(violation: GoalViolation): Record<string, unknown> {
+    const color = SEVERITY_COLORS[violation.severity] ?? SEVERITY_COLORS.medium;
+    const ts = new Date(violation.timestamp).toISOString();
+
+    const fields: Array<{ name: string; value: string; inline?: boolean }> = [
+      { name: "Goal ID", value: `\`${violation.goalId}\``, inline: true },
+      { name: "Type", value: violation.goalType, inline: true },
+      { name: "Severity", value: violation.severity.toUpperCase(), inline: true },
+      { name: "Message", value: violation.message.slice(0, 1024) },
+    ];
+
+    if (violation.projectSlug) {
+      fields.push({ name: "Project", value: violation.projectSlug, inline: true });
+    }
+
+    if (violation.actual !== undefined) {
+      const actualStr = JSON.stringify(violation.actual);
+      fields.push({
+        name: "Actual",
+        value: `\`\`\`json\n${actualStr.slice(0, 400)}\n\`\`\``,
+      });
+    }
+
+    if (violation.expected !== undefined) {
+      const expectedStr = JSON.stringify(violation.expected);
+      fields.push({
+        name: "Expected",
+        value: `\`\`\`json\n${expectedStr.slice(0, 400)}\n\`\`\``,
+      });
+    }
+
+    return {
+      title: `Goal Violation: ${violation.description}`,
+      color,
+      fields,
+      timestamp: ts,
+      footer: { text: "protoWorkstacean • Goal Evaluator" },
+    };
+  }
+}

--- a/src/integrations/langfuse_logger.ts
+++ b/src/integrations/langfuse_logger.ts
@@ -1,0 +1,142 @@
+import type { GoalViolation } from "../types/goals.ts";
+
+interface LangfuseConfig {
+  publicKey: string;
+  secretKey: string;
+  host: string;
+}
+
+interface LangfuseEvent {
+  id: string;
+  type: "event";
+  timestamp: string;
+  name: string;
+  metadata?: Record<string, unknown>;
+  input?: unknown;
+  output?: unknown;
+}
+
+/**
+ * Langfuse integration for goal violation logging.
+ * Uses the Langfuse HTTP ingestion API directly (no SDK dependency).
+ * Falls back to console logging on failure.
+ */
+export class LangfuseLogger {
+  private config: LangfuseConfig | null;
+  private buffer: LangfuseEvent[] = [];
+
+  constructor() {
+    const publicKey = process.env.LANGFUSE_PUBLIC_KEY;
+    const secretKey = process.env.LANGFUSE_SECRET_KEY;
+    const host = process.env.LANGFUSE_HOST ?? "https://cloud.langfuse.com";
+
+    if (!publicKey || !secretKey) {
+      console.info("[langfuse] LANGFUSE_PUBLIC_KEY or LANGFUSE_SECRET_KEY not set — using console fallback");
+      this.config = null;
+    } else {
+      this.config = { publicKey, secretKey, host };
+    }
+  }
+
+  /** Log a goal violation event. Returns true if sent, false on error/fallback. */
+  async logViolation(violation: GoalViolation): Promise<boolean> {
+    const event: LangfuseEvent = {
+      id: crypto.randomUUID(),
+      type: "event",
+      timestamp: new Date(violation.timestamp).toISOString(),
+      name: "world.goal.violated",
+      metadata: {
+        goalId: violation.goalId,
+        goalType: violation.goalType,
+        severity: violation.severity,
+        projectSlug: violation.projectSlug,
+      },
+      input: { worldState: violation.actual },
+      output: {
+        message: violation.message,
+        actual: violation.actual,
+        expected: violation.expected,
+      },
+    };
+
+    if (!this.config) {
+      console.log(`[langfuse:fallback] Goal violation: ${violation.goalId} — ${violation.message}`);
+      return false;
+    }
+
+    try {
+      await this._sendBatch([event]);
+      return true;
+    } catch (err) {
+      console.error("[langfuse] Integration error — falling back to console:", err);
+      console.log(`[langfuse:fallback] Goal violation: ${violation.goalId} — ${violation.message}`);
+      return false;
+    }
+  }
+
+  /** Buffer a violation for batch sending. */
+  bufferViolation(violation: GoalViolation): void {
+    const event: LangfuseEvent = {
+      id: crypto.randomUUID(),
+      type: "event",
+      timestamp: new Date(violation.timestamp).toISOString(),
+      name: "world.goal.violated",
+      metadata: {
+        goalId: violation.goalId,
+        goalType: violation.goalType,
+        severity: violation.severity,
+        projectSlug: violation.projectSlug,
+      },
+      input: { worldState: violation.actual },
+      output: {
+        message: violation.message,
+        actual: violation.actual,
+        expected: violation.expected,
+      },
+    };
+    this.buffer.push(event);
+  }
+
+  /** Flush all buffered events in a single batch request. */
+  async flush(): Promise<boolean> {
+    if (this.buffer.length === 0) return true;
+
+    const events = [...this.buffer];
+    this.buffer = [];
+
+    if (!this.config) {
+      for (const e of events) {
+        console.log(`[langfuse:fallback] Flushing event: ${e.name} — ${e.id}`);
+      }
+      return false;
+    }
+
+    try {
+      await this._sendBatch(events);
+      return true;
+    } catch (err) {
+      console.error("[langfuse] Batch flush error:", err);
+      return false;
+    }
+  }
+
+  private async _sendBatch(events: LangfuseEvent[]): Promise<void> {
+    const { publicKey, secretKey, host } = this.config!;
+    const credentials = btoa(`${publicKey}:${secretKey}`);
+
+    const resp = await fetch(`${host}/api/public/ingestion`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${credentials}`,
+      },
+      body: JSON.stringify({ batch: events }),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => "");
+      throw new Error(`Langfuse API error ${resp.status}: ${body}`);
+    }
+  }
+}

--- a/src/loaders/goals_loader.ts
+++ b/src/loaders/goals_loader.ts
@@ -1,0 +1,115 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { parse as parseYaml } from "yaml";
+import type { Goal, GoalsFile, LoadedGoals } from "../types/goals.ts";
+
+export class GoalsLoader {
+  private workspaceDir: string;
+  private projectsBaseDir: string;
+
+  constructor(workspaceDir: string, projectsBaseDir?: string) {
+    this.workspaceDir = resolve(workspaceDir);
+    this.projectsBaseDir = projectsBaseDir
+      ? resolve(projectsBaseDir)
+      : join(resolve(workspaceDir), "..", ".automaker", "projects");
+  }
+
+  /** Load global goals from workspace/goals.yaml */
+  loadGlobal(): Goal[] {
+    const goalsPath = join(this.workspaceDir, "goals.yaml");
+    if (!existsSync(goalsPath)) {
+      console.info("[goals-loader] No global goals.yaml found at", goalsPath);
+      return [];
+    }
+    return this._parseGoalsFile(goalsPath, "global");
+  }
+
+  /** Load per-project goals from .automaker/projects/{slug}/goals.yaml */
+  loadProject(projectSlug: string): Goal[] {
+    const goalsPath = join(this.projectsBaseDir, projectSlug, "goals.yaml");
+    if (!existsSync(goalsPath)) {
+      console.info(`[goals-loader] No project goals.yaml for "${projectSlug}" at`, goalsPath);
+      return [];
+    }
+    return this._parseGoalsFile(goalsPath, `project:${projectSlug}`);
+  }
+
+  /**
+   * Load and merge global + per-project goals.
+   * Project goals with the same ID override global goals.
+   */
+  loadMerged(projectSlug?: string): LoadedGoals {
+    const globalGoals = this.loadGlobal();
+
+    if (!projectSlug) {
+      return { goals: globalGoals, source: "global" };
+    }
+
+    const projectGoals = this.loadProject(projectSlug);
+
+    if (projectGoals.length === 0) {
+      return { goals: globalGoals, source: "global", projectSlug };
+    }
+
+    const merged = new Map<string, Goal>();
+    for (const goal of globalGoals) {
+      merged.set(goal.id, goal);
+    }
+    for (const goal of projectGoals) {
+      merged.set(goal.id, goal); // project overrides global for same ID
+    }
+
+    return {
+      goals: Array.from(merged.values()),
+      source: "merged",
+      projectSlug,
+    };
+  }
+
+  private _parseGoalsFile(filePath: string, source: string): Goal[] {
+    try {
+      const raw = readFileSync(filePath, "utf8");
+      const parsed = parseYaml(raw) as GoalsFile;
+
+      if (!parsed || !Array.isArray(parsed.goals)) {
+        console.warn(`[goals-loader] Invalid goals.yaml at ${filePath}: missing "goals" array`);
+        return [];
+      }
+
+      const validGoals: Goal[] = [];
+      for (const goal of parsed.goals) {
+        const validated = this._validateGoal(goal);
+        if (validated) {
+          validGoals.push(validated);
+        } else {
+          console.warn(`[goals-loader] Skipping invalid goal in ${source}:`, goal);
+        }
+      }
+
+      return validGoals;
+    } catch (err) {
+      console.error(`[goals-loader] Failed to parse goals.yaml at ${filePath}:`, err);
+      return [];
+    }
+  }
+
+  private _validateGoal(raw: unknown): Goal | null {
+    if (!raw || typeof raw !== "object") return null;
+    const g = raw as Record<string, unknown>;
+
+    if (typeof g.id !== "string" || !g.id) {
+      console.warn("[goals-loader] Schema validation error: goal missing required 'id' field", g);
+      return null;
+    }
+    if (!["Invariant", "Threshold", "Distribution"].includes(g.type as string)) {
+      console.warn(`[goals-loader] Schema validation error: unknown goal type "${g.type}" for goal "${g.id}"`);
+      return null;
+    }
+    if (typeof g.description !== "string") {
+      console.warn(`[goals-loader] Schema validation error: goal "${g.id}" missing description`);
+      return null;
+    }
+
+    return g as unknown as Goal;
+  }
+}

--- a/src/plugins/goal_evaluator_plugin.interface.ts
+++ b/src/plugins/goal_evaluator_plugin.interface.ts
@@ -1,0 +1,9 @@
+import type { GoalViolation } from "../types/goals.ts";
+import type { WorldState } from "../types/state_diff.ts";
+
+export interface IGoalEvaluatorPlugin {
+  /** Evaluate loaded goals against the given world state. Returns all violations. */
+  evaluateState(state: WorldState, projectSlug?: string): GoalViolation[];
+  /** Reload goals from disk. */
+  reloadGoals(projectSlug?: string): void;
+}

--- a/src/plugins/goal_evaluator_plugin.ts
+++ b/src/plugins/goal_evaluator_plugin.ts
@@ -1,0 +1,185 @@
+import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
+import type { Goal, GoalViolation } from "../types/goals.ts";
+import type { WorldState } from "../types/state_diff.ts";
+import type { IGoalEvaluatorPlugin } from "./goal_evaluator_plugin.interface.ts";
+import type { GoalsConfig } from "../config/goals_config.ts";
+import { DEFAULT_GOALS_CONFIG } from "../config/goals_config.ts";
+import { GoalsLoader } from "../loaders/goals_loader.ts";
+import { InvariantGoalEvaluator } from "../evaluators/invariant_goal_evaluator.ts";
+import { ThresholdGoalEvaluator } from "../evaluators/threshold_goal_evaluator.ts";
+import { DistributionGoalEvaluator } from "../evaluators/distribution_goal_evaluator.ts";
+import { LangfuseLogger } from "../integrations/langfuse_logger.ts";
+import { DiscordLogger } from "../integrations/discord_logger.ts";
+import type { GoalViolatedEventPayload } from "../types/events.ts";
+
+/**
+ * GoalEvaluatorPlugin — observe-only goal registry + evaluator.
+ *
+ * Subscribes to world.state.# topics and evaluates loaded goals against
+ * incoming world state. Emits world.goal.violated events on violations
+ * and logs to Langfuse + Discord.
+ *
+ * IMPORTANT: Operates in observe-only mode — never triggers planner actions.
+ */
+export class GoalEvaluatorPlugin implements Plugin, IGoalEvaluatorPlugin {
+  readonly name = "goal-evaluator";
+  readonly description = "Observe-only goal registry evaluator — diffs world state against goals and emits violations";
+  readonly capabilities = ["goals", "evaluation", "observe-only"];
+
+  /** observeOnly: always true — planner actions are not supported in this milestone */
+  private readonly observeOnly: boolean = true;
+
+  private config: GoalsConfig;
+  private loader: GoalsLoader;
+  private goals: Goal[] = [];
+
+  private invariantEvaluator = new InvariantGoalEvaluator();
+  private thresholdEvaluator = new ThresholdGoalEvaluator();
+  private distributionEvaluator = new DistributionGoalEvaluator();
+
+  private langfuse: LangfuseLogger;
+  private discord: DiscordLogger;
+
+  private bus: EventBus | null = null;
+  private subscriptionIds: string[] = [];
+
+  // EventBus unavailability buffer
+  private violationBuffer: GoalViolation[] = [];
+
+  constructor(config?: Partial<GoalsConfig>) {
+    this.config = { ...DEFAULT_GOALS_CONFIG, ...config };
+    this.loader = new GoalsLoader(this.config.workspaceDir, this.config.projectsBaseDir);
+    this.langfuse = new LangfuseLogger();
+    this.discord = new DiscordLogger();
+  }
+
+  install(bus: EventBus): void {
+    this.bus = bus;
+
+    // Load global goals on startup
+    this.reloadGoals();
+
+    // Subscribe to world state update events
+    const subId = bus.subscribe("world.state.#", this.name, async (msg: BusMessage) => {
+      await this._handleWorldState(msg);
+    });
+    this.subscriptionIds.push(subId);
+
+    // Flush any buffered violations now that bus is available
+    if (this.violationBuffer.length > 0) {
+      console.info(`[goal-evaluator] Flushing ${this.violationBuffer.length} buffered violation(s)`);
+      const buffered = [...this.violationBuffer];
+      this.violationBuffer = [];
+      for (const v of buffered) {
+        this._emitViolation(v);
+      }
+    }
+
+    console.log("[goal-evaluator] Plugin installed — listening on world.state.# (observe-only mode)");
+  }
+
+  uninstall(): void {
+    if (this.bus) {
+      for (const id of this.subscriptionIds) {
+        this.bus.unsubscribe(id);
+      }
+    }
+    this.subscriptionIds = [];
+    this.bus = null;
+  }
+
+  /** Evaluate all loaded goals against the provided world state. */
+  evaluateState(state: WorldState, projectSlug?: string): GoalViolation[] {
+    const violations: GoalViolation[] = [];
+
+    for (const goal of this.goals) {
+      try {
+        let violation: GoalViolation | null = null;
+
+        if (goal.type === "Invariant") {
+          violation = this.invariantEvaluator.evaluate(goal, state, projectSlug);
+        } else if (goal.type === "Threshold") {
+          violation = this.thresholdEvaluator.evaluate(goal, state, projectSlug);
+        } else if (goal.type === "Distribution") {
+          violation = this.distributionEvaluator.evaluate(goal, state, projectSlug);
+        }
+
+        if (violation) {
+          violations.push(violation);
+        }
+      } catch (err) {
+        console.error(`[goal-evaluator] Evaluation error for goal "${goal.id}" — skipping:`, err);
+      }
+    }
+
+    return violations;
+  }
+
+  /** Reload goals from disk. Optionally scoped to a project slug. */
+  reloadGoals(projectSlug?: string): void {
+    const loaded = this.loader.loadMerged(projectSlug);
+    this.goals = loaded.goals;
+    console.info(
+      `[goal-evaluator] Loaded ${this.goals.length} goal(s) from ${loaded.source}${projectSlug ? ` (project: ${projectSlug})` : ""}`,
+    );
+  }
+
+  // ── Private ───────────────────────────────────────────────────────────────
+
+  private async _handleWorldState(msg: BusMessage): Promise<void> {
+    const payload = msg.payload as Record<string, unknown>;
+    const state = (payload.state ?? payload) as WorldState;
+    const projectSlug = typeof payload.projectSlug === "string" ? payload.projectSlug : undefined;
+
+    let violations: GoalViolation[];
+    try {
+      violations = this.evaluateState(state, projectSlug);
+    } catch (err) {
+      console.error("[goal-evaluator] World state query failed — skipping evaluation cycle:", err);
+      return;
+    }
+
+    for (const violation of violations) {
+      this._emitViolation(violation);
+      // Log to integrations asynchronously; failures do not block main flow
+      this.langfuse.logViolation(violation).catch(err => {
+        console.error("[goal-evaluator] Langfuse logging error:", err);
+      });
+      this.discord.logViolation(violation).catch(err => {
+        console.error("[goal-evaluator] Discord logging error:", err);
+      });
+    }
+  }
+
+  private _emitViolation(violation: GoalViolation): void {
+    if (!this.bus) {
+      console.warn("[goal-evaluator] EventBus unavailable — buffering violation:", violation.goalId);
+      this.violationBuffer.push(violation);
+      return;
+    }
+
+    // Safety guard: never trigger planner actions in observe-only mode
+    if (!this.observeOnly) {
+      console.warn("[goal-evaluator] Planner action requested — feature not yet supported; dropping request");
+      return;
+    }
+
+    const topic = "world.goal.violated";
+    const eventPayload: GoalViolatedEventPayload = {
+      type: "world.goal.violated",
+      violation,
+    };
+
+    this.bus.publish(topic, {
+      id: crypto.randomUUID(),
+      correlationId: crypto.randomUUID(),
+      topic,
+      timestamp: Date.now(),
+      payload: eventPayload,
+    });
+
+    console.warn(
+      `[goal-evaluator] VIOLATION [${violation.severity.toUpperCase()}] goal="${violation.goalId}" — ${violation.message}`,
+    );
+  }
+}

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,0 +1,7 @@
+import type { GoalViolation } from "./goals.ts";
+
+export interface GoalViolatedEventPayload {
+  type: "world.goal.violated";
+  violation: GoalViolation;
+  worldState?: Record<string, unknown>;
+}

--- a/src/types/goals.ts
+++ b/src/types/goals.ts
@@ -1,0 +1,67 @@
+export type GoalType = "Invariant" | "Threshold" | "Distribution";
+export type Severity = "low" | "medium" | "high" | "critical";
+export type InvariantOperator = "eq" | "neq" | "truthy" | "falsy" | "in" | "not_in";
+
+export interface BaseGoal {
+  id: string;
+  type: GoalType;
+  description: string;
+  severity?: Severity;
+  enabled?: boolean;
+  tags?: string[];
+}
+
+export interface InvariantGoal extends BaseGoal {
+  type: "Invariant";
+  /** Dot-notation path into world state (e.g. "metrics.cpu.status") */
+  selector: string;
+  /** Expected value for comparison */
+  expected?: unknown;
+  /** Comparison operator (default: "truthy") */
+  operator?: InvariantOperator;
+}
+
+export interface ThresholdGoal extends BaseGoal {
+  type: "Threshold";
+  /** Dot-notation path into world state resolving to a number */
+  selector: string;
+  min?: number;
+  max?: number;
+}
+
+export interface DistributionGoal extends BaseGoal {
+  type: "Distribution";
+  /** Dot-notation path resolving to an array or map of values */
+  selector: string;
+  /** Regex pattern — all values must match */
+  pattern?: string;
+  /** Expected distribution as { value: percentage } e.g. { "active": 0.8 } */
+  distribution?: Record<string, number>;
+  /** Allowed deviation from expected distribution (0.0–1.0, default 0.1) */
+  tolerance?: number;
+}
+
+export type Goal = InvariantGoal | ThresholdGoal | DistributionGoal;
+
+export interface GoalViolation {
+  goalId: string;
+  goalType: GoalType;
+  severity: Severity;
+  description: string;
+  message: string;
+  actual: unknown;
+  expected: unknown;
+  timestamp: number;
+  projectSlug?: string;
+}
+
+export interface GoalsFile {
+  version?: string;
+  goals: Goal[];
+}
+
+export interface LoadedGoals {
+  goals: Goal[];
+  source: "global" | "project" | "merged";
+  projectSlug?: string;
+}

--- a/src/types/state_diff.ts
+++ b/src/types/state_diff.ts
@@ -1,0 +1,15 @@
+export type DiffType = "missing" | "changed" | "extra" | "type_mismatch";
+
+export interface StateDiffEntry {
+  path: string;
+  type: DiffType;
+  expected: unknown;
+  actual: unknown;
+}
+
+export interface StateDiff {
+  entries: StateDiffEntry[];
+  hasChanges: boolean;
+}
+
+export type WorldState = Record<string, unknown>;


### PR DESCRIPTION
## Summary

Implement goals.yaml schema and loader (global workspace/goals.yaml + per-project .automaker/projects/{slug}/goals.yaml overrides), GoalEvaluatorPlugin that diffs actual vs desired world state, supports Invariant/Threshold/Distribution goal types, emits world.goal.violated events to EventBus, and logs violations to Langfuse + Discord (observe-only, no actions yet). No planner in this milestone.

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added goal evaluation system to monitor application state against configurable goals
* Supports three goal types: Invariant (state conditions), Threshold (numeric bounds), and Distribution (category proportions)
* Goal violations automatically detected and logged to Discord and Langfuse integrations
* Global goals with per-project override configuration support

**Documentation**
* Added complete goal system documentation with YAML schema and configuration examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->