### PR TITLE
Milestone 2: Discord Autocomplete + Org Webhook

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1775585786162-dnqkm006",
-  "startedAt": "2026-04-08T00:22:03.548Z"
+  "featureId": "feature-1775548645158-ary3gk6qe",
+  "startedAt": "2026-04-08T00:58:37.797Z"
 }

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -122,6 +122,52 @@ Array of regex strings (escaped for YAML). Matched case-insensitively. Matching 
 | `type` | Yes | `string`, `integer`, or `boolean` |
 | `required` | No | Defaults to `false` |
 
+### Autocomplete Commands
+
+Commands can use top-level `options` instead of `subcommands` to get Discord's autocomplete UX. Set `autocomplete: true` on any string option to enable live filtering.
+
+When `project` is an autocomplete option, the plugin loads `projects.yaml` and returns matching projects as choices (filtered by slug or title). On submission, the project slug is resolved to `devChannelId` (from `discord.dev`) and `projectRepo` (from the `github` field) and included in the bus payload.
+
+```yaml
+commands:
+  - name: report-bug
+    description: Report a bug against a project
+    # Top-level options — no subcommands
+    options:
+      - name: project
+        description: Project to report against (start typing to filter)
+        type: string
+        required: true
+        autocomplete: true
+      - name: description
+        description: Brief description of the bug
+        type: string
+        required: true
+    content: "Bug report for {project}: {description}"
+    skillHint: bug_triage
+```
+
+#### `commands[].options[]` (flat/autocomplete commands)
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Option name — also the interpolation key in `content` |
+| `description` | Yes | Shown in Discord |
+| `type` | Yes | `string`, `integer`, or `boolean` |
+| `required` | No | Defaults to `false` |
+| `autocomplete` | No | When `true`, Discord sends autocomplete interactions. Only supported on `string` options. For `project` options, choices come from `projects.yaml`. |
+
+#### Flat command bus payload extras
+
+When `project` is resolved from `projects.yaml`, two extra fields are added to the inbound payload:
+
+```typescript
+{
+  devChannelId?: string;   // discord.dev channel ID for the matched project
+  projectRepo?: string;    // GitHub full name (e.g. "protoLabsAI/protoUI")
+}
+```
+
 ## Bus Topics
 
 | Topic | Direction | Description |

--- a/docs/github.md
+++ b/docs/github.md
@@ -111,6 +111,57 @@ Match `correlationId` from the inbound message — the plugin uses it to look up
 | `issues` | New issue body containing `@mention` | `bug_triage` |
 | `pull_request_review_comment` | Review comment containing `@mention` | `pr_review` |
 | `pull_request` | PR opened/updated with `@mention` in body | `pr_review` |
+| `repository` (created) | New repository created in the org | `message.inbound.onboard` |
+
+## Org Webhook: repository.created
+
+When a new repository is created in the GitHub org, the plugin publishes `message.inbound.onboard` so Ava (or any subscriber) can automatically onboard the project.
+
+### Onboard Bus Payload
+
+```typescript
+{
+  event: "repository.created";
+  owner: string;       // org or user name
+  repo: string;        // repository name
+  fullName: string;    // "owner/repo"
+  url: string;         // HTML URL of the repository
+  description: string; // repository description (empty string if none)
+  isPrivate: boolean;
+}
+```
+
+Topic: `message.inbound.onboard`
+
+### Register the Org Webhook
+
+Register a single org-level webhook so all new repositories trigger the event automatically — no per-repo webhook needed.
+
+```bash
+gh api orgs/protoLabsAI/hooks \
+  --method POST \
+  --field name=web \
+  --field "config[url]=https://hooks.proto-labs.ai/webhook/github" \
+  --field "config[content_type]=json" \
+  --field "config[secret]=$GITHUB_WEBHOOK_SECRET" \
+  --field "config[insecure_ssl]=0" \
+  --field "events[]=repository"
+```
+
+To also receive existing repo events (issues, PRs) via the org hook, add them:
+
+```bash
+  --field "events[]=repository" \
+  --field "events[]=issues" \
+  --field "events[]=issue_comment" \
+  --field "events[]=pull_request" \
+  --field "events[]=pull_request_review_comment"
+```
+
+List existing org hooks:
+```bash
+gh api orgs/protoLabsAI/hooks
+```
 
 ## Signature Validation
 

