### PR TITLE
M7: Ava as L2 Planner — LLM-A* hybrid, confidence scoring, plan learning flywheel

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1775591627181-yh8cwsbfu",
-  "startedAt": "2026-04-08T00:06:52.964Z"
+  "featureId": "feature-1775585786162-dnqkm006",
+  "startedAt": "2026-04-08T00:22:03.548Z"
 }

--- a/docs/L2_PLANNER_API.md
+++ b/docs/L2_PLANNER_API.md
@@ -1,0 +1,74 @@
+# L2 Planner API Reference
+
+## L2Dispatcher
+
+Main entry point for the planning pipeline.
+
+```typescript
+import { L2Dispatcher } from "./src/planner/dispatcher.ts";
+import { ActionGraph } from "./src/planner/action-graph.ts";
+
+const graph = new ActionGraph();
+graph.addActions([...]);
+
+const dispatcher = new L2Dispatcher(graph, {
+  routing: { l2ConfidenceThreshold: 0.5 },
+  a2aClient: myA2AClient,
+  onL3Escalation: (ctx, result) => { /* handle escalation */ },
+});
+
+const result = await dispatcher.resolve(state, goal, namedGoal);
+```
+
+### L2Result
+
+```typescript
+interface L2Result {
+  success: boolean;
+  plan?: Plan;
+  confidence: ConfidenceScore;
+  escalatedToL3: boolean;
+  error?: string;
+  planId: string;
+}
+```
+
+## A2AClient Interface
+
+Implement this to connect Ava (or any LLM) to the hybrid planner.
+
+```typescript
+interface A2AClient {
+  proposePlans(prompt: A2APrompt, maxCandidates: number): Promise<CandidatePlan[]>;
+}
+```
+
+## RoutingConfig
+
+```typescript
+interface RoutingConfig {
+  l0ConfidenceThreshold: number;  // default: 0.7
+  l1ConfidenceThreshold: number;  // default: 0.6
+  l2ConfidenceThreshold: number;  // default: 0.5
+  maxCandidates: number;          // default: 3
+  l2TimeBudgetMs: number;         // default: 30000
+  tryL1BeforeL2: boolean;         // default: true
+}
+```
+
+## Metrics API
+
+```typescript
+const metrics = dispatcher.getMetrics();
+const summary = metrics.getSummary(3600_000); // last hour
+console.log(summary.escalationRate);
+console.log(summary.successRate);
+```
+
+## Learning Registry
+
+```typescript
+const registry = dispatcher.getRuleRegistry();
+const stats = registry.getStats();
+console.log(stats.totalRules, stats.promotedRules);
+```

