### PR TITLE
M6: A* Planner (L1) — budget-bounded action graph search, anytime algorithm, HTN decomposition

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1775585786102-umif0d3u",
-  "startedAt": "2026-04-07T18:42:11.211Z"
+  "featureId": "feature-1775585786152-p9ckaz6r",
+  "startedAt": "2026-04-07T20:04:25.352Z"
 }

--- a/docs/htn-guide.md
+++ b/docs/htn-guide.md
@@ -1,0 +1,65 @@
+# HTN Decomposition Guide
+
+## Hierarchy Levels
+
+The HTN system decomposes tasks through four levels:
+
+| Level | Description | Example |
+|-------|-------------|---------|
+| portfolio | Strategic workspace tasks | "Improve portfolio health" |
+| project | Project-scoped tasks | "Stabilize CI pipeline" |
+| domain | Domain-specific tasks | "Restart failing service" |
+| action | Primitive executable actions | "Set service.status = healthy" |
+
+## Defining Tasks
+
+### Primitive Actions
+
+```ts
+import { action } from "../src/planner/action.ts";
+
+const restart = action("restart", "restart-service")
+  .level("action")
+  .requireEquals("service.status", "down")
+  .set({ "service.status": "healthy" })
+  .cost(2)
+  .build();
+```
+
+### Composite Tasks
+
+```ts
+import type { CompositeTask } from "../src/planner/types.ts";
+
+const fixService: CompositeTask = {
+  id: "fix-service",
+  name: "Fix Service",
+  level: "domain",
+  precondition: (state) => state["service.status"] === "down",
+  decompose: (state) => ["restart", "verify-health"],
+};
+```
+
+## Building the Task Network
+
+```ts
+import { TaskNetwork } from "../src/planner/task-network.ts";
+
+const network = new TaskNetwork();
+network.addPrimitiveAction(restart);
+network.addPrimitiveAction(verifyHealth);
+network.addCompositeTask(fixService);
+```
+
+## Running Decomposition
+
+```ts
+import { HTNDecomposer } from "../src/planner/htn-decomposer.ts";
+
+const decomposer = new HTNDecomposer(network);
+const result = decomposer.decompose("fix-service", currentState);
+
+if (result.success) {
+  // result.actions contains ordered primitive actions
+}
+```

--- a/docs/integration-l0-l1.md
+++ b/docs/integration-l0-l1.md
@@ -1,0 +1,55 @@
+# L0-L1 Integration Guide
+
+## Overview
+
+The L0 rule matcher handles ~80% of cases with deterministic pattern matching. When L0 cannot find a matching rule, the L0-L1 bridge invokes the L1 A* planner as fallback.
+
+## Setup
+
+```ts
+import { L0L1Bridge, type L0RuleMatcher } from "../src/matcher/l0-l1-bridge.ts";
+import { action } from "../src/planner/action.ts";
+
+// Define your L0 matcher
+const matcher: L0RuleMatcher = {
+  match(state, goal) {
+    // Your rule matching logic
+    // Return { matched: true, action } or { matched: false, reason }
+  }
+};
+
+// Define available actions for L1
+const actions = [
+  action("fix", "fix-issue").requireEquals("broken", true).set({ broken: false }).build(),
+];
+
+// Create bridge
+const bridge = new L0L1Bridge(matcher, actions, compositeTasks, {
+  defaultBudget: { timeBudgetMs: 5000 },
+});
+```
+
+## Usage
+
+```ts
+const result = bridge.resolve(currentState, goal);
+
+if (result.success) {
+  // result.plan contains the action sequence
+  for (const action of result.plan.actions) {
+    // Execute action
+  }
+} else {
+  console.error(result.error);
+}
+```
+
+## Deviation Handling
+
+| Situation | Behavior |
+|-----------|----------|
+| L0 matches | Returns single-action plan immediately |
+| L0 no match | Invokes L1 A* planner |
+| L1 budget exhausted | Returns best partial plan with warning |
+| L1 plan invalid | Returns validation failure |
+| World state changes | ReplanManager produces new plan |

--- a/docs/planner-api.md
+++ b/docs/planner-api.md
@@ -1,0 +1,103 @@
+# Planner API Reference
+
+## Entry Points
+
+### L1Planner
+
+Main entry point for the A* planner system.
+
+```ts
+import { L1Planner } from "../src/planner/l1-integration.ts";
+import { ActionGraph } from "../src/planner/action-graph.ts";
+import { TaskNetwork } from "../src/planner/task-network.ts";
+
+const planner = new L1Planner(graph, network, { defaultBudgetMs: 5000 });
+const result = planner.planFromContext(context);
+```
+
+### L0L1Bridge
+
+Connects L0 rule matcher to L1 planner with automatic fallback.
+
+```ts
+import { L0L1Bridge } from "../src/matcher/l0-l1-bridge.ts";
+
+const bridge = new L0L1Bridge(matcher, actions, compositeTasks);
+const result = bridge.resolve(state, goal);
+```
+
+## Core Types
+
+### PlannerState
+Flat key-value map representing world state for planning:
+```ts
+type StateValue = string | number | boolean | null;
+type PlannerState = Readonly<Record<string, StateValue>>;
+```
+
+### Action
+Primitive action with preconditions and effects:
+```ts
+interface Action {
+  id: string;
+  name: string;
+  cost: number;
+  level: HierarchyLevel;
+  preconditions: StatePredicate[];
+  effects: StateTransform[];
+}
+```
+
+### Plan
+Sequence of actions with cost tracking:
+```ts
+interface Plan {
+  actions: Action[];
+  totalCost: number;
+  isComplete: boolean;
+  lowerBound?: number;
+}
+```
+
+## Creating Actions
+
+Use the fluent `action()` builder:
+
+```ts
+import { action } from "../src/planner/action.ts";
+
+const restart = action("restart-svc", "Restart Service")
+  .cost(2)
+  .level("action")
+  .requireEquals("service.status", "down")
+  .set({ "service.status": "healthy" })
+  .build();
+```
+
+## Heuristics
+
+Available heuristic functions:
+
+- `zeroHeuristic` — always returns 0 (Dijkstra-equivalent)
+- `stateDiffHeuristic(goalState)` — counts differing state keys
+- `namedGoalHeuristic(namedGoal)` — uses goal-attached heuristic
+- `maxHeuristic(...fns)` — max of multiple heuristics
+
+## Search Configuration
+
+```ts
+interface SearchConfig {
+  maxExpansions?: number;   // Max nodes to expand
+  timeBudgetMs?: number;    // Time budget in ms
+  weight?: number;          // Weighted A* factor (>1 = faster, less optimal)
+}
+```
+
+## Plan Validation
+
+```ts
+import { validatePlan } from "../src/planner/plan-validator.ts";
+
+const result = validatePlan(plan, initialState, goal);
+// result.valid, result.failedAtIndex, result.finalState, result.error
+```

--- a/docs/planner-architecture.md
+++ b/docs/planner-architecture.md
@@ -1,0 +1,43 @@
+# Planner Architecture
+
+## Overview
+
+The L1 planner is a budget-bounded A* search system that serves as fallback when the L0 rule matcher cannot handle a request. It operates on an action graph where world states are nodes and actions are directed edges.
+
+## Component Layers
+
+```
+┌─────────────────────────────────────┐
+│         L0-L1 Bridge                │  ← Entry point
+│  (src/matcher/l0-l1-bridge.ts)      │
+├─────────────────────────────────────┤
+│         L1 Planner                  │  ← Orchestration
+│  (src/planner/l1-integration.ts)    │
+├─────────┬───────────┬───────────────┤
+│ Anytime │   HTN     │    Plan       │  ← Planning layers
+│ Planner │ Decomposer│  Validator    │
+├─────────┴───────────┴───────────────┤
+│         A* Search                   │  ← Core search
+│  (src/planner/a-star.ts)            │
+├─────────────────────────────────────┤
+│     Action Graph + World State      │  ← Data layer
+│  (src/planner/action-graph.ts)      │
+└─────────────────────────────────────┘
+```
+
+## Data Flow
+
+1. L0 rule matcher receives a goal and current state
+2. If no rule matches, L0-L1 bridge constructs an L0Context
+3. L1 planner runs HTN decomposition to expand available actions
+4. AnytimePlanner runs iterative weighted A* within budget
+5. Best plan is validated on a state copy
+6. Validated plan is returned to the caller
+
+## Key Design Decisions
+
+- **Immutable state**: PlannerState is `Readonly<Record<string, StateValue>>` — all mutations produce new objects
+- **Budget-bounded**: Search respects both time and expansion budgets, returning best partial plan if budget exhausted
+- **Anytime**: Starts with high-weight A* for fast initial solutions, then refines with lower weights
+- **Side-effect free validation**: Plans are validated on cloned state before committing
+- **Replanning**: If world state changes mid-execution, the replan manager produces a new plan from current state while preserving executed steps

--- a/src/matcher/l0-l1-bridge.ts
+++ b/src/matcher/l0-l1-bridge.ts
@@ -1,0 +1,125 @@
+/**
+ * L0-L1 bridge — connects the L0 rule matcher to the L1 A* planner.
+ *
+ * When L0 rule matching returns no match, this bridge:
+ * 1. Constructs an L0Context from the unmatched request
+ * 2. Passes it to the L1 planner
+ * 3. Returns the planning result
+ */
+
+import type {
+  BudgetConfig,
+  Goal,
+  L0Context,
+  L1Result,
+  NamedGoal,
+  PlannerState,
+} from "../planner/types.ts";
+import { L1Planner, type L1PlannerConfig } from "../planner/l1-integration.ts";
+import { ActionGraph } from "../planner/action-graph.ts";
+import { TaskNetwork } from "../planner/task-network.ts";
+import type { Action, CompositeTask } from "../planner/types.ts";
+
+/** L0 rule match result. */
+export interface L0MatchResult {
+  matched: boolean;
+  /** The matched rule's action, if any. */
+  action?: Action;
+  /** Reason for no match. */
+  reason?: string;
+}
+
+/** L0 rule matcher interface. */
+export interface L0RuleMatcher {
+  match(state: PlannerState, goal: Goal): L0MatchResult;
+}
+
+/** Configuration for the bridge. */
+export interface BridgeConfig {
+  l1Config?: Partial<L1PlannerConfig>;
+  defaultBudget?: BudgetConfig;
+}
+
+const DEFAULT_BUDGET: BudgetConfig = {
+  timeBudgetMs: 5000,
+  maxExpansions: 10000,
+};
+
+/**
+ * Bridge between L0 rule matcher and L1 A* planner.
+ *
+ * Usage:
+ * ```ts
+ * const bridge = new L0L1Bridge(matcher, actions, tasks, config);
+ * const result = bridge.resolve(currentState, goal);
+ * // result.success === true if either L0 matched or L1 found a plan
+ * ```
+ */
+export class L0L1Bridge {
+  private matcher: L0RuleMatcher;
+  private l1Planner: L1Planner;
+  private defaultBudget: BudgetConfig;
+
+  constructor(
+    matcher: L0RuleMatcher,
+    actions: Action[],
+    compositeTasks: CompositeTask[],
+    config: BridgeConfig = {},
+  ) {
+    this.matcher = matcher;
+    this.defaultBudget = config.defaultBudget ?? DEFAULT_BUDGET;
+
+    const graph = new ActionGraph();
+    graph.addActions(actions);
+
+    const network = new TaskNetwork();
+    for (const action of actions) {
+      network.addPrimitiveAction(action);
+    }
+    for (const task of compositeTasks) {
+      network.addCompositeTask(task);
+    }
+
+    this.l1Planner = new L1Planner(graph, network, config.l1Config);
+  }
+
+  /**
+   * Resolve a goal — try L0 first, fall back to L1 if no match.
+   */
+  resolve(
+    state: PlannerState,
+    goal: Goal,
+    namedGoal?: NamedGoal,
+    budget?: BudgetConfig,
+  ): L1Result {
+    // Step 1: Try L0 rule matcher
+    const l0Result = this.matcher.match(state, goal);
+
+    if (l0Result.matched && l0Result.action) {
+      // L0 found a matching rule — return it as a single-action plan
+      return {
+        success: true,
+        plan: {
+          actions: [l0Result.action],
+          totalCost: l0Result.action.cost,
+          isComplete: true,
+        },
+      };
+    }
+
+    // Step 2: L0 failed — invoke L1 planner
+    const context: L0Context = {
+      currentState: state,
+      goal,
+      namedGoal,
+      reason: l0Result.reason ?? "no matching rule",
+    };
+
+    return this.l1Planner.planFromContext(context, budget ?? this.defaultBudget);
+  }
+
+  /** Get the underlying L1 planner. */
+  getL1Planner(): L1Planner {
+    return this.l1Planner;
+  }
+}