--- a/lib/plugins/discord.ts
+++ b/lib/plugins/discord.ts
@@ -39,6 +39,8 @@ interface CommandOption {
   description: string;
   type: "string" | "integer" | "boolean";
   required?: boolean;
+  /** When true, Discord sends autocomplete interactions for this option. */
+  autocomplete?: boolean;
 }
 
 interface Subcommand {
@@ -52,7 +54,13 @@ interface Subcommand {
 interface CommandConfig {
   name: string;
   description: string;
-  subcommands: Subcommand[];
+  /** Subcommand-based commands (mutually exclusive with top-level `options`). */
+  subcommands?: Subcommand[];
+  /** Top-level options for flat commands (no subcommands). */
+  options?: CommandOption[];
+  /** Content template for flat commands — supports {optionName} placeholders. */
+  content?: string;
+  skillHint?: string;
 }
 
 interface DiscordConfig {
@@ -151,6 +159,35 @@ function loadAgentPoolDefs(workspaceDir: string): AgentPoolEntry[] {
     return parsed.agents ?? [];
   } catch (err) {
     console.error("[discord] Failed to parse agents.yaml:", err);
+    return [];
+  }
+}
+
+// ── Projects loader (for autocomplete + project resolution) ───────────────────
+
+interface ProjectEntry {
+  slug: string;
+  title: string;
+  github?: string;
+  status?: string;
+  discord?: { general?: string; updates?: string; dev?: string };
+}
+
+interface ProjectsYaml {
+  projects: ProjectEntry[];
+}
+
+function loadProjectsDefs(workspaceDir: string): ProjectEntry[] {
+  const projectsPath = join(workspaceDir, "projects.yaml");
+  if (!existsSync(projectsPath)) return [];
+  try {
+    const raw = readFileSync(projectsPath, "utf8");
+    const parsed = parseYaml(raw) as ProjectsYaml;
+    return (parsed.projects ?? []).filter(
+      p => p.status !== "archived" && p.status !== "suspended"
+    );
+  } catch (err) {
+    console.error("[discord] Failed to parse projects.yaml:", err);
     return [];
   }
 }
@@ -298,8 +335,29 @@ export class DiscordPlugin implements Plugin {
       });
     });
 
