### PR TITLE
Quinn PR Review — vector search context via Qdrant (codebase-wide awareness)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,124 @@
+# Architecture — protoWorkstacean
+
+protoWorkstacean is a personal agent orchestration platform built on a hierarchical topic-based pub/sub message bus. It coordinates a fleet of specialized AI agents (Quinn, Ava, Frank, Jon, etc.) across GitHub, Discord, and Plane.
+
+## Core Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                     EventBus (in-process)                │
+│           topic-based hierarchical pub/sub              │
+└───────────┬────────────────────────────────┬────────────┘
+            │                                │
+   ┌────────▼────────┐              ┌────────▼────────┐
+   │  Plugin Layer   │              │  Agent Layer    │
+   │  (lib/plugins/) │              │  (workspace/)   │
+   │                 │              │                 │
+   │ • GitHubPlugin  │              │ • Quinn (PR     │
+   │ • DiscordPlugin │              │   review, triage│
+   │ • PlanePlugin   │              │ • Ava (features)│
+   │ • A2APlugin     │              │ • Frank, Jon... │
+   │ • CeremonyPlugin│              └─────────────────┘
+   └─────────────────┘
+```
+
+## Plugin System
+
+Plugins are instantiated with a `workspaceDir` and install themselves onto the EventBus:
+
+```typescript
+export class MyPlugin implements Plugin {
+  readonly name = "my-plugin";
+  install(bus: EventBus): void { /* subscribe + serve */ }
+  uninstall(): void { /* cleanup */ }
+}
+```
+
+Plugins use `Bun.serve()` for HTTP endpoints and `bus.subscribe()` / `bus.publish()` for internal routing.
+
+## Quinn Vector Context Pipeline
+
+Quinn's PR review pipeline extends beyond the diff with codebase-wide vector search via Qdrant:
+
+```
+PR opened/synchronize
+  → GitHubPlugin → bus (message.inbound.github.*)
+  → A2APlugin → Quinn agent (pr_review skill)
+  → runReviewPipeline(diff, repo, pr)
+      ├── parseDiff + extractSymbols
+      ├── Qdrant: retrieveAllPastPRDecisions (quinn-pr-history)
+      ├── Qdrant: findAllSimilarPatterns (quinn-code-patterns)
+      ├── formatCodebaseContext + applyTokenBudget
+      └── assembleReviewPrompt → LLM call
+
+PR merged
+  → GitHubPlugin → parsePRMergePayload → handlePRMerge
+      ├── fetchPRDiff + fetchReviewDecision
+      ├── chunkDiff → embed → quinn-pr-history
+      └── extractSymbols → fetchSymbolContexts → quinn-code-patterns
+
+Developer dismisses Quinn comment
+  → GitHubPlugin → parseCommentResponsePayload
+  → handleCommentResponse → trackCommentResponse
+  → recordDismissalEvent → quinn-review-learnings
+```
+
+## Service Layer (`src/services/`)
+
+| Package | Responsibility |
+|---|---|
+| `qdrant/client.ts` | Qdrant REST API client (5s timeout, fallback on error) |
+| `qdrant/collections.ts` | Collection initialization (quinn-pr-history, quinn-code-patterns, quinn-review-learnings) |
+| `qdrant/pr-history-indexer.ts` | Index PR diff chunks |
+| `qdrant/code-patterns-indexer.ts` | Index symbol definitions |
+| `qdrant/pattern-searcher.ts` | Search for similar code patterns |
+| `qdrant/past-pr-retriever.ts` | Retrieve past PR decisions for a file |
+| `qdrant/review-learnings-indexer.ts` | Store/update dismissed comment patterns |
+| `embeddings/ollama-client.ts` | Ollama embedding API (nomic-embed-text) |
+| `diff/chunker.ts` | Parse unified diff, chunk large files |
+| `diff/symbol-extractor.ts` | Route to language-specific symbol extractors |
+| `diff/symbols/typescript.ts` | TypeScript symbol extraction via regex |
+| `diff/symbols/python.ts` | Python symbol extraction via regex |
+| `diff/symbols/go.ts` | Go symbol extraction via regex |
+| `github/diff-fetcher.ts` | Fetch PR diff, comments, and decision via GitHub API |
+| `codebase/symbol-fetcher.ts` | Fetch symbol context via GitHub raw content API |
+| `reviews/context-formatter.ts` | Format CODEBASE CONTEXT block |
+| `reviews/token-budgeter.ts` | Enforce 20% token budget cap |
+| `reviews/quinn-review-prompt.ts` | Assemble final review prompt |
+| `reviews/review-pipeline.ts` | Orchestrate full context retrieval pipeline |
+| `reviews/dismissal-tracker.ts` | Track developer responses to Quinn comments |
+| `reviews/low-signal-filter.ts` | Filter low-signal comment patterns |
+
+## External Services
+
+| Service | URL | Purpose |
+|---|---|---|
+| Qdrant | `http://qdrant:6333` | Vector search and storage |
+| Ollama | `http://ollama:11434` | Local LLM and embedding inference |
+| GitHub API | `https://api.github.com` | PR data, diffs, comments |
+| Plane | configured via `PLANE_API_URL` | Project management integration |
+| Discord | bot token | Team notifications |
+
+## Topic Conventions
+
+```
+message.inbound.github.<owner>.<repo>.<event>.<number>   — inbound from GitHub
+message.outbound.github.<owner>.<repo>.<number>          — outbound to GitHub
+message.inbound.discord.<channel>                        — inbound from Discord
+message.outbound.discord.<channel>                       — outbound to Discord
+```
+
+## Configuration
+
+All configuration is via environment variables. See `docs/CONFIGURATION_REFERENCE.md` for the full list.
+Key variables for the Quinn vector context pipeline:
+
+```
+QDRANT_URL=http://qdrant:6333
+QDRANT_VECTOR_SIZE=768
+OLLAMA_URL=http://ollama:11434
+OLLAMA_EMBED_MODEL=nomic-embed-text
+GITHUB_WEBHOOK_SECRET=<secret>
+QUINN_APP_ID=<github-app-id>
+QUINN_APP_PRIVATE_KEY=<pem-contents>
+```

--- a/docs/context-injection.md
+++ b/docs/context-injection.md
@@ -1,0 +1,86 @@
+# Context Injection — Quinn Codebase-Wide Review Context
+
+Quinn's vector context pipeline injects a `CODEBASE CONTEXT` block into review prompts,
+giving the LLM cross-repository awareness beyond the current diff.
+
+## How It Works
+
+```
+PR review triggered
+  → parseDiff(diff) — extract changed files and hunks
+  → extractAllSymbols(files) — identify changed functions/classes/exports
+  → [parallel]
+      retrieveAllPastPRDecisions(repo, filePaths)   → quinn-pr-history
+      findAllSimilarPatterns(symbols)               → quinn-code-patterns
+  → formatCodebaseContext({ pastDecisions, similarPatterns })
+  → applyTokenBudget(context, totalBudget)
+  → assembleReviewPrompt({ diff, context, ... })
+  → LLM call with enriched prompt
+```
+
+## CODEBASE CONTEXT Block Format
+
+```
+CODEBASE CONTEXT:
+
+Past PR decisions on changed files:
+  src/middleware/auth.ts:
+    - PR #142 (2026-04-01): APPROVE — Token expiry not checked; consider adding clock skew tolerance
+    - PR #138 (2026-03-15): REQUEST_CHANGES — JWT secret not validated at startup
+
+Similar code patterns across the repository:
+  `validateToken` in src/utils/jwt.ts:23 (protolabsai/protomaker)
+    23: export function validateToken(token: string): boolean {
+    24:   // Similar implementation without expiry check
+    25: }
+```
+
+## Token Budget
+
+The context block is capped at **20% of the total prompt token budget**.
+
+Token estimation: `1 token ≈ 4 characters` (GPT-style approximation).
+
+**Priority order when truncating:**
+1. Past PR decisions — always kept (highest value, historically proven)
+2. Similar code patterns — trimmed from lowest-scored pattern first
+
+If the budget is too small to include any context, the block is omitted entirely
+and the review proceeds with diff-only mode.
+
+## Fallback Behavior
+
+| Condition | Action |
+|---|---|
+| Qdrant unavailable | Log warning, skip context block, diff-only review |
+| Embedding fails for a chunk | Skip that chunk, continue with remaining |
+| No historical context found | Omit that section from the block |
+| Context exceeds 20% token budget | Truncate low-priority items |
+
+## PR History Indexing
+
+On PR merge (`pull_request.closed` + `merged: true`):
+
+```
+fetch diff + comments + decision
+  → parseDiff → chunkDiff (500-line blocks with 50-line overlap for large files)
+  → embed each chunk via Ollama
+  → upsert to quinn-pr-history with metadata
+  → extractAllSymbols → fetchSymbolContexts (GitHub raw content API)
+  → embed each symbol context
+  → upsert to quinn-code-patterns
+```
+
+## Review Learning Loop
+
+When a developer responds to a Quinn inline comment:
+
+```
+pull_request_review_comment.created (with in_reply_to_id)
+  → isDismissalResponse(responseBody) — heuristic detection
+  → trackCommentResponse({ repo, filePath, commentBody, dismissed, reason })
+  → recordDismissalEvent → quinn-review-learnings
+```
+
+Before generating a comment, Quinn checks `isLowSignalPattern(repo, fileType, commentText)`.
+If dismissal rate > 50% with at least 3 samples, the comment is skipped.

--- a/docs/qdrant-schema.md
+++ b/docs/qdrant-schema.md
@@ -1,0 +1,90 @@
+# Qdrant Schema — Quinn Vector Context
+
+Quinn uses three Qdrant collections to store codebase history and review learnings.
+All collections use cosine distance and 768-dimensional vectors from `nomic-embed-text` via Ollama.
+
+## Collections
+
+### `quinn-pr-history`
+
+Stores embedded diff chunks from merged PRs with review decisions.
+
+**Vector:** Diff chunk text (`File: <path>\n\n<diff lines>`), 768-dimensional.
+
+**Metadata fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `repo` | string | `owner/repo` slug, e.g. `protolabsai/protomaker` |
+| `pr_number` | integer | GitHub PR number |
+| `file` | string | Relative file path in the repository |
+| `decision` | string | `APPROVE` or `REQUEST_CHANGES` |
+| `merged_at` | string | ISO 8601 timestamp of merge |
+| `pr_url` | string | Full GitHub URL to the PR |
+| `chunk_index` | integer | Zero-based chunk index within the file |
+| `line_start` | integer | First line number of the chunk |
+| `line_end` | integer | Last line number of the chunk |
+| `review_issues` | string | Comma-separated summary of Quinn-flagged issues |
+
+**Query pattern:** Semantic search by file path + repo filter to retrieve past PR decisions on a file.
+
+---
+
+### `quinn-code-patterns`
+
+Stores symbol definitions with surrounding context for cross-repo pattern matching.
+
+**Vector:** `Symbol: <name> (<type>)\nFile: <path>\n\n<context lines>`, 768-dimensional.
+
+**Metadata fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `repo` | string | `owner/repo` slug |
+| `file` | string | Relative file path |
+| `symbol_name` | string | Function, class, or export name |
+| `symbol_type` | string | `function`, `class`, `interface`, `export`, `method` |
+| `language` | string | `typescript`, `python`, `go`, `unknown` |
+| `line` | integer | Line number of the symbol definition |
+| `context` | string | Definition + surrounding lines with line numbers |
+
+**Query pattern:** Semantic search for similar symbols, optionally excluding the current file.
+
+---
+
+### `quinn-review-learnings`
+
+Tracks dismissed comment patterns to prevent low-signal feedback repetition.
+
+**Vector:** Quinn comment body text, 768-dimensional.
+
+**Metadata fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `repo` | string | `owner/repo` slug |
+| `file_type` | string | File extension (`ts`, `py`, `go`, etc.) |
+| `dismissed_count` | integer | Number of times this pattern was dismissed |
+| `approval_count` | integer | Number of times this pattern led to a fix |
+| `most_recent_reason` | string | Last developer-provided dismissal reason |
+| `last_updated` | string | ISO 8601 timestamp of most recent update |
+
+**Query pattern:** Semantic search by comment text + repo + file_type filter. Dismissal rate = `dismissed_count / (dismissed_count + approval_count)`.
+
+---
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|---|---|---|
+| `QDRANT_URL` | `http://qdrant:6333` | Qdrant service URL |
+| `QDRANT_VECTOR_SIZE` | `768` | Vector dimensions (must match embedding model) |
+| `OLLAMA_URL` | `http://ollama:11434` | Ollama service URL |
+| `OLLAMA_EMBED_MODEL` | `nomic-embed-text` | Embedding model name |
+
+## Failure Modes
+
+- **Qdrant unavailable:** All Qdrant calls return empty results. Review falls back to diff-only mode.
+- **Collection missing:** `initializeCollections()` auto-creates collections on startup.
+- **Embedding failure:** Individual chunks are skipped. Warning logged if failure rate > 10%.
+- **Timeout:** All Qdrant calls have a 5-second timeout. Embedding calls have a 30-second timeout.

--- a/src/config/qdrant-schema.json
+++ b/src/config/qdrant-schema.json
@@ -1,0 +1,59 @@
+{
+  "collections": {
+    "quinn-pr-history": {
+      "description": "Embedded PR diff chunks with review decisions and metadata",
+      "vector_size": 768,
+      "distance": "Cosine",
+      "metadata_fields": {
+        "repo": "string — owner/repo slug, e.g. protolabsai/protomaker",
+        "pr_number": "integer — GitHub PR number",
+        "file": "string — relative file path in the repo",
+        "decision": "string — APPROVE or REQUEST_CHANGES",
+        "merged_at": "string — ISO 8601 timestamp of merge",
+        "pr_url": "string — full URL to the PR on GitHub",
+        "chunk_index": "integer — zero-based index of this chunk within the file",
+        "line_start": "integer — first line number of the chunk in the original file",
+        "line_end": "integer — last line number of the chunk in the original file",
+        "review_issues": "string — comma-separated summary of issues flagged in review"
+      }
+    },
+    "quinn-code-patterns": {
+      "description": "Embedded symbol definitions and surrounding context from indexed repositories",
+      "vector_size": 768,
+      "distance": "Cosine",
+      "metadata_fields": {
+        "repo": "string — owner/repo slug",
+        "file": "string — relative file path in the repo",
+        "symbol_name": "string — name of the function, class, or export",
+        "symbol_type": "string — function | class | interface | export | method",
+        "language": "string — typescript | python | go | unknown",
+        "line": "integer — line number where the symbol is defined",
+        "context": "string — symbol definition plus surrounding lines"
+      }
+    },
+    "quinn-review-learnings": {
+      "description": "Dismissed Quinn comment patterns to avoid repeating low-signal feedback",
+      "vector_size": 768,
+      "distance": "Cosine",
+      "metadata_fields": {
+        "repo": "string — owner/repo slug",
+        "file_type": "string — ts | py | go | etc",
+        "dismissed_count": "integer — number of times this pattern was dismissed",
+        "approval_count": "integer — number of times this pattern was acted upon",
+        "most_recent_reason": "string — last developer-provided reason for dismissal",
+        "last_updated": "string — ISO 8601 timestamp of most recent update"
+      }
+    }
+  },
+  "embedding_model": {
+    "provider": "ollama",
+    "model": "nomic-embed-text",
+    "dimensions": 768,
+    "base_url": "http://ollama:11434"
+  },
+  "qdrant": {
+    "base_url": "http://qdrant:6333",
+    "timeout_ms": 5000,
+    "search_top_k": 5
+  }
+}

--- a/src/services/codebase/symbol-fetcher.ts
+++ b/src/services/codebase/symbol-fetcher.ts
@@ -1,0 +1,94 @@
+/**
+ * Symbol fetcher — retrieves the definition and surrounding context for a
+ * changed symbol from the GitHub raw content API.
+ *
+ * Used by the code-patterns indexer to embed real symbol context (not just
+ * the diff line) into quinn-code-patterns.
+ */
+
+import type { ExtractedSymbol } from "../diff/symbol-extractor.ts";
+
+const GITHUB_RAW = "https://raw.githubusercontent.com";
+const CONTEXT_LINES = 10; // lines before and after the symbol definition
+
+export interface SymbolContext {
+  symbol: ExtractedSymbol;
+  context: string;
+  filePath: string;
+  repo: string;
+}
+
+/**
+ * Fetch lines around a symbol from a GitHub repo at a given ref.
+ *
+ * Returns null if the file cannot be fetched.
+ */
+export async function fetchSymbolContext(
+  owner: string,
+  repo: string,
+  ref: string,
+  symbol: ExtractedSymbol,
+  token: string,
+): Promise<SymbolContext | null> {
+  const filePath = symbol.filePath ?? "";
+  if (!filePath) return null;
+
+  const url = `${GITHUB_RAW}/${owner}/${repo}/${ref}/${filePath}`;
+
+  try {
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "User-Agent": "protoWorkstacean/1.0",
+      },
+    });
+
+    if (!res.ok) {
+      console.warn(`[symbol-fetcher] Could not fetch ${filePath} at ${ref}: ${res.status}`);
+      return null;
+    }
+
+    const text = await res.text();
+    const lines = text.split("\n");
+    const targetLine = symbol.line - 1; // convert to 0-based index
+
+    const start = Math.max(0, targetLine - CONTEXT_LINES);
+    const end = Math.min(lines.length - 1, targetLine + CONTEXT_LINES);
+    const contextLines = lines.slice(start, end + 1);
+
+    // Prefix with line numbers for clarity
+    const context = contextLines
+      .map((l, i) => `${start + i + 1}: ${l}`)
+      .join("\n");
+
+    return {
+      symbol,
+      context,
+      filePath,
+      repo: `${owner}/${repo}`,
+    };
+  } catch (err) {
+    console.error(`[symbol-fetcher] fetchSymbolContext error for ${filePath}:`, err);
+    return null;
+  }
+}
+
+/**
+ * Fetch context for multiple symbols, skipping any that fail.
+ */
+export async function fetchSymbolContexts(
+  owner: string,
+  repo: string,
+  ref: string,
+  symbols: ExtractedSymbol[],
+  token: string,
+): Promise<SymbolContext[]> {
+  const results = await Promise.allSettled(
+    symbols.map(sym => fetchSymbolContext(owner, repo, ref, sym, token)),
+  );
+
+  return results
+    .filter((r): r is PromiseFulfilledResult<SymbolContext> =>
+      r.status === "fulfilled" && r.value !== null)
+    .map(r => r.value);
+}