--- a/src/planner/__tests__/a-star.test.ts
+++ b/src/planner/__tests__/a-star.test.ts
@@ -1,0 +1,213 @@
+import { describe, test, expect } from "bun:test";
+import { aStarSearch } from "../a-star.ts";
+import { ActionGraph } from "../action-graph.ts";
+import { action } from "../action.ts";
+import { createState } from "../world-state.ts";
+import { zeroHeuristic, stateDiffHeuristic } from "../heuristic.ts";
+import { AnytimePlanner } from "../anytime-planner.ts";
+import type { PlannerState } from "../types.ts";
+
+describe("A* search", () => {
+  test("finds plan for simple linear chain", () => {
+    const graph = new ActionGraph();
+    graph.addActions([
+      action("s1", "step1")
+        .requireEquals("phase", "start")
+        .set({ phase: "mid" })
+        .cost(1)
+        .build(),
+      action("s2", "step2")
+        .requireEquals("phase", "mid")
+        .set({ phase: "goal" })
+        .cost(1)
+        .build(),
+    ]);
+
+    const initial = createState({ phase: "start" });
+    const goal = (s: PlannerState) => s.phase === "goal";
+
+    const result = aStarSearch(graph, initial, goal, zeroHeuristic);
+    expect(result.plan.isComplete).toBe(true);
+    expect(result.plan.actions.length).toBe(2);
+    expect(result.plan.totalCost).toBe(2);
+    expect(result.plan.actions[0].id).toBe("s1");
+    expect(result.plan.actions[1].id).toBe("s2");
+  });
+
+  test("finds optimal path among alternatives", () => {
+    const graph = new ActionGraph();
+    // Expensive direct path
+    graph.addAction(
+      action("direct", "direct-path")
+        .requireEquals("at", "A")
+        .set({ at: "C" })
+        .cost(10)
+        .build(),
+    );
+    // Cheap two-step path
+    graph.addActions([
+      action("ab", "A-to-B")
+        .requireEquals("at", "A")
+        .set({ at: "B" })
+        .cost(2)
+        .build(),
+      action("bc", "B-to-C")
+        .requireEquals("at", "B")
+        .set({ at: "C" })
+        .cost(3)
+        .build(),
+    ]);
+
+    const initial = createState({ at: "A" });
+    const goal = (s: PlannerState) => s.at === "C";
+    const result = aStarSearch(graph, initial, goal, zeroHeuristic);
+
+    expect(result.plan.isComplete).toBe(true);
+    expect(result.plan.totalCost).toBe(5);
+    expect(result.plan.actions.map((a) => a.id)).toEqual(["ab", "bc"]);
+  });
+
+  test("returns empty plan when initial state satisfies goal", () => {
+    const graph = new ActionGraph();
+    const initial = createState({ done: true });
+    const goal = (s: PlannerState) => s.done === true;
+
+    const result = aStarSearch(graph, initial, goal, zeroHeuristic);
+    expect(result.plan.isComplete).toBe(true);
+    expect(result.plan.actions.length).toBe(0);
+    expect(result.plan.totalCost).toBe(0);
+  });
+
+  test("returns incomplete plan when goal is unreachable", () => {
+    const graph = new ActionGraph();
+    graph.addAction(
+      action("a1", "only-action")
+        .requireEquals("x", 1)
+        .set({ x: 2 })
+        .build(),
+    );
+
+    const initial = createState({ x: 0 });
+    const goal = (s: PlannerState) => s.x === 99;
+
+    const result = aStarSearch(graph, initial, goal, zeroHeuristic);
+    expect(result.plan.isComplete).toBe(false);
+    expect(result.exhaustive).toBe(true);
+  });
+
+  test("respects maxExpansions budget", () => {
+    const graph = new ActionGraph();
+    // Create a large branching graph
+    for (let i = 0; i < 50; i++) {
+      graph.addAction(
+        action(`a${i}`, `action-${i}`)
+          .set({ [`visited_${i}`]: true })
+          .cost(1)
+          .build(),
+      );
+    }
+
+    const initial = createState({});
+    const goal = (_s: PlannerState) => false; // Unreachable
+
+    const result = aStarSearch(graph, initial, goal, zeroHeuristic, {
+      maxExpansions: 5,
+    });
+    expect(result.nodesExpanded).toBeLessThanOrEqual(5);
+    expect(result.exhaustive).toBe(false);
+  });
+
+  test("heuristic guides search efficiently", () => {
+    const graph = new ActionGraph();
+    graph.addActions([
+      action("right", "go-right")
+        .requireEquals("x", 0)
+        .set({ x: 1 })
+        .cost(1)
+        .build(),
+      action("wrong", "go-wrong")
+        .requireEquals("x", 0)
+        .set({ x: -1 })
+        .cost(1)
+        .build(),
+      action("finish", "finish")
+        .requireEquals("x", 1)
+        .set({ x: 2, done: true })
+        .cost(1)
+        .build(),
+    ]);
+
+    const goalState = createState({ x: 2, done: true });
+    const heuristic = stateDiffHeuristic(goalState);
+    const initial = createState({ x: 0, done: false });
+    const goal = (s: PlannerState) => s.x === 2 && s.done === true;
+
+    const result = aStarSearch(graph, initial, goal, heuristic);
+    expect(result.plan.isComplete).toBe(true);
+    expect(result.plan.actions.map((a) => a.id)).toEqual(["right", "finish"]);
+  });
+});
+
+describe("budget-bounded anytime search", () => {
+  test("returns best plan within budget and improves with more time", () => {
+    const graph = new ActionGraph();
+
+    // Create a simple graph where there are two paths
+    graph.addActions([
+      // Expensive direct path
+      action("direct", "direct")
+        .requireEquals("pos", "start")
+        .set({ pos: "goal" })
+        .cost(10)
+        .build(),
+      // Cheap two-step path
+      action("step1", "step1")
+        .requireEquals("pos", "start")
+        .set({ pos: "mid" })
+        .cost(2)
+        .build(),
+      action("step2", "step2")
+        .requireEquals("pos", "mid")
+        .set({ pos: "goal" })
+        .cost(2)
+        .build(),
+    ]);
+
+    const initial = createState({ pos: "start" });
+    const goal = (s: PlannerState) => s.pos === "goal";
+
+    const planner = new AnytimePlanner(graph, zeroHeuristic);
+    const result = planner.search(initial, goal, {
+      timeBudgetMs: 5000,
+    });
+
+    expect(result.searchResult.plan.isComplete).toBe(true);
+    // Should find the cheaper path
+    expect(result.searchResult.plan.totalCost).toBe(4);
+  });
+
+  test("anytime planner can be resumed for improvement", () => {
+    const graph = new ActionGraph();
+    graph.addActions([
+      action("a", "action-a")
+        .requireEquals("state", "init")
+        .set({ state: "done" })
+        .cost(5)
+        .build(),
+    ]);
+
+    const initial = createState({ state: "init" });
+    const goal = (s: PlannerState) => s.state === "done";
+
+    const planner = new AnytimePlanner(graph, zeroHeuristic);
+
+    // Initial search
+    const first = planner.search(initial, goal, { timeBudgetMs: 100 });
+    expect(first.searchResult.plan.isComplete).toBe(true);
+
+    // Resume
+    const second = planner.resume(initial, goal, { timeBudgetMs: 100 });
+    expect(second.searchResult.plan.isComplete).toBe(true);
+    expect(second.iterations).toBeGreaterThan(first.iterations);
+  });
+});

--- a/src/planner/__tests__/action-graph.test.ts
+++ b/src/planner/__tests__/action-graph.test.ts
@@ -1,0 +1,107 @@
+import { describe, test, expect } from "bun:test";
+import { ActionGraph } from "../action-graph.ts";
+import { action } from "../action.ts";
+import { createState } from "../world-state.ts";
+
+describe("action graph", () => {
+  test("empty graph returns no applicable actions", () => {
+    const graph = new ActionGraph();
+    const state = createState({ x: 1 });
+    expect(graph.getApplicableActions(state)).toEqual([]);
+  });
+
+  test("returns actions whose preconditions are met", () => {
+    const graph = new ActionGraph();
+    const a1 = action("a1", "action1")
+      .requireEquals("ready", true)
+      .set({ done: true })
+      .build();
+    const a2 = action("a2", "action2")
+      .requireEquals("ready", false)
+      .set({ done: true })
+      .build();
+
+    graph.addActions([a1, a2]);
+    const state = createState({ ready: true });
+
+    const applicable = graph.getApplicableActions(state);
+    expect(applicable.length).toBe(1);
+    expect(applicable[0].id).toBe("a1");
+  });
+
+  test("getSuccessors returns action + result state", () => {
+    const graph = new ActionGraph();
+    const a = action("a1", "set-done")
+      .requireEquals("status", "pending")
+      .set({ status: "done" })
+      .build();
+
+    graph.addAction(a);
+    const state = createState({ status: "pending" });
+    const successors = graph.getSuccessors(state);
+
+    expect(successors.length).toBe(1);
+    expect(successors[0].action.id).toBe("a1");
+    expect(successors[0].resultState.status).toBe("done");
+  });
+
+  test("removeAction works", () => {
+    const graph = new ActionGraph();
+    const a = action("a1", "test").build();
+    graph.addAction(a);
+    expect(graph.size).toBe(1);
+
+    graph.removeAction("a1");
+    expect(graph.size).toBe(0);
+  });
+
+  test("multiple actions applicable from same state", () => {
+    const graph = new ActionGraph();
+    graph.addActions([
+      action("a1", "first").set({ path: "a" }).build(),
+      action("a2", "second").set({ path: "b" }).build(),
+    ]);
+
+    const state = createState({});
+    const applicable = graph.getApplicableActions(state);
+    expect(applicable.length).toBe(2);
+  });
+
+  test("action graph search finds valid plan (multi-step)", () => {
+    const graph = new ActionGraph();
+
+    // Simple 3-step chain: start → step1 → step2 → goal
+    graph.addActions([
+      action("s1", "step1")
+        .requireEquals("phase", "start")
+        .set({ phase: "step1" })
+        .cost(1)
+        .build(),
+      action("s2", "step2")
+        .requireEquals("phase", "step1")
+        .set({ phase: "step2" })
+        .cost(1)
+        .build(),
+      action("s3", "step3")
+        .requireEquals("phase", "step2")
+        .set({ phase: "goal" })
+        .cost(1)
+        .build(),
+    ]);
+
+    const initial = createState({ phase: "start" });
+    let current = initial;
+    const path: string[] = [];
+
+    // Manually walk the graph
+    for (let step = 0; step < 3; step++) {
+      const successors = graph.getSuccessors(current);
+      expect(successors.length).toBe(1);
+      path.push(successors[0].action.id);
+      current = successors[0].resultState;
+    }
+
+    expect(path).toEqual(["s1", "s2", "s3"]);
+    expect(current.phase).toBe("goal");
+  });
+});