-    // ── Slash commands ───────────────────────────────────────────────────────
+    // ── Slash commands + autocomplete ────────────────────────────────────────
     this.client.on(Events.InteractionCreate, async interaction => {
+      // ── Autocomplete: filter projects.yaml by typed value ─────────────────
+      if (interaction.isAutocomplete()) {
+        const cmdConfig = this.config.commands.find(c => c.name === interaction.commandName);
+        if (!cmdConfig) return;
+
+        const focused = interaction.options.getFocused(true);
+        if (focused.name === "project") {
+          const projects = loadProjectsDefs(this.workspaceDir);
+          const typed = focused.value.toLowerCase();
+          const choices = projects
+            .filter(p =>
+              p.slug.toLowerCase().includes(typed) ||
+              p.title.toLowerCase().includes(typed)
+            )
+            .slice(0, 25)
+            .map(p => ({ name: p.title, value: p.slug }));
+          await interaction.respond(choices).catch(console.error);
+        }
+        return;
+      }
+
       if (!interaction.isChatInputCommand()) return;
 
       const cmdConfig = this.config.commands.find(c => c.name === interaction.commandName);
@@ -313,9 +371,56 @@ export class DiscordPlugin implements Plugin {
 
       await interaction.deferReply();
 
-      const subName = interaction.options.getSubcommand(false) ?? cmdConfig.subcommands[0]?.name;
-      const subConfig = cmdConfig.subcommands.find(s => s.name === subName)
-        ?? cmdConfig.subcommands[0];
+      // ── Flat command (top-level options, no subcommands) ─────────────────
+      const isFlatCommand = !!cmdConfig.options?.length && !cmdConfig.subcommands?.length;
+      if (isFlatCommand) {
+        // Resolve project metadata from projects.yaml if a `project` option is present
+        const projectSlug = interaction.options.getString("project");
+        let devChannelId: string | undefined;
+        let projectRepo: string | undefined;
+
+        if (projectSlug) {
+          const projects = loadProjectsDefs(this.workspaceDir);
+          const project = projects.find(p => p.slug === projectSlug);
+          if (project) {
+            devChannelId = project.discord?.dev || undefined;
+            projectRepo = project.github || undefined;
+          }
+        }
+
+        const content = this._interpolateContent(
+          cmdConfig.content ?? "",
+          cmdConfig.options ?? [],
+          interaction,
+        );
+
+        const correlationId = makeId();
+        pendingReplies.set(correlationId, { interaction });
+
+        const topicSuffix = `slash.${interaction.id}`;
+        bus.publish(`message.inbound.discord.${topicSuffix}`, {
+          id: interaction.id,
+          correlationId,
+          topic: `message.inbound.discord.${topicSuffix}`,
+          timestamp: Date.now(),
+          payload: {
+            sender: interaction.user.id,
+            channel: interaction.channelId,
+            content,
+            skillHint: cmdConfig.skillHint,
+            ...(devChannelId ? { devChannelId } : {}),
+            ...(projectRepo ? { projectRepo } : {}),
+          },
+          source: { interface: "discord" as const, channelId: interaction.channelId, userId: interaction.user.id },
+          reply: { topic: `message.outbound.discord.${topicSuffix}` },
+        });
+        return;
+      }
+
+      // ── Subcommand-based command (existing behaviour) ─────────────────────
+      const subcommands = cmdConfig.subcommands ?? [];
+      const subName = interaction.options.getSubcommand(false) ?? subcommands[0]?.name;
+      const subConfig = subcommands.find(s => s.name === subName) ?? subcommands[0];
 
       if (!subConfig) {
         await interaction.editReply("Unknown subcommand.").catch(console.error);
@@ -623,21 +728,38 @@ export class DiscordPlugin implements Plugin {
       return;
     }
 
-    const commandData = this.config.commands.map(cmd => ({
-      name: cmd.name,
-      description: cmd.description,
-      options: cmd.subcommands.map(sub => ({
-        name: sub.name,
-        type: 1, // SUB_COMMAND
-        description: sub.description,
-        options: (sub.options ?? []).map(opt => ({
-          name: opt.name,
-          description: opt.description,
-          type: OPTION_TYPE_CODES[opt.type] ?? 3,
-          required: opt.required ?? false,
+    const commandData = this.config.commands.map(cmd => {
+      // Flat command: top-level options with optional autocomplete (no subcommands)
+      if (cmd.options?.length && !cmd.subcommands?.length) {
+        return {
+          name: cmd.name,
+          description: cmd.description,
+          options: cmd.options.map(opt => ({
+            name: opt.name,
+            description: opt.description,
+            type: OPTION_TYPE_CODES[opt.type] ?? 3,
+            required: opt.required ?? false,
+            autocomplete: opt.autocomplete ?? false,
+          })),
+        };
+      }
+      // Subcommand-based command (existing behaviour)
+      return {
+        name: cmd.name,
+        description: cmd.description,
+        options: (cmd.subcommands ?? []).map(sub => ({
+          name: sub.name,
+          type: 1, // SUB_COMMAND
+          description: sub.description,
+          options: (sub.options ?? []).map(opt => ({
+            name: opt.name,
+            description: opt.description,
+            type: OPTION_TYPE_CODES[opt.type] ?? 3,
+            required: opt.required ?? false,
+          })),
         })),
-      })),
-    }));
+      };
+    });
 
     await guild.commands.set(commandData);
     console.log(

--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -303,6 +303,42 @@ export class GitHubPlugin implements Plugin {
     bus: EventBus,
     getToken: (owner: string, repo: string) => Promise<string>,
   ): void {
+    // ── Org webhook: repository.created → onboard ─────────────────────────
+    if (event === "repository" && payload.action === "created") {
+      const repo = payload.repository as Record<string, unknown> | undefined;
+      if (repo) {
+        const repoName = repo.name as string;
+        const fullName = repo.full_name as string;
+        const owner = (repo.owner as Record<string, unknown> | undefined)?.login as string;
+        const url = repo.html_url as string;
+        const description = (repo.description as string | null) ?? "";
+        const isPrivate = repo.private as boolean;
+
+        const correlationId = crypto.randomUUID();
+        const topic = "message.inbound.onboard";
+
+        bus.publish(topic, {
+          id: `repository-created-${fullName.replace("/", "-")}-${correlationId.slice(0, 8)}`,
+          correlationId,
+          topic,
+          timestamp: Date.now(),
+          payload: {
+            event: "repository.created",
+            owner,
+            repo: repoName,
+            fullName,
+            url,
+            description,
+            isPrivate,
+          },
+          source: { interface: "github" as const },
+        });
+
+        console.log(`[github] repository.created: ${fullName} → ${topic}`);
+      }
+      return;
+    }
+
     const ctx = extractContext(event, payload);
     if (!ctx) return;
 

--- a/workspace/discord.yaml
+++ b/workspace/discord.yaml
@@ -1,0 +1,39 @@
+# ── Channel IDs ───────────────────────────────────────────────────────────────
+channels:
+  # Default channel for cron-triggered posts (daily digest, etc.)
+  # Falls back to DISCORD_DIGEST_CHANNEL env var if blank.
+  digest: ""
+  # Channel for new member welcome messages. Leave blank to disable.
+  welcome: ""
+  # Channel for moderation log. Leave blank to disable.
+  modLog: ""
+
+# ── Moderation ────────────────────────────────────────────────────────────────
+moderation:
+  rateLimit:
+    maxMessages: 5
+    windowSeconds: 10
+  spamPatterns: []
+
+# ── Slash Commands ────────────────────────────────────────────────────────────
+# Autocomplete commands use top-level `options` (no subcommands).
+# Regular commands use `subcommands`.
+commands:
+  - name: report-bug
+    description: Report a bug against a project
+    # Top-level options — renders as a single command with autocomplete project picker.
+    # The `project` option value (slug) is resolved against projects.yaml to derive
+    # devChannelId (discord.dev) and projectRepo (github field) at dispatch time.
+    options:
+      - name: project
+        description: Project to report against (start typing to filter)
+        type: string
+        required: true
+        autocomplete: true
+      - name: description
+        description: Brief description of the bug
+        type: string
+        required: true
+    content: "Bug report for {project}: {description}"
+    skillHint: bug_triage
+    # admins: ["123456789"] — restrict if needed


### PR DESCRIPTION
## Summary

# Milestone 2: Discord Autocomplete + Org Webhook

Phase 3 — Autocomplete bug reports: replace 8 /report-bug subcommands in discord.yaml with single command using autocomplete option. Add autocomplete interaction handler in discord.ts that filters projects.yaml. Resolves devChannelId and projectRepo from matched project entry. Phase 4 — GitHub org webhook: add repository.created handler in github.ts that publishes message.inbound.onboard. Document org-level webhook registration (gh api orgs/prot...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Discord slash commands now support top-level options with autocomplete capabilities
  * Added intelligent project filtering in command autocomplete suggestions
  * GitHub webhook integration triggers onboarding workflows for newly created repositories
  * New "report-bug" Discord command for submitting bug reports with project selection

* **Documentation**
  * Updated Discord configuration guide with autocomplete option and flat command structure
  * Added GitHub webhook documentation for repository creation events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->