### PR TITLE
bug: .automaker-lock tracked by git causes rebase conflict on every agent branch

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,0 @@
-{
-  "pid": 7,
-  "featureId": "feature-1775612024892-b1uy101ew",
-  "startedAt": "2026-04-08T01:34:16.485Z"
-}


### PR DESCRIPTION
## Summary

## Bug

`.automaker-lock` is in `.gitignore` but is still tracked by git (committed before the gitignore entry was added). Every agent modifies it, causing force-with-lease rejections and rebase conflicts when dev advances.

## Observed (2026-04-08)

Every PR (M2, M3, Google Workspace) hit this pattern:
1. Agent commits work
2. dev advances
3. Auto-mode tries `git push --force-with-lease` -> rejected (stale info)
4. Rebase fails: `.automaker-lock` has unstaged changes
5. Manual fix every time: s...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-08T01:36:15.902Z -->