--- a/src/planner/__tests__/edge-cases.test.ts
+++ b/src/planner/__tests__/edge-cases.test.ts
@@ -1,0 +1,227 @@
+import { describe, test, expect } from "bun:test";
+import { ActionGraph } from "../action-graph.ts";
+import { action } from "../action.ts";
+import { createState, stateKey, statesEqual, emptyState } from "../world-state.ts";
+import { zeroHeuristic } from "../heuristic.ts";
+import { aStarSearch } from "../a-star.ts";
+import { validatePlan } from "../plan-validator.ts";
+import { TaskNetwork } from "../task-network.ts";
+import { HTNDecomposer } from "../htn-decomposer.ts";
+import { MemoCache, memoizeHeuristic } from "../memo-cache.ts";
+import { StateCache } from "../state-cache.ts";
+import { clusterGoals } from "../optimization.ts";
+import type { PlannerState, CompositeTask, SearchNode } from "../types.ts";
+
+describe("edge cases — empty goals", () => {
+  test("goal already satisfied returns empty plan", () => {
+    const graph = new ActionGraph();
+    graph.addAction(action("a", "test").set({ x: 1 }).build());
+
+    const initial = createState({ done: true });
+    const goal = (s: PlannerState) => s.done === true;
+
+    const result = aStarSearch(graph, initial, goal, zeroHeuristic);
+    expect(result.plan.isComplete).toBe(true);
+    expect(result.plan.actions.length).toBe(0);
+  });
+});
+
+describe("edge cases — impossible states", () => {
+  test("no actions available returns empty incomplete plan", () => {
+    const graph = new ActionGraph();
+    const initial = createState({ x: 0 });
+    const goal = (s: PlannerState) => s.x === 99;
+
+    const result = aStarSearch(graph, initial, goal, zeroHeuristic);
+    expect(result.plan.isComplete).toBe(false);
+    expect(result.exhaustive).toBe(true);
+  });
+
+  test("all preconditions unsatisfied returns incomplete plan", () => {
+    const graph = new ActionGraph();
+    graph.addAction(
+      action("a", "needs-magic")
+        .requireEquals("magic", true)
+        .set({ x: 99 })
+        .build(),
+    );
+
+    const initial = createState({ magic: false, x: 0 });
+    const goal = (s: PlannerState) => s.x === 99;
+
+    const result = aStarSearch(graph, initial, goal, zeroHeuristic);
+    expect(result.plan.isComplete).toBe(false);
+  });
+});
+
+describe("edge cases — circular dependencies", () => {
+  test("A* handles cycles without infinite loop", () => {
+    const graph = new ActionGraph();
+    // Create a cycle: A→B→A, with an exit B→C
+    graph.addActions([
+      action("ab", "A-to-B")
+        .requireEquals("pos", "A")
+        .set({ pos: "B" })
+        .cost(1)
+        .build(),
+      action("ba", "B-to-A")
+        .requireEquals("pos", "B")
+        .set({ pos: "A" })
+        .cost(1)
+        .build(),
+      action("bc", "B-to-C")
+        .requireEquals("pos", "B")
+        .set({ pos: "C" })
+        .cost(1)
+        .build(),
+    ]);
+
+    const initial = createState({ pos: "A" });
+    const goal = (s: PlannerState) => s.pos === "C";
+
+    const result = aStarSearch(graph, initial, goal, zeroHeuristic, {
+      maxExpansions: 100,
+    });
+    expect(result.plan.isComplete).toBe(true);
+    expect(result.plan.actions.map((a) => a.id)).toEqual(["ab", "bc"]);
+  });
+});
+
+describe("world state utilities", () => {
+  test("stateKey is deterministic regardless of key order", () => {
+    const s1 = createState({ b: 2, a: 1 });
+    const s2 = createState({ a: 1, b: 2 });
+    expect(stateKey(s1)).toBe(stateKey(s2));
+  });
+
+  test("statesEqual works correctly", () => {
+    const s1 = createState({ x: 1, y: "hello" });
+    const s2 = createState({ x: 1, y: "hello" });
+    const s3 = createState({ x: 2, y: "hello" });
+    expect(statesEqual(s1, s2)).toBe(true);
+    expect(statesEqual(s1, s3)).toBe(false);
+  });
+
+  test("emptyState is frozen", () => {
+    const empty = emptyState();
+    expect(Object.keys(empty).length).toBe(0);
+    expect(Object.isFrozen(empty)).toBe(true);
+  });
+});
+
+describe("memo cache", () => {
+  test("memoized heuristic caches results", () => {
+    let callCount = 0;
+    const h = (state: PlannerState, _goal: (s: PlannerState) => boolean) => {
+      callCount++;
+      return Object.keys(state).length;
+    };
+
+    const memoized = memoizeHeuristic(h, 100);
+    const state = createState({ a: 1 });
+    const goal = () => true;
+
+    const v1 = memoized(state, goal);
+    const v2 = memoized(state, goal);
+
+    expect(v1).toBe(v2);
+    expect(callCount).toBe(1); // Only called once
+  });
+
+  test("MemoCache respects maxSize", () => {
+    const cache = new MemoCache<number>(3);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("c", 3);
+    cache.set("d", 4); // Should evict "a"
+
+    expect(cache.has("a")).toBe(false);
+    expect(cache.has("d")).toBe(true);
+    expect(cache.size).toBe(3);
+  });
+});
+
+describe("state cache", () => {
+  test("caches states and tracks best g-score", () => {
+    const cache = new StateCache();
+    const node1: SearchNode = {
+      state: createState({ x: 1 }),
+      stateKey: "x=1",
+      parent: null,
+      action: null,
+      gScore: 10,
+      fScore: 15,
+    };
+
+    cache.put(node1);
+    expect(cache.has("x=1")).toBe(true);
+    expect(cache.hasBetterOrEqual("x=1", 10)).toBe(true);
+    expect(cache.hasBetterOrEqual("x=1", 5)).toBe(false);
+
+    // Better g-score should update
+    const node2 = { ...node1, gScore: 5, fScore: 10 };
+    cache.put(node2);
+    expect(cache.hasBetterOrEqual("x=1", 5)).toBe(true);
+  });
+});
+
+describe("goal clustering", () => {
+  test("clusters goals with overlapping keys", () => {
+    const goals = [
+      { id: "g1", goal: (s: PlannerState) => s.a === 1, relevantKeys: ["a", "b"] },
+      { id: "g2", goal: (s: PlannerState) => s.b === 2, relevantKeys: ["b", "c"] },
+      { id: "g3", goal: (s: PlannerState) => s.d === 3, relevantKeys: ["d"] },
+    ];
+
+    const clusters = clusterGoals(goals);
+    // g1 and g2 share key "b", so they cluster together
+    // g3 is independent
+    expect(clusters.length).toBe(2);
+
+    const bigCluster = clusters.find((c) => c.goalIds.length === 2);
+    const smallCluster = clusters.find((c) => c.goalIds.length === 1);
+    expect(bigCluster).toBeDefined();
+    expect(smallCluster).toBeDefined();
+    expect(bigCluster!.goalIds.sort()).toEqual(["g1", "g2"]);
+    expect(smallCluster!.goalIds).toEqual(["g3"]);
+  });
+});
+
+describe("HTN edge cases", () => {
+  test("decomposition of unknown task returns failure", () => {
+    const network = new TaskNetwork();
+    const decomposer = new HTNDecomposer(network);
+    const result = decomposer.decompose("nonexistent", createState({}));
+    expect(result.success).toBe(false);
+  });
+
+  test("empty network produces no actions", () => {
+    const network = new TaskNetwork();
+    const decomposer = new HTNDecomposer(network);
+    const result = decomposer.fullDecomposition(createState({}));
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("validation edge cases", () => {
+  test("empty plan validates successfully", () => {
+    const plan = { actions: [], totalCost: 0, isComplete: true };
+    const state = createState({});
+    const result = validatePlan(plan, state);
+    expect(result.valid).toBe(true);
+  });
+
+  test("validation preserves original state", () => {
+    const plan = {
+      actions: [
+        action("a", "modify").set({ x: 999 }).build(),
+      ],
+      totalCost: 1,
+      isComplete: true,
+    };
+
+    const state = createState({ x: 0 });
+    validatePlan(plan, state);
+    expect(state.x).toBe(0); // Original untouched
+  });
+});

--- a/src/planner/__tests__/integration.test.ts
+++ b/src/planner/__tests__/integration.test.ts
@@ -1,0 +1,339 @@
+import { describe, test, expect } from "bun:test";
+import { ActionGraph } from "../action-graph.ts";
+import { action } from "../action.ts";
+import { createState } from "../world-state.ts";
+import { zeroHeuristic } from "../heuristic.ts";
+import { aStarSearch } from "../a-star.ts";
+import { validatePlan, validateNoSideEffects } from "../plan-validator.ts";
+import { ReplanManager } from "../replan-manager.ts";
+import { HTNDecomposer } from "../htn-decomposer.ts";
+import { TaskNetwork } from "../task-network.ts";
+import { L1Planner } from "../l1-integration.ts";
+import { L0L1Bridge } from "../../matcher/l0-l1-bridge.ts";
+import type { L0RuleMatcher } from "../../matcher/l0-l1-bridge.ts";
+import type { PlannerState, CompositeTask } from "../types.ts";
+
+describe("plan validation", () => {
+  test("validates valid plan without side effects", () => {
+    const graph = new ActionGraph();
+    graph.addActions([
+      action("a", "step-a")
+        .requireEquals("status", "init")
+        .set({ status: "processing" })
+        .build(),
+      action("b", "step-b")
+        .requireEquals("status", "processing")
+        .set({ status: "done" })
+        .build(),
+    ]);
+
+    const initial = createState({ status: "init" });
+    const goal = (s: PlannerState) => s.status === "done";
+    const result = aStarSearch(graph, initial, goal, zeroHeuristic);
+
+    // Validate plan
+    const validation = validatePlan(result.plan, initial, goal);
+    expect(validation.valid).toBe(true);
+    expect(validation.failedAtIndex).toBe(-1);
+    expect(validation.finalState.status).toBe("done");
+
+    // Verify no side effects
+    const sideEffects = validateNoSideEffects(result.plan, initial);
+    expect(sideEffects.preserved).toBe(true);
+  });
+
+  test("detects precondition violation during validation", () => {
+    const graph = new ActionGraph();
+    const plan = {
+      actions: [
+        action("a", "requires-ready")
+          .requireEquals("ready", true)
+          .set({ done: true })
+          .build(),
+      ],
+      totalCost: 1,
+      isComplete: true,
+    };
+
+    const state = createState({ ready: false });
+    const validation = validatePlan(plan, state);
+
+    expect(validation.valid).toBe(false);
+    expect(validation.failedAtIndex).toBe(0);
+    expect(validation.error).toContain("Precondition failed");
+  });
+
+  test("detects goal not satisfied after execution", () => {
+    const plan = {
+      actions: [
+        action("a", "set-x").set({ x: 1 }).build(),
+      ],
+      totalCost: 1,
+      isComplete: true,
+    };
+
+    const state = createState({ x: 0 });
+    const goal = (s: PlannerState) => s.x === 99;
+    const validation = validatePlan(plan, state, goal);
+
+    expect(validation.valid).toBe(false);
+    expect(validation.error).toContain("does not satisfy goal");
+  });
+});
+
+describe("replan on state change", () => {
+  test("replanning occurs and recovers when world state changes", () => {
+    const graph = new ActionGraph();
+    graph.addActions([
+      action("a", "step-a")
+        .requireEquals("blocked", false)
+        .set({ phase: "mid" })
+        .cost(1)
+        .build(),
+      action("b", "step-b")
+        .requireEquals("phase", "mid")
+        .requireEquals("blocked", false)
+        .set({ phase: "done" })
+        .cost(1)
+        .build(),
+      // Alternative path that works even when blocked
+      action("c", "bypass")
+        .requireEquals("phase", "mid")
+        .requireEquals("blocked", true)
+        .set({ phase: "done" })
+        .cost(3)
+        .build(),
+    ]);
+
+    const goal = (s: PlannerState) => s.phase === "done";
+    const manager = new ReplanManager(graph, zeroHeuristic, goal);
+
+    // Original plan: a → b
+    const originalPlan = {
+      actions: [
+        graph.getAllActions()[0], // step-a
+        graph.getAllActions()[1], // step-b
+      ],
+      totalCost: 2,
+      isComplete: true,
+    };
+
+    // After executing step-a, world state changes: blocked becomes true
+    const expectedState = createState({ blocked: false, phase: "mid" });
+    const actualState = createState({ blocked: true, phase: "mid" });
+
+    const result = manager.checkAndReplan(
+      originalPlan,
+      1, // executed 1 step
+      expectedState,
+      actualState,
+      { timeBudgetMs: 5000 },
+    );
+
+    expect(result.success).toBe(true);
+    // New plan should use the bypass action
+    const lastAction = result.plan.actions[result.plan.actions.length - 1];
+    expect(lastAction.id).toBe("c");
+  });
+
+  test("no replan needed when state unchanged", () => {
+    const graph = new ActionGraph();
+    const goal = (s: PlannerState) => s.done === true;
+    const manager = new ReplanManager(graph, zeroHeuristic, goal);
+
+    const plan = {
+      actions: [action("a", "test").set({ done: true }).build()],
+      totalCost: 1,
+      isComplete: true,
+    };
+
+    const state = createState({ x: 1 });
+    const result = manager.checkAndReplan(plan, 0, state, state, {
+      timeBudgetMs: 1000,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replanFromIndex).toBe(-1);
+  });
+});
+
+describe("HTN decomposition", () => {
+  test("decomposes portfolio→project→domain→action hierarchy", () => {
+    const network = new TaskNetwork();
+
+    // Primitive actions at bottom level
+    const restartService = action("restart", "restart-service")
+      .level("action")
+      .requireEquals("service.status", "down")
+      .set({ "service.status": "healthy" })
+      .cost(2)
+      .build();
+
+    const runTests = action("tests", "run-tests")
+      .level("action")
+      .requireEquals("service.status", "healthy")
+      .set({ "tests.passed": true })
+      .cost(3)
+      .build();
+
+    network.addPrimitiveAction(restartService);
+    network.addPrimitiveAction(runTests);
+
+    // Domain-level composite: "fix service"
+    const fixService: CompositeTask = {
+      id: "fix-service",
+      name: "Fix Service",
+      level: "domain",
+      decompose: (_state) => ["restart", "tests"],
+    };
+    network.addCompositeTask(fixService);
+
+    // Project-level composite: "stabilize project"
+    const stabilizeProject: CompositeTask = {
+      id: "stabilize-project",
+      name: "Stabilize Project",
+      level: "project",
+      decompose: (_state) => ["fix-service"],
+    };
+    network.addCompositeTask(stabilizeProject);
+
+    // Portfolio-level composite: "improve health"
+    const improveHealth: CompositeTask = {
+      id: "improve-health",
+      name: "Improve Portfolio Health",
+      level: "portfolio",
+      decompose: (_state) => ["stabilize-project"],
+    };
+    network.addCompositeTask(improveHealth);
+
+    const decomposer = new HTNDecomposer(network);
+    const state = createState({ "service.status": "down" });
+
+    // Full decomposition from portfolio level
+    const result = decomposer.decompose("improve-health", state);
+    expect(result.success).toBe(true);
+    expect(result.actions.length).toBe(2);
+    expect(result.actions[0].id).toBe("restart");
+    expect(result.actions[1].id).toBe("tests");
+  });
+
+  test("decomposition fails when precondition not met", () => {
+    const network = new TaskNetwork();
+
+    const guarded: CompositeTask = {
+      id: "guarded",
+      name: "Guarded Task",
+      level: "domain",
+      precondition: (s) => s.allowed === true,
+      decompose: () => [],
+    };
+    network.addCompositeTask(guarded);
+
+    const decomposer = new HTNDecomposer(network);
+    const state = createState({ allowed: false });
+
+    const result = decomposer.decompose("guarded", state);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("L0 → L1 fallback", () => {
+  test("L1 planner is invoked when L0 rule matcher returns no match", () => {
+    const graph = new ActionGraph();
+    graph.addActions([
+      action("fix", "fix-issue")
+        .requireEquals("broken", true)
+        .set({ broken: false, fixed: true })
+        .cost(5)
+        .build(),
+    ]);
+
+    const network = new TaskNetwork();
+    network.addPrimitiveAction(graph.getAllActions()[0]);
+
+    // L0 matcher that never matches
+    const noMatchMatcher: L0RuleMatcher = {
+      match: () => ({ matched: false, reason: "no matching rule" }),
+    };
+
+    const bridge = new L0L1Bridge(
+      noMatchMatcher,
+      [...graph.getAllActions()],
+      [],
+    );
+
+    const state = createState({ broken: true });
+    const goal = (s: PlannerState) => s.fixed === true;
+
+    const result = bridge.resolve(state, goal);
+    expect(result.success).toBe(true);
+    expect(result.plan).toBeDefined();
+    expect(result.plan!.actions.length).toBe(1);
+    expect(result.plan!.actions[0].id).toBe("fix");
+  });
+
+  test("L0 match is used directly when available", () => {
+    const matchAction = action("l0-action", "L0 Match")
+      .set({ resolved: true })
+      .cost(1)
+      .build();
+
+    const alwaysMatchMatcher: L0RuleMatcher = {
+      match: () => ({ matched: true, action: matchAction }),
+    };
+
+    const bridge = new L0L1Bridge(alwaysMatchMatcher, [], []);
+
+    const state = createState({});
+    const goal = (s: PlannerState) => s.resolved === true;
+
+    const result = bridge.resolve(state, goal);
+    expect(result.success).toBe(true);
+    expect(result.plan!.actions[0].id).toBe("l0-action");
+  });
+});
+
+describe("full planning pipeline", () => {
+  test("end-to-end: define actions → plan → validate → execute", () => {
+    const graph = new ActionGraph();
+    graph.addActions([
+      action("provision", "provision-server")
+        .requireEquals("server", "none")
+        .set({ server: "provisioned" })
+        .cost(3)
+        .build(),
+      action("deploy", "deploy-app")
+        .requireEquals("server", "provisioned")
+        .set({ server: "deployed", app: "running" })
+        .cost(2)
+        .build(),
+      action("verify", "verify-health")
+        .requireEquals("app", "running")
+        .set({ verified: true })
+        .cost(1)
+        .build(),
+    ]);
+
+    const initial = createState({
+      server: "none",
+      app: "none",
+      verified: false,
+    });
+    const goal = (s: PlannerState) => s.verified === true;
+
+    // Step 1: Plan
+    const searchResult = aStarSearch(graph, initial, goal, zeroHeuristic);
+    expect(searchResult.plan.isComplete).toBe(true);
+    expect(searchResult.plan.actions.length).toBe(3);
+
+    // Step 2: Validate
+    const validation = validatePlan(searchResult.plan, initial, goal);
+    expect(validation.valid).toBe(true);
+    expect(validation.finalState.verified).toBe(true);
+
+    // Step 3: Verify no side effects
+    const sideEffects = validateNoSideEffects(searchResult.plan, initial);
+    expect(sideEffects.preserved).toBe(true);
+    expect(initial.server).toBe("none"); // Original state untouched
+  });
+});

--- a/src/planner/a-star.ts
+++ b/src/planner/a-star.ts
@@ -150,6 +150,23 @@ export function aStarSearch(
       bestFrontierNode = current;
     }
 
+    // Check goal on pop (not on generation) — guarantees optimality
+    if (goal(current.state)) {
+      if (bestGoalNode === null || current.gScore < bestGoalNode.gScore) {
+        bestGoalNode = current;
+      }
+      if (weight <= 1.0) {
+        return {
+          plan: reconstructPlan(current),
+          nodesExpanded,
+          nodesGenerated,
+          elapsedMs: Date.now() - startTime,
+          exhaustive: true,
+        };
+      }
+      continue;
+    }
+
     // Expand successors
     const successors = graph.getSuccessors(current.state);
 
@@ -174,25 +191,6 @@ export function aStarSearch(
         gScore: tentativeG,
         fScore: tentativeG + weight * h,
       };
-
-      // Check goal
-      if (goal(resultState)) {
-        if (bestGoalNode === null || tentativeG < bestGoalNode.gScore) {
-          bestGoalNode = node;
-        }
-        // For standard A* (weight=1), first goal found is optimal
-        if (weight <= 1.0) {
-          return {
-            plan: reconstructPlan(node),
-            nodesExpanded,
-            nodesGenerated,
-            elapsedMs: Date.now() - startTime,
-            exhaustive: true,
-          };
-        }
-        // For weighted A*, continue searching for better solution
-        continue;
-      }
 
       openSet.push(node);
     }

--- a/src/planner/a-star.ts
+++ b/src/planner/a-star.ts
@@ -1,0 +1,235 @@
+/**
+ * A* search algorithm with cost tracking and budget-bounded execution.
+ *
+ * Finds least-cost plans through an action graph from initial state to goal.
+ * Supports weighted A* for trading optimality for speed.
+ */
+
+import type {
+  Action,
+  Goal,
+  Plan,
+  PlannerState,
+  SearchConfig,
+  SearchNode,
+  SearchResult,
+} from "./types.ts";
+import type { ActionGraph } from "./action-graph.ts";
+import type { HeuristicFn } from "./heuristic.ts";
+import { stateKey } from "./world-state.ts";
+import { reconstructPlan, partialPlan, emptyPlan } from "./plan.ts";
+import { applyEffects } from "./action.ts";
+
+/**
+ * Min-heap priority queue for SearchNodes, ordered by fScore.
+ */
+class MinHeap {
+  private heap: SearchNode[] = [];
+
+  get size(): number {
+    return this.heap.length;
+  }
+
+  push(node: SearchNode): void {
+    this.heap.push(node);
+    this.bubbleUp(this.heap.length - 1);
+  }
+
+  pop(): SearchNode | undefined {
+    if (this.heap.length === 0) return undefined;
+    const top = this.heap[0];
+    const last = this.heap.pop()!;
+    if (this.heap.length > 0) {
+      this.heap[0] = last;
+      this.sinkDown(0);
+    }
+    return top;
+  }
+
+  peek(): SearchNode | undefined {
+    return this.heap[0];
+  }
+
+  private bubbleUp(i: number): void {
+    while (i > 0) {
+      const parent = (i - 1) >> 1;
+      if (this.heap[i].fScore >= this.heap[parent].fScore) break;
+      [this.heap[i], this.heap[parent]] = [this.heap[parent], this.heap[i]];
+      i = parent;
+    }
+  }
+
+  private sinkDown(i: number): void {
+    const n = this.heap.length;
+    while (true) {
+      let smallest = i;
+      const left = 2 * i + 1;
+      const right = 2 * i + 2;
+      if (left < n && this.heap[left].fScore < this.heap[smallest].fScore) {
+        smallest = left;
+      }
+      if (right < n && this.heap[right].fScore < this.heap[smallest].fScore) {
+        smallest = right;
+      }
+      if (smallest === i) break;
+      [this.heap[i], this.heap[smallest]] = [this.heap[smallest], this.heap[i]];
+      i = smallest;
+    }
+  }
+}
+
+/**
+ * Execute A* search on an action graph.
+ *
+ * @param graph - The action graph defining available actions
+ * @param initial - The starting world state
+ * @param goal - Predicate that tests if a state satisfies the goal
+ * @param heuristic - Heuristic function estimating remaining cost
+ * @param config - Optional search configuration (budget, weight, etc.)
+ * @returns SearchResult with plan and statistics
+ */
+export function aStarSearch(
+  graph: ActionGraph,
+  initial: PlannerState,
+  goal: Goal,
+  heuristic: HeuristicFn,
+  config: SearchConfig = {},
+): SearchResult {
+  const startTime = Date.now();
+  const weight = config.weight ?? 1.0;
+  const maxExpansions = config.maxExpansions ?? Infinity;
+  const timeBudgetMs = config.timeBudgetMs ?? Infinity;
+
+  const openSet = new MinHeap();
+  const closedSet = new Set<string>();
+  const gScores = new Map<string, number>();
+
+  let nodesExpanded = 0;
+  let nodesGenerated = 1;
+  let bestGoalNode: SearchNode | null = null;
+  let bestFrontierNode: SearchNode | null = null;
+
+  // Initialize with start node
+  const startKey = stateKey(initial);
+  const startNode: SearchNode = {
+    state: initial,
+    stateKey: startKey,
+    parent: null,
+    action: null,
+    gScore: 0,
+    fScore: weight * heuristic(initial, goal),
+  };
+  openSet.push(startNode);
+  gScores.set(startKey, 0);
+
+  // Check if initial state already satisfies goal
+  if (goal(initial)) {
+    return {
+      plan: { actions: [], totalCost: 0, isComplete: true },
+      nodesExpanded: 0,
+      nodesGenerated: 1,
+      elapsedMs: Date.now() - startTime,
+      exhaustive: true,
+    };
+  }
+
+  while (openSet.size > 0) {
+    // Budget checks
+    if (nodesExpanded >= maxExpansions) break;
+    if (Date.now() - startTime >= timeBudgetMs) break;
+
+    const current = openSet.pop()!;
+
+    // Skip if we already found a better path to this state
+    if (closedSet.has(current.stateKey)) continue;
+    closedSet.add(current.stateKey);
+    nodesExpanded++;
+
+    // Track best frontier node for partial plans
+    if (bestFrontierNode === null || current.fScore < bestFrontierNode.fScore) {
+      bestFrontierNode = current;
+    }
+
+    // Expand successors
+    const successors = graph.getSuccessors(current.state);
+
+    for (const { action, resultState } of successors) {
+      const key = stateKey(resultState);
+      if (closedSet.has(key)) continue;
+
+      const tentativeG = current.gScore + action.cost;
+      const existingG = gScores.get(key);
+
+      if (existingG !== undefined && tentativeG >= existingG) continue;
+
+      gScores.set(key, tentativeG);
+      nodesGenerated++;
+
+      const h = heuristic(resultState, goal);
+      const node: SearchNode = {
+        state: resultState,
+        stateKey: key,
+        parent: current,
+        action,
+        gScore: tentativeG,
+        fScore: tentativeG + weight * h,
+      };
+
+      // Check goal
+      if (goal(resultState)) {
+        if (bestGoalNode === null || tentativeG < bestGoalNode.gScore) {
+          bestGoalNode = node;
+        }
+        // For standard A* (weight=1), first goal found is optimal
+        if (weight <= 1.0) {
+          return {
+            plan: reconstructPlan(node),
+            nodesExpanded,
+            nodesGenerated,
+            elapsedMs: Date.now() - startTime,
+            exhaustive: true,
+          };
+        }
+        // For weighted A*, continue searching for better solution
+        continue;
+      }
+
+      openSet.push(node);
+    }
+  }
+
+  const elapsedMs = Date.now() - startTime;
+  const exhaustive = openSet.size === 0;
+
+  // Return best goal plan if found
+  if (bestGoalNode !== null) {
+    return {
+      plan: reconstructPlan(bestGoalNode),
+      nodesExpanded,
+      nodesGenerated,
+      elapsedMs,
+      exhaustive,
+    };
+  }
+
+  // Return partial plan from best frontier node
+  if (bestFrontierNode !== null && bestFrontierNode.action !== null) {
+    const lowerBound = bestFrontierNode.fScore;
+    return {
+      plan: partialPlan(bestFrontierNode, lowerBound),
+      nodesExpanded,
+      nodesGenerated,
+      elapsedMs,
+      exhaustive,
+    };
+  }
+
+  // No plan found at all
+  return {
+    plan: emptyPlan(),
+    nodesExpanded,
+    nodesGenerated,
+    elapsedMs,
+    exhaustive,
+  };
+}

--- a/src/planner/action-graph.ts
+++ b/src/planner/action-graph.ts
@@ -1,0 +1,65 @@
+/**
+ * ActionGraph — maps world states to applicable actions (edges).
+ *
+ * The action graph is an implicit graph where:
+ * - Nodes are PlannerState values
+ * - Edges are Actions whose preconditions are satisfied
+ * - Successor states are computed by applying action effects
+ */
+
+import type { Action, PlannerState } from "./types.ts";
+import { preconditionsMet, applyEffects } from "./action.ts";
+
+/** An edge in the action graph: action + resulting state. */
+export interface ActionEdge {
+  action: Action;
+  resultState: PlannerState;
+}
+
+export class ActionGraph {
+  private actions: Action[] = [];
+
+  /** Register an action in the graph. */
+  addAction(a: Action): void {
+    this.actions.push(a);
+  }
+
+  /** Register multiple actions. */
+  addActions(actions: Action[]): void {
+    for (const a of actions) {
+      this.actions.push(a);
+    }
+  }
+
+  /** Get all actions whose preconditions are satisfied by the given state. */
+  getApplicableActions(state: PlannerState): Action[] {
+    return this.actions.filter((a) => preconditionsMet(a, state));
+  }
+
+  /** Get all successor edges (action + result state) from the given state. */
+  getSuccessors(state: PlannerState): ActionEdge[] {
+    const applicable = this.getApplicableActions(state);
+    return applicable.map((a) => ({
+      action: a,
+      resultState: applyEffects(a, state),
+    }));
+  }
+
+  /** Get all registered actions. */
+  getAllActions(): readonly Action[] {
+    return this.actions;
+  }
+
+  /** Get the number of registered actions. */
+  get size(): number {
+    return this.actions.length;
+  }
+
+  /** Remove an action by ID. */
+  removeAction(id: string): boolean {
+    const idx = this.actions.findIndex((a) => a.id === id);
+    if (idx === -1) return false;
+    this.actions.splice(idx, 1);
+    return true;
+  }
+}

--- a/src/planner/action.ts
+++ b/src/planner/action.ts
@@ -1,0 +1,105 @@
+/**
+ * Action creation helpers and utilities.
+ */
+
+import type {
+  Action,
+  HierarchyLevel,
+  PlannerState,
+  StatePredicate,
+  StateTransform,
+  StateValue,
+} from "./types.ts";
+import { applyUpdate } from "./world-state.ts";
+
+/** Builder for creating actions with a fluent API. */
+export class ActionBuilder {
+  private _id: string;
+  private _name: string;
+  private _cost = 1;
+  private _level: HierarchyLevel = "action";
+  private _preconditions: StatePredicate[] = [];
+  private _effects: StateTransform[] = [];
+  private _meta: Record<string, unknown> = {};
+
+  constructor(id: string, name: string) {
+    this._id = id;
+    this._name = name;
+  }
+
+  cost(c: number): this {
+    this._cost = c;
+    return this;
+  }
+
+  level(l: HierarchyLevel): this {
+    this._level = l;
+    return this;
+  }
+
+  /** Add a precondition that checks if a key equals a specific value. */
+  requireEquals(key: string, value: StateValue): this {
+    this._preconditions.push((s) => s[key] === value);
+    return this;
+  }
+
+  /** Add a precondition that checks if a key is truthy. */
+  requireTruthy(key: string): this {
+    this._preconditions.push((s) => !!s[key]);
+    return this;
+  }
+
+  /** Add a custom precondition. */
+  require(pred: StatePredicate): this {
+    this._preconditions.push(pred);
+    return this;
+  }
+
+  /** Add an effect that sets key-value pairs. */
+  set(updates: Record<string, StateValue>): this {
+    this._effects.push((s) => applyUpdate(s, updates));
+    return this;
+  }
+
+  /** Add a custom effect transform. */
+  effect(transform: StateTransform): this {
+    this._effects.push(transform);
+    return this;
+  }
+
+  meta(m: Record<string, unknown>): this {
+    this._meta = { ...this._meta, ...m };
+    return this;
+  }
+
+  build(): Action {
+    return {
+      id: this._id,
+      name: this._name,
+      cost: this._cost,
+      level: this._level,
+      preconditions: [...this._preconditions],
+      effects: [...this._effects],
+      meta: Object.keys(this._meta).length > 0 ? { ...this._meta } : undefined,
+    };
+  }
+}
+
+/** Shorthand to create an ActionBuilder. */
+export function action(id: string, name: string): ActionBuilder {
+  return new ActionBuilder(id, name);
+}
+
+/** Check if all preconditions of an action are satisfied by the given state. */
+export function preconditionsMet(a: Action, state: PlannerState): boolean {
+  return a.preconditions.every((p) => p(state));
+}
+
+/** Apply all effects of an action to a state, returning the new state. */
+export function applyEffects(a: Action, state: PlannerState): PlannerState {
+  let current = state;
+  for (const eff of a.effects) {
+    current = eff(current);
+  }
+  return current;
+}

--- a/src/planner/anytime-planner.ts
+++ b/src/planner/anytime-planner.ts
@@ -1,0 +1,167 @@
+/**
+ * AnytimePlanner — wraps A* with budget-bounded anytime search.
+ *
+ * Returns the best plan found within the budget and can be resumed
+ * to improve the solution with additional time.
+ */
+
+import type {
+  BudgetConfig,
+  Goal,
+  PlannerState,
+  SearchConfig,
+  SearchResult,
+} from "./types.ts";
+import type { ActionGraph } from "./action-graph.ts";
+import type { HeuristicFn } from "./heuristic.ts";
+import { BudgetManager } from "./budget-manager.ts";
+import { aStarSearch } from "./a-star.ts";
+
+export interface AnytimeResult {
+  /** Best plan found so far. */
+  searchResult: SearchResult;
+  /** Whether more time could improve the result. */
+  canImprove: boolean;
+  /** Number of iterations performed. */
+  iterations: number;
+}
+
+export class AnytimePlanner {
+  private graph: ActionGraph;
+  private heuristic: HeuristicFn;
+  private bestResult: SearchResult | null = null;
+  private iterationCount = 0;
+
+  constructor(graph: ActionGraph, heuristic: HeuristicFn) {
+    this.graph = graph;
+    this.heuristic = heuristic;
+  }
+
+  /**
+   * Search for a plan within the given budget.
+   *
+   * Uses iterative weighted A* — starts with a high weight for fast
+   * initial solutions, then reduces weight to improve quality.
+   */
+  search(
+    initial: PlannerState,
+    goal: Goal,
+    budget: BudgetConfig,
+  ): AnytimeResult {
+    const manager = new BudgetManager(budget);
+    this.iterationCount = 0;
+
+    // Weights to try: start aggressive (fast), then refine
+    const weights = [3.0, 2.0, 1.5, 1.0];
+
+    for (const weight of weights) {
+      if (!manager.hasRemaining()) break;
+
+      const config: SearchConfig = {
+        timeBudgetMs: manager.remainingTimeMs(),
+        maxExpansions: manager.remainingExpansions(),
+        weight,
+      };
+
+      const result = aStarSearch(
+        this.graph,
+        initial,
+        goal,
+        this.heuristic,
+        config,
+      );
+
+      this.iterationCount++;
+
+      // Keep the best complete plan found
+      if (result.plan.isComplete) {
+        if (
+          this.bestResult === null ||
+          !this.bestResult.plan.isComplete ||
+          result.plan.totalCost < this.bestResult.plan.totalCost
+        ) {
+          this.bestResult = result;
+        }
+        // If we found an optimal solution (weight=1), stop
+        if (weight <= 1.0 && result.exhaustive) break;
+      } else if (this.bestResult === null) {
+        // Keep partial result if we have nothing better
+        this.bestResult = result;
+      }
+    }
+
+    // If no result found at all, do one final search with remaining budget
+    if (this.bestResult === null) {
+      const config: SearchConfig = {
+        timeBudgetMs: manager.remainingTimeMs(),
+        weight: 1.0,
+      };
+      this.bestResult = aStarSearch(
+        this.graph,
+        initial,
+        goal,
+        this.heuristic,
+        config,
+      );
+      this.iterationCount++;
+    }
+
+    const canImprove =
+      !this.bestResult.exhaustive &&
+      (!this.bestResult.plan.isComplete ||
+        (this.bestResult.plan.lowerBound !== undefined &&
+          this.bestResult.plan.totalCost > this.bestResult.plan.lowerBound));
+
+    return {
+      searchResult: this.bestResult,
+      canImprove,
+      iterations: this.iterationCount,
+    };
+  }
+
+  /**
+   * Resume search with additional budget to try to improve the current best plan.
+   */
+  resume(
+    initial: PlannerState,
+    goal: Goal,
+    additionalBudget: BudgetConfig,
+  ): AnytimeResult {
+    // Run with weight=1.0 for optimal search
+    const config: SearchConfig = {
+      timeBudgetMs: additionalBudget.timeBudgetMs,
+      maxExpansions: additionalBudget.maxExpansions,
+      weight: 1.0,
+    };
+
+    const result = aStarSearch(
+      this.graph,
+      initial,
+      goal,
+      this.heuristic,
+      config,
+    );
+
+    this.iterationCount++;
+
+    if (
+      result.plan.isComplete &&
+      (this.bestResult === null ||
+        !this.bestResult.plan.isComplete ||
+        result.plan.totalCost < this.bestResult.plan.totalCost)
+    ) {
+      this.bestResult = result;
+    }
+
+    return {
+      searchResult: this.bestResult ?? result,
+      canImprove: !result.exhaustive,
+      iterations: this.iterationCount,
+    };
+  }
+
+  /** Get the current best result without searching. */
+  currentBest(): SearchResult | null {
+    return this.bestResult;
+  }
+}

--- a/src/planner/budget-manager.ts
+++ b/src/planner/budget-manager.ts
@@ -1,0 +1,56 @@
+/**
+ * Budget manager for anytime planning.
+ * Tracks time and expansion budgets, reports remaining capacity.
+ */
+
+import type { BudgetConfig, BudgetStatus } from "./types.ts";
+
+export class BudgetManager {
+  private startTime: number;
+  private expansionsUsed = 0;
+  private readonly timeBudgetMs: number;
+  private readonly maxExpansions: number;
+
+  constructor(config: BudgetConfig) {
+    this.timeBudgetMs = config.timeBudgetMs;
+    this.maxExpansions = config.maxExpansions ?? Infinity;
+    this.startTime = Date.now();
+  }
+
+  /** Reset the budget timer (for resumption). */
+  reset(): void {
+    this.startTime = Date.now();
+    this.expansionsUsed = 0;
+  }
+
+  /** Record that one node was expanded. */
+  recordExpansion(): void {
+    this.expansionsUsed++;
+  }
+
+  /** Get current budget status. */
+  status(): BudgetStatus {
+    const elapsedMs = Date.now() - this.startTime;
+    return {
+      elapsedMs,
+      expansionsUsed: this.expansionsUsed,
+      timeRemaining: Math.max(0, this.timeBudgetMs - elapsedMs),
+      isExhausted: elapsedMs >= this.timeBudgetMs || this.expansionsUsed >= this.maxExpansions,
+    };
+  }
+
+  /** Check if any budget remains. */
+  hasRemaining(): boolean {
+    return !this.status().isExhausted;
+  }
+
+  /** Get remaining time budget in ms. */
+  remainingTimeMs(): number {
+    return Math.max(0, this.timeBudgetMs - (Date.now() - this.startTime));
+  }
+
+  /** Get remaining expansion budget. */
+  remainingExpansions(): number {
+    return Math.max(0, this.maxExpansions - this.expansionsUsed);
+  }
+}

--- a/src/planner/executor.ts
+++ b/src/planner/executor.ts
@@ -1,0 +1,90 @@
+/**
+ * Plan executor — applies plan actions to a world state sequentially.
+ * Used by the validator to simulate execution on a copy.
+ */
+
+import type { Action, Plan, PlannerState } from "./types.ts";
+import { preconditionsMet, applyEffects } from "./action.ts";
+import { cloneState } from "./world-state.ts";
+
+/** Result of executing a single action. */
+export interface ExecutionStepResult {
+  actionIndex: number;
+  action: Action;
+  success: boolean;
+  stateBefore: PlannerState;
+  stateAfter: PlannerState;
+  error?: string;
+}
+
+/** Result of executing an entire plan. */
+export interface ExecutionResult {
+  success: boolean;
+  steps: ExecutionStepResult[];
+  finalState: PlannerState;
+  /** Index of first failed step (-1 if all succeeded). */
+  failedAtIndex: number;
+  /** Number of steps successfully executed. */
+  stepsCompleted: number;
+}
+
+/**
+ * Execute a plan on a cloned copy of the given state.
+ * Does NOT modify the original state.
+ *
+ * For each action:
+ * 1. Check preconditions against current state
+ * 2. If preconditions fail, stop and report failure
+ * 3. Apply effects to produce next state
+ */
+export function executePlan(
+  plan: Plan,
+  initialState: PlannerState,
+): ExecutionResult {
+  let currentState = cloneState(initialState);
+  const steps: ExecutionStepResult[] = [];
+
+  for (let i = 0; i < plan.actions.length; i++) {
+    const action = plan.actions[i];
+    const stateBefore = currentState;
+
+    // Check preconditions
+    if (!preconditionsMet(action, currentState)) {
+      steps.push({
+        actionIndex: i,
+        action,
+        success: false,
+        stateBefore,
+        stateAfter: stateBefore,
+        error: `Precondition failed for action "${action.name}" (${action.id}) at step ${i}`,
+      });
+
+      return {
+        success: false,
+        steps,
+        finalState: currentState,
+        failedAtIndex: i,
+        stepsCompleted: i,
+      };
+    }
+
+    // Apply effects
+    const stateAfter = applyEffects(action, currentState);
+    steps.push({
+      actionIndex: i,
+      action,
+      success: true,
+      stateBefore,
+      stateAfter,
+    });
+    currentState = stateAfter;
+  }
+
+  return {
+    success: true,
+    steps,
+    finalState: currentState,
+    failedAtIndex: -1,
+    stepsCompleted: plan.actions.length,
+  };
+}

--- a/src/planner/heuristic.ts
+++ b/src/planner/heuristic.ts
@@ -1,0 +1,62 @@
+/**
+ * Heuristic functions for A* search.
+ *
+ * A heuristic must be admissible (never overestimate) for A* to find optimal plans.
+ * For weighted A*, the heuristic is multiplied by a weight factor.
+ */
+
+import type { Goal, NamedGoal, PlannerState } from "./types.ts";
+
+/** Heuristic function type: estimates cost from state to goal. */
+export type HeuristicFn = (state: PlannerState, goal: Goal) => number;
+
+/**
+ * Zero heuristic — always returns 0.
+ * Makes A* equivalent to Dijkstra's algorithm. Always admissible.
+ */
+export function zeroHeuristic(_state: PlannerState, _goal: Goal): number {
+  return 0;
+}
+
+/**
+ * Goal-provided heuristic — uses the heuristic function attached to a NamedGoal.
+ * Falls back to zero if no heuristic is provided.
+ */
+export function namedGoalHeuristic(namedGoal: NamedGoal): HeuristicFn {
+  return (state: PlannerState, _goal: Goal): number => {
+    if (namedGoal.heuristic) {
+      return namedGoal.heuristic(state);
+    }
+    return 0;
+  };
+}
+
+/**
+ * State-difference heuristic — counts the number of state keys that differ
+ * from a known goal state. Useful when the goal state is fully specified.
+ */
+export function stateDiffHeuristic(goalState: PlannerState): HeuristicFn {
+  return (state: PlannerState, _goal: Goal): number => {
+    let diff = 0;
+    for (const key of Object.keys(goalState)) {
+      if (state[key] !== goalState[key]) {
+        diff++;
+      }
+    }
+    return diff;
+  };
+}
+
+/**
+ * Composite heuristic — returns the maximum of multiple heuristics.
+ * If each component is admissible, the max is also admissible.
+ */
+export function maxHeuristic(...heuristics: HeuristicFn[]): HeuristicFn {
+  return (state: PlannerState, goal: Goal): number => {
+    let best = 0;
+    for (const h of heuristics) {
+      best = Math.max(best, h(state, goal));
+    }
+    return best;
+  };
+}

--- a/src/planner/hierarchy-levels.ts
+++ b/src/planner/hierarchy-levels.ts
@@ -1,0 +1,41 @@
+/**
+ * HTN hierarchy level definitions.
+ *
+ * The hierarchy has four levels:
+ * - portfolio: highest-level strategic tasks (e.g., "improve project health")
+ * - project: project-scoped tasks (e.g., "fix CI pipeline")
+ * - domain: domain-specific tasks (e.g., "restart failing service")
+ * - action: primitive executable actions (e.g., "set service.status = healthy")
+ */
+
+import type { HierarchyLevel } from "./types.ts";
+import { HIERARCHY_ORDER } from "./types.ts";
+
+/** Get the next level down in the hierarchy. Returns null at bottom level. */
+export function childLevel(level: HierarchyLevel): HierarchyLevel | null {
+  const idx = HIERARCHY_ORDER.indexOf(level);
+  if (idx === -1 || idx >= HIERARCHY_ORDER.length - 1) return null;
+  return HIERARCHY_ORDER[idx + 1];
+}
+
+/** Get the next level up in the hierarchy. Returns null at top level. */
+export function parentLevel(level: HierarchyLevel): HierarchyLevel | null {
+  const idx = HIERARCHY_ORDER.indexOf(level);
+  if (idx <= 0) return null;
+  return HIERARCHY_ORDER[idx - 1];
+}
+
+/** Check if a level is the bottom (primitive action) level. */
+export function isPrimitiveLevel(level: HierarchyLevel): boolean {
+  return level === "action";
+}
+
+/** Check if a level is the top (portfolio) level. */
+export function isTopLevel(level: HierarchyLevel): boolean {
+  return level === "portfolio";
+}
+
+/** Get the depth of a level (0 = portfolio, 3 = action). */
+export function levelDepth(level: HierarchyLevel): number {
+  return HIERARCHY_ORDER.indexOf(level);
+}

--- a/src/planner/htn-decomposer.ts
+++ b/src/planner/htn-decomposer.ts
@@ -1,0 +1,138 @@
+/**
+ * HTN (Hierarchical Task Network) decomposer.
+ *
+ * Decomposes high-level tasks through the portfolio→project→domain→action
+ * hierarchy, producing primitive action sequences for the A* planner.
+ */
+
+import type { Action, CompositeTask, HierarchyLevel, PlannerState } from "./types.ts";
+import { HIERARCHY_ORDER } from "./types.ts";
+import { TaskNetwork } from "./task-network.ts";
+import { childLevel, isPrimitiveLevel } from "./hierarchy-levels.ts";
+
+/** Result of HTN decomposition. */
+export interface DecompositionResult {
+  success: boolean;
+  actions: Action[];
+  /** Path of decomposition steps taken. */
+  decompositionPath: string[];
+  error?: string;
+}
+
+export class HTNDecomposer {
+  private network: TaskNetwork;
+
+  constructor(network: TaskNetwork) {
+    this.network = network;
+  }
+
+  /**
+   * Decompose a task at any level into primitive actions.
+   *
+   * Walks down the hierarchy: portfolio→project→domain→action.
+   * At each level, the composite task's decompose function determines
+   * which sub-tasks to expand.
+   */
+  decompose(taskId: string, state: PlannerState): DecompositionResult {
+    const path: string[] = [taskId];
+    const actions = this.network.decompose(taskId, state);
+
+    if (actions === null) {
+      return {
+        success: false,
+        actions: [],
+        decompositionPath: path,
+        error: `Failed to decompose task "${taskId}"`,
+      };
+    }
+
+    return {
+      success: true,
+      actions,
+      decompositionPath: path,
+    };
+  }
+
+  /**
+   * Decompose all applicable tasks at a given hierarchy level.
+   * Returns the union of all primitive actions produced.
+   */
+  decomposeLevel(level: HierarchyLevel, state: PlannerState): DecompositionResult {
+    if (isPrimitiveLevel(level)) {
+      // At action level, just return all applicable primitive actions
+      const primitives = this.network.getPrimitiveActions();
+      return {
+        success: true,
+        actions: primitives,
+        decompositionPath: [level],
+      };
+    }
+
+    const tasks = this.network.getTasksAtLevel(level);
+    const allActions: Action[] = [];
+    const path: string[] = [level];
+
+    for (const entry of tasks) {
+      if (entry.type !== "composite") continue;
+
+      const composite = entry.task;
+      if (composite.precondition && !composite.precondition(state)) continue;
+
+      const result = this.decompose(composite.id, state);
+      if (result.success) {
+        allActions.push(...result.actions);
+        path.push(...result.decompositionPath);
+      }
+    }
+
+    return {
+      success: allActions.length > 0,
+      actions: allActions,
+      decompositionPath: path,
+    };
+  }
+
+  /**
+   * Full top-down decomposition: start from portfolio level and decompose
+   * all the way down to primitive actions.
+   */
+  fullDecomposition(state: PlannerState): DecompositionResult {
+    const allActions: Action[] = [];
+    const path: string[] = [];
+
+    for (const level of HIERARCHY_ORDER) {
+      if (isPrimitiveLevel(level)) {
+        // Collect remaining primitive actions not yet gathered
+        const primitives = this.network.getPrimitiveActions();
+        for (const a of primitives) {
+          if (!allActions.some((existing) => existing.id === a.id)) {
+            allActions.push(a);
+          }
+        }
+        path.push(level);
+        continue;
+      }
+
+      const result = this.decomposeLevel(level, state);
+      if (result.success) {
+        for (const a of result.actions) {
+          if (!allActions.some((existing) => existing.id === a.id)) {
+            allActions.push(a);
+          }
+        }
+        path.push(...result.decompositionPath);
+      }
+    }
+
+    return {
+      success: allActions.length > 0,
+      actions: allActions,
+      decompositionPath: path,
+    };
+  }
+
+  /** Get the underlying task network. */
+  getNetwork(): TaskNetwork {
+    return this.network;
+  }
+}

--- a/src/planner/l1-integration.ts
+++ b/src/planner/l1-integration.ts
@@ -1,0 +1,134 @@
+/**
+ * L1 planner integration — entry point for invoking the A* planner
+ * as fallback when L0 rule matching fails.
+ */
+
+import type {
+  BudgetConfig,
+  Goal,
+  L0Context,
+  L1Result,
+  NamedGoal,
+  PlannerState,
+} from "./types.ts";
+import { ActionGraph } from "./action-graph.ts";
+import { AnytimePlanner } from "./anytime-planner.ts";
+import { HTNDecomposer } from "./htn-decomposer.ts";
+import { TaskNetwork } from "./task-network.ts";
+import { validatePlan } from "./plan-validator.ts";
+import { zeroHeuristic, namedGoalHeuristic } from "./heuristic.ts";
+import type { HeuristicFn } from "./heuristic.ts";
+
+/** Configuration for the L1 planner. */
+export interface L1PlannerConfig {
+  /** Default time budget for planning (ms). */
+  defaultBudgetMs: number;
+  /** Maximum node expansions per search. */
+  maxExpansions?: number;
+}
+
+const DEFAULT_CONFIG: L1PlannerConfig = {
+  defaultBudgetMs: 5000,
+  maxExpansions: 10000,
+};
+
+export class L1Planner {
+  private graph: ActionGraph;
+  private network: TaskNetwork;
+  private decomposer: HTNDecomposer;
+  private config: L1PlannerConfig;
+
+  constructor(
+    graph: ActionGraph,
+    network: TaskNetwork,
+    config: Partial<L1PlannerConfig> = {},
+  ) {
+    this.graph = graph;
+    this.network = network;
+    this.decomposer = new HTNDecomposer(network);
+    this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  /**
+   * Plan from L0 context — the main entry point when L0 rule matcher
+   * cannot find a matching rule.
+   */
+  planFromContext(context: L0Context, budgetOverride?: BudgetConfig): L1Result {
+    const budget: BudgetConfig = budgetOverride ?? {
+      timeBudgetMs: this.config.defaultBudgetMs,
+      maxExpansions: this.config.maxExpansions,
+    };
+
+    // Select heuristic: use goal-provided heuristic if available
+    const heuristic: HeuristicFn = context.namedGoal
+      ? namedGoalHeuristic(context.namedGoal)
+      : zeroHeuristic;
+
+    // Try HTN decomposition first to expand available actions
+    const htnResult = this.decomposer.fullDecomposition(context.currentState);
+    if (htnResult.success) {
+      // Add decomposed actions to the graph
+      for (const action of htnResult.actions) {
+        this.graph.addAction(action);
+      }
+    }
+
+    // Run anytime A* search
+    const planner = new AnytimePlanner(this.graph, heuristic);
+    const anytimeResult = planner.search(
+      context.currentState,
+      context.goal,
+      budget,
+    );
+
+    const searchResult = anytimeResult.searchResult;
+
+    if (!searchResult.plan.isComplete) {
+      return {
+        success: false,
+        plan: searchResult.plan,
+        searchResult,
+        error: `L1 planner could not find complete plan: ${searchResult.nodesExpanded} nodes expanded, ${searchResult.elapsedMs}ms elapsed`,
+      };
+    }
+
+    // Validate plan before returning
+    const validation = validatePlan(
+      searchResult.plan,
+      context.currentState,
+      context.goal,
+    );
+
+    if (!validation.valid) {
+      return {
+        success: false,
+        plan: searchResult.plan,
+        searchResult,
+        validationResult: validation,
+        error: `Plan validation failed: ${validation.error}`,
+      };
+    }
+
+    return {
+      success: true,
+      plan: searchResult.plan,
+      searchResult,
+      validationResult: validation,
+    };
+  }
+
+  /** Get the action graph. */
+  getGraph(): ActionGraph {
+    return this.graph;
+  }
+
+  /** Get the task network. */
+  getNetwork(): TaskNetwork {
+    return this.network;
+  }
+
+  /** Get the HTN decomposer. */
+  getDecomposer(): HTNDecomposer {
+    return this.decomposer;
+  }
+}

--- a/src/planner/memo-cache.ts
+++ b/src/planner/memo-cache.ts
@@ -1,0 +1,74 @@
+/**
+ * Memoization cache for heuristic calculations.
+ * Caches heuristic values by state key to avoid redundant computation.
+ */
+
+import type { Goal, PlannerState } from "./types.ts";
+import type { HeuristicFn } from "./heuristic.ts";
+import { stateKey } from "./world-state.ts";
+
+/**
+ * Wrap a heuristic function with memoization.
+ * Cached values are keyed by the state's deterministic hash.
+ */
+export function memoizeHeuristic(
+  heuristic: HeuristicFn,
+  maxSize = 10000,
+): HeuristicFn {
+  const cache = new Map<string, number>();
+
+  return (state: PlannerState, goal: Goal): number => {
+    const key = stateKey(state);
+    const cached = cache.get(key);
+    if (cached !== undefined) return cached;
+
+    const value = heuristic(state, goal);
+
+    // Evict oldest entries if cache is full
+    if (cache.size >= maxSize) {
+      const firstKey = cache.keys().next().value;
+      if (firstKey !== undefined) {
+        cache.delete(firstKey);
+      }
+    }
+
+    cache.set(key, value);
+    return value;
+  };
+}
+
+/** A standalone memo cache for arbitrary key-value pairs. */
+export class MemoCache<V> {
+  private cache = new Map<string, V>();
+  private maxSize: number;
+
+  constructor(maxSize = 10000) {
+    this.maxSize = maxSize;
+  }
+
+  get(key: string): V | undefined {
+    return this.cache.get(key);
+  }
+
+  set(key: string, value: V): void {
+    if (this.cache.size >= this.maxSize) {
+      const firstKey = this.cache.keys().next().value;
+      if (firstKey !== undefined) {
+        this.cache.delete(firstKey);
+      }
+    }
+    this.cache.set(key, value);
+  }
+
+  has(key: string): boolean {
+    return this.cache.has(key);
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+
+  get size(): number {
+    return this.cache.size;
+  }
+}

--- a/src/planner/optimization.ts
+++ b/src/planner/optimization.ts
@@ -1,0 +1,117 @@
+/**
+ * Performance optimization utilities for the planner.
+ *
+ * - Goal clustering for multi-goal planning
+ * - Optimized state cloning
+ * - Fast state key computation
+ */
+
+import type { Action, Goal, PlannerState, StateValue } from "./types.ts";
+import { stateKey } from "./world-state.ts";
+import { preconditionsMet } from "./action.ts";
+
+/**
+ * Cluster multiple goals by shared state keys they depend on.
+ * Goals that touch overlapping state keys are grouped together
+ * so they can be planned for jointly.
+ */
+export function clusterGoals(
+  goals: Array<{ id: string; goal: Goal; relevantKeys: string[] }>,
+): Array<{ goalIds: string[]; combinedGoal: Goal }> {
+  // Union-find for clustering by overlapping keys
+  const keyToCluster = new Map<string, number>();
+  const clusters = new Map<number, Set<string>>();
+  let nextCluster = 0;
+
+  for (const { id, relevantKeys } of goals) {
+    let targetCluster: number | null = null;
+
+    for (const key of relevantKeys) {
+      const existing = keyToCluster.get(key);
+      if (existing !== undefined) {
+        if (targetCluster === null) {
+          targetCluster = existing;
+        } else if (targetCluster !== existing) {
+          // Merge clusters
+          const mergeFrom = clusters.get(existing)!;
+          const mergeInto = clusters.get(targetCluster)!;
+          for (const gid of mergeFrom) {
+            mergeInto.add(gid);
+          }
+          for (const k of keyToCluster.keys()) {
+            if (keyToCluster.get(k) === existing) {
+              keyToCluster.set(k, targetCluster);
+            }
+          }
+          clusters.delete(existing);
+        }
+      }
+    }
+
+    if (targetCluster === null) {
+      targetCluster = nextCluster++;
+      clusters.set(targetCluster, new Set());
+    }
+
+    clusters.get(targetCluster)!.add(id);
+    for (const key of relevantKeys) {
+      keyToCluster.set(key, targetCluster);
+    }
+  }
+
+  // Build result
+  const goalMap = new Map(goals.map((g) => [g.id, g.goal]));
+  const result: Array<{ goalIds: string[]; combinedGoal: Goal }> = [];
+
+  for (const goalIds of clusters.values()) {
+    const ids = [...goalIds];
+    const subGoals = ids.map((id) => goalMap.get(id)!);
+    const combinedGoal: Goal = (state) => subGoals.every((g) => g(state));
+    result.push({ goalIds: ids, combinedGoal });
+  }
+
+  return result;
+}
+
+/**
+ * Pre-filter actions by checking which state keys each action's preconditions
+ * actually read. This allows skipping actions that can't possibly be affected
+ * by a state change.
+ */
+export function filterActionsByChangedKeys(
+  actions: Action[],
+  state: PlannerState,
+  changedKeys: Set<string>,
+): Action[] {
+  // If no keys changed, all previously applicable actions remain applicable
+  if (changedKeys.size === 0) return actions.filter((a) => preconditionsMet(a, state));
+
+  return actions.filter((a) => preconditionsMet(a, state));
+}
+
+/**
+ * Fast incremental state key update.
+ * Instead of recomputing the full state key, updates only changed parts.
+ */
+export function incrementalStateKey(
+  baseKey: string,
+  changedKey: string,
+  newValue: StateValue,
+): string {
+  // For simplicity and correctness, just recompute
+  // The stateKey function is already fast for typical state sizes
+  // This function exists as an optimization point for future tuning
+  const pattern = new RegExp(`${escapeRegex(changedKey)}=[^|]*`);
+  const replacement = `${changedKey}=${String(newValue)}`;
+
+  if (pattern.test(baseKey)) {
+    return baseKey.replace(pattern, replacement);
+  }
+
+  // Key didn't exist before — need full recompute
+  return baseKey;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/planner/plan-validator.ts
+++ b/src/planner/plan-validator.ts
@@ -1,0 +1,83 @@
+/**
+ * Plan validator — validates a plan by executing it on a world state copy.
+ *
+ * Ensures:
+ * - All preconditions are met before each action
+ * - Effects are properly applied
+ * - The final state satisfies the goal
+ * - Original state is never modified
+ */
+
+import type { Goal, Plan, PlannerState, ValidationResult } from "./types.ts";
+import { cloneState } from "./world-state.ts";
+import { executePlan } from "./executor.ts";
+
+/**
+ * Validate a plan by executing it on a copy of the world state.
+ *
+ * @param plan - The plan to validate
+ * @param initialState - The starting world state (not modified)
+ * @param goal - Optional goal predicate to check after execution
+ * @returns ValidationResult indicating success/failure
+ */
+export function validatePlan(
+  plan: Plan,
+  initialState: PlannerState,
+  goal?: Goal,
+): ValidationResult {
+  // Execute on a clone to ensure no side effects
+  const stateCopy = cloneState(initialState);
+  const execResult = executePlan(plan, stateCopy);
+
+  if (!execResult.success) {
+    return {
+      valid: false,
+      failedAtIndex: execResult.failedAtIndex,
+      finalState: execResult.finalState,
+      error: execResult.steps[execResult.failedAtIndex]?.error ??
+        "Unknown execution failure",
+    };
+  }
+
+  // If a goal is provided, check that the final state satisfies it
+  if (goal && !goal(execResult.finalState)) {
+    return {
+      valid: false,
+      failedAtIndex: -1,
+      finalState: execResult.finalState,
+      error: "Plan executed successfully but final state does not satisfy goal",
+    };
+  }
+
+  return {
+    valid: true,
+    failedAtIndex: -1,
+    finalState: execResult.finalState,
+  };
+}
+
+/**
+ * Validate that the original state is not modified by validation.
+ * Returns true if original state is preserved.
+ */
+export function validateNoSideEffects(
+  plan: Plan,
+  initialState: PlannerState,
+): { preserved: boolean; originalState: PlannerState } {
+  const originalSnapshot = cloneState(initialState);
+  validatePlan(plan, initialState);
+
+  // Check that original state was not mutated
+  const keys = new Set([
+    ...Object.keys(originalSnapshot),
+    ...Object.keys(initialState),
+  ]);
+
+  for (const key of keys) {
+    if (originalSnapshot[key] !== initialState[key]) {
+      return { preserved: false, originalState: originalSnapshot };
+    }
+  }
+
+  return { preserved: true, originalState: originalSnapshot };
+}

--- a/src/planner/plan.ts
+++ b/src/planner/plan.ts
@@ -1,0 +1,61 @@
+/**
+ * Plan construction and manipulation utilities.
+ */
+
+import type { Action, Plan, SearchNode } from "./types.ts";
+
+/** Create an empty plan. */
+export function emptyPlan(): Plan {
+  return {
+    actions: [],
+    totalCost: 0,
+    isComplete: false,
+  };
+}
+
+/** Reconstruct a plan by following parent pointers from a search node. */
+export function reconstructPlan(node: SearchNode): Plan {
+  const actions: Action[] = [];
+  let current: SearchNode | null = node;
+
+  while (current !== null) {
+    if (current.action !== null) {
+      actions.unshift(current.action);
+    }
+    current = current.parent;
+  }
+
+  const totalCost = actions.reduce((sum, a) => sum + a.cost, 0);
+
+  return {
+    actions,
+    totalCost,
+    isComplete: true,
+  };
+}
+
+/** Create a partial (incomplete) plan from the best node found so far. */
+export function partialPlan(node: SearchNode, lowerBound: number): Plan {
+  const plan = reconstructPlan(node);
+  return {
+    ...plan,
+    isComplete: false,
+    lowerBound,
+  };
+}
+
+/** Merge an already-executed prefix with a new plan suffix. */
+export function mergePlans(executed: Action[], suffix: Plan): Plan {
+  const executedCost = executed.reduce((sum, a) => sum + a.cost, 0);
+  return {
+    actions: [...executed, ...suffix.actions],
+    totalCost: executedCost + suffix.totalCost,
+    isComplete: suffix.isComplete,
+    lowerBound: suffix.lowerBound,
+  };
+}
+
+/** Get the remaining actions in a plan starting from a given index. */
+export function remainingActions(plan: Plan, fromIndex: number): Action[] {
+  return plan.actions.slice(fromIndex);
+}

--- a/src/planner/replan-manager.ts
+++ b/src/planner/replan-manager.ts
@@ -1,0 +1,131 @@
+/**
+ * Replan manager — handles mid-execution state changes by replanning.
+ *
+ * When the world state changes during plan execution:
+ * 1. Detect which plan steps are invalidated
+ * 2. Preserve already-executed steps
+ * 3. Invoke A* from current state with remaining goals
+ * 4. Merge new plan with executed prefix
+ */
+
+import type {
+  BudgetConfig,
+  Goal,
+  Plan,
+  PlannerState,
+  SearchResult,
+} from "./types.ts";
+import type { ActionGraph } from "./action-graph.ts";
+import type { HeuristicFn } from "./heuristic.ts";
+import { aStarSearch } from "./a-star.ts";
+import { detectInvalidation } from "./state-change-detector.ts";
+import { mergePlans } from "./plan.ts";
+import { validatePlan } from "./plan-validator.ts";
+
+/** Result of a replan attempt. */
+export interface ReplanResult {
+  /** Whether replanning succeeded. */
+  success: boolean;
+  /** The new merged plan (executed prefix + new suffix). */
+  plan: Plan;
+  /** Index from which the plan was replanned. */
+  replanFromIndex: number;
+  /** The A* search result for the new suffix. */
+  searchResult?: SearchResult;
+  /** Error message if replanning failed. */
+  error?: string;
+}
+
+export class ReplanManager {
+  private graph: ActionGraph;
+  private heuristic: HeuristicFn;
+  private goal: Goal;
+
+  constructor(graph: ActionGraph, heuristic: HeuristicFn, goal: Goal) {
+    this.graph = graph;
+    this.heuristic = heuristic;
+    this.goal = goal;
+  }
+
+  /**
+   * Check if a state change requires replanning, and if so, produce a new plan.
+   *
+   * @param currentPlan - The plan being executed
+   * @param executedUpTo - How many actions have been executed (0-based exclusive)
+   * @param expectedState - The state we expected after executing those actions
+   * @param actualState - The actual current world state
+   * @param budget - Time/expansion budget for replanning
+   */
+  checkAndReplan(
+    currentPlan: Plan,
+    executedUpTo: number,
+    expectedState: PlannerState,
+    actualState: PlannerState,
+    budget: BudgetConfig,
+  ): ReplanResult {
+    // Detect if plan is invalidated
+    const change = detectInvalidation(
+      currentPlan,
+      executedUpTo,
+      expectedState,
+      actualState,
+    );
+
+    // No state change or plan still valid
+    if (change === null || !change.planInvalidated) {
+      return {
+        success: true,
+        plan: currentPlan,
+        replanFromIndex: -1,
+      };
+    }
+
+    // Plan is invalidated — replan from current actual state
+    const replanFromIndex = change.invalidatedFromIndex;
+    const executedActions = currentPlan.actions.slice(0, executedUpTo);
+
+    // Run A* from actual state
+    const searchResult = aStarSearch(
+      this.graph,
+      actualState,
+      this.goal,
+      this.heuristic,
+      {
+        timeBudgetMs: budget.timeBudgetMs,
+        maxExpansions: budget.maxExpansions,
+      },
+    );
+
+    if (!searchResult.plan.isComplete) {
+      return {
+        success: false,
+        plan: currentPlan,
+        replanFromIndex,
+        searchResult,
+        error: "Replanning could not find a complete plan from current state",
+      };
+    }
+
+    // Validate the new plan
+    const validation = validatePlan(searchResult.plan, actualState, this.goal);
+    if (!validation.valid) {
+      return {
+        success: false,
+        plan: currentPlan,
+        replanFromIndex,
+        searchResult,
+        error: `Replan validation failed: ${validation.error}`,
+      };
+    }
+
+    // Merge executed prefix with new plan
+    const mergedPlan = mergePlans(executedActions, searchResult.plan);
+
+    return {
+      success: true,
+      plan: mergedPlan,
+      replanFromIndex,
+      searchResult,
+    };
+  }
+}

--- a/src/planner/state-cache.ts
+++ b/src/planner/state-cache.ts
@@ -1,0 +1,58 @@
+/**
+ * State cache — caches evaluated states in the closed set for reuse.
+ * Optimizes state comparison and lookup.
+ */
+
+import type { PlannerState, SearchNode } from "./types.ts";
+import { stateKey } from "./world-state.ts";
+
+/** Cached state entry with metadata. */
+export interface CachedState {
+  state: PlannerState;
+  key: string;
+  bestGScore: number;
+  node: SearchNode;
+}
+
+export class StateCache {
+  private cache = new Map<string, CachedState>();
+
+  /** Add or update a state in the cache. */
+  put(node: SearchNode): void {
+    const existing = this.cache.get(node.stateKey);
+    if (existing && existing.bestGScore <= node.gScore) return;
+
+    this.cache.set(node.stateKey, {
+      state: node.state,
+      key: node.stateKey,
+      bestGScore: node.gScore,
+      node,
+    });
+  }
+
+  /** Look up a state by its key. */
+  get(key: string): CachedState | undefined {
+    return this.cache.get(key);
+  }
+
+  /** Check if a state has been visited with a better or equal g-score. */
+  hasBetterOrEqual(key: string, gScore: number): boolean {
+    const existing = this.cache.get(key);
+    return existing !== undefined && existing.bestGScore <= gScore;
+  }
+
+  /** Check if a state key is in the cache. */
+  has(key: string): boolean {
+    return this.cache.has(key);
+  }
+
+  /** Clear the cache. */
+  clear(): void {
+    this.cache.clear();
+  }
+
+  /** Get the number of cached states. */
+  get size(): number {
+    return this.cache.size;
+  }
+}

--- a/src/planner/state-change-detector.ts
+++ b/src/planner/state-change-detector.ts
@@ -1,0 +1,83 @@
+/**
+ * State change detector — monitors world state for changes that
+ * invalidate the current plan during execution.
+ */
+
+import type { Action, Plan, PlannerState } from "./types.ts";
+import { preconditionsMet } from "./action.ts";
+
+/** Describes a detected state change that affects the plan. */
+export interface StateChange {
+  /** Keys that changed. */
+  changedKeys: string[];
+  /** Index of first plan action invalidated by this change. */
+  invalidatedFromIndex: number;
+  /** Whether any remaining actions are invalidated. */
+  planInvalidated: boolean;
+}
+
+/**
+ * Compare two states and return the set of keys that differ.
+ */
+export function diffStates(
+  before: PlannerState,
+  after: PlannerState,
+): string[] {
+  const allKeys = new Set([
+    ...Object.keys(before),
+    ...Object.keys(after),
+  ]);
+  const changed: string[] = [];
+  for (const key of allKeys) {
+    if (before[key] !== after[key]) {
+      changed.push(key);
+    }
+  }
+  return changed;
+}
+
+/**
+ * Detect whether a state change invalidates any remaining plan actions.
+ *
+ * @param plan - The current plan
+ * @param fromIndex - The index of the next action to execute
+ * @param expectedState - The state we expected at this point
+ * @param actualState - The actual current world state
+ * @returns StateChange describing the impact, or null if plan is still valid
+ */
+export function detectInvalidation(
+  plan: Plan,
+  fromIndex: number,
+  expectedState: PlannerState,
+  actualState: PlannerState,
+): StateChange | null {
+  const changedKeys = diffStates(expectedState, actualState);
+  if (changedKeys.length === 0) return null;
+
+  // Check if any remaining action's preconditions are broken
+  // by simulating from the actual state
+  let currentState = actualState;
+  for (let i = fromIndex; i < plan.actions.length; i++) {
+    const action = plan.actions[i];
+    if (!preconditionsMet(action, currentState)) {
+      return {
+        changedKeys,
+        invalidatedFromIndex: i,
+        planInvalidated: true,
+      };
+    }
+    // Simulate applying the action to check subsequent steps
+    let nextState = currentState;
+    for (const eff of action.effects) {
+      nextState = eff(nextState);
+    }
+    currentState = nextState;
+  }
+
+  // State changed but plan is still valid
+  return {
+    changedKeys,
+    invalidatedFromIndex: -1,
+    planInvalidated: false,
+  };
+}

--- a/src/planner/task-network.ts
+++ b/src/planner/task-network.ts
@@ -1,0 +1,107 @@
+/**
+ * Task network — stores composite and primitive tasks for HTN decomposition.
+ *
+ * A task network maps task IDs to either:
+ * - CompositeTask: decomposes into sub-tasks
+ * - Action: primitive executable action
+ */
+
+import type { Action, CompositeTask, HierarchyLevel, PlannerState } from "./types.ts";
+import { isPrimitiveLevel } from "./hierarchy-levels.ts";
+
+/** A task in the network can be composite or primitive. */
+export type TaskEntry =
+  | { type: "composite"; task: CompositeTask }
+  | { type: "primitive"; action: Action };
+
+export class TaskNetwork {
+  private tasks = new Map<string, TaskEntry>();
+
+  /** Register a composite task. */
+  addCompositeTask(task: CompositeTask): void {
+    this.tasks.set(task.id, { type: "composite", task });
+  }
+
+  /** Register a primitive action. */
+  addPrimitiveAction(action: Action): void {
+    this.tasks.set(action.id, { type: "primitive", action });
+  }
+
+  /** Look up a task by ID. */
+  getTask(id: string): TaskEntry | undefined {
+    return this.tasks.get(id);
+  }
+
+  /** Get all tasks at a specific hierarchy level. */
+  getTasksAtLevel(level: HierarchyLevel): TaskEntry[] {
+    const result: TaskEntry[] = [];
+    for (const entry of this.tasks.values()) {
+      if (entry.type === "composite" && entry.task.level === level) {
+        result.push(entry);
+      } else if (entry.type === "primitive" && entry.action.level === level) {
+        result.push(entry);
+      }
+    }
+    return result;
+  }
+
+  /** Get all composite tasks. */
+  getCompositeTasks(): CompositeTask[] {
+    const result: CompositeTask[] = [];
+    for (const entry of this.tasks.values()) {
+      if (entry.type === "composite") result.push(entry.task);
+    }
+    return result;
+  }
+
+  /** Get all primitive actions. */
+  getPrimitiveActions(): Action[] {
+    const result: Action[] = [];
+    for (const entry of this.tasks.values()) {
+      if (entry.type === "primitive") result.push(entry.action);
+    }
+    return result;
+  }
+
+  /**
+   * Recursively decompose a task ID into primitive actions.
+   * Returns null if decomposition fails (e.g., unknown task ID, precondition not met).
+   */
+  decompose(taskId: string, state: PlannerState): Action[] | null {
+    const entry = this.tasks.get(taskId);
+    if (!entry) return null;
+
+    if (entry.type === "primitive") {
+      return [entry.action];
+    }
+
+    const composite = entry.task;
+
+    // Check precondition if present
+    if (composite.precondition && !composite.precondition(state)) {
+      return null;
+    }
+
+    const subItems = composite.decompose(state);
+    const result: Action[] = [];
+
+    for (const item of subItems) {
+      if (typeof item === "string") {
+        // Sub-task ID — recurse
+        const subActions = this.decompose(item, state);
+        if (subActions === null) return null;
+        result.push(...subActions);
+      } else {
+        // Inline primitive action
+        result.push(item);
+      }
+    }
+
+    return result;
+  }
+
+  /** Get the number of tasks in the network. */
+  get size(): number {
+    return this.tasks.size;
+  }
+}

--- a/src/planner/types.ts
+++ b/src/planner/types.ts
@@ -1,0 +1,166 @@
+/**
+ * Core type definitions for the L1 A* planner system.
+ *
+ * The planner operates on flat key-value state maps where:
+ * - World states are nodes in the action graph
+ * - Actions are directed edges between states
+ * - A* search finds least-cost paths from initial to goal state
+ */
+
+// ── State types ──────────────────────────────────────────────────────────────
+
+/** Primitive values that can appear in planner state. */
+export type StateValue = string | number | boolean | null;
+
+/** Immutable flat key-value map representing a planner world state. */
+export type PlannerState = Readonly<Record<string, StateValue>>;
+
+/** A predicate that tests whether a state satisfies some condition. */
+export type StatePredicate = (state: PlannerState) => boolean;
+
+/** A function that produces a new state from an existing one (must not mutate input). */
+export type StateTransform = (state: PlannerState) => PlannerState;
+
+// ── Hierarchy ────────────────────────────────────────────────────────────────
+
+/** HTN decomposition levels, from most abstract to most concrete. */
+export type HierarchyLevel = "portfolio" | "project" | "domain" | "action";
+
+/** Ordered hierarchy from abstract to concrete. */
+export const HIERARCHY_ORDER: readonly HierarchyLevel[] = [
+  "portfolio",
+  "project",
+  "domain",
+  "action",
+] as const;
+
+// ── Action types ─────────────────────────────────────────────────────────────
+
+/** A primitive action that can be executed in the planner. */
+export interface Action {
+  id: string;
+  name: string;
+  cost: number;
+  level: HierarchyLevel;
+  preconditions: StatePredicate[];
+  effects: StateTransform[];
+  /** Optional metadata for HTN decomposition. */
+  meta?: Record<string, unknown>;
+}
+
+/** A composite task in the HTN hierarchy that decomposes into sub-tasks. */
+export interface CompositeTask {
+  id: string;
+  name: string;
+  level: HierarchyLevel;
+  /** Returns ordered list of sub-task IDs or Actions to decompose into. */
+  decompose: (state: PlannerState) => Array<string | Action>;
+  /** Optional precondition for applicability at this level. */
+  precondition?: StatePredicate;
+}
+
+// ── Plan types ───────────────────────────────────────────────────────────────
+
+/** A sequence of actions forming a plan. */
+export interface Plan {
+  actions: Action[];
+  totalCost: number;
+  isComplete: boolean;
+  /** Lower bound on optimal cost (for anytime search). */
+  lowerBound?: number;
+}
+
+/** Result of plan validation. */
+export interface ValidationResult {
+  valid: boolean;
+  /** Index of first action that failed validation (-1 if all passed). */
+  failedAtIndex: number;
+  /** Final state after executing valid actions. */
+  finalState: PlannerState;
+  /** Error message if validation failed. */
+  error?: string;
+}
+
+// ── Goal types ───────────────────────────────────────────────────────────────
+
+/** A goal is a predicate on world state that the planner tries to satisfy. */
+export type Goal = StatePredicate;
+
+/** Named goal with metadata. */
+export interface NamedGoal {
+  id: string;
+  name: string;
+  test: Goal;
+  /** Optional heuristic estimate of cost to achieve this goal from a given state. */
+  heuristic?: (state: PlannerState) => number;
+}
+
+// ── Search types ─────────────────────────────────────────────────────────────
+
+/** A node in the A* search graph. */
+export interface SearchNode {
+  state: PlannerState;
+  stateKey: string;
+  parent: SearchNode | null;
+  action: Action | null;
+  /** Cost from start (g-score). */
+  gScore: number;
+  /** Estimated total cost (f-score = g + h). */
+  fScore: number;
+}
+
+/** Configuration for A* search. */
+export interface SearchConfig {
+  /** Maximum number of nodes to expand before stopping. */
+  maxExpansions?: number;
+  /** Time budget in milliseconds. */
+  timeBudgetMs?: number;
+  /** Weight for weighted A* (>1 trades optimality for speed). */
+  weight?: number;
+}
+
+/** Result of an A* search. */
+export interface SearchResult {
+  plan: Plan;
+  nodesExpanded: number;
+  nodesGenerated: number;
+  elapsedMs: number;
+  /** Whether search was exhaustive or cut short by budget. */
+  exhaustive: boolean;
+}
+
+// ── Budget types ─────────────────────────────────────────────────────────────
+
+/** Budget configuration for anytime planning. */
+export interface BudgetConfig {
+  timeBudgetMs: number;
+  maxExpansions?: number;
+}
+
+/** Status of budget consumption. */
+export interface BudgetStatus {
+  elapsedMs: number;
+  expansionsUsed: number;
+  timeRemaining: number;
+  isExhausted: boolean;
+}
+
+// ── L0/L1 bridge types ──────────────────────────────────────────────────────
+
+/** Context passed from L0 rule matcher to L1 planner. */
+export interface L0Context {
+  currentState: PlannerState;
+  goal: Goal;
+  namedGoal?: NamedGoal;
+  /** Why L0 could not handle this (e.g., "no matching rule"). */
+  reason: string;
+}
+
+/** Result from L1 planner back to the system. */
+export interface L1Result {
+  success: boolean;
+  plan?: Plan;
+  validationResult?: ValidationResult;
+  searchResult?: SearchResult;
+  error?: string;
+}

--- a/src/planner/world-state.ts
+++ b/src/planner/world-state.ts
@@ -1,0 +1,70 @@
+/**
+ * Immutable world state utilities for the planner.
+ * Provides cloning, comparison, and hashing for PlannerState.
+ */
+
+import type { PlannerState, StateValue } from "./types.ts";
+
+/** Create a deep clone of a planner state. */
+export function cloneState(state: PlannerState): PlannerState {
+  return { ...state };
+}
+
+/** Apply a set of key-value updates to a state, returning a new state. */
+export function applyUpdate(
+  state: PlannerState,
+  updates: Record<string, StateValue>,
+): PlannerState {
+  return { ...state, ...updates };
+}
+
+/**
+ * Produce a deterministic hash key for a planner state.
+ * Keys are sorted alphabetically for consistency.
+ */
+export function stateKey(state: PlannerState): string {
+  const keys = Object.keys(state).sort();
+  const parts: string[] = [];
+  for (const k of keys) {
+    parts.push(`${k}=${String(state[k])}`);
+  }
+  return parts.join("|");
+}
+
+/** Check if two planner states are equal (same keys and values). */
+export function statesEqual(a: PlannerState, b: PlannerState): boolean {
+  const aKeys = Object.keys(a).sort();
+  const bKeys = Object.keys(b).sort();
+  if (aKeys.length !== bKeys.length) return false;
+  for (let i = 0; i < aKeys.length; i++) {
+    if (aKeys[i] !== bKeys[i]) return false;
+    if (a[aKeys[i]] !== b[bKeys[i]]) return false;
+  }
+  return true;
+}
+
+/** Create an empty planner state. */
+export function emptyState(): PlannerState {
+  return Object.freeze({});
+}
+
+/** Create a planner state from key-value pairs. */
+export function createState(
+  entries: Record<string, StateValue>,
+): PlannerState {
+  return Object.freeze({ ...entries });
+}
+
+/** Get a subset of state keys. */
+export function projectState(
+  state: PlannerState,
+  keys: string[],
+): PlannerState {
+  const result: Record<string, StateValue> = {};
+  for (const k of keys) {
+    if (k in state) {
+      result[k] = state[k];
+    }
+  }
+  return Object.freeze(result);
+}


### PR DESCRIPTION
## Summary

Implement action graph (world states as nodes, actions as edges), A* search with cost bounds (budget-bounded, anytime algorithm — returns best plan within budget and improves with more time), plan validation (execute on world state copy before committing), replan on mid-execution state change, and HTN decomposition at top levels (portfolio→project→domain→action). L1 invoked when L0 rule matcher finds no match.

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive planning docs: HTN decomposition guide, L0→L1 integration guide, planner API reference, and planner architecture overview.

* **New Features**
  * New planning subsystem: budgeted A* search, anytime refinement, HTN decomposition, L0 rule matcher → L1 planner bridge, plan execution/validation, replanning, heuristics, caching and goal clustering utilities.

* **Tests**
  * Added extensive unit and integration test coverage across planner components.

* **Chores**
  * Updated lockfile metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->