--- a/docs/L2_PLANNER_ARCHITECTURE.md
+++ b/docs/L2_PLANNER_ARCHITECTURE.md
@@ -1,0 +1,64 @@
+# L2 Planner Architecture
+
+## Overview
+
+The L2 planner is a hybrid LLM-A* planning system that sits between the deterministic L0/L1 layers and human escalation (L3). It combines creative plan generation from an LLM agent (Ava) with rigorous A* validation and optimization.
+
+## Layer Model
+
+```
+L0 (Deterministic Rules) → L1 (A* Search) → L2 (LLM-A* Hybrid) → L3 (Human)
+```
+
+- **L0**: Pattern-matching rule engine. Fast, deterministic, zero-cost. Handles ~80% of cases.
+- **L1**: A* search with HTN decomposition. Finds optimal plans within budget. Handles ~15%.
+- **L2**: LLM proposes creative plans, A* validates and optimizes. Handles novel situations.
+- **L3**: Human-in-the-loop for cases where L2 confidence is too low.
+
+## L2 Hybrid Planning Flow
+
+1. **Routing**: `L2Router` intercepts L0/L1 failures or low-confidence results
+2. **Proposal**: `A2AProposer` sends structured prompt to Ava (LLM) via A2A protocol
+3. **Validation**: `AStarValidator` checks each candidate plan against A* simulation
+4. **Optimization**: A* attempts to find a lower-cost alternative
+5. **Confidence**: `ConfidenceScorer` evaluates plan quality (feasibility, goal alignment, cost, constraints)
+6. **Escalation**: `EscalationTrigger` routes low-confidence plans to L3
+
+## Learning Flywheel
+
+Every successful L2 plan is fed into the learning flywheel:
+
+1. `RuleExtractor` extracts generalizable conditions from the plan
+2. `PlanConverter` creates a `LearnedRule` in the `RuleRegistry`
+3. On subsequent requests, `PatternMatcher` checks learned rules first
+4. After enough successful executions, `RuleMigration` promotes the rule to L0
+5. Result: escalation rate decreases over time as the system learns
+
+## Confidence Scoring
+
+Confidence is a weighted composite of:
+- **Feasibility** (35%): Can actions execute in order?
+- **Goal Alignment** (30%): Does the final state satisfy the goal?
+- **Cost Efficiency** (15%): Is the cost reasonable?
+- **Constraint Satisfaction** (20%): Are all constraints met?
+
+## Configuration
+
+See `src/config/routing-config.yaml` for tunable thresholds.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/planner/l2-router.ts` | Top-level L0→L1→L2→L3 routing |
+| `src/planner/hybrid-planner.ts` | LLM-A* hybrid planning engine |
+| `src/planner/a2a-proposer.ts` | LLM candidate generation via A2A |
+| `src/planner/astar-validator.ts` | A* plan validation and optimization |
+| `src/planner/confidence-scorer.ts` | Plan quality scoring |
+| `src/planner/escalation-trigger.ts` | L3 escalation decisions |
+| `src/planner/dispatcher.ts` | Full pipeline dispatcher |
+| `src/learning/plan-converter.ts` | Plan → rule conversion |
+| `src/learning/rule-registry.ts` | Learned rule storage |
+| `src/learning/rule-migration.ts` | L2 → L0 rule promotion |
+| `src/monitoring/l2-metrics.ts` | Invocation/success telemetry |
+| `src/monitoring/escalation-tracker.ts` | Escalation trend tracking |

--- a/docs/OPERATIONAL_RUNBOOK.md
+++ b/docs/OPERATIONAL_RUNBOOK.md
@@ -1,0 +1,78 @@
+# L2 Planner Operational Runbook
+
+## Monitoring
+
+### Dashboard
+
+See `monitoring/dashboards/l2-planner-dashboard.json` for the dashboard definition.
+
+Key panels:
+- **Escalation Rate**: Should trend downward over time
+- **Success Rate**: Target > 80%
+- **Confidence Distribution**: Healthy system has most plans > 0.7
+- **Learned Rules Count**: Should grow steadily
+
+### Alerts
+
+| Condition | Severity | Action |
+|-----------|----------|--------|
+| Escalation rate > 50% (1h window) | Warning | Check L2 planner health |
+| Escalation rate > 80% (1h window) | Critical | Check A2A connectivity and action graph |
+| P95 latency > 30s | Warning | Check A2A response times |
+| Learned rule failure rate > 30% | Warning | Trigger rule audit |
+
+## Common Operations
+
+### Adjusting Confidence Thresholds
+
+Edit `src/config/routing-config.yaml`:
+```yaml
+routing:
+  l2_confidence_threshold: 0.5  # Lower = more autonomous, higher = more escalations
+```
+
+### Inspecting Learned Rules
+
+```typescript
+const registry = dispatcher.getRuleRegistry();
+const stats = registry.getStats();
+const rules = registry.getAll();
+```
+
+### Rolling Back a Learned Rule
+
+```typescript
+const migration = new RuleMigration(registry, versioning, auditor);
+migration.rollback("rule-id");
+```
+
+### Checking Escalation Trends
+
+```typescript
+const tracker = dispatcher.getEscalationTracker();
+const trend = tracker.getTrend(3600_000); // 1-hour buckets
+const reasons = tracker.getTopReasons(10);
+```
+
+## Troubleshooting
+
+### High Escalation Rate
+
+1. Check A2A client connectivity (is Ava responding?)
+2. Verify action graph has sufficient actions for the goal types
+3. Check if confidence threshold is too high
+4. Review top escalation reasons: `tracker.getTopReasons(10)`
+
+### Learned Rule Causing Failures
+
+1. Identify the rule: `registry.findByGoal(goalPattern)`
+2. Check failure count: `rule.failureCount`
+3. Rollback if needed: `migration.rollback(rule.id)`
+4. Audit trail: `auditor.getForRule(rule.id)`
+
+### L2 Planner Not Learning
+
+1. Check minimum learning confidence: plans below 0.8 are not extracted
+2. Check promotion threshold: rules need 3 successes before promotion
+3. Verify registry is not at max capacity (500 default)
+4. Check if plans are too long (max 10 actions for extraction)

--- a/docs/PLAN_LEARNING_FLYWHEEL.md
+++ b/docs/PLAN_LEARNING_FLYWHEEL.md
@@ -1,0 +1,72 @@
+# Plan Learning Flywheel
+
+## Concept
+
+The learning flywheel converts expensive L2 (LLM-assisted) plans into cheap L0 (deterministic) rules. Over time, this drives the escalation rate toward zero as the system learns to handle more situations autonomously.
+
+## Cycle
+
+```
+Request → L2 (LLM + A*) → Successful Plan → Extract Rule → Register Rule
+                                                              ↓
+Request → Check Learned Rules → Match! → Use Learned Plan → Record Success
+                                                              ↓
+                                              Promote to L0 (after N successes)
+```
+
+## Components
+
+### RuleExtractor
+
+Extracts generalizable conditions from successful L2 plans:
+- Uses the plan's first action preconditions as rule conditions
+- Captures relevant state keys from the initial state
+- Configurable minimum confidence threshold (default: 0.8)
+
+### RuleRegistry
+
+Stores learned rules with:
+- Success/failure tracking
+- Version history
+- Active/inactive status
+- Promotion tracking (to L0)
+- Automatic pruning of low-performing rules
+
+### PatternMatcher
+
+Checks incoming requests against learned rules:
+- Exact goal pattern matching
+- State condition evaluation
+- Selects best rule by: success rate → confidence → cost
+
+### PlanConverter
+
+Orchestrates the conversion pipeline:
+- Validates plan eligibility
+- Creates or updates rules
+- Triggers promotion check
+
+### RuleMigration
+
+Safe promotion from L2 registry to L0:
+- Version snapshots before promotion
+- Audit trail of all events
+- Auto-rollback on performance degradation
+
+## Configuration
+
+```yaml
+learning:
+  min_learning_confidence: 0.8
+  promotion_threshold: 3
+  max_learned_rules: 500
+  auto_rollback_enabled: true
+```
+
+## Monitoring
+
+Track flywheel health via:
+- `rulesLearned`: Total rules in registry
+- `rulesPromoted`: Rules promoted to L0
+- `l0HitRate`: Ratio of requests handled by learned rules
+- `escalationRateDelta`: Change in escalation rate (negative = improving)

--- a/monitoring/dashboards/l2-planner-dashboard.json
+++ b/monitoring/dashboards/l2-planner-dashboard.json
@@ -1,0 +1,72 @@
+{
+  "dashboard": {
+    "title": "L2 Planner Dashboard",
+    "description": "Monitors L2 hybrid planner performance, escalation rates, and learning flywheel progress",
+    "panels": [
+      {
+        "title": "L2 Invocation Rate",
+        "type": "timeseries",
+        "metric": "l2_invocation_count",
+        "description": "Number of L2 planner invocations over time"
+      },
+      {
+        "title": "Success Rate",
+        "type": "gauge",
+        "metric": "l2_success_rate",
+        "thresholds": {
+          "green": 0.8,
+          "yellow": 0.5,
+          "red": 0.0
+        }
+      },
+      {
+        "title": "Escalation Rate (L2 → L3)",
+        "type": "timeseries",
+        "metric": "escalation_rate",
+        "description": "Rate of escalations from L2 to L3 (human). Should decrease over time."
+      },
+      {
+        "title": "Confidence Distribution",
+        "type": "histogram",
+        "metric": "l2_confidence_distribution",
+        "description": "Distribution of L2 plan confidence scores"
+      },
+      {
+        "title": "Learned Rules Count",
+        "type": "stat",
+        "metric": "learned_rules_total",
+        "description": "Total number of rules in the learned rule registry"
+      },
+      {
+        "title": "Rules Promoted to L0",
+        "type": "stat",
+        "metric": "rules_promoted_to_l0",
+        "description": "Number of learned rules promoted to L0 deterministic planner"
+      },
+      {
+        "title": "Layer Distribution",
+        "type": "piechart",
+        "metric": "layer_distribution",
+        "description": "Breakdown of requests handled by each layer (L0/L1/L2/L3)"
+      },
+      {
+        "title": "Average Latency",
+        "type": "timeseries",
+        "metric": "l2_avg_latency_ms",
+        "description": "Average L2 planning latency in milliseconds"
+      },
+      {
+        "title": "P95 Latency",
+        "type": "timeseries",
+        "metric": "l2_p95_latency_ms",
+        "description": "95th percentile L2 planning latency"
+      },
+      {
+        "title": "Learning Flywheel Progress",
+        "type": "timeseries",
+        "metric": "escalation_rate",
+        "description": "Escalation rate over time — should trend downward as the system learns"
+      }
+    ]
+  }
+}

--- a/src/config/routing-config.yaml
+++ b/src/config/routing-config.yaml
@@ -1,0 +1,47 @@
+# L2 Planner Routing Configuration
+#
+# Controls when requests escalate from L0/L1 to L2 (Ava LLM)
+# and from L2 to L3 (human-in-the-loop).
+
+routing:
+  # Minimum confidence for L0 result to be accepted (0–1)
+  l0_confidence_threshold: 0.7
+
+  # Minimum confidence for L1 result to be accepted (0–1)
+  l1_confidence_threshold: 0.6
+
+  # Minimum L2 confidence before escalating to L3 human (0–1)
+  l2_confidence_threshold: 0.5
+
+  # Maximum number of LLM candidate plans to request
+  max_candidates: 3
+
+  # Time budget for L2 planning (ms)
+  l2_time_budget_ms: 30000
+
+  # Whether to attempt L1 before escalating to L2
+  try_l1_before_l2: true
+
+confidence:
+  # Weights for confidence breakdown components (must sum to 1.0)
+  weights:
+    feasibility: 0.35
+    goal_alignment: 0.30
+    cost_efficiency: 0.15
+    constraint_satisfaction: 0.20
+
+  # Borderline zone: if within this % of threshold, request confirmation
+  borderline_margin: 0.05
+
+learning:
+  # Minimum confidence for a plan to be eligible for rule extraction
+  min_learning_confidence: 0.8
+
+  # Number of successful executions before promoting to L0 rule
+  promotion_threshold: 3
+
+  # Maximum rules in the learned registry before pruning
+  max_learned_rules: 500
+
+  # Auto-rollback if learned rule causes escalation rate increase
+  auto_rollback_enabled: true

--- a/src/learning/feedback-collector.ts
+++ b/src/learning/feedback-collector.ts
@@ -1,0 +1,118 @@
+/**
+ * FeedbackCollector — collects human feedback on escalated plans
+ * and plan execution outcomes.
+ *
+ * Feeds data into the learning flywheel so successful patterns
+ * can be extracted and promoted.
+ */
+
+/** Human feedback on an escalated plan. */
+export interface HumanFeedback {
+  planId: string;
+  timestamp: number;
+  /** Human's decision. */
+  decision: "approve" | "reject" | "modify";
+  /** Optional modification instructions. */
+  feedback?: string;
+  /** Human's assessment of plan quality. */
+  qualityRating?: number;
+  /** Who provided the feedback. */
+  decidedBy: string;
+}
+
+/** Plan execution outcome. */
+export interface ExecutionOutcome {
+  planId: string;
+  timestamp: number;
+  success: boolean;
+  /** How long execution took (ms). */
+  durationMs: number;
+  /** Which actions succeeded/failed. */
+  actionOutcomes: Array<{
+    actionId: string;
+    success: boolean;
+    error?: string;
+  }>;
+  /** Goal was satisfied after execution. */
+  goalSatisfied: boolean;
+}
+
+/** Collected feedback entry (union type). */
+export type FeedbackEntry =
+  | { type: "human"; data: HumanFeedback }
+  | { type: "execution"; data: ExecutionOutcome };
+
+export class FeedbackCollector {
+  private entries: FeedbackEntry[] = [];
+  private maxEntries: number;
+
+  constructor(maxEntries: number = 5000) {
+    this.maxEntries = maxEntries;
+  }
+
+  /**
+   * Record human feedback on a plan.
+   */
+  recordHumanFeedback(feedback: HumanFeedback): void {
+    this.entries.push({ type: "human", data: feedback });
+    this.trim();
+  }
+
+  /**
+   * Record a plan execution outcome.
+   */
+  recordOutcome(outcome: ExecutionOutcome): void {
+    this.entries.push({ type: "execution", data: outcome });
+    this.trim();
+  }
+
+  /**
+   * Get all feedback for a specific plan.
+   */
+  getForPlan(planId: string): FeedbackEntry[] {
+    return this.entries.filter((e) => {
+      if (e.type === "human") return e.data.planId === planId;
+      return e.data.planId === planId;
+    });
+  }
+
+  /**
+   * Get plans that were approved by humans (good for learning).
+   */
+  getApprovedPlans(): HumanFeedback[] {
+    return this.entries
+      .filter((e): e is { type: "human"; data: HumanFeedback } =>
+        e.type === "human" && e.data.decision === "approve",
+      )
+      .map((e) => e.data);
+  }
+
+  /**
+   * Get plans that executed successfully (good for learning).
+   */
+  getSuccessfulExecutions(): ExecutionOutcome[] {
+    return this.entries
+      .filter((e): e is { type: "execution"; data: ExecutionOutcome } =>
+        e.type === "execution" && e.data.success && e.data.goalSatisfied,
+      )
+      .map((e) => e.data);
+  }
+
+  /**
+   * Get all entries.
+   */
+  getAll(): readonly FeedbackEntry[] {
+    return this.entries;
+  }
+
+  /** Clear all entries. */
+  clear(): void {
+    this.entries.length = 0;
+  }
+
+  private trim(): void {
+    if (this.entries.length > this.maxEntries) {
+      this.entries.splice(0, this.entries.length - this.maxEntries);
+    }
+  }
+}

--- a/src/learning/outcome-analyzer.ts
+++ b/src/learning/outcome-analyzer.ts
@@ -1,0 +1,82 @@
+/**
+ * OutcomeAnalyzer — analyzes plan execution outcomes to identify
+ * patterns suitable for rule learning.
+ */
+
+import type { FeedbackCollector, ExecutionOutcome, HumanFeedback } from "./feedback-collector.ts";
+
+/** Analysis result for a goal pattern. */
+export interface GoalAnalysis {
+  goalPattern: string;
+  totalAttempts: number;
+  successfulAttempts: number;
+  successRate: number;
+  avgDurationMs: number;
+  /** Plan IDs that succeeded and should be considered for learning. */
+  learnablePlanIds: string[];
+}
+
+export class OutcomeAnalyzer {
+  constructor(private collector: FeedbackCollector) {}
+
+  /**
+   * Analyze outcomes for plans matching a given set of plan IDs.
+   */
+  analyzeByPlanIds(planIds: string[]): {
+    successRate: number;
+    approvalRate: number;
+    avgDuration: number;
+    learnable: string[];
+  } {
+    const outcomes = planIds
+      .flatMap((id) => this.collector.getForPlan(id))
+      .filter((e) => e.type === "execution")
+      .map((e) => e.data as ExecutionOutcome);
+
+    const humanFeedback = planIds
+      .flatMap((id) => this.collector.getForPlan(id))
+      .filter((e) => e.type === "human")
+      .map((e) => e.data as HumanFeedback);
+
+    const successes = outcomes.filter((o) => o.success && o.goalSatisfied);
+    const approved = humanFeedback.filter((f) => f.decision === "approve");
+
+    return {
+      successRate: outcomes.length > 0 ? successes.length / outcomes.length : 0,
+      approvalRate: humanFeedback.length > 0 ? approved.length / humanFeedback.length : 0,
+      avgDuration: outcomes.length > 0
+        ? outcomes.reduce((s, o) => s + o.durationMs, 0) / outcomes.length
+        : 0,
+      learnable: successes.map((o) => o.planId),
+    };
+  }
+
+  /**
+   * Get all plan IDs eligible for learning (success + goal satisfied).
+   */
+  getLearnablePlanIds(): string[] {
+    return this.collector.getSuccessfulExecutions().map((o) => o.planId);
+  }
+
+  /**
+   * Identify plans that were rejected or failed — useful for negative learning.
+   */
+  getFailedPatterns(): Array<{ planId: string; reason: string }> {
+    const failed: Array<{ planId: string; reason: string }> = [];
+
+    for (const entry of this.collector.getAll()) {
+      if (entry.type === "human" && entry.data.decision === "reject") {
+        failed.push({ planId: entry.data.planId, reason: entry.data.feedback ?? "rejected by human" });
+      }
+      if (entry.type === "execution" && !entry.data.success) {
+        const failedAction = entry.data.actionOutcomes.find((a) => !a.success);
+        failed.push({
+          planId: entry.data.planId,
+          reason: failedAction?.error ?? "execution failed",
+        });
+      }
+    }
+
+    return failed;
+  }
+}

--- a/src/learning/pattern-matcher.ts
+++ b/src/learning/pattern-matcher.ts
@@ -1,0 +1,103 @@
+/**
+ * PatternMatcher — matches incoming planning requests against learned rules.
+ *
+ * Used by the L2 router to check if a learned rule can handle a request
+ * before invoking the full hybrid planner.
+ */
+
+import type { PlannerState, Goal, Plan } from "../planner/types.ts";
+import type { LearnedRule } from "./rule-registry.ts";
+import { RuleRegistry } from "./rule-registry.ts";
+
+/** Match result from the pattern matcher. */
+export interface PatternMatch {
+  matched: boolean;
+  rule?: LearnedRule;
+  plan?: Plan;
+  confidence: number;
+}
+
+export class PatternMatcher {
+  private registry: RuleRegistry;
+
+  constructor(registry: RuleRegistry) {
+    this.registry = registry;
+  }
+
+  /**
+   * Try to match a state against learned rules.
+   * Returns the best matching rule if any.
+   */
+  match(state: PlannerState, goalPattern: string): PatternMatch {
+    // First, try exact goal pattern match
+    const goalRules = this.registry.findByGoal(goalPattern);
+    if (goalRules.length > 0) {
+      const matching = goalRules.filter((r) =>
+        r.conditions.every((c) => c(state)),
+      );
+
+      if (matching.length > 0) {
+        const best = this.selectBest(matching);
+        return {
+          matched: true,
+          rule: best,
+          plan: {
+            actions: best.actions,
+            totalCost: best.totalCost,
+            isComplete: true,
+          },
+          confidence: this.ruleConfidence(best),
+        };
+      }
+    }
+
+    // Try general state matching
+    const stateMatches = this.registry.findMatching(state);
+    if (stateMatches.length > 0) {
+      const best = this.selectBest(stateMatches);
+      return {
+        matched: true,
+        rule: best,
+        plan: {
+          actions: best.actions,
+          totalCost: best.totalCost,
+          isComplete: true,
+        },
+        confidence: this.ruleConfidence(best),
+      };
+    }
+
+    return { matched: false, confidence: 0 };
+  }
+
+  /**
+   * Select the best rule from a list of matches.
+   * Prefers: highest success rate → highest confidence → lowest cost.
+   */
+  private selectBest(rules: LearnedRule[]): LearnedRule {
+    return rules.sort((a, b) => {
+      // Success rate
+      const aRate = a.successCount / Math.max(1, a.successCount + a.failureCount);
+      const bRate = b.successCount / Math.max(1, b.successCount + b.failureCount);
+      if (aRate !== bRate) return bRate - aRate;
+
+      // Confidence
+      if (a.confidence !== b.confidence) return b.confidence - a.confidence;
+
+      // Cost
+      return a.totalCost - b.totalCost;
+    })[0];
+  }
+
+  /**
+   * Compute confidence for a learned rule based on its track record.
+   */
+  private ruleConfidence(rule: LearnedRule): number {
+    const total = rule.successCount + rule.failureCount;
+    if (total === 0) return rule.confidence * 0.5; // Untested rule
+
+    const successRate = rule.successCount / total;
+    // Blend original confidence with empirical success rate
+    return 0.3 * rule.confidence + 0.7 * successRate;
+  }
+}

--- a/src/learning/plan-converter.ts
+++ b/src/learning/plan-converter.ts
@@ -1,0 +1,111 @@
+/**
+ * PlanConverter — converts successful L2 plans into L0-compatible rules.
+ *
+ * This is the core of the learning flywheel: when L2 successfully solves
+ * a problem, the solution is distilled into a deterministic rule that L0
+ * can use directly, eliminating future L2 invocations for the same pattern.
+ */
+
+import type { Action, Plan, PlannerState, StatePredicate, StateTransform } from "../planner/types.ts";
+import type { L2Result } from "../planner/routing-interface.ts";
+import type { LearnedRule } from "./rule-registry.ts";
+import { RuleExtractor, type RuleExtractionConfig } from "./rule-extractor.ts";
+import { RuleRegistry } from "./rule-registry.ts";
+
+/** Configuration for plan conversion. */
+export interface PlanConverterConfig {
+  /** Extraction config. */
+  extraction?: Partial<RuleExtractionConfig>;
+  /** Number of successful executions before promoting to L0. */
+  promotionThreshold: number;
+}
+
+const DEFAULT_CONFIG: PlanConverterConfig = {
+  promotionThreshold: 3,
+};
+
+/** Result of a conversion attempt. */
+export interface ConversionResult {
+  /** Whether the plan was successfully converted to a rule. */
+  converted: boolean;
+  /** The created/updated rule, if any. */
+  rule?: LearnedRule;
+  /** Reason for failure, if any. */
+  reason?: string;
+}
+
+export class PlanConverter {
+  private extractor: RuleExtractor;
+  private registry: RuleRegistry;
+  private config: PlanConverterConfig;
+
+  constructor(
+    registry: RuleRegistry,
+    config: Partial<PlanConverterConfig> = {},
+  ) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.extractor = new RuleExtractor(config.extraction);
+    this.registry = registry;
+  }
+
+  /**
+   * Attempt to convert a successful L2 result into a learned rule.
+   */
+  convert(
+    result: L2Result,
+    goalPattern: string,
+    initialState: PlannerState,
+  ): ConversionResult {
+    // Check if we already have a rule for this plan
+    const existing = this.registry.findByGoal(goalPattern);
+    if (existing.length > 0) {
+      // Update existing rule's success count
+      const best = existing[0];
+      this.registry.recordSuccess(best.id);
+      return {
+        converted: true,
+        rule: this.registry.get(best.id),
+        reason: "Updated existing rule success count",
+      };
+    }
+
+    // Extract a new rule
+    const rule = this.extractor.extract(result, goalPattern, initialState);
+    if (!rule) {
+      return {
+        converted: false,
+        reason: "Plan not eligible for rule extraction (low confidence, too short, or too long)",
+      };
+    }
+
+    this.registry.register(rule);
+
+    return {
+      converted: true,
+      rule,
+    };
+  }
+
+  /**
+   * Get rules ready for promotion to L0.
+   */
+  getPromotionCandidates(): LearnedRule[] {
+    return this.registry.getPromotionCandidates(this.config.promotionThreshold);
+  }
+
+  /**
+   * Execute the full learning flywheel cycle:
+   * 1. Convert plan to rule
+   * 2. Check if any rules are ready for L0 promotion
+   * 3. Return promotion candidates
+   */
+  learningCycle(
+    result: L2Result,
+    goalPattern: string,
+    initialState: PlannerState,
+  ): { conversion: ConversionResult; promotionCandidates: LearnedRule[] } {
+    const conversion = this.convert(result, goalPattern, initialState);
+    const promotionCandidates = this.getPromotionCandidates();
+    return { conversion, promotionCandidates };
+  }
+}

--- a/src/learning/rule-auditor.ts
+++ b/src/learning/rule-auditor.ts
@@ -1,0 +1,77 @@
+/**
+ * RuleAuditor — audit trail for rule lifecycle events.
+ *
+ * Logs all rule creation, promotion, rollback, and deactivation events
+ * for compliance and debugging.
+ */
+
+/** Types of audit events. */
+export type AuditEventType = "create" | "promote" | "rollback" | "deactivate" | "update" | "prune";
+
+/** An audit log entry. */
+export interface AuditEvent {
+  ruleId: string;
+  type: AuditEventType;
+  timestamp: number;
+  version: number;
+  details: string;
+}
+
+export class RuleAuditor {
+  private events: AuditEvent[] = [];
+  private maxEvents: number;
+
+  constructor(maxEvents: number = 10000) {
+    this.maxEvents = maxEvents;
+  }
+
+  /**
+   * Log an audit event.
+   */
+  logEvent(event: AuditEvent): void {
+    this.events.push(event);
+    if (this.events.length > this.maxEvents) {
+      this.events.splice(0, this.events.length - this.maxEvents);
+    }
+  }
+
+  /**
+   * Get all events for a rule.
+   */
+  getForRule(ruleId: string): AuditEvent[] {
+    return this.events.filter((e) => e.ruleId === ruleId);
+  }
+
+  /**
+   * Get events by type.
+   */
+  getByType(type: AuditEventType): AuditEvent[] {
+    return this.events.filter((e) => e.type === type);
+  }
+
+  /**
+   * Get recent events (last N).
+   */
+  getRecent(limit: number = 50): AuditEvent[] {
+    return this.events.slice(-limit);
+  }
+
+  /**
+   * Get all events in a time range.
+   */
+  getInRange(startMs: number, endMs: number): AuditEvent[] {
+    return this.events.filter((e) => e.timestamp >= startMs && e.timestamp <= endMs);
+  }
+
+  /**
+   * Get all events.
+   */
+  getAll(): readonly AuditEvent[] {
+    return this.events;
+  }
+
+  /** Clear all events. */
+  clear(): void {
+    this.events.length = 0;
+  }
+}

--- a/src/learning/rule-extractor.ts
+++ b/src/learning/rule-extractor.ts
@@ -1,0 +1,120 @@
+/**
+ * RuleExtractor — extracts generalizable patterns from successful L2 plans.
+ *
+ * Analyzes plan structure, identifies reusable patterns, and creates
+ * rule conditions for the RuleRegistry.
+ */
+
+import type { Action, Plan, PlannerState, StatePredicate } from "../planner/types.ts";
+import type { L2Result, ConfidenceScore } from "../planner/routing-interface.ts";
+import type { LearnedRule } from "./rule-registry.ts";
+
+/** Configuration for rule extraction. */
+export interface RuleExtractionConfig {
+  /** Minimum confidence for a plan to be eligible for extraction. */
+  minConfidence: number;
+  /** Minimum number of actions for a plan to be worth extracting. */
+  minActions: number;
+  /** Maximum number of actions for a single rule. */
+  maxActions: number;
+}
+
+const DEFAULT_CONFIG: RuleExtractionConfig = {
+  minConfidence: 0.8,
+  minActions: 1,
+  maxActions: 10,
+};
+
+export class RuleExtractor {
+  private config: RuleExtractionConfig;
+
+  constructor(config: Partial<RuleExtractionConfig> = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  /**
+   * Attempt to extract a learned rule from a successful L2 result.
+   * Returns null if the result isn't suitable for extraction.
+   */
+  extract(
+    result: L2Result,
+    goalPattern: string,
+    initialState: PlannerState,
+  ): LearnedRule | null {
+    // Check eligibility
+    if (!result.success || !result.plan) return null;
+    if (result.confidence.overall < this.config.minConfidence) return null;
+    if (result.plan.actions.length < this.config.minActions) return null;
+    if (result.plan.actions.length > this.config.maxActions) return null;
+
+    // Extract conditions from the initial state
+    const conditions = this.extractConditions(result.plan, initialState);
+
+    const now = Date.now();
+    return {
+      id: `learned-${result.planId}`,
+      name: `Rule from L2 plan ${result.planId.slice(0, 8)}`,
+      goalPattern,
+      conditions,
+      actions: [...result.plan.actions],
+      totalCost: result.plan.totalCost,
+      successCount: 1, // Starts with 1 (the original success)
+      failureCount: 0,
+      confidence: result.confidence.overall,
+      version: 1,
+      createdAt: now,
+      updatedAt: now,
+      sourcePlanId: result.planId,
+      promotedToL0: false,
+      active: true,
+    };
+  }
+
+  /**
+   * Extract state conditions from the plan's preconditions.
+   *
+   * Creates predicates that check the initial state matches
+   * the preconditions of the first action in the plan.
+   */
+  private extractConditions(plan: Plan, initialState: PlannerState): StatePredicate[] {
+    if (plan.actions.length === 0) return [];
+
+    // Use the first action's preconditions as rule conditions
+    const firstAction = plan.actions[0];
+    const conditions: StatePredicate[] = [...firstAction.preconditions];
+
+    // Also add a condition checking that relevant state keys match
+    const relevantKeys = this.findRelevantStateKeys(plan, initialState);
+    if (relevantKeys.length > 0) {
+      const stateSnapshot = Object.fromEntries(
+        relevantKeys.map((k) => [k, initialState[k]]),
+      );
+      conditions.push((state: PlannerState) =>
+        relevantKeys.every((k) => state[k] === stateSnapshot[k]),
+      );
+    }
+
+    return conditions;
+  }
+
+  /**
+   * Find state keys that are relevant to the plan (used in preconditions/effects).
+   */
+  private findRelevantStateKeys(plan: Plan, initialState: PlannerState): string[] {
+    const keys = new Set<string>();
+
+    for (const action of plan.actions) {
+      // Run effects on empty state to find keys they modify
+      for (const effect of action.effects) {
+        const result = effect({});
+        for (const key of Object.keys(result)) {
+          if (key in initialState) {
+            keys.add(key);
+          }
+        }
+      }
+    }
+
+    return Array.from(keys);
+  }
+}

--- a/src/learning/rule-migration.ts
+++ b/src/learning/rule-migration.ts
@@ -1,0 +1,117 @@
+/**
+ * RuleMigration — migrates learned rules from the L2 registry to L0.
+ *
+ * Handles safe promotion with rollback capability if the new rule
+ * degrades performance.
+ */
+
+import type { LearnedRule, RuleRegistry } from "./rule-registry.ts";
+import type { RuleVersioning, RuleVersion } from "./rule-versioning.ts";
+import type { RuleAuditor } from "./rule-auditor.ts";
+
+/** Migration result. */
+export interface MigrationResult {
+  ruleId: string;
+  success: boolean;
+  version: number;
+  error?: string;
+}
+
+/** Migration config. */
+export interface MigrationConfig {
+  /** Whether to auto-rollback if performance degrades. */
+  autoRollback: boolean;
+  /** Max escalation rate increase before triggering rollback. */
+  maxEscalationRateIncrease: number;
+}
+
+const DEFAULT_CONFIG: MigrationConfig = {
+  autoRollback: true,
+  maxEscalationRateIncrease: 0.1,
+};
+
+export class RuleMigration {
+  private config: MigrationConfig;
+
+  constructor(
+    private registry: RuleRegistry,
+    private versioning: RuleVersioning,
+    private auditor: RuleAuditor,
+    config: Partial<MigrationConfig> = {},
+  ) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  /**
+   * Promote a learned rule to L0.
+   */
+  promote(ruleId: string): MigrationResult {
+    const rule = this.registry.get(ruleId);
+    if (!rule) {
+      return { ruleId, success: false, version: 0, error: "Rule not found" };
+    }
+
+    if (rule.promotedToL0) {
+      return { ruleId, success: false, version: rule.version, error: "Already promoted" };
+    }
+
+    // Create a version snapshot before promotion
+    this.versioning.createVersion(rule);
+
+    // Mark as promoted
+    this.registry.markPromoted(ruleId);
+
+    // Audit the promotion
+    this.auditor.logEvent({
+      ruleId,
+      type: "promote",
+      timestamp: Date.now(),
+      version: rule.version,
+      details: `Promoted to L0 after ${rule.successCount} successes`,
+    });
+
+    return { ruleId, success: true, version: rule.version };
+  }
+
+  /**
+   * Rollback a promoted rule to its previous version.
+   */
+  rollback(ruleId: string): MigrationResult {
+    const previousVersion = this.versioning.getPreviousVersion(ruleId);
+    if (!previousVersion) {
+      return { ruleId, success: false, version: 0, error: "No previous version to rollback to" };
+    }
+
+    // Deactivate current version
+    this.registry.deactivate(ruleId);
+
+    // Log rollback
+    this.auditor.logEvent({
+      ruleId,
+      type: "rollback",
+      timestamp: Date.now(),
+      version: previousVersion.version,
+      details: "Rolled back due to performance degradation",
+    });
+
+    return { ruleId, success: true, version: previousVersion.version };
+  }
+
+  /**
+   * Check if a rule should be rolled back based on performance.
+   */
+  shouldRollback(ruleId: string, currentEscalationRate: number, baselineRate: number): boolean {
+    if (!this.config.autoRollback) return false;
+
+    const increase = currentEscalationRate - baselineRate;
+    return increase > this.config.maxEscalationRateIncrease;
+  }
+
+  /**
+   * Promote all eligible rules.
+   */
+  promoteEligible(promotionThreshold: number = 3): MigrationResult[] {
+    const candidates = this.registry.getPromotionCandidates(promotionThreshold);
+    return candidates.map((c) => this.promote(c.id));
+  }
+}

--- a/src/learning/rule-registry.ts
+++ b/src/learning/rule-registry.ts
@@ -1,0 +1,209 @@
+/**
+ * RuleRegistry — stores learned rules with versioning and rollback.
+ *
+ * Rules are extracted from successful L2 plans and stored here for
+ * promotion to L0 after sufficient successful executions.
+ */
+
+import type { Action, PlannerState, StatePredicate, StateTransform } from "../planner/types.ts";
+
+/** A learned rule derived from a successful L2 plan. */
+export interface LearnedRule {
+  id: string;
+  /** Human-readable name. */
+  name: string;
+  /** The goal this rule addresses. */
+  goalPattern: string;
+  /** State conditions that must hold for this rule to apply. */
+  conditions: StatePredicate[];
+  /** The action sequence to execute. */
+  actions: Action[];
+  /** Total cost of the action sequence. */
+  totalCost: number;
+  /** Number of successful executions. */
+  successCount: number;
+  /** Number of failed executions after learning. */
+  failureCount: number;
+  /** Confidence at time of extraction. */
+  confidence: number;
+  /** Version number (incremented on updates). */
+  version: number;
+  /** When this rule was created. */
+  createdAt: number;
+  /** When this rule was last updated. */
+  updatedAt: number;
+  /** The L2 plan ID that generated this rule. */
+  sourcePlanId: string;
+  /** Whether this rule has been promoted to L0. */
+  promotedToL0: boolean;
+  /** Whether this rule is currently active. */
+  active: boolean;
+}
+
+/** Registry statistics. */
+export interface RegistryStats {
+  totalRules: number;
+  activeRules: number;
+  promotedRules: number;
+  avgConfidence: number;
+  avgSuccessRate: number;
+}
+
+export class RuleRegistry {
+  private rules: Map<string, LearnedRule> = new Map();
+  private maxRules: number;
+
+  constructor(maxRules: number = 500) {
+    this.maxRules = maxRules;
+  }
+
+  /**
+   * Register a new learned rule.
+   */
+  register(rule: LearnedRule): void {
+    // Prune if at capacity
+    if (this.rules.size >= this.maxRules && !this.rules.has(rule.id)) {
+      this.pruneLowestPerformers();
+    }
+
+    this.rules.set(rule.id, { ...rule });
+  }
+
+  /**
+   * Get a rule by ID.
+   */
+  get(id: string): LearnedRule | undefined {
+    const rule = this.rules.get(id);
+    return rule ? { ...rule } : undefined;
+  }
+
+  /**
+   * Find rules matching a goal pattern.
+   */
+  findByGoal(goalPattern: string): LearnedRule[] {
+    return Array.from(this.rules.values())
+      .filter((r) => r.active && r.goalPattern === goalPattern);
+  }
+
+  /**
+   * Find active rules whose conditions match a state.
+   */
+  findMatching(state: PlannerState): LearnedRule[] {
+    return Array.from(this.rules.values())
+      .filter((r) => r.active && r.conditions.every((c) => c(state)));
+  }
+
+  /**
+   * Record a successful execution of a rule.
+   */
+  recordSuccess(ruleId: string): void {
+    const rule = this.rules.get(ruleId);
+    if (rule) {
+      rule.successCount++;
+      rule.updatedAt = Date.now();
+    }
+  }
+
+  /**
+   * Record a failed execution of a rule.
+   */
+  recordFailure(ruleId: string): void {
+    const rule = this.rules.get(ruleId);
+    if (rule) {
+      rule.failureCount++;
+      rule.updatedAt = Date.now();
+    }
+  }
+
+  /**
+   * Mark a rule as promoted to L0.
+   */
+  markPromoted(ruleId: string): void {
+    const rule = this.rules.get(ruleId);
+    if (rule) {
+      rule.promotedToL0 = true;
+      rule.updatedAt = Date.now();
+    }
+  }
+
+  /**
+   * Deactivate a rule (e.g., on rollback).
+   */
+  deactivate(ruleId: string): void {
+    const rule = this.rules.get(ruleId);
+    if (rule) {
+      rule.active = false;
+      rule.updatedAt = Date.now();
+    }
+  }
+
+  /**
+   * Get rules eligible for promotion (enough successful executions).
+   */
+  getPromotionCandidates(promotionThreshold: number = 3): LearnedRule[] {
+    return Array.from(this.rules.values())
+      .filter((r) => r.active && !r.promotedToL0 && r.successCount >= promotionThreshold)
+      .sort((a, b) => b.successCount - a.successCount);
+  }
+
+  /**
+   * Get all active rules.
+   */
+  getAll(): LearnedRule[] {
+    return Array.from(this.rules.values()).filter((r) => r.active);
+  }
+
+  /**
+   * Get registry statistics.
+   */
+  getStats(): RegistryStats {
+    const all = Array.from(this.rules.values());
+    const active = all.filter((r) => r.active);
+    const promoted = all.filter((r) => r.promotedToL0);
+    const avgConfidence = active.length > 0
+      ? active.reduce((sum, r) => sum + r.confidence, 0) / active.length
+      : 0;
+    const avgSuccessRate = active.length > 0
+      ? active.reduce((sum, r) => {
+          const total = r.successCount + r.failureCount;
+          return sum + (total > 0 ? r.successCount / total : 0);
+        }, 0) / active.length
+      : 0;
+
+    return {
+      totalRules: all.length,
+      activeRules: active.length,
+      promotedRules: promoted.length,
+      avgConfidence,
+      avgSuccessRate,
+    };
+  }
+
+  /** Number of rules. */
+  get size(): number {
+    return this.rules.size;
+  }
+
+  /**
+   * Remove lowest-performing rules to stay under capacity.
+   */
+  private pruneLowestPerformers(): void {
+    const rules = Array.from(this.rules.values())
+      .filter((r) => !r.promotedToL0) // Never prune promoted rules
+      .sort((a, b) => {
+        const aRate = a.successCount + a.failureCount > 0
+          ? a.successCount / (a.successCount + a.failureCount)
+          : 0;
+        const bRate = b.successCount + b.failureCount > 0
+          ? b.successCount / (b.successCount + b.failureCount)
+          : 0;
+        return aRate - bRate;
+      });
+
+    // Remove bottom 10%
+    const toRemove = Math.max(1, Math.floor(rules.length * 0.1));
+    for (let i = 0; i < toRemove && i < rules.length; i++) {
+      this.rules.delete(rules[i].id);
+    }
+  }
+}

--- a/src/learning/rule-versioning.ts
+++ b/src/learning/rule-versioning.ts
@@ -1,0 +1,77 @@
+/**
+ * RuleVersioning — version control for learned rules.
+ *
+ * Maintains a history of rule versions for rollback capability.
+ */
+
+import type { LearnedRule } from "./rule-registry.ts";
+
+/** A snapshot of a rule at a specific version. */
+export interface RuleVersion {
+  ruleId: string;
+  version: number;
+  snapshot: LearnedRule;
+  timestamp: number;
+}
+
+export class RuleVersioning {
+  private versions: Map<string, RuleVersion[]> = new Map();
+  private maxVersionsPerRule: number;
+
+  constructor(maxVersionsPerRule: number = 10) {
+    this.maxVersionsPerRule = maxVersionsPerRule;
+  }
+
+  /**
+   * Create a version snapshot of a rule.
+   */
+  createVersion(rule: LearnedRule): RuleVersion {
+    const version: RuleVersion = {
+      ruleId: rule.id,
+      version: rule.version,
+      snapshot: { ...rule, actions: [...rule.actions], conditions: [...rule.conditions] },
+      timestamp: Date.now(),
+    };
+
+    const history = this.versions.get(rule.id) ?? [];
+    history.push(version);
+
+    // Trim old versions
+    if (history.length > this.maxVersionsPerRule) {
+      history.splice(0, history.length - this.maxVersionsPerRule);
+    }
+
+    this.versions.set(rule.id, history);
+    return version;
+  }
+
+  /**
+   * Get the previous version of a rule (for rollback).
+   */
+  getPreviousVersion(ruleId: string): RuleVersion | null {
+    const history = this.versions.get(ruleId);
+    if (!history || history.length < 1) return null;
+    return history[history.length - 1];
+  }
+
+  /**
+   * Get version history for a rule.
+   */
+  getHistory(ruleId: string): RuleVersion[] {
+    return this.versions.get(ruleId) ?? [];
+  }
+
+  /**
+   * Get a specific version of a rule.
+   */
+  getVersion(ruleId: string, version: number): RuleVersion | null {
+    const history = this.versions.get(ruleId);
+    if (!history) return null;
+    return history.find((v) => v.version === version) ?? null;
+  }
+
+  /** Number of rules with version history. */
+  get size(): number {
+    return this.versions.size;
+  }
+}

--- a/src/learning/success-metrics.ts
+++ b/src/learning/success-metrics.ts
@@ -1,0 +1,91 @@
+/**
+ * SuccessMetrics — measures learning flywheel effectiveness.
+ *
+ * Tracks how well the system is converting L2 successes into L0 rules
+ * and whether that is actually reducing escalation rates.
+ */
+
+import type { RuleRegistry, RegistryStats } from "./rule-registry.ts";
+import type { L2Metrics, L2MetricsSummary } from "../monitoring/l2-metrics.ts";
+import type { EscalationTracker } from "../monitoring/escalation-tracker.ts";
+
+/** Flywheel health metrics. */
+export interface FlywheelMetrics {
+  /** Rules learned over the time window. */
+  rulesLearned: number;
+  /** Rules promoted to L0. */
+  rulesPromoted: number;
+  /** Ratio of L0 hits to total requests (higher = flywheel working). */
+  l0HitRate: number;
+  /** Escalation rate trend (negative = improving). */
+  escalationRateDelta: number;
+  /** Overall flywheel health score (0–1). */
+  healthScore: number;
+}
+
+export class SuccessMetrics {
+  constructor(
+    private ruleRegistry: RuleRegistry,
+    private l2Metrics: L2Metrics,
+    private escalationTracker: EscalationTracker,
+  ) {}
+
+  /**
+   * Compute flywheel effectiveness metrics.
+   */
+  compute(windowMs?: number): FlywheelMetrics {
+    const registryStats = this.ruleRegistry.getStats();
+    const l2Summary = this.l2Metrics.getSummary(windowMs);
+    const escalationTrend = this.escalationTracker.getTrend();
+
+    const l0Hits = l2Summary.layerDistribution["l0"] ?? 0;
+    const totalRequests = l2Summary.totalInvocations;
+    const l0HitRate = totalRequests > 0 ? l0Hits / totalRequests : 0;
+
+    const escalationRateDelta = this.computeEscalationDelta(escalationTrend);
+
+    return {
+      rulesLearned: registryStats.totalRules,
+      rulesPromoted: registryStats.promotedRules,
+      l0HitRate,
+      escalationRateDelta,
+      healthScore: this.computeHealthScore(l0HitRate, escalationRateDelta, registryStats),
+    };
+  }
+
+  /**
+   * Compute the change in escalation rate (negative = improvement).
+   */
+  private computeEscalationDelta(trend: Array<{ l2ToL3Rate: number }>): number {
+    if (trend.length < 2) return 0;
+
+    const recent = trend.slice(-3);
+    const earlier = trend.slice(-6, -3);
+
+    if (earlier.length === 0) return 0;
+
+    const recentAvg = recent.reduce((s, t) => s + t.l2ToL3Rate, 0) / recent.length;
+    const earlierAvg = earlier.reduce((s, t) => s + t.l2ToL3Rate, 0) / earlier.length;
+
+    return recentAvg - earlierAvg;
+  }
+
+  /**
+   * Compute overall health score (0–1).
+   */
+  private computeHealthScore(
+    l0HitRate: number,
+    escalationDelta: number,
+    registryStats: RegistryStats,
+  ): number {
+    // Weighted composite:
+    // - 40% L0 hit rate (higher = better)
+    // - 30% escalation improvement (negative delta = better)
+    // - 30% rule quality (avg success rate of learned rules)
+    const hitScore = l0HitRate;
+    const escalationScore = Math.max(0, 1.0 - Math.abs(escalationDelta));
+    const qualityScore = registryStats.avgSuccessRate;
+
+    return 0.4 * hitScore + 0.3 * escalationScore + 0.3 * qualityScore;
+  }
+}

--- a/src/monitoring/escalation-tracker.ts
+++ b/src/monitoring/escalation-tracker.ts
@@ -1,0 +1,125 @@
+/**
+ * EscalationTracker — tracks escalation events across all planner layers.
+ *
+ * Monitors the escalation pipeline: L0→L1→L2→L3 and tracks whether
+ * the learning flywheel is reducing escalation rates over time.
+ */
+
+/** An escalation event. */
+export interface EscalationEvent {
+  id: string;
+  timestamp: number;
+  fromLayer: "l0" | "l1" | "l2";
+  toLayer: "l1" | "l2" | "l3";
+  goalPattern: string;
+  reason: string;
+  correlationId: string;
+  /** Whether a learned rule could have handled this (retroactive check). */
+  learnedRuleAvailable?: boolean;
+}
+
+/** Escalation trend data point. */
+export interface EscalationTrend {
+  timestamp: number;
+  l0ToL1Rate: number;
+  l1ToL2Rate: number;
+  l2ToL3Rate: number;
+  overallEscalationRate: number;
+}
+
+export class EscalationTracker {
+  private events: EscalationEvent[] = [];
+  private maxEvents: number;
+
+  constructor(maxEvents: number = 5000) {
+    this.maxEvents = maxEvents;
+  }
+
+  /**
+   * Record an escalation event.
+   */
+  record(event: EscalationEvent): void {
+    this.events.push(event);
+    if (this.events.length > this.maxEvents) {
+      this.events.splice(0, this.events.length - this.maxEvents);
+    }
+  }
+
+  /**
+   * Get escalation counts for a time window.
+   */
+  getCounts(windowMs?: number): Record<string, number> {
+    const cutoff = windowMs ? Date.now() - windowMs : 0;
+    const filtered = this.events.filter((e) => e.timestamp >= cutoff);
+
+    const counts: Record<string, number> = {
+      l0_to_l1: 0,
+      l1_to_l2: 0,
+      l2_to_l3: 0,
+      total: filtered.length,
+    };
+
+    for (const e of filtered) {
+      const key = `${e.fromLayer}_to_${e.toLayer}`;
+      counts[key] = (counts[key] ?? 0) + 1;
+    }
+
+    return counts;
+  }
+
+  /**
+   * Compute escalation rate trend over time.
+   */
+  getTrend(bucketMs: number = 3600_000): EscalationTrend[] {
+    if (this.events.length === 0) return [];
+
+    const minTs = this.events[0].timestamp;
+    const maxTs = this.events[this.events.length - 1].timestamp;
+    const trends: EscalationTrend[] = [];
+
+    for (let t = minTs; t <= maxTs; t += bucketMs) {
+      const end = t + bucketMs;
+      const bucket = this.events.filter((e) => e.timestamp >= t && e.timestamp < end);
+
+      if (bucket.length === 0) continue;
+
+      const l0l1 = bucket.filter((e) => e.fromLayer === "l0" && e.toLayer === "l1").length;
+      const l1l2 = bucket.filter((e) => e.fromLayer === "l1" && e.toLayer === "l2").length;
+      const l2l3 = bucket.filter((e) => e.fromLayer === "l2" && e.toLayer === "l3").length;
+
+      trends.push({
+        timestamp: t,
+        l0ToL1Rate: l0l1 / bucket.length,
+        l1ToL2Rate: l1l2 / bucket.length,
+        l2ToL3Rate: l2l3 / bucket.length,
+        overallEscalationRate: bucket.length > 0 ? 1 : 0,
+      });
+    }
+
+    return trends;
+  }
+
+  /**
+   * Get the most common escalation reasons.
+   */
+  getTopReasons(limit: number = 10): Array<{ reason: string; count: number }> {
+    const counts = new Map<string, number>();
+    for (const e of this.events) {
+      counts.set(e.reason, (counts.get(e.reason) ?? 0) + 1);
+    }
+    return Array.from(counts.entries())
+      .map(([reason, count]) => ({ reason, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, limit);
+  }
+
+  /** Get all events. */
+  getEvents(): readonly EscalationEvent[] {
+    return this.events;
+  }
+
+  /** Clear all events. */
+  clear(): void {
+    this.events.length = 0;
+  }
+}

--- a/src/monitoring/l2-metrics.ts
+++ b/src/monitoring/l2-metrics.ts
@@ -1,0 +1,162 @@
+/**
+ * L2Metrics — telemetry for L2 planner invocations and outcomes.
+ *
+ * Tracks: invocation rate, success rate, confidence distribution,
+ * plan quality metrics, and latency.
+ */
+
+/** A single L2 invocation record. */
+export interface L2InvocationRecord {
+  planId: string;
+  timestamp: number;
+  success: boolean;
+  confidence: number;
+  escalatedToL3: boolean;
+  latencyMs: number;
+  candidateCount: number;
+  planActionCount: number;
+  planCost: number;
+  /** Which layer ultimately handled the request. */
+  handledBy: "l0" | "l1" | "l2" | "l3";
+}
+
+/** Aggregated metrics over a time window. */
+export interface L2MetricsSummary {
+  totalInvocations: number;
+  successCount: number;
+  failureCount: number;
+  l3EscalationCount: number;
+  successRate: number;
+  escalationRate: number;
+  avgConfidence: number;
+  avgLatencyMs: number;
+  p95LatencyMs: number;
+  confidenceDistribution: { bucket: string; count: number }[];
+  /** Breakdown by handling layer. */
+  layerDistribution: Record<string, number>;
+}
+
+export class L2Metrics {
+  private records: L2InvocationRecord[] = [];
+  private maxRecords: number;
+
+  constructor(maxRecords: number = 10000) {
+    this.maxRecords = maxRecords;
+  }
+
+  /**
+   * Record an L2 invocation.
+   */
+  record(entry: L2InvocationRecord): void {
+    this.records.push(entry);
+    if (this.records.length > this.maxRecords) {
+      this.records.splice(0, this.records.length - this.maxRecords);
+    }
+  }
+
+  /**
+   * Get summary metrics for a time window.
+   */
+  getSummary(windowMs?: number): L2MetricsSummary {
+    const cutoff = windowMs ? Date.now() - windowMs : 0;
+    const filtered = this.records.filter((r) => r.timestamp >= cutoff);
+
+    if (filtered.length === 0) {
+      return this.emptySummary();
+    }
+
+    const successCount = filtered.filter((r) => r.success).length;
+    const escalationCount = filtered.filter((r) => r.escalatedToL3).length;
+    const latencies = filtered.map((r) => r.latencyMs).sort((a, b) => a - b);
+
+    return {
+      totalInvocations: filtered.length,
+      successCount,
+      failureCount: filtered.length - successCount,
+      l3EscalationCount: escalationCount,
+      successRate: successCount / filtered.length,
+      escalationRate: escalationCount / filtered.length,
+      avgConfidence: filtered.reduce((s, r) => s + r.confidence, 0) / filtered.length,
+      avgLatencyMs: latencies.reduce((s, l) => s + l, 0) / latencies.length,
+      p95LatencyMs: latencies[Math.floor(latencies.length * 0.95)] ?? 0,
+      confidenceDistribution: this.buildConfidenceDistribution(filtered),
+      layerDistribution: this.buildLayerDistribution(filtered),
+    };
+  }
+
+  /**
+   * Get the escalation rate trend over time (bucketed by interval).
+   */
+  getEscalationTrend(bucketMs: number = 3600_000): Array<{ timestamp: number; escalationRate: number }> {
+    if (this.records.length === 0) return [];
+
+    const minTs = this.records[0].timestamp;
+    const maxTs = this.records[this.records.length - 1].timestamp;
+    const buckets: Array<{ timestamp: number; total: number; escalated: number }> = [];
+
+    for (let t = minTs; t <= maxTs; t += bucketMs) {
+      buckets.push({ timestamp: t, total: 0, escalated: 0 });
+    }
+
+    for (const record of this.records) {
+      const idx = Math.min(
+        Math.floor((record.timestamp - minTs) / bucketMs),
+        buckets.length - 1,
+      );
+      if (idx >= 0 && idx < buckets.length) {
+        buckets[idx].total++;
+        if (record.escalatedToL3) buckets[idx].escalated++;
+      }
+    }
+
+    return buckets
+      .filter((b) => b.total > 0)
+      .map((b) => ({
+        timestamp: b.timestamp,
+        escalationRate: b.escalated / b.total,
+      }));
+  }
+
+  /** Get all raw records. */
+  getRecords(): readonly L2InvocationRecord[] {
+    return this.records;
+  }
+
+  /** Clear all records. */
+  clear(): void {
+    this.records.length = 0;
+  }
+
+  private buildConfidenceDistribution(records: L2InvocationRecord[]): { bucket: string; count: number }[] {
+    const buckets = new Map<string, number>();
+    for (const r of records) {
+      const bucket = `${(Math.floor(r.confidence * 10) / 10).toFixed(1)}-${((Math.floor(r.confidence * 10) + 1) / 10).toFixed(1)}`;
+      buckets.set(bucket, (buckets.get(bucket) ?? 0) + 1);
+    }
+    return Array.from(buckets.entries()).map(([bucket, count]) => ({ bucket, count }));
+  }
+
+  private buildLayerDistribution(records: L2InvocationRecord[]): Record<string, number> {
+    const dist: Record<string, number> = {};
+    for (const r of records) {
+      dist[r.handledBy] = (dist[r.handledBy] ?? 0) + 1;
+    }
+    return dist;
+  }
+
+  private emptySummary(): L2MetricsSummary {
+    return {
+      totalInvocations: 0,
+      successCount: 0,
+      failureCount: 0,
+      l3EscalationCount: 0,
+      successRate: 0,
+      escalationRate: 0,
+      avgConfidence: 0,
+      avgLatencyMs: 0,
+      p95LatencyMs: 0,
+      confidenceDistribution: [],
+      layerDistribution: {},
+    };
+  }
+}

--- a/src/monitoring/metrics-aggregator.ts
+++ b/src/monitoring/metrics-aggregator.ts
@@ -1,0 +1,64 @@
+/**
+ * MetricsAggregator — combines L2 metrics and escalation tracking
+ * into a unified view for dashboards and reporting.
+ */
+
+import { L2Metrics, type L2MetricsSummary } from "./l2-metrics.ts";
+import { EscalationTracker, type EscalationTrend } from "./escalation-tracker.ts";
+import type { RegistryStats } from "../learning/rule-registry.ts";
+import { RuleRegistry } from "../learning/rule-registry.ts";
+
+/** Complete system health snapshot. */
+export interface SystemHealthSnapshot {
+  timestamp: number;
+  l2Metrics: L2MetricsSummary;
+  escalationCounts: Record<string, number>;
+  escalationTrend: EscalationTrend[];
+  ruleRegistryStats: RegistryStats;
+  /** Whether the system is improving (escalation rate decreasing). */
+  isImproving: boolean;
+}
+
+export class MetricsAggregator {
+  constructor(
+    private l2Metrics: L2Metrics,
+    private escalationTracker: EscalationTracker,
+    private ruleRegistry: RuleRegistry,
+  ) {}
+
+  /**
+   * Generate a complete system health snapshot.
+   */
+  getSnapshot(windowMs?: number): SystemHealthSnapshot {
+    const l2Summary = this.l2Metrics.getSummary(windowMs);
+    const escalationCounts = this.escalationTracker.getCounts(windowMs);
+    const escalationTrend = this.escalationTracker.getTrend();
+    const registryStats = this.ruleRegistry.getStats();
+
+    return {
+      timestamp: Date.now(),
+      l2Metrics: l2Summary,
+      escalationCounts,
+      escalationTrend,
+      ruleRegistryStats: registryStats,
+      isImproving: this.checkImprovement(escalationTrend),
+    };
+  }
+
+  /**
+   * Check if escalation rate is trending downward.
+   */
+  private checkImprovement(trend: EscalationTrend[]): boolean {
+    if (trend.length < 2) return false;
+
+    const recent = trend.slice(-3);
+    const earlier = trend.slice(-6, -3);
+
+    if (earlier.length === 0) return false;
+
+    const recentAvg = recent.reduce((s, t) => s + t.l2ToL3Rate, 0) / recent.length;
+    const earlierAvg = earlier.reduce((s, t) => s + t.l2ToL3Rate, 0) / earlier.length;
+
+    return recentAvg < earlierAvg;
+  }
+}

--- a/src/planner/a2a-proposer.ts
+++ b/src/planner/a2a-proposer.ts
@@ -1,0 +1,102 @@
+/**
+ * A2AProposer — LLM-based candidate plan proposer via Agent-to-Agent protocol.
+ *
+ * Sends the current state + goal to Ava (LLM agent) and receives candidate plans.
+ * The A2A interface is abstracted so tests can provide mock proposers.
+ */
+
+import type { Action, Goal, Plan, PlannerState } from "./types.ts";
+import type { CandidatePlan, L2Context } from "./routing-interface.ts";
+
+/** Interface for A2A communication with an LLM agent. */
+export interface A2AClient {
+  /**
+   * Request candidate plans from the LLM agent.
+   *
+   * @param prompt - Structured prompt describing state, goal, and available actions
+   * @param maxCandidates - Maximum number of candidate plans to request
+   * @returns Array of candidate plans
+   */
+  proposePlans(prompt: A2APrompt, maxCandidates: number): Promise<CandidatePlan[]>;
+}
+
+/** Structured prompt sent to the LLM agent. */
+export interface A2APrompt {
+  /** Current world state as key-value pairs. */
+  state: PlannerState;
+  /** Human-readable goal description. */
+  goalDescription: string;
+  /** Goal ID if available. */
+  goalId?: string;
+  /** Available actions the LLM can use in its plan. */
+  availableActions: ActionSummary[];
+  /** Context about why lower layers failed. */
+  failureContext: string[];
+  /** Maximum plan length. */
+  maxPlanLength: number;
+}
+
+/** Simplified action description for the LLM. */
+export interface ActionSummary {
+  id: string;
+  name: string;
+  cost: number;
+  /** Human-readable preconditions. */
+  preconditionsSummary: string;
+  /** Human-readable effects. */
+  effectsSummary: string;
+}
+
+export class A2AProposer {
+  constructor(private client: A2AClient) {}
+
+  /**
+   * Generate candidate plans by querying the LLM via A2A.
+   */
+  async propose(
+    context: L2Context,
+    availableActions: readonly Action[],
+    maxCandidates: number = 3,
+  ): Promise<CandidatePlan[]> {
+    const prompt = this.buildPrompt(context, availableActions);
+    return this.client.proposePlans(prompt, maxCandidates);
+  }
+
+  /**
+   * Build a structured A2A prompt from context.
+   */
+  private buildPrompt(
+    context: L2Context,
+    availableActions: readonly Action[],
+  ): A2APrompt {
+    const actionSummaries: ActionSummary[] = availableActions.map((a) => ({
+      id: a.id,
+      name: a.name,
+      cost: a.cost,
+      preconditionsSummary: `${a.preconditions.length} preconditions`,
+      effectsSummary: `${a.effects.length} effects`,
+    }));
+
+    const failureReasons = context.failures.map(
+      (f) => `${f.layer.toUpperCase()} failed: ${f.reason}`,
+    );
+
+    return {
+      state: context.currentState,
+      goalDescription: context.namedGoal?.name ?? "unnamed goal",
+      goalId: context.namedGoal?.id,
+      availableActions: actionSummaries,
+      failureContext: failureReasons,
+      maxPlanLength: 20,
+    };
+  }
+}
+
+/**
+ * NoOpA2AClient — returns empty candidates. Used as default when no LLM is configured.
+ */
+export class NoOpA2AClient implements A2AClient {
+  async proposePlans(_prompt: A2APrompt, _maxCandidates: number): Promise<CandidatePlan[]> {
+    return [];
+  }
+}

--- a/src/planner/astar-validator.ts
+++ b/src/planner/astar-validator.ts
@@ -1,0 +1,110 @@
+/**
+ * AStarValidator — validates LLM-proposed candidate plans using A* search.
+ *
+ * Takes candidate plans from A2AProposer, validates each via plan-validator,
+ * and optionally runs A* to find a cost-optimal alternative.
+ */
+
+import type { Goal, Plan, PlannerState, SearchResult, BudgetConfig } from "./types.ts";
+import type { CandidatePlan, ValidationOutcome } from "./routing-interface.ts";
+import { ActionGraph } from "./action-graph.ts";
+import { AnytimePlanner } from "./anytime-planner.ts";
+import { validatePlan } from "./plan-validator.ts";
+import { zeroHeuristic } from "./heuristic.ts";
+import type { HeuristicFn } from "./heuristic.ts";
+
+/** Configuration for the A* validator. */
+export interface AStarValidatorConfig {
+  /** Whether to run A* optimization after validating candidates. */
+  optimizeWithAStar: boolean;
+  /** Budget for A* optimization search. */
+  optimizationBudget: BudgetConfig;
+}
+
+const DEFAULT_CONFIG: AStarValidatorConfig = {
+  optimizeWithAStar: true,
+  optimizationBudget: {
+    timeBudgetMs: 5000,
+    maxExpansions: 5000,
+  },
+};
+
+export class AStarValidator {
+  private graph: ActionGraph;
+  private config: AStarValidatorConfig;
+
+  constructor(graph: ActionGraph, config: Partial<AStarValidatorConfig> = {}) {
+    this.graph = graph;
+    this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  /**
+   * Validate a single candidate plan.
+   */
+  validateCandidate(
+    candidate: CandidatePlan,
+    initialState: PlannerState,
+    goal: Goal,
+  ): ValidationOutcome {
+    const validation = validatePlan(candidate.plan, initialState, goal);
+
+    return {
+      feasible: validation.valid,
+      validatedPlan: validation.valid ? candidate.plan : undefined,
+      validationResult: validation,
+    };
+  }
+
+  /**
+   * Validate all candidates and return outcomes ordered by quality.
+   */
+  validateCandidates(
+    candidates: CandidatePlan[],
+    initialState: PlannerState,
+    goal: Goal,
+  ): Array<{ candidate: CandidatePlan; outcome: ValidationOutcome }> {
+    const results = candidates.map((candidate) => ({
+      candidate,
+      outcome: this.validateCandidate(candidate, initialState, goal),
+    }));
+
+    // Sort by: feasible first, then by plan cost
+    results.sort((a, b) => {
+      if (a.outcome.feasible !== b.outcome.feasible) {
+        return a.outcome.feasible ? -1 : 1;
+      }
+      const aCost = a.candidate.plan.totalCost;
+      const bCost = b.candidate.plan.totalCost;
+      return aCost - bCost;
+    });
+
+    return results;
+  }
+
+  /**
+   * Run A* to find an optimized plan, comparing against the best candidate.
+   */
+  optimize(
+    initialState: PlannerState,
+    goal: Goal,
+    heuristic: HeuristicFn = zeroHeuristic,
+    bestCandidateCost?: number,
+  ): { plan: Plan; searchResult: SearchResult } | null {
+    if (!this.config.optimizeWithAStar) return null;
+
+    const planner = new AnytimePlanner(this.graph, heuristic);
+    const result = planner.search(initialState, goal, this.config.optimizationBudget);
+
+    if (!result.searchResult.plan.isComplete) return null;
+
+    // Only return if A* found something better (or no candidate existed)
+    if (bestCandidateCost !== undefined && result.searchResult.plan.totalCost >= bestCandidateCost) {
+      return null;
+    }
+
+    return {
+      plan: result.searchResult.plan,
+      searchResult: result.searchResult,
+    };
+  }
+}

--- a/src/planner/confidence-scorer.ts
+++ b/src/planner/confidence-scorer.ts
@@ -1,0 +1,134 @@
+/**
+ * ConfidenceScorer — evaluates plan quality and produces a composite
+ * confidence score used for routing decisions (L2 → L3 escalation).
+ */
+
+import type { Goal, Plan, PlannerState, ValidationResult } from "./types.ts";
+import type { ConfidenceBreakdown, ConfidenceScore, CandidatePlan } from "./routing-interface.ts";
+import { cloneState } from "./world-state.ts";
+import { executePlan } from "./executor.ts";
+
+/** Weights for each confidence component. */
+export interface ConfidenceWeights {
+  feasibility: number;
+  goalAlignment: number;
+  costEfficiency: number;
+  constraintSatisfaction: number;
+}
+
+export const DEFAULT_WEIGHTS: ConfidenceWeights = {
+  feasibility: 0.35,
+  goalAlignment: 0.30,
+  costEfficiency: 0.15,
+  constraintSatisfaction: 0.20,
+};
+
+export class ConfidenceScorer {
+  private weights: ConfidenceWeights;
+
+  constructor(weights: Partial<ConfidenceWeights> = {}) {
+    this.weights = { ...DEFAULT_WEIGHTS, ...weights };
+  }
+
+  /**
+   * Score a validated plan's confidence.
+   */
+  score(
+    plan: Plan,
+    initialState: PlannerState,
+    goal: Goal,
+    validation: ValidationResult,
+    candidate?: CandidatePlan,
+  ): ConfidenceScore {
+    const breakdown = this.computeBreakdown(plan, initialState, goal, validation, candidate);
+    const overall = this.computeOverall(breakdown);
+    return { overall, breakdown };
+  }
+
+  /**
+   * Compute individual confidence factors.
+   */
+  private computeBreakdown(
+    plan: Plan,
+    initialState: PlannerState,
+    goal: Goal,
+    validation: ValidationResult,
+    candidate?: CandidatePlan,
+  ): ConfidenceBreakdown {
+    return {
+      feasibility: this.scoreFeasibility(plan, validation),
+      goalAlignment: this.scoreGoalAlignment(plan, initialState, goal, validation),
+      costEfficiency: this.scoreCostEfficiency(plan),
+      constraintSatisfaction: this.scoreConstraintSatisfaction(plan, validation, candidate),
+    };
+  }
+
+  /**
+   * Weighted composite of breakdown scores.
+   */
+  private computeOverall(breakdown: ConfidenceBreakdown): number {
+    const w = this.weights;
+    return (
+      w.feasibility * breakdown.feasibility +
+      w.goalAlignment * breakdown.goalAlignment +
+      w.costEfficiency * breakdown.costEfficiency +
+      w.constraintSatisfaction * breakdown.constraintSatisfaction
+    );
+  }
+
+  /**
+   * Feasibility: 1.0 if plan is valid and complete, penalized for partial plans.
+   */
+  private scoreFeasibility(plan: Plan, validation: ValidationResult): number {
+    if (!validation.valid) return 0;
+    if (!plan.isComplete) return 0.3;
+    if (plan.actions.length === 0) return 0.5;
+    return 1.0;
+  }
+
+  /**
+   * Goal alignment: does the final state satisfy the goal?
+   */
+  private scoreGoalAlignment(
+    plan: Plan,
+    initialState: PlannerState,
+    goal: Goal,
+    validation: ValidationResult,
+  ): number {
+    if (!validation.valid) return 0;
+    // Try executing on a state clone to check goal satisfaction
+    const stateCopy = cloneState(initialState);
+    const execResult = executePlan(plan, stateCopy);
+    if (!execResult.success) return 0;
+    return goal(execResult.finalState) ? 1.0 : 0.2;
+  }
+
+  /**
+   * Cost efficiency: normalized inverse cost (lower cost → higher score).
+   * Uses a sigmoid-like function so very high costs don't dominate.
+   */
+  private scoreCostEfficiency(plan: Plan): number {
+    if (plan.actions.length === 0) return 1.0;
+    const avgCost = plan.totalCost / plan.actions.length;
+    // Sigmoid normalization: 1 / (1 + avgCost / 10)
+    return 1.0 / (1.0 + avgCost / 10.0);
+  }
+
+  /**
+   * Constraint satisfaction: all preconditions met, no failures in execution chain.
+   */
+  private scoreConstraintSatisfaction(
+    plan: Plan,
+    validation: ValidationResult,
+    candidate?: CandidatePlan,
+  ): number {
+    let score = validation.valid ? 1.0 : 0;
+
+    // If LLM provided a high self-confidence, boost slightly
+    if (candidate && candidate.llmConfidence > 0.8) {
+      score = Math.min(1.0, score + 0.1);
+    }
+
+    return score;
+  }
+}

--- a/src/planner/conflict-detector.ts
+++ b/src/planner/conflict-detector.ts
@@ -1,0 +1,104 @@
+/**
+ * ConflictDetector — detects conflicts between actions in a plan.
+ *
+ * Checks for:
+ * - Actions with contradictory effects
+ * - Precondition violations due to earlier effects
+ * - Resource conflicts (same state key modified by multiple actions)
+ */
+
+import type { Action, Plan, PlannerState } from "./types.ts";
+import { applyEffects, preconditionsMet } from "./action.ts";
+import { cloneState } from "./world-state.ts";
+
+/** A detected conflict between two actions. */
+export interface PlanConflict {
+  type: "precondition_violation" | "contradictory_effects" | "resource_conflict";
+  /** Index of the first action involved. */
+  actionIndexA: number;
+  /** Index of the second action involved (may be same as A for self-conflicts). */
+  actionIndexB: number;
+  description: string;
+}
+
+/**
+ * Detect conflicts in a plan by simulating execution.
+ */
+export function detectConflicts(plan: Plan, initialState: PlannerState): PlanConflict[] {
+  const conflicts: PlanConflict[] = [];
+  let state = cloneState(initialState);
+
+  for (let i = 0; i < plan.actions.length; i++) {
+    const action = plan.actions[i];
+
+    // Check preconditions against current simulated state
+    if (!preconditionsMet(action, state)) {
+      // Find which earlier action invalidated the preconditions
+      const invalidator = findInvalidator(plan.actions, i, initialState);
+      conflicts.push({
+        type: "precondition_violation",
+        actionIndexA: invalidator,
+        actionIndexB: i,
+        description: `Action "${action.name}" (index ${i}) has unsatisfied preconditions after effects of action at index ${invalidator}`,
+      });
+    }
+
+    // Apply effects to advance simulated state
+    state = applyEffects(action, state);
+  }
+
+  // Check for contradictory effects (actions that undo each other)
+  for (let i = 0; i < plan.actions.length - 1; i++) {
+    for (let j = i + 1; j < plan.actions.length; j++) {
+      if (hasContradictoryEffects(plan.actions[i], plan.actions[j])) {
+        conflicts.push({
+          type: "contradictory_effects",
+          actionIndexA: i,
+          actionIndexB: j,
+          description: `Actions "${plan.actions[i].name}" and "${plan.actions[j].name}" have contradictory effects`,
+        });
+      }
+    }
+  }
+
+  return conflicts;
+}
+
+/**
+ * Find which action invalidated preconditions for a later action.
+ */
+function findInvalidator(actions: Action[], targetIndex: number, initialState: PlannerState): number {
+  let state = cloneState(initialState);
+  const targetAction = actions[targetIndex];
+
+  for (let i = 0; i < targetIndex; i++) {
+    const prevState = cloneState(state);
+    state = applyEffects(actions[i], state);
+
+    // If preconditions were met before this action but not after, this is the invalidator
+    if (preconditionsMet(targetAction, prevState) && !preconditionsMet(targetAction, state)) {
+      return i;
+    }
+  }
+
+  return 0; // Default: initial state didn't satisfy preconditions
+}
+
+/**
+ * Check if two actions have effects that contradict each other.
+ * Two effects contradict if they set the same state key to different values.
+ */
+function hasContradictoryEffects(a: Action, b: Action): boolean {
+  // Compare effect outputs by running them on a sample state
+  const sampleState: PlannerState = {};
+  const stateAfterA = applyEffects(a, sampleState);
+  const stateAfterB = applyEffects(b, sampleState);
+
+  for (const key of Object.keys(stateAfterA)) {
+    if (key in stateAfterB && stateAfterA[key] !== stateAfterB[key]) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/planner/dispatcher.ts
+++ b/src/planner/dispatcher.ts
@@ -1,0 +1,180 @@
+/**
+ * L2-aware Dispatcher — orchestrates the full L0→L1→L2→L3 planning pipeline.
+ *
+ * Extends the existing planning orchestrator with L2 hybrid planning,
+ * confidence-based routing, and learning flywheel integration.
+ */
+
+import type { Goal, PlannerState, NamedGoal, BudgetConfig, Plan } from "./types.ts";
+import type { L2Result, RoutingConfig } from "./routing-interface.ts";
+import { DEFAULT_ROUTING_CONFIG } from "./routing-interface.ts";
+import { L2Router, type L2RouterConfig, type L3EscalationHandler } from "./l2-router.ts";
+import { HybridPlanner } from "./hybrid-planner.ts";
+import { ActionGraph } from "./action-graph.ts";
+import type { A2AClient } from "./a2a-proposer.ts";
+import { NoOpA2AClient } from "./a2a-proposer.ts";
+import { L1Planner } from "./l1-integration.ts";
+import { TaskNetwork } from "./task-network.ts";
+import type { L0RuleMatcher } from "../matcher/l0-l1-bridge.ts";
+import { L0Interface } from "./l0-interface.ts";
+import { L1Interface } from "./l1-interface.ts";
+import { PlanConverter } from "../learning/plan-converter.ts";
+import { RuleRegistry } from "../learning/rule-registry.ts";
+import { PatternMatcher as LearnedPatternMatcher } from "../learning/pattern-matcher.ts";
+import { L2Metrics, type L2InvocationRecord } from "../monitoring/l2-metrics.ts";
+import { EscalationTracker } from "../monitoring/escalation-tracker.ts";
+
+/** Configuration for the L2-aware dispatcher. */
+export interface L2DispatcherConfig {
+  routing?: Partial<RoutingConfig>;
+  /** A2A client for LLM communication. */
+  a2aClient?: A2AClient;
+  /** L3 escalation callback. */
+  onL3Escalation?: L3EscalationHandler;
+}
+
+/**
+ * L2Dispatcher — full pipeline dispatcher with learning flywheel.
+ */
+export class L2Dispatcher {
+  private router: L2Router;
+  private ruleRegistry: RuleRegistry;
+  private planConverter: PlanConverter;
+  private learnedMatcher: LearnedPatternMatcher;
+  private l0Interface: L0Interface;
+  private l1Interface: L1Interface;
+  private metrics: L2Metrics;
+  private escalationTracker: EscalationTracker;
+
+  constructor(
+    graph: ActionGraph,
+    config: L2DispatcherConfig = {},
+    l1Planner?: L1Planner,
+    l0Matcher?: L0RuleMatcher,
+  ) {
+    const routingConfig: RoutingConfig = {
+      ...DEFAULT_ROUTING_CONFIG,
+      ...config.routing,
+    };
+
+    const a2aClient = config.a2aClient ?? new NoOpA2AClient();
+    const hybridPlanner = new HybridPlanner(a2aClient, graph, { routing: routingConfig });
+
+    this.router = new L2Router(
+      hybridPlanner,
+      { routing: routingConfig, onL3Escalation: config.onL3Escalation },
+      l1Planner,
+      l0Matcher,
+    );
+
+    this.ruleRegistry = new RuleRegistry();
+    this.planConverter = new PlanConverter(this.ruleRegistry);
+    this.learnedMatcher = new LearnedPatternMatcher(this.ruleRegistry);
+    this.l0Interface = new L0Interface(l0Matcher ?? null);
+    this.l1Interface = new L1Interface(l1Planner ?? null);
+    this.metrics = new L2Metrics();
+    this.escalationTracker = new EscalationTracker();
+  }
+
+  /**
+   * Resolve a goal through the full planning pipeline.
+   *
+   * 1. Check learned rules first
+   * 2. Route through L0→L1→L2→L3
+   * 3. Feed successful results into learning flywheel
+   * 4. Record metrics
+   */
+  async resolve(
+    state: PlannerState,
+    goal: Goal,
+    namedGoal?: NamedGoal,
+    budget?: BudgetConfig,
+  ): Promise<L2Result> {
+    const startTime = Date.now();
+    const goalPattern = namedGoal?.id ?? "unnamed";
+
+    // Step 1: Check learned rules
+    const learnedMatch = this.learnedMatcher.match(state, goalPattern);
+    if (learnedMatch.matched && learnedMatch.plan) {
+      this.ruleRegistry.recordSuccess(learnedMatch.rule!.id);
+      const result: L2Result = {
+        success: true,
+        plan: learnedMatch.plan,
+        confidence: {
+          overall: learnedMatch.confidence,
+          breakdown: { feasibility: 1, goalAlignment: 1, costEfficiency: 0.8, constraintSatisfaction: 1 },
+        },
+        escalatedToL3: false,
+        planId: crypto.randomUUID(),
+      };
+      this.recordMetrics(result, startTime, "l0");
+      return result;
+    }
+
+    // Step 2: Route through L0→L1→L2
+    const result = await this.router.resolve(state, goal, namedGoal, budget);
+    const handledBy = result.escalatedToL3 ? "l3" : "l2";
+    this.recordMetrics(result, startTime, handledBy);
+
+    // Step 3: Learning flywheel
+    if (result.success && result.plan) {
+      this.planConverter.learningCycle(result, goalPattern, state);
+    }
+
+    // Step 4: Track escalations
+    if (result.escalatedToL3) {
+      this.escalationTracker.record({
+        id: result.planId,
+        timestamp: Date.now(),
+        fromLayer: "l2",
+        toLayer: "l3",
+        goalPattern,
+        reason: result.error ?? "low confidence",
+        correlationId: result.planId,
+      });
+    }
+
+    return result;
+  }
+
+  /** Record metrics for an invocation. */
+  private recordMetrics(result: L2Result, startTime: number, handledBy: string): void {
+    this.metrics.record({
+      planId: result.planId,
+      timestamp: Date.now(),
+      success: result.success,
+      confidence: result.confidence.overall,
+      escalatedToL3: result.escalatedToL3,
+      latencyMs: Date.now() - startTime,
+      candidateCount: result.selectedCandidate ? 1 : 0,
+      planActionCount: result.plan?.actions.length ?? 0,
+      planCost: result.plan?.totalCost ?? 0,
+      handledBy: handledBy as "l0" | "l1" | "l2" | "l3",
+    });
+  }
+
+  /** Access the rule registry. */
+  getRuleRegistry(): RuleRegistry {
+    return this.ruleRegistry;
+  }
+
+  /** Access L2 metrics. */
+  getMetrics(): L2Metrics {
+    return this.metrics;
+  }
+
+  /** Access escalation tracker. */
+  getEscalationTracker(): EscalationTracker {
+    return this.escalationTracker;
+  }
+
+  /** Access the L0 interface. */
+  getL0Interface(): L0Interface {
+    return this.l0Interface;
+  }
+
+  /** Access the L1 interface. */
+  getL1Interface(): L1Interface {
+    return this.l1Interface;
+  }
+}

--- a/src/planner/escalation-trigger.ts
+++ b/src/planner/escalation-trigger.ts
@@ -1,0 +1,78 @@
+/**
+ * EscalationTrigger — decides when to escalate from L2 to L3 (human).
+ *
+ * Triggers escalation when confidence is below threshold or borderline.
+ * Borderline plans (within margin of threshold) are flagged for lightweight review.
+ */
+
+import type { ConfidenceScore, L2Result, RoutingConfig } from "./routing-interface.ts";
+import { DEFAULT_ROUTING_CONFIG } from "./routing-interface.ts";
+
+/** Result of an escalation evaluation. */
+export interface EscalationEvaluation {
+  shouldEscalate: boolean;
+  /** Plan is near the threshold — may warrant lightweight confirmation. */
+  isBorderline: boolean;
+  reason: string;
+  confidence: number;
+  threshold: number;
+}
+
+export class EscalationTrigger {
+  private threshold: number;
+  private borderlineMargin: number;
+
+  constructor(
+    threshold?: number,
+    borderlineMargin: number = 0.05,
+  ) {
+    this.threshold = threshold ?? DEFAULT_ROUTING_CONFIG.l2ConfidenceThreshold;
+    this.borderlineMargin = borderlineMargin;
+  }
+
+  /**
+   * Evaluate whether an L2 result should be escalated to L3.
+   */
+  evaluate(confidence: ConfidenceScore): EscalationEvaluation {
+    const { overall } = confidence;
+
+    if (overall < this.threshold) {
+      return {
+        shouldEscalate: true,
+        isBorderline: false,
+        reason: `Confidence ${overall.toFixed(3)} below threshold ${this.threshold}`,
+        confidence: overall,
+        threshold: this.threshold,
+      };
+    }
+
+    const isBorderline = overall < this.threshold + this.borderlineMargin;
+    if (isBorderline) {
+      return {
+        shouldEscalate: false,
+        isBorderline: true,
+        reason: `Confidence ${overall.toFixed(3)} is borderline (within ${this.borderlineMargin} of threshold ${this.threshold})`,
+        confidence: overall,
+        threshold: this.threshold,
+      };
+    }
+
+    return {
+      shouldEscalate: false,
+      isBorderline: false,
+      reason: `Confidence ${overall.toFixed(3)} above threshold ${this.threshold}`,
+      confidence: overall,
+      threshold: this.threshold,
+    };
+  }
+
+  /** Update threshold at runtime (e.g., from config hot-reload). */
+  setThreshold(threshold: number): void {
+    this.threshold = threshold;
+  }
+
+  /** Get current threshold. */
+  getThreshold(): number {
+    return this.threshold;
+  }
+}

--- a/src/planner/hybrid-planner.ts
+++ b/src/planner/hybrid-planner.ts
@@ -1,0 +1,195 @@
+/**
+ * HybridPlanner — LLM-A* hybrid planning engine.
+ *
+ * Combines LLM (Ava via A2A) for creative plan proposal with A* for
+ * validation and cost-optimal path finding.
+ *
+ * Flow:
+ *   1. Send context to A2AProposer → get candidate plans
+ *   2. Validate each candidate with AStarValidator
+ *   3. Optionally optimize with A* if no candidate is good enough
+ *   4. Score confidence of best plan
+ *   5. Return L2Result with plan + confidence
+ */
+
+import type { Goal, Plan, PlannerState, Action, ValidationResult } from "./types.ts";
+import type { L2Context, L2Result, CandidatePlan, RoutingConfig, ConfidenceScore } from "./routing-interface.ts";
+import { DEFAULT_ROUTING_CONFIG } from "./routing-interface.ts";
+import { A2AProposer, type A2AClient, NoOpA2AClient } from "./a2a-proposer.ts";
+import { AStarValidator, type AStarValidatorConfig } from "./astar-validator.ts";
+import { ConfidenceScorer } from "./confidence-scorer.ts";
+import { EscalationTrigger } from "./escalation-trigger.ts";
+import { ActionGraph } from "./action-graph.ts";
+import { validatePlan } from "./plan-validator.ts";
+import { zeroHeuristic, namedGoalHeuristic } from "./heuristic.ts";
+import type { HeuristicFn } from "./heuristic.ts";
+
+/** Configuration for the hybrid planner. */
+export interface HybridPlannerConfig {
+  routing: RoutingConfig;
+  validator?: Partial<AStarValidatorConfig>;
+  /** Borderline margin for escalation trigger. */
+  borderlineMargin?: number;
+}
+
+export class HybridPlanner {
+  private proposer: A2AProposer;
+  private validator: AStarValidator;
+  private scorer: ConfidenceScorer;
+  private trigger: EscalationTrigger;
+  private graph: ActionGraph;
+  private config: RoutingConfig;
+
+  constructor(
+    a2aClient: A2AClient,
+    graph: ActionGraph,
+    config: Partial<HybridPlannerConfig> = {},
+  ) {
+    this.graph = graph;
+    this.config = config.routing ?? DEFAULT_ROUTING_CONFIG;
+    this.proposer = new A2AProposer(a2aClient);
+    this.validator = new AStarValidator(graph, config.validator);
+    this.scorer = new ConfidenceScorer();
+    this.trigger = new EscalationTrigger(
+      this.config.l2ConfidenceThreshold,
+      config.borderlineMargin,
+    );
+  }
+
+  /**
+   * Generate and validate a plan using LLM-A* hybrid approach.
+   */
+  async plan(context: L2Context): Promise<L2Result> {
+    const planId = crypto.randomUUID();
+    const availableActions = this.graph.getAllActions();
+    const heuristic = this.selectHeuristic(context);
+
+    // Step 1: Get LLM candidates
+    let candidates: CandidatePlan[];
+    try {
+      candidates = await this.proposer.propose(
+        context,
+        availableActions,
+        this.config.maxCandidates,
+      );
+    } catch (err) {
+      // LLM failure — fall through to A* only
+      candidates = [];
+    }
+
+    // Step 2: Validate candidates
+    let bestPlan: Plan | undefined;
+    let bestCandidate: CandidatePlan | undefined;
+    let bestValidation = this.emptyValidation();
+
+    if (candidates.length > 0) {
+      const validated = this.validator.validateCandidates(
+        candidates,
+        context.currentState,
+        context.goal,
+      );
+
+      const firstFeasible = validated.find((v) => v.outcome.feasible);
+      if (firstFeasible) {
+        bestPlan = firstFeasible.outcome.validatedPlan;
+        bestCandidate = firstFeasible.candidate;
+        bestValidation = firstFeasible.outcome.validationResult;
+      }
+    }
+
+    // Step 3: A* optimization — try to beat the best candidate or find a plan if none exists
+    const astarResult = this.validator.optimize(
+      context.currentState,
+      context.goal,
+      heuristic,
+      bestPlan?.totalCost,
+    );
+
+    if (astarResult) {
+      bestPlan = astarResult.plan;
+      bestValidation = validatePlan(astarResult.plan, context.currentState, context.goal);
+    }
+
+    // Step 4: Score confidence
+    if (!bestPlan) {
+      return this.failureResult(planId, "No feasible plan found from LLM candidates or A* optimization");
+    }
+
+    const confidence = this.scorer.score(
+      bestPlan,
+      context.currentState,
+      context.goal,
+      bestValidation,
+      bestCandidate,
+    );
+
+    // Step 5: Check escalation
+    const escalation = this.trigger.evaluate(confidence);
+
+    return {
+      success: !escalation.shouldEscalate,
+      plan: bestPlan,
+      confidence,
+      selectedCandidate: bestCandidate,
+      validation: {
+        feasible: bestValidation.valid,
+        validatedPlan: bestPlan,
+        validationResult: bestValidation,
+        optimizedPlan: astarResult?.plan,
+        costDelta: bestCandidate && astarResult
+          ? bestCandidate.plan.totalCost - astarResult.plan.totalCost
+          : undefined,
+      },
+      searchResult: astarResult?.searchResult,
+      escalatedToL3: escalation.shouldEscalate,
+      error: escalation.shouldEscalate ? escalation.reason : undefined,
+      planId,
+    };
+  }
+
+  /** Select appropriate heuristic for the context. */
+  private selectHeuristic(context: L2Context): HeuristicFn {
+    return context.namedGoal
+      ? namedGoalHeuristic(context.namedGoal)
+      : zeroHeuristic;
+  }
+
+  /** Create a failure result. */
+  private failureResult(planId: string, error: string): L2Result {
+    return {
+      success: false,
+      confidence: {
+        overall: 0,
+        breakdown: {
+          feasibility: 0,
+          goalAlignment: 0,
+          costEfficiency: 0,
+          constraintSatisfaction: 0,
+        },
+      },
+      escalatedToL3: true,
+      error,
+      planId,
+    };
+  }
+
+  /** Create empty validation for initial state. */
+  private emptyValidation(): ValidationResult {
+    return {
+      valid: false,
+      failedAtIndex: -1,
+      finalState: {} as PlannerState,
+      error: "No candidate validated",
+    };
+  }
+
+  /** Access the A* validator for testing/introspection. */
+  getValidator(): AStarValidator {
+    return this.validator;
+  }
+
+  /** Access the escalation trigger for testing. */
+  getEscalationTrigger(): EscalationTrigger {
+    return this.trigger;
+  }
+}

--- a/src/planner/l0-interface.ts
+++ b/src/planner/l0-interface.ts
@@ -1,0 +1,64 @@
+/**
+ * L0Interface — L0 planner interface for L2 integration.
+ *
+ * Provides a standardized way for the L2 system to query L0 capabilities
+ * and check if L0 can handle a request before invoking L2.
+ */
+
+import type { Goal, PlannerState, Plan } from "./types.ts";
+import type { L0RuleMatcher, L0MatchResult } from "../matcher/l0-l1-bridge.ts";
+
+/** L0 capability check result. */
+export interface L0CapabilityResult {
+  canHandle: boolean;
+  confidence: number;
+  matchResult?: L0MatchResult;
+  plan?: Plan;
+}
+
+export class L0Interface {
+  constructor(private matcher: L0RuleMatcher | null) {}
+
+  /**
+   * Check if L0 can handle a request and with what confidence.
+   */
+  checkCapability(state: PlannerState, goal: Goal): L0CapabilityResult {
+    if (!this.matcher) {
+      return { canHandle: false, confidence: 0 };
+    }
+
+    const result = this.matcher.match(state, goal);
+
+    if (result.matched && result.action) {
+      return {
+        canHandle: true,
+        confidence: 1.0, // L0 rule matches are deterministic
+        matchResult: result,
+        plan: {
+          actions: [result.action],
+          totalCost: result.action.cost,
+          isComplete: true,
+        },
+      };
+    }
+
+    return {
+      canHandle: false,
+      confidence: 0,
+      matchResult: result,
+    };
+  }
+
+  /**
+   * Report that an L0 rule failed at runtime (for learning feedback).
+   */
+  reportFailure(goalId: string, actionId: string, error: string): void {
+    // This is a hook for the learning system to track L0 failures
+    // that might benefit from L2 intervention
+  }
+
+  /** Whether L0 matcher is configured. */
+  isAvailable(): boolean {
+    return this.matcher !== null;
+  }
+}

--- a/src/planner/l1-interface.ts
+++ b/src/planner/l1-interface.ts
@@ -1,0 +1,82 @@
+/**
+ * L1Interface — L1 planner interface for L2 integration.
+ *
+ * Provides a standardized way for the L2 system to query L1 capabilities
+ * and check if L1 can handle a request before invoking L2.
+ */
+
+import type { Goal, PlannerState, Plan, BudgetConfig, L0Context, L1Result } from "./types.ts";
+import { L1Planner, type L1PlannerConfig } from "./l1-integration.ts";
+
+/** L1 capability check result. */
+export interface L1CapabilityResult {
+  canHandle: boolean;
+  confidence: number;
+  result?: L1Result;
+}
+
+export class L1Interface {
+  constructor(private planner: L1Planner | null) {}
+
+  /**
+   * Check if L1 can handle a request and with what confidence.
+   */
+  checkCapability(
+    state: PlannerState,
+    goal: Goal,
+    budget?: BudgetConfig,
+  ): L1CapabilityResult {
+    if (!this.planner) {
+      return { canHandle: false, confidence: 0 };
+    }
+
+    const context: L0Context = {
+      currentState: state,
+      goal,
+      reason: "L1 capability check",
+    };
+
+    const result = this.planner.planFromContext(context, budget);
+
+    if (result.success && result.plan) {
+      // Estimate confidence based on search completeness and plan quality
+      const confidence = this.estimateConfidence(result);
+      return {
+        canHandle: true,
+        confidence,
+        result,
+      };
+    }
+
+    return {
+      canHandle: false,
+      confidence: 0,
+      result,
+    };
+  }
+
+  /**
+   * Estimate confidence in the L1 result.
+   */
+  private estimateConfidence(result: L1Result): number {
+    let confidence = 0.5; // Base confidence for any L1 result
+
+    if (result.plan?.isComplete) confidence += 0.2;
+    if (result.validationResult?.valid) confidence += 0.2;
+    if (result.searchResult?.exhaustive) confidence += 0.1;
+
+    return Math.min(1.0, confidence);
+  }
+
+  /**
+   * Report that an L1 plan failed at runtime.
+   */
+  reportFailure(goalId: string, error: string): void {
+    // Hook for learning system to track L1 failures
+  }
+
+  /** Whether L1 planner is configured. */
+  isAvailable(): boolean {
+    return this.planner !== null;
+  }
+}

--- a/src/planner/l2-router.ts
+++ b/src/planner/l2-router.ts
@@ -1,0 +1,207 @@
+/**
+ * L2Router — routing layer that intercepts L0/L1 failures or low-confidence
+ * decisions and delegates to the L2 Ava hybrid planner.
+ *
+ * Decision tree:
+ *   1. Try L0 rule match → if confident, return
+ *   2. Try L1 A* search → if confident, return
+ *   3. Invoke L2 hybrid (LLM-A*) → if confident, return
+ *   4. Escalate to L3 (human-in-the-loop)
+ */
+
+import type { Goal, L0Context, L1Result, NamedGoal, Plan, PlannerState, BudgetConfig } from "./types.ts";
+import type {
+  FailureContext,
+  L2Context,
+  L2Result,
+  RoutingConfig,
+  RoutingDecision,
+  RoutingTarget,
+} from "./routing-interface.ts";
+import { DEFAULT_ROUTING_CONFIG } from "./routing-interface.ts";
+import { HybridPlanner } from "./hybrid-planner.ts";
+import { L1Planner } from "./l1-integration.ts";
+import type { L0RuleMatcher } from "../matcher/l0-l1-bridge.ts";
+
+/** Callback for L3 escalation. */
+export type L3EscalationHandler = (context: L2Context, result: L2Result) => void;
+
+export interface L2RouterConfig {
+  routing: RoutingConfig;
+  /** Handler called when escalating to L3. */
+  onL3Escalation?: L3EscalationHandler;
+}
+
+export class L2Router {
+  private config: RoutingConfig;
+  private hybridPlanner: HybridPlanner;
+  private l1Planner: L1Planner | null;
+  private l0Matcher: L0RuleMatcher | null;
+  private onL3Escalation: L3EscalationHandler | null;
+
+  constructor(
+    hybridPlanner: HybridPlanner,
+    config: Partial<L2RouterConfig> = {},
+    l1Planner?: L1Planner,
+    l0Matcher?: L0RuleMatcher,
+  ) {
+    this.config = config.routing ?? DEFAULT_ROUTING_CONFIG;
+    this.hybridPlanner = hybridPlanner;
+    this.l1Planner = l1Planner ?? null;
+    this.l0Matcher = l0Matcher ?? null;
+    this.onL3Escalation = config.onL3Escalation ?? null;
+  }
+
+  /**
+   * Route a planning request through L0 → L1 → L2 → L3.
+   */
+  async resolve(
+    state: PlannerState,
+    goal: Goal,
+    namedGoal?: NamedGoal,
+    budget?: BudgetConfig,
+  ): Promise<L2Result> {
+    const correlationId = crypto.randomUUID();
+    const failures: FailureContext[] = [];
+
+    // Step 1: Try L0
+    if (this.l0Matcher) {
+      const l0Result = this.l0Matcher.match(state, goal);
+      if (l0Result.matched && l0Result.action) {
+        return this.l0SuccessResult(l0Result.action, correlationId);
+      }
+      failures.push({
+        layer: "l0",
+        reason: l0Result.reason ?? "no matching rule",
+      });
+    }
+
+    // Step 2: Try L1 (if configured)
+    if (this.config.tryL1BeforeL2 && this.l1Planner) {
+      const l0Context: L0Context = {
+        currentState: state,
+        goal,
+        namedGoal,
+        reason: failures[0]?.reason ?? "no L0 matcher configured",
+      };
+
+      const l1Result = this.l1Planner.planFromContext(l0Context, budget);
+      if (l1Result.success && l1Result.plan) {
+        return this.l1SuccessResult(l1Result, correlationId);
+      }
+      failures.push({
+        layer: "l1",
+        reason: l1Result.error ?? "L1 planning failed",
+        partialResult: l1Result,
+      });
+    }
+
+    // Step 3: Invoke L2 hybrid planner
+    const l2Context: L2Context = {
+      currentState: state,
+      goal,
+      namedGoal,
+      failures,
+      l0Context: {
+        currentState: state,
+        goal,
+        namedGoal,
+        reason: failures.map((f) => f.reason).join("; "),
+      },
+      correlationId,
+    };
+
+    const l2Result = await this.hybridPlanner.plan(l2Context);
+
+    // Step 4: Escalate to L3 if needed
+    if (l2Result.escalatedToL3 && this.onL3Escalation) {
+      this.onL3Escalation(l2Context, l2Result);
+    }
+
+    return l2Result;
+  }
+
+  /**
+   * Direct L2 invocation — skips L0/L1, used when explicitly routing to L2.
+   */
+  async invokeL2(context: L2Context): Promise<L2Result> {
+    const result = await this.hybridPlanner.plan(context);
+
+    if (result.escalatedToL3 && this.onL3Escalation) {
+      this.onL3Escalation(context, result);
+    }
+
+    return result;
+  }
+
+  /**
+   * Make a routing decision without executing — for introspection.
+   */
+  decideRoute(
+    state: PlannerState,
+    goal: Goal,
+    l0Confidence?: number,
+    l1Confidence?: number,
+  ): RoutingDecision {
+    // Check L0
+    if (l0Confidence !== undefined && l0Confidence >= this.config.l0ConfidenceThreshold) {
+      return {
+        target: "l0",
+        reason: `L0 confidence ${l0Confidence} >= threshold ${this.config.l0ConfidenceThreshold}`,
+        confidence: l0Confidence,
+        context: { currentState: state, goal, reason: "l0 sufficient" },
+      };
+    }
+
+    // Check L1
+    if (l1Confidence !== undefined && l1Confidence >= this.config.l1ConfidenceThreshold) {
+      return {
+        target: "l1",
+        reason: `L1 confidence ${l1Confidence} >= threshold ${this.config.l1ConfidenceThreshold}`,
+        confidence: l1Confidence,
+        context: { currentState: state, goal, reason: "l1 sufficient" },
+      };
+    }
+
+    // Route to L2
+    return {
+      target: "l2",
+      reason: "L0/L1 confidence below thresholds or unavailable",
+      context: {
+        currentState: state,
+        goal,
+        failures: [],
+        correlationId: crypto.randomUUID(),
+      } as L2Context,
+    };
+  }
+
+  /** Wrap an L0 match as an L2Result. */
+  private l0SuccessResult(action: import("./types.ts").Action, correlationId: string): L2Result {
+    return {
+      success: true,
+      plan: { actions: [action], totalCost: action.cost, isComplete: true },
+      confidence: {
+        overall: 1.0,
+        breakdown: { feasibility: 1, goalAlignment: 1, costEfficiency: 1, constraintSatisfaction: 1 },
+      },
+      escalatedToL3: false,
+      planId: correlationId,
+    };
+  }
+
+  /** Wrap an L1 result as an L2Result. */
+  private l1SuccessResult(l1Result: L1Result, correlationId: string): L2Result {
+    return {
+      success: true,
+      plan: l1Result.plan,
+      confidence: {
+        overall: 0.85,
+        breakdown: { feasibility: 1, goalAlignment: 0.9, costEfficiency: 0.7, constraintSatisfaction: 0.8 },
+      },
+      searchResult: l1Result.searchResult,
+      escalatedToL3: false,
+      planId: correlationId,
+    };
+  }
+}

--- a/src/planner/plan-cost-function.ts
+++ b/src/planner/plan-cost-function.ts
@@ -1,0 +1,68 @@
+/**
+ * PlanCostFunction — custom cost computation for L2 hybrid planning.
+ *
+ * Computes costs considering action weights, risk factors, and historical success rates.
+ */
+
+import type { Plan, Action } from "./types.ts";
+
+/** Cost factors for plan evaluation. */
+export interface CostFactors {
+  /** Base action cost multiplier. */
+  baseCostWeight: number;
+  /** Risk penalty per action. */
+  riskPenalty: number;
+  /** Bonus for previously successful action sequences. */
+  historicalSuccessBonus: number;
+  /** Penalty for plan length. */
+  lengthPenalty: number;
+}
+
+export const DEFAULT_COST_FACTORS: CostFactors = {
+  baseCostWeight: 1.0,
+  riskPenalty: 0.5,
+  lengthPenalty: 0.1,
+  historicalSuccessBonus: 0.2,
+};
+
+/**
+ * Compute the effective cost of a plan considering multiple factors.
+ */
+export function computePlanCost(
+  plan: Plan,
+  factors: CostFactors = DEFAULT_COST_FACTORS,
+  successRates?: Map<string, number>,
+): number {
+  let cost = 0;
+
+  for (const action of plan.actions) {
+    let actionCost = action.cost * factors.baseCostWeight;
+
+    // Apply historical success bonus if available
+    if (successRates) {
+      const rate = successRates.get(action.id);
+      if (rate !== undefined) {
+        actionCost -= rate * factors.historicalSuccessBonus;
+      }
+    }
+
+    cost += Math.max(0, actionCost);
+  }
+
+  // Length penalty
+  cost += plan.actions.length * factors.lengthPenalty;
+
+  return cost;
+}
+
+/**
+ * Compare two plans and return the cost difference (negative = first is better).
+ */
+export function comparePlanCosts(
+  planA: Plan,
+  planB: Plan,
+  factors?: CostFactors,
+  successRates?: Map<string, number>,
+): number {
+  return computePlanCost(planA, factors, successRates) - computePlanCost(planB, factors, successRates);
+}

--- a/src/planner/plan-optimizer.ts
+++ b/src/planner/plan-optimizer.ts
@@ -1,0 +1,75 @@
+/**
+ * PlanOptimizer — optimizes plans by removing redundant actions,
+ * reordering where possible, and trimming unnecessary steps.
+ */
+
+import type { Plan, PlannerState, Goal } from "./types.ts";
+import { validatePlan } from "./plan-validator.ts";
+import { cloneState } from "./world-state.ts";
+import { applyEffects } from "./action.ts";
+
+/** Optimization result with before/after stats. */
+export interface OptimizationResult {
+  optimizedPlan: Plan;
+  originalCost: number;
+  optimizedCost: number;
+  actionsRemoved: number;
+  valid: boolean;
+}
+
+/**
+ * Remove redundant actions from a plan.
+ *
+ * An action is redundant if removing it doesn't affect goal satisfaction.
+ * Uses a greedy approach: try removing each action and check if plan still works.
+ */
+export function removeRedundantActions(
+  plan: Plan,
+  initialState: PlannerState,
+  goal: Goal,
+): OptimizationResult {
+  const originalCost = plan.totalCost;
+  let optimizedActions = [...plan.actions];
+
+  // Try removing each action (reverse order to preserve indices)
+  for (let i = optimizedActions.length - 1; i >= 0; i--) {
+    const without = [...optimizedActions.slice(0, i), ...optimizedActions.slice(i + 1)];
+    const candidate: Plan = {
+      actions: without,
+      totalCost: without.reduce((sum, a) => sum + a.cost, 0),
+      isComplete: true,
+    };
+
+    const validation = validatePlan(candidate, initialState, goal);
+    if (validation.valid) {
+      optimizedActions = without;
+    }
+  }
+
+  const optimizedPlan: Plan = {
+    actions: optimizedActions,
+    totalCost: optimizedActions.reduce((sum, a) => sum + a.cost, 0),
+    isComplete: plan.isComplete,
+  };
+
+  const validation = validatePlan(optimizedPlan, initialState, goal);
+
+  return {
+    optimizedPlan,
+    originalCost,
+    optimizedCost: optimizedPlan.totalCost,
+    actionsRemoved: plan.actions.length - optimizedActions.length,
+    valid: validation.valid,
+  };
+}
+
+/**
+ * Full optimization pass: remove redundant actions.
+ */
+export function optimizePlan(
+  plan: Plan,
+  initialState: PlannerState,
+  goal: Goal,
+): OptimizationResult {
+  return removeRedundantActions(plan, initialState, goal);
+}

--- a/src/planner/quality-metrics.ts
+++ b/src/planner/quality-metrics.ts
@@ -1,0 +1,85 @@
+/**
+ * QualityMetrics — individual metric computations for plan quality assessment.
+ *
+ * Used by ConfidenceScorer and monitoring systems to evaluate plan quality.
+ */
+
+import type { Plan, PlannerState, Goal, ValidationResult } from "./types.ts";
+
+/** Quality metric result. */
+export interface QualityMetric {
+  name: string;
+  value: number;
+  /** 0–1 normalized score. */
+  normalizedScore: number;
+  description: string;
+}
+
+/**
+ * Compute plan length quality — shorter plans are generally better.
+ */
+export function planLengthMetric(plan: Plan): QualityMetric {
+  const len = plan.actions.length;
+  // Score decays with length: 1/(1 + len/5)
+  const normalizedScore = 1.0 / (1.0 + len / 5.0);
+  return {
+    name: "plan_length",
+    value: len,
+    normalizedScore,
+    description: `Plan has ${len} actions`,
+  };
+}
+
+/**
+ * Compute total cost quality.
+ */
+export function totalCostMetric(plan: Plan): QualityMetric {
+  const normalizedScore = 1.0 / (1.0 + plan.totalCost / 20.0);
+  return {
+    name: "total_cost",
+    value: plan.totalCost,
+    normalizedScore,
+    description: `Total plan cost: ${plan.totalCost}`,
+  };
+}
+
+/**
+ * Compute plan completeness quality.
+ */
+export function completenessMetric(plan: Plan): QualityMetric {
+  const value = plan.isComplete ? 1 : 0;
+  return {
+    name: "completeness",
+    value,
+    normalizedScore: value,
+    description: plan.isComplete ? "Plan is complete" : "Plan is incomplete",
+  };
+}
+
+/**
+ * Compute validation quality.
+ */
+export function validationMetric(validation: ValidationResult): QualityMetric {
+  const value = validation.valid ? 1 : 0;
+  return {
+    name: "validation",
+    value,
+    normalizedScore: value,
+    description: validation.valid ? "Plan passes validation" : `Validation failed: ${validation.error}`,
+  };
+}
+
+/**
+ * Compute all quality metrics for a plan.
+ */
+export function computeAllMetrics(
+  plan: Plan,
+  validation: ValidationResult,
+): QualityMetric[] {
+  return [
+    planLengthMetric(plan),
+    totalCostMetric(plan),
+    completenessMetric(plan),
+    validationMetric(validation),
+  ];
+}

--- a/src/planner/routing-interface.ts
+++ b/src/planner/routing-interface.ts
@@ -1,0 +1,137 @@
+/**
+ * Routing interface — types for L0/L1/L2 planner routing decisions.
+ *
+ * Extends the existing L0Context and L1Result types with confidence-aware
+ * routing, L2 context, and escalation metadata.
+ */
+
+import type { Goal, L0Context, L1Result, NamedGoal, Plan, PlannerState, SearchResult, ValidationResult } from "./types.ts";
+
+// ── Confidence types ────────────────────────────────────────────────────────
+
+/** Breakdown of individual confidence factors. */
+export interface ConfidenceBreakdown {
+  /** Plan feasibility score (0–1): can actions be executed in order? */
+  feasibility: number;
+  /** Goal alignment score (0–1): does plan satisfy goal constraints? */
+  goalAlignment: number;
+  /** Cost efficiency score (0–1): is cost reasonable vs alternatives? */
+  costEfficiency: number;
+  /** Constraint satisfaction score (0–1): are all constraints met? */
+  constraintSatisfaction: number;
+}
+
+/** Confidence score with overall value and breakdown. */
+export interface ConfidenceScore {
+  /** Overall confidence 0–1 (weighted composite of breakdown). */
+  overall: number;
+  breakdown: ConfidenceBreakdown;
+}
+
+// ── L2 context and result types ─────────────────────────────────────────────
+
+/** Why a lower layer failed or had low confidence. */
+export interface FailureContext {
+  layer: "l0" | "l1";
+  reason: string;
+  confidence?: number;
+  /** The partial or failed result from the lower layer. */
+  partialResult?: L1Result;
+}
+
+/** Context passed to the L2 planner. */
+export interface L2Context {
+  currentState: PlannerState;
+  goal: Goal;
+  namedGoal?: NamedGoal;
+  /** Why the request escalated to L2. */
+  failures: FailureContext[];
+  /** Original L0 context if available. */
+  l0Context?: L0Context;
+  /** Correlation ID for tracing. */
+  correlationId: string;
+}
+
+/** A candidate plan proposed by the LLM (A2A). */
+export interface CandidatePlan {
+  /** Actions in the proposed plan. */
+  plan: Plan;
+  /** Rationale from the LLM for this plan. */
+  rationale: string;
+  /** LLM's self-assessed confidence (0–1). */
+  llmConfidence: number;
+}
+
+/** Result from A* validation of a candidate plan. */
+export interface ValidationOutcome {
+  /** Whether the A* validator considers the plan feasible. */
+  feasible: boolean;
+  /** The validated/optimized plan (may differ from candidate). */
+  validatedPlan?: Plan;
+  /** A* validation result. */
+  validationResult: ValidationResult;
+  /** If A* found a better plan, include it. */
+  optimizedPlan?: Plan;
+  /** Cost comparison: original vs optimized. */
+  costDelta?: number;
+}
+
+/** Result from the L2 hybrid planner. */
+export interface L2Result {
+  success: boolean;
+  plan?: Plan;
+  confidence: ConfidenceScore;
+  /** The candidate that was selected (if any). */
+  selectedCandidate?: CandidatePlan;
+  /** Validation outcome from A*. */
+  validation?: ValidationOutcome;
+  /** Search stats from A* validation. */
+  searchResult?: SearchResult;
+  /** If escalated to L3 (human). */
+  escalatedToL3: boolean;
+  /** Reason for failure or escalation. */
+  error?: string;
+  /** Plan ID for learning flywheel tracking. */
+  planId: string;
+}
+
+// ── Routing decision types ──────────────────────────────────────────────────
+
+/** Which layer should handle the request. */
+export type RoutingTarget = "l0" | "l1" | "l2" | "l3_human";
+
+/** A routing decision with rationale. */
+export interface RoutingDecision {
+  target: RoutingTarget;
+  reason: string;
+  confidence?: number;
+  /** Context to pass to the selected layer. */
+  context: L0Context | L2Context;
+}
+
+// ── Routing config types ────────────────────────────────────────────────────
+
+/** Configuration for routing thresholds. */
+export interface RoutingConfig {
+  /** Minimum confidence for L0 result to be accepted (0–1). */
+  l0ConfidenceThreshold: number;
+  /** Minimum confidence for L1 result to be accepted (0–1). */
+  l1ConfidenceThreshold: number;
+  /** Minimum confidence for L2 result to be accepted (0–1). */
+  l2ConfidenceThreshold: number;
+  /** Maximum number of LLM candidates to request. */
+  maxCandidates: number;
+  /** Time budget for L2 planning (ms). */
+  l2TimeBudgetMs: number;
+  /** Whether to attempt L1 before escalating to L2. */
+  tryL1BeforeL2: boolean;
+}
+
+export const DEFAULT_ROUTING_CONFIG: RoutingConfig = {
+  l0ConfidenceThreshold: 0.7,
+  l1ConfidenceThreshold: 0.6,
+  l2ConfidenceThreshold: 0.5,
+  maxCandidates: 3,
+  l2TimeBudgetMs: 30_000,
+  tryL1BeforeL2: true,
+};

--- a/tests/integration/test_e2e_learning.ts
+++ b/tests/integration/test_e2e_learning.ts
@@ -1,0 +1,132 @@
+/**
+ * End-to-end integration test: full L0→L1→L2→L3 pipeline
+ * with learning flywheel validation.
+ */
+
+import { describe, test, expect } from "bun:test";
+import type { Goal, PlannerState, Action, Plan } from "../../src/planner/types.ts";
+import type { A2AClient, A2APrompt } from "../../src/planner/a2a-proposer.ts";
+import type { CandidatePlan } from "../../src/planner/routing-interface.ts";
+import { L2Dispatcher } from "../../src/planner/dispatcher.ts";
+import { ActionGraph } from "../../src/planner/action-graph.ts";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeAction(
+  id: string,
+  cost: number,
+  pre: (s: PlannerState) => boolean,
+  eff: (s: PlannerState) => PlannerState,
+): Action {
+  return {
+    id,
+    name: id,
+    cost,
+    level: "action" as const,
+    preconditions: [pre],
+    effects: [eff],
+  };
+}
+
+class MockA2AClient implements A2AClient {
+  callCount = 0;
+  async proposePlans(_prompt: A2APrompt, _max: number): Promise<CandidatePlan[]> {
+    this.callCount++;
+    return [];
+  }
+}
+
+// ── Integration tests ───────────────────────────────────────────────────────
+
+describe("E2E: L2 Dispatcher + Learning Flywheel", () => {
+  const action1 = makeAction("step-1", 3, (s) => s["phase"] === 0, (s) => ({ ...s, phase: 1 }));
+  const action2 = makeAction("step-2", 2, (s) => s["phase"] === 1, (s) => ({ ...s, phase: 2 }));
+  const goal: Goal = (s) => s["phase"] === 2;
+  const state: PlannerState = { phase: 0 };
+  const namedGoal = { id: "advance-phase", name: "Advance to phase 2", test: goal };
+
+  test("resolves through A* when no LLM configured", async () => {
+    const graph = new ActionGraph();
+    graph.addActions([action1, action2]);
+
+    const dispatcher = new L2Dispatcher(graph, {
+      routing: { l0ConfidenceThreshold: 0.7, l1ConfidenceThreshold: 0.6, l2ConfidenceThreshold: 0.5, maxCandidates: 3, l2TimeBudgetMs: 5000, tryL1BeforeL2: false },
+    });
+
+    const result = await dispatcher.resolve(state, goal, namedGoal);
+    expect(result.success).toBe(true);
+    expect(result.plan?.isComplete).toBe(true);
+    expect(result.plan?.actions).toHaveLength(2);
+  });
+
+  test("learning flywheel creates rules from successful plans", async () => {
+    const graph = new ActionGraph();
+    graph.addActions([action1, action2]);
+
+    const dispatcher = new L2Dispatcher(graph, {
+      routing: { l0ConfidenceThreshold: 0.7, l1ConfidenceThreshold: 0.6, l2ConfidenceThreshold: 0.5, maxCandidates: 3, l2TimeBudgetMs: 5000, tryL1BeforeL2: false },
+    });
+
+    // First resolve — should create a learned rule
+    await dispatcher.resolve(state, goal, namedGoal);
+
+    const registry = dispatcher.getRuleRegistry();
+    expect(registry.size).toBeGreaterThanOrEqual(1);
+  });
+
+  test("learned rules speed up subsequent resolves", async () => {
+    const graph = new ActionGraph();
+    graph.addActions([action1, action2]);
+
+    const a2a = new MockA2AClient();
+    const dispatcher = new L2Dispatcher(graph, {
+      a2aClient: a2a,
+      routing: { l0ConfidenceThreshold: 0.7, l1ConfidenceThreshold: 0.6, l2ConfidenceThreshold: 0.5, maxCandidates: 3, l2TimeBudgetMs: 5000, tryL1BeforeL2: false },
+    });
+
+    // First resolve — goes through L2, creates rule
+    const result1 = await dispatcher.resolve(state, goal, namedGoal);
+    expect(result1.success).toBe(true);
+    const callsAfterFirst = a2a.callCount;
+
+    // Second resolve — should use learned rule, skip L2
+    const result2 = await dispatcher.resolve(state, goal, namedGoal);
+    expect(result2.success).toBe(true);
+    // A2A should NOT have been called again (learned rule used)
+    expect(a2a.callCount).toBe(callsAfterFirst);
+  });
+
+  test("metrics track invocations and escalation rate", async () => {
+    const graph = new ActionGraph();
+    graph.addActions([action1, action2]);
+
+    const dispatcher = new L2Dispatcher(graph, {
+      routing: { l0ConfidenceThreshold: 0.7, l1ConfidenceThreshold: 0.6, l2ConfidenceThreshold: 0.5, maxCandidates: 3, l2TimeBudgetMs: 5000, tryL1BeforeL2: false },
+    });
+
+    await dispatcher.resolve(state, goal, namedGoal);
+
+    const metrics = dispatcher.getMetrics();
+    const summary = metrics.getSummary();
+    expect(summary.totalInvocations).toBeGreaterThanOrEqual(1);
+    expect(summary.successRate).toBeGreaterThan(0);
+  });
+
+  test("escalation is tracked when plan impossible", async () => {
+    const graph = new ActionGraph(); // Empty — no plan possible
+    let escalated = false;
+
+    const dispatcher = new L2Dispatcher(graph, {
+      routing: { l0ConfidenceThreshold: 0.7, l1ConfidenceThreshold: 0.6, l2ConfidenceThreshold: 0.5, maxCandidates: 3, l2TimeBudgetMs: 5000, tryL1BeforeL2: false },
+      onL3Escalation: () => { escalated = true; },
+    });
+
+    const impossibleGoal: Goal = (s) => s["impossible"] === true;
+    await dispatcher.resolve(state, impossibleGoal);
+
+    expect(escalated).toBe(true);
+    const tracker = dispatcher.getEscalationTracker();
+    const counts = tracker.getCounts();
+    expect(counts.total).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tests/learning/test_plan_learning_flywheel.ts
+++ b/tests/learning/test_plan_learning_flywheel.ts
@@ -1,0 +1,326 @@
+/**
+ * Tests for the plan learning flywheel — rule extraction, registry, and promotion.
+ */
+
+import { describe, test, expect } from "bun:test";
+import type { Action, Plan, PlannerState } from "../../src/planner/types.ts";
+import type { L2Result } from "../../src/planner/routing-interface.ts";
+import { RuleRegistry } from "../../src/learning/rule-registry.ts";
+import { RuleExtractor } from "../../src/learning/rule-extractor.ts";
+import { PlanConverter } from "../../src/learning/plan-converter.ts";
+import { PatternMatcher } from "../../src/learning/pattern-matcher.ts";
+import { RuleVersioning } from "../../src/learning/rule-versioning.ts";
+import { RuleAuditor } from "../../src/learning/rule-auditor.ts";
+import { RuleMigration } from "../../src/learning/rule-migration.ts";
+import { FeedbackCollector } from "../../src/learning/feedback-collector.ts";
+import { OutcomeAnalyzer } from "../../src/learning/outcome-analyzer.ts";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeAction(id: string, cost: number): Action {
+  return {
+    id,
+    name: id,
+    cost,
+    level: "action" as const,
+    preconditions: [(s: PlannerState) => s["ready"] === true],
+    effects: [(s: PlannerState) => ({ ...s, done: true })],
+  };
+}
+
+function makeL2Result(planId: string, plan: Plan, confidence: number): L2Result {
+  return {
+    success: true,
+    plan,
+    confidence: {
+      overall: confidence,
+      breakdown: {
+        feasibility: confidence,
+        goalAlignment: confidence,
+        costEfficiency: confidence,
+        constraintSatisfaction: confidence,
+      },
+    },
+    escalatedToL3: false,
+    planId,
+  };
+}
+
+// ── RuleRegistry tests ──────────────────────────────────────────────────────
+
+describe("RuleRegistry", () => {
+  test("registers and retrieves rules", () => {
+    const registry = new RuleRegistry();
+    const rule = {
+      id: "r1",
+      name: "Test Rule",
+      goalPattern: "fix-issue",
+      conditions: [(s: PlannerState) => s["ready"] === true],
+      actions: [makeAction("a1", 5)],
+      totalCost: 5,
+      successCount: 1,
+      failureCount: 0,
+      confidence: 0.9,
+      version: 1,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sourcePlanId: "plan-1",
+      promotedToL0: false,
+      active: true,
+    };
+
+    registry.register(rule);
+    expect(registry.get("r1")?.name).toBe("Test Rule");
+    expect(registry.size).toBe(1);
+  });
+
+  test("finds rules by goal pattern", () => {
+    const registry = new RuleRegistry();
+    registry.register({
+      id: "r1", name: "R1", goalPattern: "fix-issue",
+      conditions: [], actions: [], totalCost: 0,
+      successCount: 3, failureCount: 0, confidence: 0.9,
+      version: 1, createdAt: Date.now(), updatedAt: Date.now(),
+      sourcePlanId: "p1", promotedToL0: false, active: true,
+    });
+    registry.register({
+      id: "r2", name: "R2", goalPattern: "deploy",
+      conditions: [], actions: [], totalCost: 0,
+      successCount: 1, failureCount: 0, confidence: 0.8,
+      version: 1, createdAt: Date.now(), updatedAt: Date.now(),
+      sourcePlanId: "p2", promotedToL0: false, active: true,
+    });
+
+    expect(registry.findByGoal("fix-issue")).toHaveLength(1);
+    expect(registry.findByGoal("deploy")).toHaveLength(1);
+    expect(registry.findByGoal("unknown")).toHaveLength(0);
+  });
+
+  test("tracks success/failure counts", () => {
+    const registry = new RuleRegistry();
+    registry.register({
+      id: "r1", name: "R1", goalPattern: "test",
+      conditions: [], actions: [], totalCost: 0,
+      successCount: 0, failureCount: 0, confidence: 0.9,
+      version: 1, createdAt: Date.now(), updatedAt: Date.now(),
+      sourcePlanId: "p1", promotedToL0: false, active: true,
+    });
+
+    registry.recordSuccess("r1");
+    registry.recordSuccess("r1");
+    registry.recordFailure("r1");
+
+    const rule = registry.get("r1")!;
+    expect(rule.successCount).toBe(2);
+    expect(rule.failureCount).toBe(1);
+  });
+
+  test("returns promotion candidates above threshold", () => {
+    const registry = new RuleRegistry();
+    registry.register({
+      id: "r1", name: "R1", goalPattern: "test",
+      conditions: [], actions: [], totalCost: 0,
+      successCount: 5, failureCount: 0, confidence: 0.9,
+      version: 1, createdAt: Date.now(), updatedAt: Date.now(),
+      sourcePlanId: "p1", promotedToL0: false, active: true,
+    });
+    registry.register({
+      id: "r2", name: "R2", goalPattern: "test2",
+      conditions: [], actions: [], totalCost: 0,
+      successCount: 1, failureCount: 0, confidence: 0.8,
+      version: 1, createdAt: Date.now(), updatedAt: Date.now(),
+      sourcePlanId: "p2", promotedToL0: false, active: true,
+    });
+
+    const candidates = registry.getPromotionCandidates(3);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].id).toBe("r1");
+  });
+
+  test("deactivated rules are excluded from queries", () => {
+    const registry = new RuleRegistry();
+    registry.register({
+      id: "r1", name: "R1", goalPattern: "test",
+      conditions: [], actions: [], totalCost: 0,
+      successCount: 1, failureCount: 0, confidence: 0.9,
+      version: 1, createdAt: Date.now(), updatedAt: Date.now(),
+      sourcePlanId: "p1", promotedToL0: false, active: true,
+    });
+
+    registry.deactivate("r1");
+    expect(registry.findByGoal("test")).toHaveLength(0);
+    expect(registry.getAll()).toHaveLength(0);
+  });
+});
+
+// ── PlanConverter tests ─────────────────────────────────────────────────────
+
+describe("PlanConverter", () => {
+  test("converts high-confidence plan to rule", () => {
+    const registry = new RuleRegistry();
+    const converter = new PlanConverter(registry);
+
+    const plan: Plan = {
+      actions: [makeAction("a1", 5)],
+      totalCost: 5,
+      isComplete: true,
+    };
+
+    const result = makeL2Result("plan-1", plan, 0.9);
+    const conversion = converter.convert(result, "fix-issue", { ready: true });
+
+    expect(conversion.converted).toBe(true);
+    expect(conversion.rule).toBeDefined();
+    expect(registry.size).toBe(1);
+  });
+
+  test("rejects low-confidence plans", () => {
+    const registry = new RuleRegistry();
+    const converter = new PlanConverter(registry);
+
+    const plan: Plan = {
+      actions: [makeAction("a1", 5)],
+      totalCost: 5,
+      isComplete: true,
+    };
+
+    const result = makeL2Result("plan-1", plan, 0.3);
+    const conversion = converter.convert(result, "fix-issue", { ready: true });
+
+    expect(conversion.converted).toBe(false);
+    expect(registry.size).toBe(0);
+  });
+
+  test("learning cycle returns conversion and promotion candidates", () => {
+    const registry = new RuleRegistry();
+    const converter = new PlanConverter(registry, { promotionThreshold: 1 });
+
+    const plan: Plan = {
+      actions: [makeAction("a1", 5)],
+      totalCost: 5,
+      isComplete: true,
+    };
+
+    const result = makeL2Result("plan-1", plan, 0.9);
+    const cycle = converter.learningCycle(result, "fix-issue", { ready: true });
+
+    expect(cycle.conversion.converted).toBe(true);
+    expect(cycle.promotionCandidates.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ── PatternMatcher tests ────────────────────────────────────────────────────
+
+describe("PatternMatcher", () => {
+  test("matches learned rule against state", () => {
+    const registry = new RuleRegistry();
+    const matcher = new PatternMatcher(registry);
+
+    registry.register({
+      id: "r1", name: "R1", goalPattern: "fix-issue",
+      conditions: [(s) => s["ready"] === true],
+      actions: [makeAction("a1", 5)],
+      totalCost: 5,
+      successCount: 3, failureCount: 0, confidence: 0.9,
+      version: 1, createdAt: Date.now(), updatedAt: Date.now(),
+      sourcePlanId: "p1", promotedToL0: false, active: true,
+    });
+
+    const match = matcher.match({ ready: true }, "fix-issue");
+    expect(match.matched).toBe(true);
+    expect(match.plan?.actions).toHaveLength(1);
+    expect(match.confidence).toBeGreaterThan(0);
+  });
+
+  test("no match when conditions not met", () => {
+    const registry = new RuleRegistry();
+    const matcher = new PatternMatcher(registry);
+
+    registry.register({
+      id: "r1", name: "R1", goalPattern: "fix-issue",
+      conditions: [(s) => s["ready"] === true],
+      actions: [makeAction("a1", 5)],
+      totalCost: 5,
+      successCount: 3, failureCount: 0, confidence: 0.9,
+      version: 1, createdAt: Date.now(), updatedAt: Date.now(),
+      sourcePlanId: "p1", promotedToL0: false, active: true,
+    });
+
+    const match = matcher.match({ ready: false }, "fix-issue");
+    expect(match.matched).toBe(false);
+  });
+});
+
+// ── RuleMigration tests ─────────────────────────────────────────────────────
+
+describe("RuleMigration", () => {
+  test("promotes eligible rule", () => {
+    const registry = new RuleRegistry();
+    const versioning = new RuleVersioning();
+    const auditor = new RuleAuditor();
+    const migration = new RuleMigration(registry, versioning, auditor);
+
+    registry.register({
+      id: "r1", name: "R1", goalPattern: "test",
+      conditions: [], actions: [], totalCost: 0,
+      successCount: 5, failureCount: 0, confidence: 0.9,
+      version: 1, createdAt: Date.now(), updatedAt: Date.now(),
+      sourcePlanId: "p1", promotedToL0: false, active: true,
+    });
+
+    const result = migration.promote("r1");
+    expect(result.success).toBe(true);
+    expect(registry.get("r1")?.promotedToL0).toBe(true);
+    expect(auditor.getForRule("r1")).toHaveLength(1);
+  });
+
+  test("rollback deactivates rule", () => {
+    const registry = new RuleRegistry();
+    const versioning = new RuleVersioning();
+    const auditor = new RuleAuditor();
+    const migration = new RuleMigration(registry, versioning, auditor);
+
+    const rule = {
+      id: "r1", name: "R1", goalPattern: "test",
+      conditions: [], actions: [], totalCost: 0,
+      successCount: 5, failureCount: 0, confidence: 0.9,
+      version: 1, createdAt: Date.now(), updatedAt: Date.now(),
+      sourcePlanId: "p1", promotedToL0: false, active: true,
+    };
+
+    registry.register(rule);
+    versioning.createVersion(rule);
+    const result = migration.rollback("r1");
+
+    expect(result.success).toBe(true);
+    expect(registry.get("r1")?.active).toBe(false);
+  });
+});
+
+// ── FeedbackCollector tests ─────────────────────────────────────────────────
+
+describe("FeedbackCollector", () => {
+  test("collects and retrieves feedback", () => {
+    const collector = new FeedbackCollector();
+
+    collector.recordHumanFeedback({
+      planId: "p1",
+      timestamp: Date.now(),
+      decision: "approve",
+      decidedBy: "user-1",
+    });
+
+    collector.recordOutcome({
+      planId: "p1",
+      timestamp: Date.now(),
+      success: true,
+      durationMs: 100,
+      actionOutcomes: [{ actionId: "a1", success: true }],
+      goalSatisfied: true,
+    });
+
+    expect(collector.getForPlan("p1")).toHaveLength(2);
+    expect(collector.getApprovedPlans()).toHaveLength(1);
+    expect(collector.getSuccessfulExecutions()).toHaveLength(1);
+  });
+});

--- a/tests/planner/test_hybrid_planner.ts
+++ b/tests/planner/test_hybrid_planner.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for HybridPlanner — LLM-A* hybrid planning engine.
+ */
+
+import { describe, test, expect } from "bun:test";
+import type { Goal, PlannerState, Action, Plan } from "../../src/planner/types.ts";
+import type { A2AClient, A2APrompt } from "../../src/planner/a2a-proposer.ts";
+import type { CandidatePlan, L2Context } from "../../src/planner/routing-interface.ts";
+import { HybridPlanner } from "../../src/planner/hybrid-planner.ts";
+import { ActionGraph } from "../../src/planner/action-graph.ts";
+import { ConfidenceScorer } from "../../src/planner/confidence-scorer.ts";
+import { EscalationTrigger } from "../../src/planner/escalation-trigger.ts";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeAction(id: string, cost: number, pre: (s: PlannerState) => boolean, eff: (s: PlannerState) => PlannerState): Action {
+  return { id, name: id, cost, level: "action" as const, preconditions: [pre], effects: [eff] };
+}
+
+class MockA2AClient implements A2AClient {
+  private candidates: CandidatePlan[];
+  constructor(candidates: CandidatePlan[] = []) { this.candidates = candidates; }
+  async proposePlans(_p: A2APrompt, _m: number): Promise<CandidatePlan[]> { return this.candidates; }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("HybridPlanner", () => {
+  const action1 = makeAction("a1", 3, (s) => s["x"] === 0, (s) => ({ ...s, x: 1 }));
+  const action2 = makeAction("a2", 2, (s) => s["x"] === 1, (s) => ({ ...s, x: 2 }));
+
+  const goal: Goal = (s) => s["x"] === 2;
+  const state: PlannerState = { x: 0 };
+
+  test("finds plan via A* when no LLM candidates", async () => {
+    const graph = new ActionGraph();
+    graph.addActions([action1, action2]);
+
+    const planner = new HybridPlanner(new MockA2AClient(), graph);
+    const context: L2Context = {
+      currentState: state,
+      goal,
+      failures: [],
+      correlationId: "test-1",
+    };
+
+    const result = await planner.plan(context);
+    expect(result.success).toBe(true);
+    expect(result.plan?.isComplete).toBe(true);
+    expect(result.plan?.actions).toHaveLength(2);
+    expect(result.confidence.overall).toBeGreaterThan(0);
+  });
+
+  test("validates LLM-proposed candidate", async () => {
+    const graph = new ActionGraph();
+    graph.addActions([action1, action2]);
+
+    const validPlan: Plan = {
+      actions: [action1, action2],
+      totalCost: 5,
+      isComplete: true,
+    };
+
+    const client = new MockA2AClient([{
+      plan: validPlan,
+      rationale: "Chain a1→a2 achieves goal",
+      llmConfidence: 0.9,
+    }]);
+
+    const planner = new HybridPlanner(client, graph);
+    const context: L2Context = {
+      currentState: state,
+      goal,
+      failures: [],
+      correlationId: "test-2",
+    };
+
+    const result = await planner.plan(context);
+    expect(result.success).toBe(true);
+    expect(result.confidence.overall).toBeGreaterThan(0);
+  });
+
+  test("rejects invalid LLM candidate and falls back to A*", async () => {
+    const graph = new ActionGraph();
+    graph.addActions([action1, action2]);
+
+    // Invalid plan: action2 before action1 (precondition violation)
+    const invalidPlan: Plan = {
+      actions: [action2, action1],
+      totalCost: 5,
+      isComplete: true,
+    };
+
+    const client = new MockA2AClient([{
+      plan: invalidPlan,
+      rationale: "Reversed order",
+      llmConfidence: 0.5,
+    }]);
+
+    const planner = new HybridPlanner(client, graph);
+    const context: L2Context = {
+      currentState: state,
+      goal,
+      failures: [],
+      correlationId: "test-3",
+    };
+
+    const result = await planner.plan(context);
+    // Should still find a plan via A* optimization
+    expect(result.plan?.isComplete).toBe(true);
+  });
+
+  test("escalates to L3 when no plan found", async () => {
+    const graph = new ActionGraph(); // Empty — no actions available
+
+    const planner = new HybridPlanner(new MockA2AClient(), graph);
+    const context: L2Context = {
+      currentState: state,
+      goal,
+      failures: [],
+      correlationId: "test-4",
+    };
+
+    const result = await planner.plan(context);
+    expect(result.success).toBe(false);
+    expect(result.escalatedToL3).toBe(true);
+    expect(result.confidence.overall).toBe(0);
+  });
+
+  test("returns confidence breakdown", async () => {
+    const graph = new ActionGraph();
+    graph.addActions([action1, action2]);
+
+    const planner = new HybridPlanner(new MockA2AClient(), graph);
+    const context: L2Context = {
+      currentState: state,
+      goal,
+      failures: [],
+      correlationId: "test-5",
+    };
+
+    const result = await planner.plan(context);
+    expect(result.confidence.breakdown.feasibility).toBeDefined();
+    expect(result.confidence.breakdown.goalAlignment).toBeDefined();
+    expect(result.confidence.breakdown.costEfficiency).toBeDefined();
+    expect(result.confidence.breakdown.constraintSatisfaction).toBeDefined();
+  });
+});
+
+describe("ConfidenceScorer", () => {
+  const action = makeAction("a", 5, () => true, (s) => ({ ...s, done: true }));
+
+  test("scores valid complete plan highly", () => {
+    const scorer = new ConfidenceScorer();
+    const plan: Plan = { actions: [action], totalCost: 5, isComplete: true };
+    const state: PlannerState = { done: false };
+    const goal: Goal = (s) => s["done"] === true;
+
+    const score = scorer.score(plan, state, goal, {
+      valid: true,
+      failedAtIndex: -1,
+      finalState: { done: true },
+    });
+
+    expect(score.overall).toBeGreaterThan(0.5);
+    expect(score.breakdown.feasibility).toBe(1.0);
+  });
+
+  test("scores invalid plan as zero", () => {
+    const scorer = new ConfidenceScorer();
+    const plan: Plan = { actions: [action], totalCost: 5, isComplete: true };
+    const state: PlannerState = { done: false };
+    const goal: Goal = (s) => s["done"] === true;
+
+    const score = scorer.score(plan, state, goal, {
+      valid: false,
+      failedAtIndex: 0,
+      finalState: state,
+      error: "fail",
+    });
+
+    expect(score.overall).toBe(0);
+  });
+});
+
+describe("EscalationTrigger", () => {
+  test("escalates when below threshold", () => {
+    const trigger = new EscalationTrigger(0.5);
+    const result = trigger.evaluate({
+      overall: 0.3,
+      breakdown: { feasibility: 0.3, goalAlignment: 0.3, costEfficiency: 0.3, constraintSatisfaction: 0.3 },
+    });
+    expect(result.shouldEscalate).toBe(true);
+  });
+
+  test("does not escalate when above threshold", () => {
+    const trigger = new EscalationTrigger(0.5);
+    const result = trigger.evaluate({
+      overall: 0.8,
+      breakdown: { feasibility: 0.8, goalAlignment: 0.8, costEfficiency: 0.8, constraintSatisfaction: 0.8 },
+    });
+    expect(result.shouldEscalate).toBe(false);
+    expect(result.isBorderline).toBe(false);
+  });
+
+  test("flags borderline confidence", () => {
+    const trigger = new EscalationTrigger(0.5, 0.05);
+    const result = trigger.evaluate({
+      overall: 0.52,
+      breakdown: { feasibility: 0.5, goalAlignment: 0.5, costEfficiency: 0.5, constraintSatisfaction: 0.6 },
+    });
+    expect(result.shouldEscalate).toBe(false);
+    expect(result.isBorderline).toBe(true);
+  });
+});

--- a/tests/planner/test_l2_router.ts
+++ b/tests/planner/test_l2_router.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for L2Router — verifies routing logic from L0→L1→L2→L3.
+ */
+
+import { describe, test, expect } from "bun:test";
+import type { Goal, PlannerState, Action, Plan, L0Context } from "../../src/planner/types.ts";
+import type { L0RuleMatcher, L0MatchResult } from "../../src/matcher/l0-l1-bridge.ts";
+import type { A2AClient, A2APrompt } from "../../src/planner/a2a-proposer.ts";
+import type { CandidatePlan } from "../../src/planner/routing-interface.ts";
+import { L2Router } from "../../src/planner/l2-router.ts";
+import { HybridPlanner } from "../../src/planner/hybrid-planner.ts";
+import { ActionGraph } from "../../src/planner/action-graph.ts";
+import { DEFAULT_ROUTING_CONFIG } from "../../src/planner/routing-interface.ts";
+
+// ── Test helpers ────────────────────────────────────────────────────────────
+
+function makeAction(id: string, cost: number, pre: (s: PlannerState) => boolean, eff: (s: PlannerState) => PlannerState): Action {
+  return {
+    id,
+    name: id,
+    cost,
+    level: "action" as const,
+    preconditions: [pre],
+    effects: [eff],
+  };
+}
+
+function makeGraph(actions: Action[]): ActionGraph {
+  const g = new ActionGraph();
+  g.addActions(actions);
+  return g;
+}
+
+class MockA2AClient implements A2AClient {
+  private candidates: CandidatePlan[];
+  constructor(candidates: CandidatePlan[] = []) {
+    this.candidates = candidates;
+  }
+  async proposePlans(_prompt: A2APrompt, _max: number): Promise<CandidatePlan[]> {
+    return this.candidates;
+  }
+}
+
+class MockL0Matcher implements L0RuleMatcher {
+  private result: L0MatchResult;
+  constructor(result: L0MatchResult) {
+    this.result = result;
+  }
+  match(_state: PlannerState, _goal: Goal): L0MatchResult {
+    return this.result;
+  }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("L2Router", () => {
+  const action = makeAction(
+    "fix-issue",
+    5,
+    (s) => s["issue_open"] === true,
+    (s) => ({ ...s, issue_open: false }),
+  );
+
+  const goal: Goal = (s) => s["issue_open"] === false;
+  const state: PlannerState = { issue_open: true };
+
+  test("routes to L0 when matcher finds a match", async () => {
+    const matcher = new MockL0Matcher({
+      matched: true,
+      action,
+    });
+
+    const graph = makeGraph([action]);
+    const hybrid = new HybridPlanner(new MockA2AClient(), graph);
+    const router = new L2Router(hybrid, {}, undefined, matcher);
+
+    const result = await router.resolve(state, goal);
+    expect(result.success).toBe(true);
+    expect(result.plan?.actions).toHaveLength(1);
+    expect(result.plan?.actions[0].id).toBe("fix-issue");
+    expect(result.escalatedToL3).toBe(false);
+  });
+
+  test("falls through to L2 when L0 has no match and L1 unavailable", async () => {
+    const matcher = new MockL0Matcher({
+      matched: false,
+      reason: "no matching rule",
+    });
+
+    const graph = makeGraph([action]);
+    const hybrid = new HybridPlanner(new MockA2AClient(), graph);
+    const router = new L2Router(hybrid, {}, undefined, matcher);
+
+    const result = await router.resolve(state, goal);
+    // L2 should attempt A* optimization since no LLM candidates
+    expect(result.planId).toBeDefined();
+  });
+
+  test("decideRoute returns l0 for high L0 confidence", () => {
+    const graph = makeGraph([action]);
+    const hybrid = new HybridPlanner(new MockA2AClient(), graph);
+    const router = new L2Router(hybrid);
+
+    const decision = router.decideRoute(state, goal, 0.9, undefined);
+    expect(decision.target).toBe("l0");
+  });
+
+  test("decideRoute returns l1 for high L1 confidence", () => {
+    const graph = makeGraph([action]);
+    const hybrid = new HybridPlanner(new MockA2AClient(), graph);
+    const router = new L2Router(hybrid);
+
+    const decision = router.decideRoute(state, goal, 0.3, 0.8);
+    expect(decision.target).toBe("l1");
+  });
+
+  test("decideRoute returns l2 when both below threshold", () => {
+    const graph = makeGraph([action]);
+    const hybrid = new HybridPlanner(new MockA2AClient(), graph);
+    const router = new L2Router(hybrid);
+
+    const decision = router.decideRoute(state, goal, 0.3, 0.3);
+    expect(decision.target).toBe("l2");
+  });
+
+  test("invokes L3 escalation handler when confidence too low", async () => {
+    let escalated = false;
+    const graph = makeGraph([]); // Empty graph → no plan possible
+    const hybrid = new HybridPlanner(new MockA2AClient(), graph);
+    const router = new L2Router(hybrid, {
+      onL3Escalation: () => { escalated = true; },
+    });
+
+    const impossibleGoal: Goal = (s) => s["impossible"] === true;
+    await router.resolve(state, impossibleGoal);
+    expect(escalated).toBe(true);
+  });
+
+  test("invokeL2 directly invokes hybrid planner", async () => {
+    const graph = makeGraph([action]);
+    const hybrid = new HybridPlanner(new MockA2AClient(), graph);
+    const router = new L2Router(hybrid);
+
+    const result = await router.invokeL2({
+      currentState: state,
+      goal,
+      failures: [],
+      correlationId: "test-123",
+    });
+
+    expect(result.planId).toBeDefined();
+    expect(result.confidence).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Implement L2 routing (invoke Ava when L0/L1 fail or confidence below threshold), LLM-A* hybrid (Ava proposes candidate plan via A2A, A* validates and optimizes), confidence scoring (L2 self-reports; low confidence → L3 human), and plan learning flywheel (successful L2 plans become L0 rules automatically — system improves itself). This closes the loop: every human escalation teaches the planner a new rule, driving escalation rate toward zero over time.

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced plan learning flywheel system that converts successful planning outcomes into reusable rules, improving performance on recurring patterns.
  * Added comprehensive monitoring dashboard with metrics for escalation rates, success rates, confidence distribution, and learned rules growth.
  * Implemented hybrid planning layer combining LLM-assisted proposals with A* validation for optimized plan selection.
  * Added escalation tracking and health metrics to monitor system performance and improvement over time.

* **Documentation**
  * Added API reference, architecture guide, operational runbook, and learning flywheel documentation.
  * Added monitoring dashboard definition with key performance indicators.
  * Added routing configuration file with configurable thresholds and learning parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->