--- a/src/services/diff/chunker.ts
+++ b/src/services/diff/chunker.ts
@@ -1,0 +1,152 @@
+/**
+ * Diff chunker — parses unified diff format and splits large files into
+ * semantic chunks for embedding.
+ *
+ * Files <= 1000 lines: single chunk per file.
+ * Files > 1000 lines: split into 500-line blocks with 50-line overlap.
+ */
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+export interface DiffHunk {
+  header: string;
+  lines: string[];
+  startLine: number;
+  endLine: number;
+}
+
+export interface DiffFile {
+  path: string;
+  hunks: DiffHunk[];
+  added: string[];   // only added/modified lines (no context lines)
+  removed: string[]; // only removed lines
+}
+
+export interface DiffChunk {
+  filePath: string;
+  content: string;
+  lineStart: number;
+  lineEnd: number;
+  chunkIndex: number;
+}
+
+// ── Diff parser ────────────────────────────────────────────────────────────────
+
+/**
+ * Parse a unified diff string into per-file structures.
+ */
+export function parseDiff(diffText: string): DiffFile[] {
+  const files: DiffFile[] = [];
+  const fileBlocks = diffText.split(/^diff --git /m).filter(Boolean);
+
+  for (const block of fileBlocks) {
+    const lines = block.split("\n");
+
+    // Extract file path from "a/foo.ts b/foo.ts" header
+    const pathMatch = lines[0]?.match(/^a\/(.+?) b\//);
+    if (!pathMatch) continue;
+    const path = pathMatch[1];
+
+    const hunks: DiffHunk[] = [];
+    const added: string[] = [];
+    const removed: string[] = [];
+
+    let currentHunk: DiffHunk | null = null;
+    let currentLine = 0;
+
+    for (const line of lines.slice(1)) {
+      const hunkHeader = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+      if (hunkHeader) {
+        if (currentHunk) hunks.push(currentHunk);
+        currentLine = parseInt(hunkHeader[1], 10);
+        currentHunk = {
+          header: line,
+          lines: [],
+          startLine: currentLine,
+          endLine: currentLine,
+        };
+        continue;
+      }
+
+      if (!currentHunk) continue;
+
+      currentHunk.lines.push(line);
+
+      if (line.startsWith("+")) {
+        added.push(line.slice(1));
+        currentLine++;
+        currentHunk.endLine = currentLine;
+      } else if (line.startsWith("-")) {
+        removed.push(line.slice(1));
+      } else {
+        // Context line
+        currentLine++;
+        currentHunk.endLine = currentLine;
+      }
+    }
+
+    if (currentHunk) hunks.push(currentHunk);
+
+    files.push({ path, hunks, added, removed });
+  }
+
+  return files;
+}
+
+// ── Chunker ────────────────────────────────────────────────────────────────────
+
+const CHUNK_SIZE = 500;
+const CHUNK_OVERLAP = 50;
+const LARGE_FILE_THRESHOLD = 1000;
+
+/**
+ * Convert parsed diff files into flat chunks ready for embedding.
+ *
+ * Each chunk contains the raw diff lines from one or more hunks, plus
+ * metadata about the file path and line range.
+ */
+export function chunkDiff(files: DiffFile[]): DiffChunk[] {
+  const chunks: DiffChunk[] = [];
+
+  for (const file of files) {
+    // Flatten all hunk lines into a single array with line tracking
+    const allLines: { text: string; line: number }[] = [];
+    for (const hunk of file.hunks) {
+      let lineNum = hunk.startLine;
+      for (const line of hunk.lines) {
+        allLines.push({ text: line, line: lineNum });
+        if (!line.startsWith("-")) lineNum++;
+      }
+    }
+
+    if (allLines.length === 0) continue;
+
+    if (allLines.length <= LARGE_FILE_THRESHOLD) {
+      // Single chunk for small/medium files
+      chunks.push({
+        filePath: file.path,
+        content: allLines.map(l => l.text).join("\n"),
+        lineStart: allLines[0].line,
+        lineEnd: allLines[allLines.length - 1].line,
+        chunkIndex: 0,
+      });
+    } else {
+      // Split large files into overlapping blocks
+      let chunkIndex = 0;
+      let i = 0;
+      while (i < allLines.length) {
+        const block = allLines.slice(i, i + CHUNK_SIZE);
+        chunks.push({
+          filePath: file.path,
+          content: block.map(l => l.text).join("\n"),
+          lineStart: block[0].line,
+          lineEnd: block[block.length - 1].line,
+          chunkIndex: chunkIndex++,
+        });
+        i += CHUNK_SIZE - CHUNK_OVERLAP;
+      }
+    }
+  }
+
+  return chunks;
+}

--- a/src/services/diff/symbol-extractor.ts
+++ b/src/services/diff/symbol-extractor.ts
@@ -1,0 +1,99 @@
+/**
+ * Symbol extractor — routes diff lines to language-specific extractors.
+ *
+ * Supports: TypeScript (.ts, .tsx, .js, .jsx), Python (.py), Go (.go).
+ * For unsupported languages, logs a warning and returns an empty array.
+ */
+
+import { extractTypeScriptSymbols } from "./symbols/typescript.ts";
+import { extractPythonSymbols } from "./symbols/python.ts";
+import { extractGoSymbols } from "./symbols/go.ts";
+import type { DiffFile } from "./chunker.ts";
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+export type SymbolType = "function" | "class" | "interface" | "export" | "method";
+export type Language = "typescript" | "python" | "go" | "unknown";
+
+export interface ExtractedSymbol {
+  name: string;
+  type: SymbolType;
+  line: number;
+  language: Language;
+  filePath?: string;
+}
+
+// ── Language detection ─────────────────────────────────────────────────────────
+
+function detectLanguage(filePath: string): Language {
+  const ext = filePath.split(".").pop()?.toLowerCase() ?? "";
+  if (["ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs"].includes(ext)) return "typescript";
+  if (ext === "py") return "python";
+  if (ext === "go") return "go";
+  return "unknown";
+}
+
+// ── Main extractor ─────────────────────────────────────────────────────────────
+
+/**
+ * Extract symbols from all added/modified lines in a diff file.
+ *
+ * Only processes added lines (lines starting with "+") from hunks.
+ * Skips unsupported languages with a warning.
+ */
+export function extractSymbols(file: DiffFile): ExtractedSymbol[] {
+  const language = detectLanguage(file.path);
+
+  if (language === "unknown") {
+    const ext = file.path.split(".").pop() ?? "unknown";
+    console.warn(`[symbol-extractor] Unsupported language extension .${ext} for ${file.path} — skipping pattern extraction`);
+    return [];
+  }
+
+  const symbols: ExtractedSymbol[] = [];
+
+  for (const hunk of file.hunks) {
+    // Only extract from added/modified lines
+    const addedLines: string[] = [];
+    const lineNumbers: number[] = [];
+    let lineNum = hunk.startLine;
+
+    for (const line of hunk.lines) {
+      if (line.startsWith("+")) {
+        addedLines.push(line.slice(1)); // strip the leading "+"
+        lineNumbers.push(lineNum);
+        lineNum++;
+      } else if (!line.startsWith("-")) {
+        // Context line — advance line counter but don't extract
+        lineNum++;
+      }
+      // Removed lines (-) don't advance the new file's line counter
+    }
+
+    if (addedLines.length === 0) continue;
+
+    let extracted: ExtractedSymbol[];
+    const startLine = lineNumbers[0] ?? hunk.startLine;
+
+    if (language === "typescript") {
+      extracted = extractTypeScriptSymbols(addedLines, startLine);
+    } else if (language === "python") {
+      extracted = extractPythonSymbols(addedLines, startLine);
+    } else {
+      extracted = extractGoSymbols(addedLines, startLine);
+    }
+
+    for (const sym of extracted) {
+      symbols.push({ ...sym, filePath: file.path });
+    }
+  }
+
+  return symbols;
+}
+
+/**
+ * Extract symbols from multiple diff files.
+ */
+export function extractAllSymbols(files: DiffFile[]): ExtractedSymbol[] {
+  return files.flatMap(f => extractSymbols(f));
+}

--- a/src/services/diff/symbols/go.ts
+++ b/src/services/diff/symbols/go.ts
@@ -1,0 +1,50 @@
+/**
+ * Go symbol extractor.
+ *
+ * Extracts function/method definitions, type declarations from Go source lines.
+ */
+
+import type { ExtractedSymbol } from "../symbol-extractor.ts";
+
+const PATTERNS: Array<{ regex: RegExp; type: ExtractedSymbol["type"] }> = [
+  // func FooBar(...) or func (r *Receiver) Method(...)
+  { regex: /^func\s+(?:\(\w+\s+[*\w]+\)\s+)?(\w+)\s*\(/, type: "function" },
+  // type Foo struct { / type Foo interface {
+  { regex: /^type\s+(\w+)\s+(?:struct|interface)\s*\{/, type: "class" },
+  // type Foo = Bar (type alias)
+  { regex: /^type\s+(\w+)\s*=/, type: "interface" },
+  // var FooBar = ... (package-level variable)
+  { regex: /^var\s+(\w+)\s+/, type: "export" },
+  // const FooBar = ... (exported constant)
+  { regex: /^const\s+([A-Z]\w+)\s+/, type: "export" },
+];
+
+/**
+ * Extract symbols from Go added/modified lines.
+ */
+export function extractGoSymbols(
+  lines: string[],
+  lineOffset: number = 1,
+): ExtractedSymbol[] {
+  const symbols: ExtractedSymbol[] = [];
+  const seen = new Set<string>();
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lineNumber = lineOffset + i;
+
+    for (const { regex, type } of PATTERNS) {
+      const match = line.match(regex);
+      if (!match?.[1]) continue;
+
+      const name = match[1];
+      if (!seen.has(`${name}:${lineNumber}`)) {
+        seen.add(`${name}:${lineNumber}`);
+        symbols.push({ name, type, line: lineNumber, language: "go" });
+      }
+      break;
+    }
+  }
+
+  return symbols;
+}

--- a/src/services/diff/symbols/python.ts
+++ b/src/services/diff/symbols/python.ts
@@ -1,0 +1,46 @@
+/**
+ * Python symbol extractor.
+ *
+ * Extracts function definitions, class declarations from Python source lines.
+ */
+
+import type { ExtractedSymbol } from "../symbol-extractor.ts";
+
+const PATTERNS: Array<{ regex: RegExp; type: ExtractedSymbol["type"] }> = [
+  // def foo( / async def foo(
+  { regex: /^(?:async\s+)?def\s+(\w+)\s*\(/, type: "function" },
+  // class Foo( / class Foo:
+  { regex: /^class\s+(\w+)\s*[:(]/, type: "class" },
+  // __all__ = [...] — export equivalent
+  { regex: /^__all__\s*=/, type: "export" },
+];
+
+/**
+ * Extract symbols from Python added/modified lines.
+ */
+export function extractPythonSymbols(
+  lines: string[],
+  lineOffset: number = 1,
+): ExtractedSymbol[] {
+  const symbols: ExtractedSymbol[] = [];
+  const seen = new Set<string>();
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lineNumber = lineOffset + i;
+
+    for (const { regex, type } of PATTERNS) {
+      const match = line.match(regex);
+      if (!match) continue;
+
+      const name = match[1] ?? "__all__";
+      if (!seen.has(`${name}:${lineNumber}`)) {
+        seen.add(`${name}:${lineNumber}`);
+        symbols.push({ name, type, line: lineNumber, language: "python" });
+      }
+      break;
+    }
+  }
+
+  return symbols;
+}

--- a/src/services/diff/symbols/typescript.ts
+++ b/src/services/diff/symbols/typescript.ts
@@ -1,0 +1,69 @@
+/**
+ * TypeScript/JavaScript symbol extractor.
+ *
+ * Extracts function definitions, class/interface declarations, and export
+ * statements from TypeScript source code lines.
+ */
+
+import type { ExtractedSymbol } from "../symbol-extractor.ts";
+
+// Patterns for TypeScript symbol extraction
+const PATTERNS: Array<{ regex: RegExp; type: ExtractedSymbol["type"] }> = [
+  // function foo(...) / async function foo(...) / export function foo(...)
+  { regex: /^(?:export\s+)?(?:async\s+)?function\s+(\w+)\s*[(<]/, type: "function" },
+  // const foo = (...) => / export const foo = async (...) =>
+  { regex: /^(?:export\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s+)?(?:\(|function)/, type: "function" },
+  // class Foo / export class Foo / export default class Foo
+  { regex: /^(?:export\s+)?(?:default\s+)?class\s+(\w+)[\s{<(]/, type: "class" },
+  // interface Foo / export interface Foo
+  { regex: /^(?:export\s+)?interface\s+(\w+)[\s{<]/, type: "interface" },
+  // type Foo = / export type Foo =
+  { regex: /^(?:export\s+)?type\s+(\w+)\s*[=<{]/, type: "interface" },
+  // export { foo, bar }
+  { regex: /^export\s+\{([^}]+)\}/, type: "export" },
+  // export default foo / export default function
+  { regex: /^export\s+default\s+(?:function\s+)?(\w+)/, type: "export" },
+  // method definitions inside classes: methodName(...) or async methodName(...)
+  { regex: /^\s+(?:async\s+)?(\w+)\s*\((?!.*=>)/, type: "function" },
+];
+
+/**
+ * Extract symbols from TypeScript/JavaScript added/modified lines.
+ */
+export function extractTypeScriptSymbols(
+  lines: string[],
+  lineOffset: number = 1,
+): ExtractedSymbol[] {
+  const symbols: ExtractedSymbol[] = [];
+  const seen = new Set<string>();
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trimStart();
+    const lineNumber = lineOffset + i;
+
+    for (const { regex, type } of PATTERNS) {
+      const match = line.match(regex);
+      if (!match) continue;
+
+      if (type === "export" && match[1]) {
+        // Handle export { foo, bar } — extract multiple names
+        const names = match[1].split(",").map(n => n.trim().split(/\s+as\s+/)[0].trim());
+        for (const name of names) {
+          if (name && !seen.has(`${name}:${lineNumber}`)) {
+            seen.add(`${name}:${lineNumber}`);
+            symbols.push({ name, type, line: lineNumber, language: "typescript" });
+          }
+        }
+      } else if (match[1]) {
+        const name = match[1];
+        if (!seen.has(`${name}:${lineNumber}`)) {
+          seen.add(`${name}:${lineNumber}`);
+          symbols.push({ name, type, line: lineNumber, language: "typescript" });
+        }
+      }
+      break; // First matching pattern wins per line
+    }
+  }
+
+  return symbols;
+}

--- a/src/services/embeddings/ollama-client.ts
+++ b/src/services/embeddings/ollama-client.ts
@@ -1,0 +1,79 @@
+/**
+ * Ollama embeddings client.
+ *
+ * Calls the Ollama /api/embeddings endpoint to convert text to vector embeddings.
+ *
+ * Base URL: OLLAMA_URL env var (default: http://ollama:11434)
+ * Model:    OLLAMA_EMBED_MODEL env var (default: nomic-embed-text)
+ */
+
+const OLLAMA_URL = process.env.OLLAMA_URL ?? "http://ollama:11434";
+const EMBED_MODEL = process.env.OLLAMA_EMBED_MODEL ?? "nomic-embed-text";
+const TIMEOUT_MS = 30_000; // embeddings can take a few seconds
+
+interface OllamaEmbedResponse {
+  embedding: number[];
+}
+
+/**
+ * Generate an embedding vector for the given text.
+ * Returns null if the Ollama service is unavailable or fails.
+ */
+export async function embed(text: string): Promise<number[] | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const res = await fetch(`${OLLAMA_URL}/api/embeddings`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: EMBED_MODEL, prompt: text }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      console.error(`[ollama] embed failed ${res.status}: ${await res.text()}`);
+      return null;
+    }
+
+    const data = await res.json() as OllamaEmbedResponse;
+    if (!Array.isArray(data.embedding) || data.embedding.length === 0) {
+      console.error("[ollama] embed returned empty embedding");
+      return null;
+    }
+
+    return data.embedding;
+  } catch (err) {
+    console.error("[ollama] embed error:", err);
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Embed multiple texts, skipping failed chunks.
+ * Returns array of { text, vector } — failed chunks are omitted.
+ */
+export async function embedMany(
+  texts: string[],
+): Promise<Array<{ text: string; vector: number[] }>> {
+  const results: Array<{ text: string; vector: number[] }> = [];
+  let failureCount = 0;
+
+  for (const text of texts) {
+    const vector = await embed(text);
+    if (vector !== null) {
+      results.push({ text, vector });
+    } else {
+      failureCount++;
+      // Alert if failure rate exceeds 10%
+      const total = results.length + failureCount;
+      if (total >= 10 && failureCount / total > 0.1) {
+        console.warn(`[ollama] High embedding failure rate: ${failureCount}/${total}`);
+      }
+    }
+  }
+
+  return results;
+}

--- a/src/services/github/diff-fetcher.ts
+++ b/src/services/github/diff-fetcher.ts
@@ -1,0 +1,173 @@
+/**
+ * GitHub diff fetcher — retrieves PR diff, inline review comments, and
+ * the overall review decision (APPROVE / REQUEST_CHANGES) from the GitHub API.
+ */
+
+const GITHUB_API = "https://api.github.com";
+const USER_AGENT = "protoWorkstacean/1.0";
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+export interface PRMetadata {
+  owner: string;
+  repo: string;
+  prNumber: number;
+  baseBranch: string;
+  mergedAt: string;
+  prUrl: string;
+  title: string;
+}
+
+export interface ReviewComment {
+  body: string;
+  path: string;
+  line: number | null;
+  author: string;
+  isQuinn: boolean;
+}
+
+export type ReviewDecision = "APPROVE" | "REQUEST_CHANGES" | "COMMENT" | "PENDING";
+
+export interface PRReviewData {
+  diff: string;
+  comments: ReviewComment[];
+  decision: ReviewDecision;
+  reviewIssues: string;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "User-Agent": USER_AGENT,
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+// ── Fetchers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Fetch the unified diff for a PR.
+ * Returns empty string if unavailable.
+ */
+export async function fetchPRDiff(meta: PRMetadata, token: string): Promise<string> {
+  const url = `${GITHUB_API}/repos/${meta.owner}/${meta.repo}/pulls/${meta.prNumber}`;
+  try {
+    const res = await fetch(url, {
+      headers: {
+        ...makeHeaders(token),
+        Accept: "application/vnd.github.diff",
+      },
+    });
+    if (!res.ok) {
+      console.error(`[diff-fetcher] fetchPRDiff failed ${res.status}`);
+      return "";
+    }
+    return await res.text();
+  } catch (err) {
+    console.error("[diff-fetcher] fetchPRDiff error:", err);
+    return "";
+  }
+}
+
+/**
+ * Fetch inline review comments for a PR.
+ */
+export async function fetchReviewComments(
+  meta: PRMetadata,
+  token: string,
+): Promise<ReviewComment[]> {
+  const url = `${GITHUB_API}/repos/${meta.owner}/${meta.repo}/pulls/${meta.prNumber}/comments`;
+  try {
+    const res = await fetch(url, { headers: makeHeaders(token) });
+    if (!res.ok) {
+      console.error(`[diff-fetcher] fetchReviewComments failed ${res.status}`);
+      return [];
+    }
+    const raw = await res.json() as Array<{
+      body?: string;
+      path?: string;
+      line?: number | null;
+      original_line?: number | null;
+      user?: { login?: string };
+    }>;
+
+    return raw.map(c => ({
+      body: c.body ?? "",
+      path: c.path ?? "",
+      line: c.line ?? c.original_line ?? null,
+      author: c.user?.login ?? "",
+      isQuinn: (c.user?.login ?? "").includes("quinn"),
+    }));
+  } catch (err) {
+    console.error("[diff-fetcher] fetchReviewComments error:", err);
+    return [];
+  }
+}
+
+/**
+ * Fetch the overall review decision for a PR.
+ * Returns the most recent non-PENDING state submitted by a reviewer.
+ */
+export async function fetchReviewDecision(
+  meta: PRMetadata,
+  token: string,
+): Promise<ReviewDecision> {
+  const url = `${GITHUB_API}/repos/${meta.owner}/${meta.repo}/pulls/${meta.prNumber}/reviews`;
+  try {
+    const res = await fetch(url, { headers: makeHeaders(token) });
+    if (!res.ok) return "PENDING";
+
+    const reviews = await res.json() as Array<{
+      state?: string;
+      submitted_at?: string;
+    }>;
+
+    // Find the most recent decisive state
+    const decisive = reviews
+      .filter(r => r.state === "APPROVED" || r.state === "CHANGES_REQUESTED")
+      .sort((a, b) => new Date(b.submitted_at ?? 0).getTime() - new Date(a.submitted_at ?? 0).getTime());
+
+    if (!decisive.length) return "COMMENT";
+    return decisive[0].state === "APPROVED" ? "APPROVE" : "REQUEST_CHANGES";
+  } catch (err) {
+    console.error("[diff-fetcher] fetchReviewDecision error:", err);
+    return "PENDING";
+  }
+}
+
+/**
+ * Summarize review issues into a short comma-separated string.
+ * Extracts first sentence or up to 80 chars from each Quinn comment body.
+ */
+export function summarizeReviewIssues(comments: ReviewComment[]): string {
+  return comments
+    .filter(c => c.isQuinn && c.body.trim().length > 0)
+    .map(c => c.body.split(/\n|\./)[0].trim().slice(0, 80))
+    .filter(Boolean)
+    .slice(0, 5)
+    .join("; ");
+}
+
+/**
+ * Fetch all PR review data in one call.
+ */
+export async function fetchPRReviewData(
+  meta: PRMetadata,
+  token: string,
+): Promise<PRReviewData> {
+  const [diff, comments, decision] = await Promise.all([
+    fetchPRDiff(meta, token),
+    fetchReviewComments(meta, token),
+    fetchReviewDecision(meta, token),
+  ]);
+
+  return {
+    diff,
+    comments,
+    decision,
+    reviewIssues: summarizeReviewIssues(comments),
+  };
+}

--- a/src/services/qdrant/client.ts
+++ b/src/services/qdrant/client.ts
@@ -1,0 +1,185 @@
+/**
+ * Qdrant HTTP client — thin wrapper around the Qdrant REST API.
+ *
+ * All requests use a 5-second timeout. If Qdrant is unavailable the methods
+ * return null / empty arrays so callers can fall back to diff-only review.
+ *
+ * Base URL: QDRANT_URL env var (default: http://qdrant:6333)
+ */
+
+const QDRANT_URL = process.env.QDRANT_URL ?? "http://qdrant:6333";
+const TIMEOUT_MS = 5_000;
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+export interface QdrantVector {
+  id: string | number;
+  vector: number[];
+  payload: Record<string, unknown>;
+}
+
+export interface QdrantSearchResult {
+  id: string | number;
+  score: number;
+  payload: Record<string, unknown>;
+}
+
+export interface QdrantCollectionConfig {
+  vectorSize: number;
+  distance?: "Cosine" | "Euclid" | "Dot";
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+async function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ── Collection management ──────────────────────────────────────────────────────
+
+/**
+ * Create a collection if it does not already exist.
+ * Returns true on success, false if Qdrant is unavailable.
+ */
+export async function ensureCollection(
+  name: string,
+  config: QdrantCollectionConfig,
+): Promise<boolean> {
+  try {
+    const res = await fetchWithTimeout(`${QDRANT_URL}/collections/${name}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        vectors: {
+          size: config.vectorSize,
+          distance: config.distance ?? "Cosine",
+        },
+        on_disk_payload: true,
+      }),
+    });
+    if (res.status === 200 || res.status === 409) {
+      // 200 = created, 409 = already exists — both are fine
+      return true;
+    }
+    const text = await res.text();
+    console.error(`[qdrant] ensureCollection(${name}) failed ${res.status}: ${text}`);
+    return false;
+  } catch (err) {
+    console.error(`[qdrant] ensureCollection(${name}) error:`, err);
+    return false;
+  }
+}
+
+/**
+ * List all collection names. Returns empty array if Qdrant is unavailable.
+ */
+export async function listCollections(): Promise<string[]> {
+  try {
+    const res = await fetchWithTimeout(`${QDRANT_URL}/collections`, { method: "GET" });
+    if (!res.ok) return [];
+    const data = await res.json() as { result?: { collections?: { name: string }[] } };
+    return data.result?.collections?.map(c => c.name) ?? [];
+  } catch {
+    return [];
+  }
+}
+
+// ── Point operations ───────────────────────────────────────────────────────────
+
+/**
+ * Upsert points into a collection.
+ * Returns true on success, false on failure.
+ */
+export async function upsertPoints(
+  collection: string,
+  points: QdrantVector[],
+): Promise<boolean> {
+  if (points.length === 0) return true;
+  try {
+    const res = await fetchWithTimeout(`${QDRANT_URL}/collections/${collection}/points`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ points }),
+    });
+    if (res.ok) return true;
+    const text = await res.text();
+    console.error(`[qdrant] upsertPoints(${collection}) failed ${res.status}: ${text}`);
+    return false;
+  } catch (err) {
+    console.error(`[qdrant] upsertPoints(${collection}) error:`, err);
+    return false;
+  }
+}
+
+/**
+ * Search for similar vectors in a collection.
+ * Returns top-K results sorted by score descending.
+ * Returns empty array if Qdrant is unavailable.
+ */
+export async function searchPoints(
+  collection: string,
+  vector: number[],
+  topK: number = 5,
+  filter?: Record<string, unknown>,
+): Promise<QdrantSearchResult[]> {
+  try {
+    const body: Record<string, unknown> = {
+      vector,
+      limit: topK,
+      with_payload: true,
+    };
+    if (filter) body.filter = filter;
+
+    const res = await fetchWithTimeout(`${QDRANT_URL}/collections/${collection}/points/search`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      console.error(`[qdrant] search(${collection}) failed ${res.status}: ${text}`);
+      return [];
+    }
+    const data = await res.json() as { result?: QdrantSearchResult[] };
+    return data.result ?? [];
+  } catch (err) {
+    console.error(`[qdrant] search(${collection}) error:`, err);
+    return [];
+  }
+}
+
+/**
+ * Count points in a collection. Returns -1 if unavailable.
+ */
+export async function countPoints(collection: string): Promise<number> {
+  try {
+    const res = await fetchWithTimeout(`${QDRANT_URL}/collections/${collection}/points/count`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ exact: false }),
+    });
+    if (!res.ok) return -1;
+    const data = await res.json() as { result?: { count?: number } };
+    return data.result?.count ?? 0;
+  } catch {
+    return -1;
+  }
+}
+
+/**
+ * Health check — returns true if Qdrant is reachable.
+ */
+export async function checkHealth(): Promise<boolean> {
+  try {
+    const res = await fetchWithTimeout(`${QDRANT_URL}/healthz`, { method: "GET" });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}

--- a/src/services/qdrant/code-patterns-indexer.ts
+++ b/src/services/qdrant/code-patterns-indexer.ts
@@ -1,0 +1,66 @@
+/**
+ * Code patterns indexer — indexes symbol definitions with surrounding context
+ * into quinn-code-patterns.
+ *
+ * For each extracted symbol, embeds the definition + context lines and stores
+ * to Qdrant for cross-repo pattern matching.
+ */
+
+import { upsertPoints } from "./client.ts";
+import { COLLECTION_CODE_PATTERNS } from "./collections.ts";
+import { embed } from "../embeddings/ollama-client.ts";
+import type { SymbolContext } from "../codebase/symbol-fetcher.ts";
+
+/**
+ * Index symbol contexts into quinn-code-patterns.
+ * Returns number of points successfully indexed.
+ */
+export async function indexCodePatterns(symbolContexts: SymbolContext[]): Promise<number> {
+  let indexed = 0;
+  let failures = 0;
+
+  for (const sc of symbolContexts) {
+    const text = `Symbol: ${sc.symbol.name} (${sc.symbol.type})\nFile: ${sc.filePath}\n\n${sc.context}`;
+    const vector = await embed(text);
+
+    if (!vector) {
+      failures++;
+      const total = indexed + failures;
+      if (total >= 10 && failures / total > 0.1) {
+        console.warn(`[code-patterns-indexer] High embedding failure rate: ${failures}/${total}`);
+      }
+      continue;
+    }
+
+    const id = `${sc.repo}-${sc.filePath.replace(/\//g, "_")}-${sc.symbol.name}-${sc.symbol.line}`;
+    const pointId = hashString(id);
+
+    const success = await upsertPoints(COLLECTION_CODE_PATTERNS, [{
+      id: pointId,
+      vector,
+      payload: {
+        repo: sc.repo,
+        file: sc.filePath,
+        symbol_name: sc.symbol.name,
+        symbol_type: sc.symbol.type,
+        language: sc.symbol.language,
+        line: sc.symbol.line,
+        context: sc.context,
+      },
+    }]);
+
+    if (success) indexed++;
+  }
+
+  console.log(`[code-patterns-indexer] ${indexed} symbol contexts indexed, ${failures} failed`);
+  return indexed;
+}
+
+function hashString(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) {
+    h = ((h << 5) + h) ^ s.charCodeAt(i);
+    h = h >>> 0;
+  }
+  return h;
+}

--- a/src/services/qdrant/collections.ts
+++ b/src/services/qdrant/collections.ts
@@ -1,0 +1,52 @@
+/**
+ * Initialize Qdrant collections for Quinn's vector context pipeline.
+ *
+ * Three collections:
+ *   quinn-pr-history       — embedded diff chunks from merged PRs
+ *   quinn-code-patterns    — symbol definitions and surrounding context
+ *   quinn-review-learnings — dismissed comment patterns for low-signal filtering
+ *
+ * Calls ensureCollection for each — creates if not present, no-ops if already exists.
+ */
+
+import { ensureCollection } from "./client.ts";
+
+// Vector dimension must match the configured Ollama embedding model.
+// nomic-embed-text produces 768-dimensional vectors.
+const VECTOR_SIZE = parseInt(process.env.QDRANT_VECTOR_SIZE ?? "768", 10);
+
+export const COLLECTION_PR_HISTORY = "quinn-pr-history";
+export const COLLECTION_CODE_PATTERNS = "quinn-code-patterns";
+export const COLLECTION_REVIEW_LEARNINGS = "quinn-review-learnings";
+
+/**
+ * Initialize all three Quinn Qdrant collections.
+ * Safe to call multiple times — uses PUT which is idempotent.
+ * Returns true if all collections are ready.
+ */
+export async function initializeCollections(): Promise<boolean> {
+  const results = await Promise.all([
+    ensureCollection(COLLECTION_PR_HISTORY, {
+      vectorSize: VECTOR_SIZE,
+      distance: "Cosine",
+    }),
+    ensureCollection(COLLECTION_CODE_PATTERNS, {
+      vectorSize: VECTOR_SIZE,
+      distance: "Cosine",
+    }),
+    ensureCollection(COLLECTION_REVIEW_LEARNINGS, {
+      vectorSize: VECTOR_SIZE,
+      distance: "Cosine",
+    }),
+  ]);
+
+  const allReady = results.every(r => r);
+
+  if (allReady) {
+    console.log("[qdrant] Collections initialized: quinn-pr-history, quinn-code-patterns, quinn-review-learnings");
+  } else {
+    console.warn("[qdrant] One or more collections failed to initialize — vector context will be unavailable");
+  }
+
+  return allReady;
+}

--- a/src/services/qdrant/past-pr-retriever.ts
+++ b/src/services/qdrant/past-pr-retriever.ts
@@ -1,0 +1,78 @@
+/**
+ * Past PR retriever — queries quinn-pr-history for the 3 most recent PRs
+ * that touched a given file, returning decisions and flagged issues.
+ */
+
+import { searchPoints } from "./client.ts";
+import { COLLECTION_PR_HISTORY } from "./collections.ts";
+import { embed } from "../embeddings/ollama-client.ts";
+
+const PAST_PR_LIMIT = 3;
+
+export interface PastPRDecision {
+  prNumber: number;
+  prUrl: string;
+  decision: string;
+  mergedAt: string;
+  reviewIssues: string;
+  file: string;
+  score: number;
+}
+
+/**
+ * Retrieve the 3 most recent PR decisions for a given file.
+ * Uses semantic search on the file path — not a metadata filter — so it
+ * also surfaces PRs that touched closely related files.
+ *
+ * Returns empty array if Qdrant is unavailable.
+ */
+export async function retrievePastPRDecisions(
+  repo: string,
+  filePath: string,
+): Promise<PastPRDecision[]> {
+  const query = `File: ${filePath} in repo ${repo}`;
+  const vector = await embed(query);
+  if (!vector) return [];
+
+  // Filter by repo to avoid cross-repo noise
+  const filter = {
+    must: [{ key: "repo", match: { value: repo } }],
+  };
+
+  const results = await searchPoints(
+    COLLECTION_PR_HISTORY,
+    vector,
+    PAST_PR_LIMIT,
+    filter,
+  );
+
+  return results.map(r => ({
+    prNumber: Number(r.payload.pr_number ?? 0),
+    prUrl: String(r.payload.pr_url ?? ""),
+    decision: String(r.payload.decision ?? ""),
+    mergedAt: String(r.payload.merged_at ?? ""),
+    reviewIssues: String(r.payload.review_issues ?? ""),
+    file: String(r.payload.file ?? ""),
+    score: r.score,
+  }));
+}
+
+/**
+ * Retrieve past PR decisions for a list of files.
+ * Returns a map of filePath → decisions.
+ */
+export async function retrieveAllPastPRDecisions(
+  repo: string,
+  filePaths: string[],
+): Promise<Map<string, PastPRDecision[]>> {
+  const resultMap = new Map<string, PastPRDecision[]>();
+
+  for (const filePath of filePaths) {
+    const decisions = await retrievePastPRDecisions(repo, filePath);
+    if (decisions.length > 0) {
+      resultMap.set(filePath, decisions);
+    }
+  }
+
+  return resultMap;
+}

--- a/src/services/qdrant/pattern-searcher.ts
+++ b/src/services/qdrant/pattern-searcher.ts
@@ -1,0 +1,70 @@
+/**
+ * Pattern searcher — queries quinn-code-patterns for similar usages of changed
+ * symbols across the repository.
+ */
+
+import { searchPoints } from "./client.ts";
+import { COLLECTION_CODE_PATTERNS } from "./collections.ts";
+import { embed } from "../embeddings/ollama-client.ts";
+import type { ExtractedSymbol } from "../diff/symbol-extractor.ts";
+
+const TOP_K = 5;
+
+export interface SimilarPattern {
+  repo: string;
+  file: string;
+  symbolName: string;
+  symbolType: string;
+  line: number;
+  context: string;
+  score: number;
+}
+
+/**
+ * Find top-5 similar code patterns for a given symbol.
+ * Returns empty array if Qdrant is unavailable or embedding fails.
+ */
+export async function findSimilarPatterns(
+  symbol: ExtractedSymbol,
+  excludeFile?: string,
+): Promise<SimilarPattern[]> {
+  const query = `${symbol.name} ${symbol.type} ${symbol.language}`;
+  const vector = await embed(query);
+  if (!vector) return [];
+
+  const filter = excludeFile
+    ? { must_not: [{ key: "file", match: { value: excludeFile } }] }
+    : undefined;
+
+  const results = await searchPoints(COLLECTION_CODE_PATTERNS, vector, TOP_K, filter);
+
+  return results.map(r => ({
+    repo: String(r.payload.repo ?? ""),
+    file: String(r.payload.file ?? ""),
+    symbolName: String(r.payload.symbol_name ?? ""),
+    symbolType: String(r.payload.symbol_type ?? ""),
+    line: Number(r.payload.line ?? 0),
+    context: String(r.payload.context ?? ""),
+    score: r.score,
+  }));
+}
+
+/**
+ * Find similar patterns for all extracted symbols.
+ * Skips symbols that fail to embed — logs warning but continues.
+ */
+export async function findAllSimilarPatterns(
+  symbols: ExtractedSymbol[],
+): Promise<Map<string, SimilarPattern[]>> {
+  const results = new Map<string, SimilarPattern[]>();
+
+  for (const symbol of symbols) {
+    const key = `${symbol.name}:${symbol.filePath ?? ""}`;
+    const patterns = await findSimilarPatterns(symbol, symbol.filePath);
+    if (patterns.length > 0) {
+      results.set(key, patterns);
+    }
+  }
+
+  return results;
+}

--- a/src/services/qdrant/pr-history-indexer.ts
+++ b/src/services/qdrant/pr-history-indexer.ts
@@ -1,0 +1,82 @@
+/**
+ * PR history indexer — indexes merged PR diff chunks into quinn-pr-history.
+ *
+ * Called on PR merge webhook. For each file chunk in the diff:
+ *   1. Embed the chunk text via Ollama
+ *   2. Store to Qdrant with metadata: repo, pr_number, file, decision, merged_at, pr_url
+ */
+
+import { upsertPoints } from "./client.ts";
+import { COLLECTION_PR_HISTORY } from "./collections.ts";
+import { embed } from "../embeddings/ollama-client.ts";
+import type { DiffChunk } from "../diff/chunker.ts";
+import type { PRMetadata, ReviewDecision } from "../github/diff-fetcher.ts";
+
+export interface PRHistoryRecord {
+  meta: PRMetadata;
+  chunks: DiffChunk[];
+  decision: ReviewDecision;
+  reviewIssues: string;
+}
+
+/**
+ * Index all diff chunks from a merged PR into quinn-pr-history.
+ *
+ * Skips chunks that fail to embed (logs warning).
+ * Returns the number of points successfully indexed.
+ */
+export async function indexPRHistory(record: PRHistoryRecord): Promise<number> {
+  const { meta, chunks, decision, reviewIssues } = record;
+  let indexed = 0;
+  let failures = 0;
+
+  for (const chunk of chunks) {
+    const text = `File: ${chunk.filePath}\n\n${chunk.content}`;
+    const vector = await embed(text);
+
+    if (!vector) {
+      failures++;
+      const total = indexed + failures;
+      if (total >= 10 && failures / total > 0.1) {
+        console.warn(`[pr-history-indexer] High embedding failure rate: ${failures}/${total}`);
+      }
+      continue;
+    }
+
+    const id = `${meta.owner}-${meta.repo}-${meta.prNumber}-${chunk.filePath.replace(/\//g, "_")}-${chunk.chunkIndex}`;
+    // Use a numeric hash for the Qdrant point ID
+    const pointId = hashString(id);
+
+    const success = await upsertPoints(COLLECTION_PR_HISTORY, [{
+      id: pointId,
+      vector,
+      payload: {
+        repo: `${meta.owner}/${meta.repo}`,
+        pr_number: meta.prNumber,
+        file: chunk.filePath,
+        decision,
+        merged_at: meta.mergedAt,
+        pr_url: meta.prUrl,
+        chunk_index: chunk.chunkIndex,
+        line_start: chunk.lineStart,
+        line_end: chunk.lineEnd,
+        review_issues: reviewIssues,
+      },
+    }]);
+
+    if (success) indexed++;
+  }
+
+  console.log(`[pr-history-indexer] PR #${meta.prNumber} ${meta.owner}/${meta.repo}: ${indexed} chunks indexed, ${failures} failed`);
+  return indexed;
+}
+
+/** Simple deterministic hash for stable point IDs. */
+function hashString(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) {
+    h = ((h << 5) + h) ^ s.charCodeAt(i);
+    h = h >>> 0; // keep unsigned 32-bit
+  }
+  return h;
+}

--- a/src/services/qdrant/review-learnings-indexer.ts
+++ b/src/services/qdrant/review-learnings-indexer.ts
@@ -1,0 +1,86 @@
+/**
+ * Review learnings indexer — stores and updates dismissed Quinn comment patterns
+ * in quinn-review-learnings.
+ *
+ * Tracks dismissal/approval counts per (repo, file_type, pattern) so the
+ * low-signal filter can skip historically dismissed comments.
+ */
+
+import { upsertPoints, searchPoints } from "./client.ts";
+import { COLLECTION_REVIEW_LEARNINGS } from "./collections.ts";
+import { embed } from "../embeddings/ollama-client.ts";
+
+export interface DismissalEvent {
+  repo: string;
+  fileType: string;
+  commentPattern: string;
+  dismissed: boolean;
+  reason?: string;
+}
+
+export interface LearningRecord {
+  repo: string;
+  fileType: string;
+  dismissedCount: number;
+  approvalCount: number;
+  mostRecentReason: string;
+  lastUpdated: string;
+}
+
+/**
+ * Upsert a dismissal event into quinn-review-learnings.
+ *
+ * If a similar pattern already exists (cosine similarity > 0.9), increments
+ * its counters. Otherwise creates a new entry.
+ */
+export async function recordDismissalEvent(event: DismissalEvent): Promise<boolean> {
+  const vector = await embed(event.commentPattern);
+  if (!vector) return false;
+
+  // Search for an existing similar pattern in this repo+file_type context
+  const filter = {
+    must: [
+      { key: "repo", match: { value: event.repo } },
+      { key: "file_type", match: { value: event.fileType } },
+    ],
+  };
+
+  const existing = await searchPoints(COLLECTION_REVIEW_LEARNINGS, vector, 1, filter);
+
+  let dismissedCount = event.dismissed ? 1 : 0;
+  let approvalCount = event.dismissed ? 0 : 1;
+  let pointId: number;
+
+  if (existing.length > 0 && existing[0].score > 0.9) {
+    // Update existing record
+    const prev = existing[0].payload;
+    dismissedCount += Number(prev.dismissed_count ?? 0);
+    approvalCount += Number(prev.approval_count ?? 0);
+    pointId = Number(existing[0].id);
+  } else {
+    // New pattern
+    pointId = hashString(`${event.repo}-${event.fileType}-${event.commentPattern}-${Date.now()}`);
+  }
+
+  return await upsertPoints(COLLECTION_REVIEW_LEARNINGS, [{
+    id: pointId,
+    vector,
+    payload: {
+      repo: event.repo,
+      file_type: event.fileType,
+      dismissed_count: dismissedCount,
+      approval_count: approvalCount,
+      most_recent_reason: event.reason ?? "",
+      last_updated: new Date().toISOString(),
+    },
+  }]);
+}
+
+function hashString(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) {
+    h = ((h << 5) + h) ^ s.charCodeAt(i);
+    h = h >>> 0;
+  }
+  return h;
+}

--- a/src/services/reviews/context-formatter.ts
+++ b/src/services/reviews/context-formatter.ts
@@ -1,0 +1,77 @@
+/**
+ * Context formatter — assembles retrieved Qdrant context into a structured
+ * CODEBASE CONTEXT block for injection into Quinn's review prompt.
+ *
+ * Block format:
+ *   CODEBASE CONTEXT:
+ *   Past PR decisions on <file>:
+ *     - PR #<n> (<date>): APPROVE/REQUEST_CHANGES — <issues>
+ *   Similar code patterns:
+ *     - `<symbol>` used in <file>:<line> (<repo>)
+ *       <context snippet>
+ */
+
+import type { PastPRDecision } from "../qdrant/past-pr-retriever.ts";
+import type { SimilarPattern } from "../qdrant/pattern-searcher.ts";
+
+export interface CodebaseContext {
+  pastDecisions: Map<string, PastPRDecision[]>;   // filePath → decisions
+  similarPatterns: Map<string, SimilarPattern[]>; // symbolKey → patterns
+}
+
+/**
+ * Format a CODEBASE CONTEXT block from retrieved context.
+ *
+ * Returns an empty string if no context is available.
+ */
+export function formatCodebaseContext(ctx: CodebaseContext): string {
+  const sections: string[] = [];
+
+  // ── Past PR decisions ──────────────────────────────────────────────────────
+  if (ctx.pastDecisions.size > 0) {
+    const lines: string[] = ["Past PR decisions on changed files:"];
+
+    for (const [filePath, decisions] of ctx.pastDecisions) {
+      lines.push(`  ${filePath}:`);
+      for (const d of decisions) {
+        const date = formatDate(d.mergedAt);
+        const issues = d.reviewIssues ? ` — ${d.reviewIssues}` : "";
+        lines.push(`    - PR #${d.prNumber} (${date}): ${d.decision}${issues}`);
+      }
+    }
+
+    sections.push(lines.join("\n"));
+  }
+
+  // ── Similar code patterns ──────────────────────────────────────────────────
+  if (ctx.similarPatterns.size > 0) {
+    const lines: string[] = ["Similar code patterns across the repository:"];
+
+    for (const [symbolKey, patterns] of ctx.similarPatterns) {
+      const symbolName = symbolKey.split(":")[0];
+      for (const p of patterns) {
+        lines.push(`  \`${symbolName}\` in ${p.file}:${p.line} (${p.repo})`);
+        // Include a short context snippet (first 3 lines)
+        const snippet = p.context.split("\n").slice(0, 3).join("\n    ");
+        if (snippet.trim()) {
+          lines.push(`    ${snippet}`);
+        }
+      }
+    }
+
+    sections.push(lines.join("\n"));
+  }
+
+  if (sections.length === 0) return "";
+
+  return ["CODEBASE CONTEXT:", ...sections].join("\n\n") + "\n";
+}
+
+function formatDate(isoString: string): string {
+  if (!isoString) return "unknown date";
+  try {
+    return new Date(isoString).toISOString().slice(0, 10);
+  } catch {
+    return isoString.slice(0, 10);
+  }
+}

--- a/src/services/reviews/dismissal-tracker.ts
+++ b/src/services/reviews/dismissal-tracker.ts
@@ -1,0 +1,75 @@
+/**
+ * Dismissal tracker — intercepts developer responses to Quinn inline comments
+ * and feeds them into the review learning loop.
+ *
+ * Called by the github-comment-response webhook handler when a developer
+ * replies to or dismisses a Quinn review comment.
+ */
+
+import { recordDismissalEvent } from "../qdrant/review-learnings-indexer.ts";
+
+export interface CommentResponseEvent {
+  repo: string;
+  filePath: string;
+  commentBody: string;
+  responseBody: string;
+  dismissed: boolean;
+  reason?: string;
+}
+
+/**
+ * Detect file type from file path extension.
+ */
+function fileTypeFromPath(filePath: string): string {
+  return filePath.split(".").pop()?.toLowerCase() ?? "unknown";
+}
+
+/**
+ * Process a developer response to a Quinn comment.
+ *
+ * Records the dismissal or approval in quinn-review-learnings.
+ * Logs error but does not throw — failure here must not block the review flow.
+ */
+export async function trackCommentResponse(event: CommentResponseEvent): Promise<void> {
+  const fileType = fileTypeFromPath(event.filePath);
+
+  try {
+    await recordDismissalEvent({
+      repo: event.repo,
+      fileType,
+      commentPattern: event.commentBody,
+      dismissed: event.dismissed,
+      reason: event.reason,
+    });
+
+    console.log(
+      `[dismissal-tracker] ${event.dismissed ? "Dismissed" : "Approved"} pattern in ${event.repo} (${fileType})` +
+      (event.reason ? `: ${event.reason}` : ""),
+    );
+  } catch (err) {
+    console.error("[dismissal-tracker] Failed to record comment response:", err);
+    // Non-fatal — learning loop failure must not block review
+  }
+}
+
+/**
+ * Determine whether a developer response body indicates dismissal.
+ *
+ * Heuristics: "won't fix", "not applicable", "disagree", "by design", etc.
+ */
+export function isDismissalResponse(responseBody: string): boolean {
+  const lower = responseBody.toLowerCase();
+  const dismissalPhrases = [
+    "won't fix",
+    "wontfix",
+    "not applicable",
+    "n/a",
+    "by design",
+    "disagree",
+    "false positive",
+    "not an issue",
+    "intentional",
+    "this is fine",
+  ];
+  return dismissalPhrases.some(phrase => lower.includes(phrase));
+}

--- a/src/services/reviews/low-signal-filter.ts
+++ b/src/services/reviews/low-signal-filter.ts
@@ -1,0 +1,75 @@
+/**
+ * Low-signal filter — queries quinn-review-learnings to determine whether a
+ * comment pattern has historically been dismissed by developers.
+ *
+ * If dismissal rate > 50% for this repo/file_type combo, the pattern is
+ * considered low-signal and should be skipped or de-prioritized.
+ */
+
+import { searchPoints } from "../qdrant/client.ts";
+import { COLLECTION_REVIEW_LEARNINGS } from "../qdrant/collections.ts";
+import { embed } from "../embeddings/ollama-client.ts";
+
+export interface LowSignalCheckResult {
+  isLowSignal: boolean;
+  dismissalRate: number;
+  dismissedCount: number;
+  approvalCount: number;
+  mostRecentReason: string;
+}
+
+const DISMISSAL_THRESHOLD = 0.5;
+const MIN_SAMPLES = 3; // Need at least 3 data points to classify as low-signal
+
+/**
+ * Check whether a comment pattern is low-signal for the given repo and file type.
+ *
+ * Returns { isLowSignal: false } if Qdrant is unavailable, embedding fails,
+ * or there are insufficient samples — erring on the side of showing comments.
+ */
+export async function isLowSignalPattern(
+  repo: string,
+  fileType: string,
+  commentText: string,
+): Promise<LowSignalCheckResult> {
+  const defaultResult: LowSignalCheckResult = {
+    isLowSignal: false,
+    dismissalRate: 0,
+    dismissedCount: 0,
+    approvalCount: 0,
+    mostRecentReason: "",
+  };
+
+  const vector = await embed(commentText);
+  if (!vector) return defaultResult;
+
+  const filter = {
+    must: [
+      { key: "repo", match: { value: repo } },
+      { key: "file_type", match: { value: fileType } },
+    ],
+  };
+
+  const results = await searchPoints(COLLECTION_REVIEW_LEARNINGS, vector, 1, filter);
+  if (results.length === 0) return defaultResult;
+
+  const top = results[0];
+  // Only use results with high similarity (same pattern)
+  if (top.score < 0.85) return defaultResult;
+
+  const dismissed = Number(top.payload.dismissed_count ?? 0);
+  const approved = Number(top.payload.approval_count ?? 0);
+  const total = dismissed + approved;
+
+  if (total < MIN_SAMPLES) return defaultResult;
+
+  const dismissalRate = dismissed / total;
+
+  return {
+    isLowSignal: dismissalRate > DISMISSAL_THRESHOLD,
+    dismissalRate,
+    dismissedCount: dismissed,
+    approvalCount: approved,
+    mostRecentReason: String(top.payload.most_recent_reason ?? ""),
+  };
+}

--- a/src/services/reviews/quinn-review-prompt.ts
+++ b/src/services/reviews/quinn-review-prompt.ts
@@ -1,0 +1,81 @@
+/**
+ * Quinn review prompt assembler.
+ *
+ * Builds the full review prompt by prepending a CODEBASE CONTEXT block
+ * (retrieved from Qdrant) before the diff section.
+ *
+ * The context block is token-budgeted to at most 20% of the total prompt budget.
+ */
+
+import { formatCodebaseContext } from "./context-formatter.ts";
+import { applyTokenBudget, estimateTokens } from "./token-budgeter.ts";
+import type { CodebaseContext } from "./context-formatter.ts";
+
+// Default total prompt token budget (conservative estimate for most models)
+const DEFAULT_PROMPT_BUDGET = 8_000;
+
+export interface ReviewPromptInput {
+  diff: string;
+  repo: string;
+  prNumber: number;
+  prUrl: string;
+  title: string;
+  context?: CodebaseContext;
+  promptBudget?: number;
+}
+
+export interface AssembledPrompt {
+  prompt: string;
+  contextTokens: number;
+  diffTokens: number;
+  totalTokens: number;
+  hasContext: boolean;
+}
+
+/**
+ * Assemble the full Quinn review prompt with optional CODEBASE CONTEXT block.
+ *
+ * Structure:
+ *   [CODEBASE CONTEXT block — if context available]
+ *   PR: <title>
+ *   Repo: <owner/repo> | PR #<n>
+ *   URL: <pr_url>
+ *
+ *   <diff>
+ */
+export function assembleReviewPrompt(input: ReviewPromptInput): AssembledPrompt {
+  const budget = input.promptBudget ?? DEFAULT_PROMPT_BUDGET;
+
+  let contextBlock = "";
+  if (input.context) {
+    const budgeted = applyTokenBudget(input.context, budget);
+    contextBlock = formatCodebaseContext(budgeted);
+  }
+
+  const header = [
+    `PR: ${input.title}`,
+    `Repo: ${input.repo} | PR #${input.prNumber}`,
+    `URL: ${input.prUrl}`,
+  ].join("\n");
+
+  const parts = [
+    contextBlock,
+    header,
+    "",
+    input.diff,
+  ].filter(Boolean);
+
+  const prompt = parts.join("\n");
+
+  const contextTokens = estimateTokens(contextBlock);
+  const diffTokens = estimateTokens(input.diff);
+  const totalTokens = estimateTokens(prompt);
+
+  return {
+    prompt,
+    contextTokens,
+    diffTokens,
+    totalTokens,
+    hasContext: contextBlock.length > 0,
+  };
+}

--- a/src/services/reviews/review-pipeline.ts
+++ b/src/services/reviews/review-pipeline.ts
@@ -1,0 +1,104 @@
+/**
+ * Quinn review pipeline — orchestrates the full Qdrant context retrieval and
+ * prompt assembly pipeline.
+ *
+ * Steps:
+ *   1. Parse diff → extract symbols
+ *   2. Retrieve past PR decisions for each changed file (from quinn-pr-history)
+ *   3. Find similar code patterns for each changed symbol (from quinn-code-patterns)
+ *   4. Format CODEBASE CONTEXT block
+ *   5. Apply token budget
+ *   6. Assemble review prompt
+ *
+ * If Qdrant is unavailable at any step, logs a warning and continues with
+ * diff-only review (no CODEBASE CONTEXT block).
+ */
+
+import { parseDiff, chunkDiff } from "../diff/chunker.ts";
+import { extractAllSymbols } from "../diff/symbol-extractor.ts";
+import { retrieveAllPastPRDecisions } from "../qdrant/past-pr-retriever.ts";
+import { findAllSimilarPatterns } from "../qdrant/pattern-searcher.ts";
+import { assembleReviewPrompt } from "./quinn-review-prompt.ts";
+import { checkHealth } from "../qdrant/client.ts";
+import type { AssembledPrompt } from "./quinn-review-prompt.ts";
+import type { CodebaseContext } from "./context-formatter.ts";
+
+export interface PipelineInput {
+  repo: string;
+  prNumber: number;
+  prUrl: string;
+  title: string;
+  diff: string;
+  promptBudget?: number;
+}
+
+export interface PipelineResult {
+  assembled: AssembledPrompt;
+  qdrantAvailable: boolean;
+  symbolCount: number;
+  fileCount: number;
+}
+
+/**
+ * Run the full Quinn context retrieval and prompt assembly pipeline.
+ */
+export async function runReviewPipeline(input: PipelineInput): Promise<PipelineResult> {
+  const { repo, prNumber, prUrl, title, diff } = input;
+
+  // Parse diff into files and symbols
+  const diffFiles = parseDiff(diff);
+  const symbols = extractAllSymbols(diffFiles);
+  const filePaths = [...new Set(diffFiles.map(f => f.path))];
+
+  // Check Qdrant availability
+  const qdrantAvailable = await checkHealth();
+
+  let context: CodebaseContext | undefined;
+
+  if (qdrantAvailable) {
+    try {
+      const [pastDecisions, similarPatterns] = await Promise.all([
+        retrieveAllPastPRDecisions(repo, filePaths),
+        findAllSimilarPatterns(symbols),
+      ]);
+
+      if (pastDecisions.size > 0 || similarPatterns.size > 0) {
+        context = { pastDecisions, similarPatterns };
+      }
+    } catch (err) {
+      console.warn("[review-pipeline] Qdrant context retrieval failed — proceeding with diff-only review:", err);
+    }
+  } else {
+    console.warn("[review-pipeline] Qdrant unavailable — proceeding with diff-only review");
+  }
+
+  const assembled = assembleReviewPrompt({
+    diff,
+    repo,
+    prNumber,
+    prUrl,
+    title,
+    context,
+    promptBudget: input.promptBudget,
+  });
+
+  console.log(
+    `[review-pipeline] PR #${prNumber} ${repo}: ` +
+    `${filePaths.length} files, ${symbols.length} symbols, ` +
+    `context=${assembled.hasContext}, tokens=${assembled.totalTokens}`,
+  );
+
+  return {
+    assembled,
+    qdrantAvailable,
+    symbolCount: symbols.length,
+    fileCount: filePaths.length,
+  };
+}
+
+/**
+ * Index PR history after a merge (called from the merge webhook).
+ * Extracted here to allow the review pipeline to also trigger indexing.
+ */
+export { indexPRHistory } from "../qdrant/pr-history-indexer.ts";
+export { initializeCollections } from "../qdrant/collections.ts";

--- a/src/services/reviews/token-budgeter.ts
+++ b/src/services/reviews/token-budgeter.ts
@@ -1,0 +1,113 @@
+/**
+ * Token budgeter — enforces a 20% token budget cap on the CODEBASE CONTEXT block.
+ *
+ * Token estimation: 1 token ≈ 4 characters (GPT-style approximation).
+ *
+ * Priority order when truncating:
+ *   1. Past PR decisions (always keep — highest value)
+ *   2. Similar code patterns (trim from lowest-scored pattern)
+ *   3. Learnings summary (drop first if over budget)
+ */
+
+import type { CodebaseContext } from "./context-formatter.ts";
+import type { SimilarPattern } from "../qdrant/pattern-searcher.ts";
+
+const CHARS_PER_TOKEN = 4;
+const CONTEXT_BUDGET_FRACTION = 0.2;
+
+/**
+ * Estimate token count from a string.
+ */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+/**
+ * Apply token budget to the CodebaseContext.
+ *
+ * totalPromptBudget: total token budget for the full prompt.
+ * Returns a trimmed CodebaseContext that fits within 20% of that budget.
+ */
+export function applyTokenBudget(
+  ctx: CodebaseContext,
+  totalPromptBudget: number,
+): CodebaseContext {
+  const maxContextTokens = Math.floor(totalPromptBudget * CONTEXT_BUDGET_FRACTION);
+
+  // Start with the full context and measure
+  let currentTokens = estimateContextTokens(ctx);
+
+  if (currentTokens <= maxContextTokens) return ctx;
+
+  // Trim similar patterns (lowest priority, trim from end) until within budget
+  const trimmedPatterns = new Map(
+    [...ctx.similarPatterns].map(([k, v]) => [k, [...v]])
+  );
+
+  while (currentTokens > maxContextTokens) {
+    const removed = removeLowestScoredPattern(trimmedPatterns);
+    if (!removed) break; // Nothing left to remove
+    currentTokens = estimateContextTokens({
+      pastDecisions: ctx.pastDecisions,
+      similarPatterns: trimmedPatterns,
+    });
+  }
+
+  return {
+    pastDecisions: ctx.pastDecisions,
+    similarPatterns: trimmedPatterns,
+  };
+}
+
+/**
+ * Estimate tokens used by a CodebaseContext.
+ */
+function estimateContextTokens(ctx: CodebaseContext): number {
+  let chars = "CODEBASE CONTEXT:\n".length;
+
+  for (const [filePath, decisions] of ctx.pastDecisions) {
+    chars += filePath.length + 20;
+    for (const d of decisions) {
+      chars += `PR #${d.prNumber} (${d.mergedAt}): ${d.decision} — ${d.reviewIssues}`.length + 10;
+    }
+  }
+
+  for (const [symbolKey, patterns] of ctx.similarPatterns) {
+    chars += symbolKey.length + 10;
+    for (const p of patterns) {
+      chars += p.file.length + p.context.length + 30;
+    }
+  }
+
+  return estimateTokens(chars.toString()) + Math.floor(chars / CHARS_PER_TOKEN);
+}
+
+/**
+ * Remove the lowest-scored pattern from the map.
+ * Returns false if no patterns remain.
+ */
+function removeLowestScoredPattern(
+  patterns: Map<string, SimilarPattern[]>,
+): boolean {
+  let lowestKey: string | null = null;
+  let lowestScore = Infinity;
+  let lowestIndex = -1;
+
+  for (const [key, pats] of patterns) {
+    for (let i = 0; i < pats.length; i++) {
+      if (pats[i].score < lowestScore) {
+        lowestScore = pats[i].score;
+        lowestKey = key;
+        lowestIndex = i;
+      }
+    }
+  }
+
+  if (lowestKey === null || lowestIndex === -1) return false;
+
+  const pats = patterns.get(lowestKey)!;
+  pats.splice(lowestIndex, 1);
+  if (pats.length === 0) patterns.delete(lowestKey);
+
+  return true;
+}

--- a/src/webhooks/github-comment-response.ts
+++ b/src/webhooks/github-comment-response.ts
@@ -1,0 +1,149 @@
+/**
+ * GitHub comment response webhook handler.
+ *
+ * Intercepts developer replies to Quinn inline review comments.
+ * When a developer responds to a Quinn comment (dismisses, replies, resolves),
+ * the event is fed into the review learning pipeline.
+ *
+ * Relevant events:
+ *   - pull_request_review_comment (action: created) — reply to Quinn's inline comment
+ *   - pull_request_review (action: dismissed) — developer dismisses a review
+ */
+
+import { trackCommentResponse, isDismissalResponse } from "../services/reviews/dismissal-tracker.ts";
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+export interface ReviewCommentPayload {
+  action: string;
+  comment: {
+    body: string;
+    path: string;
+    in_reply_to_id?: number;
+    user: { login: string };
+  };
+  pull_request: {
+    number: number;
+  };
+  repository: {
+    name: string;
+    owner: { login: string };
+  };
+}
+
+export interface ReviewDismissalPayload {
+  action: "dismissed";
+  review: {
+    body: string | null;
+    state: string;
+    user: { login: string };
+    dismissed_review?: {
+      dismissal_message: string;
+    };
+  };
+  pull_request: {
+    number: number;
+  };
+  repository: {
+    name: string;
+    owner: { login: string };
+  };
+}
+
+// ── Handlers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Handle a pull_request_review_comment event.
+ *
+ * Only processes comments that are replies (have in_reply_to_id) to Quinn's comments.
+ * The original Quinn comment body is passed as commentBody for pattern matching.
+ */
+export async function handleCommentResponse(
+  payload: ReviewCommentPayload,
+  quinnCommentBody: string,
+): Promise<void> {
+  if (payload.action !== "created") return;
+  if (!payload.comment.in_reply_to_id) return;
+
+  const owner = payload.repository.owner.login;
+  const repo = payload.repository.name;
+  const repoSlug = `${owner}/${repo}`;
+  const filePath = payload.comment.path;
+  const responseBody = payload.comment.body;
+  const author = payload.comment.user.login;
+
+  // Skip if the responder is Quinn itself (avoid feedback loop)
+  if (author.includes("quinn")) return;
+
+  const dismissed = isDismissalResponse(responseBody);
+
+  await trackCommentResponse({
+    repo: repoSlug,
+    filePath,
+    commentBody: quinnCommentBody,
+    responseBody,
+    dismissed,
+    reason: dismissed ? responseBody.slice(0, 200) : undefined,
+  });
+
+  console.log(
+    `[github-comment-response] Comment response on ${repoSlug}#${payload.pull_request.number} ` +
+    `by @${author}: ${dismissed ? "dismissed" : "engaged"}`,
+  );
+}
+
+/**
+ * Handle a pull_request_review dismissed event.
+ */
+export async function handleReviewDismissal(
+  payload: ReviewDismissalPayload,
+  quinnCommentBody: string,
+  filePath: string,
+): Promise<void> {
+  if (payload.action !== "dismissed") return;
+  if (!payload.review.user.login.includes("quinn")) return;
+
+  const owner = payload.repository.owner.login;
+  const repo = payload.repository.name;
+  const repoSlug = `${owner}/${repo}`;
+  const reason = payload.review.dismissed_review?.dismissal_message ?? "";
+
+  await trackCommentResponse({
+    repo: repoSlug,
+    filePath,
+    commentBody: quinnCommentBody,
+    responseBody: reason,
+    dismissed: true,
+    reason: reason.slice(0, 200),
+  });
+
+  console.log(
+    `[github-comment-response] Review dismissed on ${repoSlug}#${payload.pull_request.number}` +
+    (reason ? `: ${reason}` : ""),
+  );
+}
+
+/**
+ * Parse and route a raw GitHub webhook event to the appropriate handler.
+ * Returns true if the event was handled.
+ */
+export function parseCommentResponsePayload(
+  event: string,
+  payload: unknown,
+): { type: "comment_response" | "review_dismissal" | "unhandled" } {
+  if (event === "pull_request_review_comment") {
+    const p = payload as ReviewCommentPayload;
+    if (p.action === "created" && p.comment.in_reply_to_id) {
+      return { type: "comment_response" };
+    }
+  }
+
+  if (event === "pull_request_review") {
+    const p = payload as ReviewDismissalPayload;
+    if (p.action === "dismissed") {
+      return { type: "review_dismissal" };
+    }
+  }
+
+  return { type: "unhandled" };
+}

--- a/src/webhooks/github-pr-merge.ts
+++ b/src/webhooks/github-pr-merge.ts
@@ -1,0 +1,134 @@
+/**
+ * GitHub PR merge webhook handler.
+ *
+ * Listens for pull_request.closed events with merged=true.
+ * On merge:
+ *   1. Fetch full PR diff via GitHub API
+ *   2. Parse diff and chunk for embedding
+ *   3. Extract symbols from changed files
+ *   4. Index diff chunks to quinn-pr-history (Qdrant)
+ *   5. Fetch symbol contexts and index to quinn-code-patterns
+ *
+ * This handler is designed to be called from the existing GitHubPlugin
+ * webhook receiver or a standalone HTTP handler.
+ */
+
+import { fetchPRDiff, fetchReviewComments, fetchReviewDecision, summarizeReviewIssues } from "../services/github/diff-fetcher.ts";
+import { parseDiff, chunkDiff } from "../services/diff/chunker.ts";
+import { extractAllSymbols } from "../services/diff/symbol-extractor.ts";
+import { fetchSymbolContexts } from "../services/codebase/symbol-fetcher.ts";
+import { indexPRHistory } from "../services/qdrant/pr-history-indexer.ts";
+import { indexCodePatterns } from "../services/qdrant/code-patterns-indexer.ts";
+import type { PRMetadata } from "../services/github/diff-fetcher.ts";
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+export interface PRMergePayload {
+  action: "closed";
+  pull_request: {
+    number: number;
+    merged: boolean;
+    merged_at: string | null;
+    html_url: string;
+    title: string;
+    base: { ref: string; sha: string };
+    head: { sha: string };
+  };
+  repository: {
+    name: string;
+    owner: { login: string };
+  };
+}
+
+// ── Handler ────────────────────────────────────────────────────────────────────
+
+/**
+ * Handle a pull_request.closed event.
+ * No-ops if the PR was closed without merging.
+ */
+export async function handlePRMerge(
+  payload: PRMergePayload,
+  getToken: (owner: string, repo: string) => Promise<string>,
+): Promise<void> {
+  const pr = payload.pull_request;
+
+  if (!pr.merged || !pr.merged_at) {
+    // PR was closed without merging — nothing to index
+    return;
+  }
+
+  const owner = payload.repository.owner.login;
+  const repo = payload.repository.name;
+  const prNumber = pr.number;
+
+  console.log(`[github-pr-merge] Processing merged PR #${prNumber} in ${owner}/${repo}`);
+
+  const token = await getToken(owner, repo);
+
+  const meta: PRMetadata = {
+    owner,
+    repo,
+    prNumber,
+    baseBranch: pr.base.ref,
+    mergedAt: pr.merged_at,
+    prUrl: pr.html_url,
+    title: pr.title,
+  };
+
+  // Fetch diff, comments, and review decision in parallel
+  const [diff, comments, decision] = await Promise.all([
+    fetchPRDiff(meta, token),
+    fetchReviewComments(meta, token),
+    fetchReviewDecision(meta, token),
+  ]);
+
+  if (!diff) {
+    console.warn(`[github-pr-merge] Empty diff for PR #${prNumber} — skipping indexing`);
+    return;
+  }
+
+  const reviewIssues = summarizeReviewIssues(comments);
+  const diffFiles = parseDiff(diff);
+  const chunks = chunkDiff(diffFiles);
+  const symbols = extractAllSymbols(diffFiles);
+
+  // Index PR history
+  await indexPRHistory({
+    meta,
+    chunks,
+    decision,
+    reviewIssues,
+  });
+
+  // Index code patterns (symbol contexts)
+  if (symbols.length > 0) {
+    const symbolContexts = await fetchSymbolContexts(owner, repo, pr.head.sha, symbols, token);
+    if (symbolContexts.length > 0) {
+      await indexCodePatterns(symbolContexts);
+    }
+  }
+
+  console.log(
+    `[github-pr-merge] Indexed PR #${prNumber} ${owner}/${repo}: ` +
+    `${chunks.length} chunks, ${symbols.length} symbols, decision=${decision}`,
+  );
+}
+
+/**
+ * Parse and validate a raw GitHub webhook payload for the PR merge handler.
+ * Returns null if the event is not a merged PR close event.
+ */
+export function parsePRMergePayload(
+  event: string,
+  payload: unknown,
+): PRMergePayload | null {
+  if (event !== "pull_request") return null;
+
+  const p = payload as Record<string, unknown>;
+  if (p.action !== "closed") return null;
+
+  const pr = p.pull_request as Record<string, unknown> | undefined;
+  if (!pr?.merged) return null;
+
+  return payload as PRMergePayload;
+}

--- a/tests/e2e/qdrant-context-pipeline.test.ts
+++ b/tests/e2e/qdrant-context-pipeline.test.ts
@@ -1,0 +1,328 @@
+/**
+ * E2E test for the Qdrant context pipeline.
+ *
+ * Tests the complete flow without live Qdrant/Ollama (uses mocked fetch).
+ * Verifies: diff parsing → symbol extraction → context formatting → prompt assembly.
+ */
+
+import { describe, test, expect, beforeAll, mock } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// ── Load fixture ───────────────────────────────────────────────────────────────
+
+const fixtureDir = join(import.meta.dir, "../fixtures");
+const samplePR = JSON.parse(readFileSync(join(fixtureDir, "sample-pr-diff.json"), "utf8"));
+
+// ── Import pipeline modules ────────────────────────────────────────────────────
+
+import { parseDiff, chunkDiff } from "../../src/services/diff/chunker.ts";
+import { extractAllSymbols } from "../../src/services/diff/symbol-extractor.ts";
+import { formatCodebaseContext } from "../../src/services/reviews/context-formatter.ts";
+import { assembleReviewPrompt } from "../../src/services/reviews/quinn-review-prompt.ts";
+import { applyTokenBudget, estimateTokens } from "../../src/services/reviews/token-budgeter.ts";
+import { isDismissalResponse } from "../../src/services/reviews/dismissal-tracker.ts";
+import { parsePRMergePayload } from "../../src/webhooks/github-pr-merge.ts";
+import { parseCommentResponsePayload } from "../../src/webhooks/github-comment-response.ts";
+import { summarizeReviewIssues } from "../../src/services/github/diff-fetcher.ts";
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("Diff Parser", () => {
+  test("parses sample diff into files", () => {
+    const files = parseDiff(samplePR.diff);
+    expect(files.length).toBeGreaterThan(0);
+    expect(files[0].path).toBe("src/middleware/auth.ts");
+  });
+
+  test("extracts added lines from hunks", () => {
+    const files = parseDiff(samplePR.diff);
+    const authFile = files.find(f => f.path === "src/middleware/auth.ts");
+    expect(authFile).toBeDefined();
+    expect(authFile!.added.length).toBeGreaterThan(0);
+  });
+
+  test("chunks small diff files as single chunk", () => {
+    const files = parseDiff(samplePR.diff);
+    const chunks = chunkDiff(files);
+    expect(chunks.length).toBeGreaterThan(0);
+    // All chunks in sample diff should be single chunks (small files)
+    const authChunks = chunks.filter(c => c.filePath === "src/middleware/auth.ts");
+    expect(authChunks.length).toBe(1);
+    expect(authChunks[0].chunkIndex).toBe(0);
+  });
+});
+
+describe("Symbol Extractor", () => {
+  test("extracts TypeScript symbols from diff", () => {
+    const files = parseDiff(samplePR.diff);
+    const symbols = extractAllSymbols(files);
+    expect(symbols.length).toBeGreaterThan(0);
+
+    const names = symbols.map(s => s.name);
+    // Should find validateToken function and AuthMiddleware class and AuthToken interface
+    expect(names).toContain("validateToken");
+    expect(names).toContain("AuthMiddleware");
+  });
+
+  test("assigns correct language to TypeScript files", () => {
+    const files = parseDiff(samplePR.diff);
+    const symbols = extractAllSymbols(files);
+    for (const sym of symbols) {
+      expect(sym.language).toBe("typescript");
+    }
+  });
+
+  test("skips unsupported file extensions", () => {
+    const files = [
+      {
+        path: "config/settings.toml",
+        hunks: [{ header: "@@ -0,0 +1,3 @@", lines: ["+[server]", "+port = 8080"], startLine: 1, endLine: 3 }],
+        added: ["[server]", "port = 8080"],
+        removed: [],
+      },
+    ];
+    const symbols = extractAllSymbols(files);
+    expect(symbols.length).toBe(0);
+  });
+});
+
+describe("Context Formatter", () => {
+  test("formats CODEBASE CONTEXT block with past PR decisions", () => {
+    const ctx = {
+      pastDecisions: new Map([
+        ["src/middleware/auth.ts", [
+          {
+            prNumber: 142,
+            prUrl: "https://github.com/protolabsai/protomaker/pull/142",
+            decision: "APPROVE",
+            mergedAt: "2026-04-01T12:00:00Z",
+            reviewIssues: "Token expiry not checked",
+            file: "src/middleware/auth.ts",
+            score: 0.92,
+          },
+        ]],
+      ]),
+      similarPatterns: new Map(),
+    };
+
+    const block = formatCodebaseContext(ctx);
+    expect(block).toContain("CODEBASE CONTEXT:");
+    expect(block).toContain("PR #142");
+    expect(block).toContain("APPROVE");
+    expect(block).toContain("Token expiry not checked");
+  });
+
+  test("returns empty string when no context", () => {
+    const ctx = {
+      pastDecisions: new Map(),
+      similarPatterns: new Map(),
+    };
+    const block = formatCodebaseContext(ctx);
+    expect(block).toBe("");
+  });
+
+  test("formats similar patterns section", () => {
+    const ctx = {
+      pastDecisions: new Map(),
+      similarPatterns: new Map([
+        ["validateToken:src/middleware/auth.ts", [
+          {
+            repo: "protolabsai/protomaker",
+            file: "src/utils/jwt.ts",
+            symbolName: "validateToken",
+            symbolType: "function",
+            line: 23,
+            context: "23: export function validateToken(token: string): boolean {\n24:   // ...\n25: }",
+            score: 0.87,
+          },
+        ]],
+      ]),
+    };
+
+    const block = formatCodebaseContext(ctx);
+    expect(block).toContain("CODEBASE CONTEXT:");
+    expect(block).toContain("validateToken");
+    expect(block).toContain("src/utils/jwt.ts:23");
+  });
+});
+
+describe("Token Budgeter", () => {
+  test("estimates token count from text", () => {
+    const tokens = estimateTokens("Hello world"); // 11 chars / 4 = 3 tokens
+    expect(tokens).toBeGreaterThan(0);
+  });
+
+  test("respects 20% budget cap", () => {
+    const manyPatterns = new Map<string, Array<{ repo: string; file: string; symbolName: string; symbolType: string; line: number; context: string; score: number }>>();
+    // Add 20 patterns to exceed budget
+    for (let i = 0; i < 20; i++) {
+      manyPatterns.set(`symbol${i}:file${i}.ts`, [{
+        repo: "test/repo",
+        file: `src/file${i}.ts`,
+        symbolName: `symbol${i}`,
+        symbolType: "function",
+        line: i * 10,
+        context: "A".repeat(500), // 500 chars each
+        score: 0.9 - i * 0.01,
+      }]);
+    }
+
+    const ctx = {
+      pastDecisions: new Map(),
+      similarPatterns: manyPatterns,
+    };
+
+    // Small budget of 1000 tokens = 200 tokens for context
+    const budgeted = applyTokenBudget(ctx, 1000);
+
+    // Verify that patterns were trimmed
+    const totalPatterns = [...budgeted.similarPatterns.values()].reduce((acc, p) => acc + p.length, 0);
+    expect(totalPatterns).toBeLessThan(20);
+  });
+});
+
+describe("Review Prompt Assembler", () => {
+  test("assembles prompt with diff", () => {
+    const result = assembleReviewPrompt({
+      diff: samplePR.diff,
+      repo: samplePR.repo,
+      prNumber: samplePR.prNumber,
+      prUrl: samplePR.prUrl,
+      title: samplePR.title,
+    });
+
+    expect(result.prompt).toContain("src/middleware/auth.ts");
+    expect(result.prompt).toContain(`PR #${samplePR.prNumber}`);
+    expect(result.hasContext).toBe(false);
+    expect(result.diffTokens).toBeGreaterThan(0);
+  });
+
+  test("prepends CODEBASE CONTEXT block when context provided", () => {
+    const ctx = {
+      pastDecisions: new Map([
+        ["src/middleware/auth.ts", [
+          {
+            prNumber: 100,
+            prUrl: "https://github.com/test/repo/pull/100",
+            decision: "REQUEST_CHANGES",
+            mergedAt: "2026-03-01T10:00:00Z",
+            reviewIssues: "Missing error handling",
+            file: "src/middleware/auth.ts",
+            score: 0.91,
+          },
+        ]],
+      ]),
+      similarPatterns: new Map(),
+    };
+
+    const result = assembleReviewPrompt({
+      diff: samplePR.diff,
+      repo: samplePR.repo,
+      prNumber: samplePR.prNumber,
+      prUrl: samplePR.prUrl,
+      title: samplePR.title,
+      context: ctx,
+    });
+
+    expect(result.hasContext).toBe(true);
+    expect(result.prompt).toContain("CODEBASE CONTEXT:");
+    expect(result.contextTokens).toBeGreaterThan(0);
+    // Context should appear before the diff
+    const contextIdx = result.prompt.indexOf("CODEBASE CONTEXT:");
+    const diffIdx = result.prompt.indexOf("diff --git");
+    expect(contextIdx).toBeLessThan(diffIdx);
+  });
+});
+
+describe("Dismissal Tracker", () => {
+  test("detects dismissal phrases", () => {
+    expect(isDismissalResponse("this is fine, by design")).toBe(true);
+    expect(isDismissalResponse("won't fix — we handle this upstream")).toBe(true);
+    expect(isDismissalResponse("false positive")).toBe(true);
+    expect(isDismissalResponse("great catch, fixing now")).toBe(false);
+    expect(isDismissalResponse("thanks for the review")).toBe(false);
+  });
+});
+
+describe("PR Merge Webhook Parser", () => {
+  test("accepts merged PR close event", () => {
+    const payload = {
+      action: "closed",
+      pull_request: {
+        number: 42,
+        merged: true,
+        merged_at: "2026-04-01T12:00:00Z",
+        html_url: "https://github.com/test/repo/pull/42",
+        title: "feat: add feature",
+        base: { ref: "main", sha: "abc123" },
+        head: { sha: "def456" },
+      },
+      repository: {
+        name: "repo",
+        owner: { login: "test" },
+      },
+    };
+    const result = parsePRMergePayload("pull_request", payload);
+    expect(result).not.toBeNull();
+    expect(result!.pull_request.number).toBe(42);
+  });
+
+  test("rejects unmerged PR close event", () => {
+    const payload = {
+      action: "closed",
+      pull_request: { number: 42, merged: false, merged_at: null },
+      repository: { name: "repo", owner: { login: "test" } },
+    };
+    const result = parsePRMergePayload("pull_request", payload);
+    expect(result).toBeNull();
+  });
+
+  test("rejects non-PR events", () => {
+    const result = parsePRMergePayload("push", {});
+    expect(result).toBeNull();
+  });
+});
+
+describe("Review Comments Summary", () => {
+  test("summarizes Quinn comments into review issues string", () => {
+    const comments = samplePR.reviewComments;
+    const summary = summarizeReviewIssues(comments);
+    expect(summary.length).toBeGreaterThan(0);
+    expect(summary).toContain("Token expiry");
+  });
+});
+
+describe("Comment Response Webhook Parser", () => {
+  test("identifies comment reply events", () => {
+    const payload = {
+      action: "created",
+      comment: {
+        body: "this is by design",
+        path: "src/auth.ts",
+        in_reply_to_id: 12345,
+        user: { login: "developer" },
+      },
+      pull_request: { number: 10 },
+      repository: { name: "repo", owner: { login: "test" } },
+    };
+    const result = parseCommentResponsePayload("pull_request_review_comment", payload);
+    expect(result.type).toBe("comment_response");
+  });
+
+  test("identifies review dismissal events", () => {
+    const payload = {
+      action: "dismissed",
+      review: {
+        body: null,
+        state: "dismissed",
+        user: { login: "protoquinn[bot]" },
+        dismissed_review: { dismissal_message: "not applicable" },
+      },
+      pull_request: { number: 10 },
+      repository: { name: "repo", owner: { login: "test" } },
+    };
+    const result = parseCommentResponsePayload("pull_request_review", payload);
+    expect(result.type).toBe("review_dismissal");
+  });
+});

--- a/tests/fixtures/sample-pr-diff.json
+++ b/tests/fixtures/sample-pr-diff.json
@@ -1,0 +1,22 @@
+{
+  "prNumber": 142,
+  "repo": "protolabsai/protomaker",
+  "owner": "protolabsai",
+  "title": "feat: add JWT token validation middleware",
+  "prUrl": "https://github.com/protolabsai/protomaker/pull/142",
+  "mergedAt": "2026-04-01T12:00:00Z",
+  "baseBranch": "main",
+  "headSha": "abc123def456",
+  "decision": "APPROVE",
+  "reviewIssues": "Token expiry not checked; consider adding clock skew tolerance",
+  "diff": "diff --git a/src/middleware/auth.ts b/src/middleware/auth.ts\nindex 0000000..1234567 100644\n--- /dev/null\n+++ b/src/middleware/auth.ts\n@@ -0,0 +1,45 @@\n+import { verify } from 'jsonwebtoken';\n+\n+export interface AuthToken {\n+  userId: string;\n+  role: string;\n+  exp: number;\n+}\n+\n+export function validateToken(token: string): AuthToken | null {\n+  try {\n+    const secret = process.env.JWT_SECRET;\n+    if (!secret) {\n+      console.error('JWT_SECRET not configured');\n+      return null;\n+    }\n+    const decoded = verify(token, secret) as AuthToken;\n+    return decoded;\n+  } catch {\n+    return null;\n+  }\n+}\n+\n+export class AuthMiddleware {\n+  private secret: string;\n+\n+  constructor(secret: string) {\n+    this.secret = secret;\n+  }\n+\n+  handle(req: Request): AuthToken | null {\n+    const authHeader = req.headers.get('Authorization');\n+    if (!authHeader?.startsWith('Bearer ')) return null;\n+    const token = authHeader.slice(7);\n+    return validateToken(token);\n+  }\n+}\ndiff --git a/src/routes/api.ts b/src/routes/api.ts\nindex 1111111..2222222 100644\n--- a/src/routes/api.ts\n+++ b/src/routes/api.ts\n@@ -1,5 +1,12 @@\n import { Router } from './router';\n+import { AuthMiddleware } from '../middleware/auth';\n+\n+const auth = new AuthMiddleware(process.env.JWT_SECRET ?? '');\n \n export function createRouter(): Router {\n   const router = new Router();\n+\n+  router.use((req) => {\n+    const token = auth.handle(req);\n+    if (!token) throw new Error('Unauthorized');\n+  });\n+\n   return router;\n }",
+  "reviewComments": [
+    {
+      "body": "Token expiry not checked — consider verifying the `exp` field explicitly and adding clock skew tolerance (e.g., 30s leeway).",
+      "path": "src/middleware/auth.ts",
+      "line": 18,
+      "author": "protoquinn[bot]",
+      "isQuinn": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Extend Quinn's PR reviewer with codebase-wide context retrieval via Qdrant, matching CodeRabbit's key differentiator: catching inconsistencies across the repo that diff-only review misses.

## Motivation

Diff-only review is blind to cross-file patterns. CodeRabbit's main edge over OSS alternatives is LanceDB vector search over full repo history — it can flag 'this change is inconsistent with how you handle it in 5 other files.' We have Qdrant + mem0 already in the stack. This feature wires them...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AI-powered code reviews now leverage context from past pull requests and similar code patterns across your repository for more targeted feedback.
  * System intelligently learns from developer responses to review suggestions, improving recommendation accuracy over time.

* **Documentation**
  * Added comprehensive architecture documentation describing the review system's design and data flow.
  * Added configuration schema reference for vector storage setup.

* **Tests**
  * Added end-to-end test suite covering the complete context injection and retrieval pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->