### PR TITLE
docs: restructure docs/ into Diátaxis format

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,74 @@
 # protoWorkstacean Docs
 
-Plugin, routing, and bus documentation. For deployment config (docker-compose, env vars, network setup) see the [homelab-iac repo](https://github.com/protoLabsAI/homelab-iac/blob/main/stacks/ai/docker-compose.yml).
+Documentation for the protoWorkstacean agent orchestration platform, organized using the [Diátaxis](https://diataxis.fr/) framework.
 
-| File | Description |
-|------|-------------|
-| [a2a.md](a2a.md) | A2A plugin — signal flow diagram, skill routing table, agent registry config, chain execution, bus topics |
-| [discord.md](discord.md) | Discord plugin — setup, discord.yaml config reference, slash commands, bus topics, moderation |
-| [github.md](github.md) | GitHub plugin — webhook setup, github.yaml config, signature validation, bus topics |
-| [hitl.md](hitl.md) | Human-in-the-loop gate — plan/plan_resume flow, HITLRequest/Response types, renderers, expiry, testing |
-| [plane-integration.md](plane-integration.md) | Plane integration — webhook setup via Django ORM, trigger rules, bidirectional sync, known gotchas |
-| [scheduler.md](scheduler.md) | Cron scheduler — YAML format, bus commands, one-shot schedules, missed fire behavior |
-| [extensions.md](extensions.md) | Agent extensions — Pi SDK runtime tools vs workspace bus plugins, when to use each |
-| [testing.md](testing.md) | Testing methodology — test scripts, SQLite polling pattern, debug output |
+For deployment config (docker-compose, env vars, network setup) see the [homelab-iac repo](https://github.com/protoLabsAI/homelab-iac/blob/main/stacks/ai/docker-compose.yml).
+
+---
+
+## Tutorials — Learning-oriented
+
+Step-by-step guides for getting started. Follow these when you're new to the system.
+
+| Doc | Description |
+|-----|-------------|
+| [tutorials/getting-started.md](tutorials/getting-started.md) | Install → first plugin running → first onboard |
+
+---
+
+## How-to Guides — Task-oriented
+
+Goal-focused instructions for specific tasks. Use these when you know what you want to do.
+
+| Doc | Description |
+|-----|-------------|
+| [how-to/onboard-a-project.md](how-to/onboard-a-project.md) | Provision GitHub scaffold, Plane project, and Discord channels for a new repo |
+| [how-to/configure-discord.md](how-to/configure-discord.md) | Set up the Discord bot, discord.yaml, slash commands, and autocomplete |
+| [how-to/set-up-google-workspace.md](how-to/set-up-google-workspace.md) | Enable Drive, Calendar, and Gmail integration via OAuth2 |
+| [how-to/create-a-ceremony.md](how-to/create-a-ceremony.md) | Create recurring scheduled tasks (cron ceremonies) via YAML or the bus |
+| [how-to/use-quinn-pr-review.md](how-to/use-quinn-pr-review.md) | Set up GitHub webhooks, configure Quinn's vector context pipeline |
+
+---
+
+## Reference — Information-oriented
+
+Precise technical descriptions of the API contracts and schemas. Use these when you need to look something up.
+
+| Doc | Description |
+|-----|-------------|
+| [reference/plugins.md](reference/plugins.md) | Plugin interface contract, EventBus API, BusMessage shape, Pi SDK extensions |
+| [reference/bus-topics.md](reference/bus-topics.md) | All bus topics across all plugins — publishers, subscribers, payload shapes |
+| [reference/agent-skills.md](reference/agent-skills.md) | Full skill registry — agents, keywords, chains, A2A protocol |
+| [reference/config-files.md](reference/config-files.md) | All `workspace/*.yaml` schemas and environment variables |
+
+---
+
+## Explanation — Understanding-oriented
+
+Background, concepts, and design rationale. Read these to understand *why* things work the way they do.
+
+| Doc | Description |
+|-----|-------------|
+| [explanation/architecture.md](explanation/architecture.md) | Bus, plugins, agents — how they connect and the design principles behind them |
+| [explanation/plugin-lifecycle.md](explanation/plugin-lifecycle.md) | How plugins register, subscribe, and why hot-reload requires restart |
+| [explanation/agent-identity.md](explanation/agent-identity.md) | Multi-bot design, per-agent GitHub App tokens, `contextId` threading |
+
+---
+
+## Legacy flat docs
+
+The original flat docs are preserved as-is for reference and backward-compatible links:
+
+| Doc | Description |
+|-----|-------------|
+| [a2a.md](a2a.md) | A2A plugin — signal flow diagram, skill routing, chain execution, bus topics |
+| [discord.md](discord.md) | Discord plugin — setup, discord.yaml config, slash commands, bus topics |
+| [github.md](github.md) | GitHub plugin — webhook setup, github.yaml config, signature validation |
+| [hitl.md](hitl.md) | HITL gate — plan/plan_resume flow, HITLRequest/Response types, testing |
+| [plane-integration.md](plane-integration.md) | Plane integration — webhook setup, trigger rules, bidirectional sync |
+| [scheduler.md](scheduler.md) | Cron scheduler — YAML format, bus commands, missed fire behavior |
+| [extensions.md](extensions.md) | Agent extensions — Pi SDK tools vs workspace bus plugins |
+| [testing.md](testing.md) | Testing methodology — test scripts, SQLite polling pattern |
+| [architecture.md](architecture.md) | Original architecture overview |
+| [events.md](events.md) | Event catalog — GoalEvaluatorPlugin events |
+| [context-injection.md](context-injection.md) | Quinn's vector context injection detail |

--- a/docs/explanation/agent-identity.md
+++ b/docs/explanation/agent-identity.md
@@ -1,0 +1,91 @@
+# Agent Identity — Multi-Bot Design and Per-Agent Tokens
+
+_This is an explanation doc. It explains why the fleet uses separate GitHub App identities per agent and how that affects message delivery._
+
+---
+
+## The problem: one server, multiple agent voices
+
+protoWorkstacean routes messages to multiple agents — Quinn for code review and triage, Ava for features and planning, Frank for infrastructure. When these agents post responses back to GitHub, Discord, or Plane, they should appear as distinct identities. A Quinn review should show `protoquinn[bot]`, not a generic bot. An Ava feature creation comment should show `protoava[bot]`.
+
+This matters because:
+- **Attribution** — humans reading GitHub issues can tell at a glance whether Quinn or Ava made the observation
+- **Filtering** — bots can be muted or filtered selectively
+- **Trust signals** — a PR review from `protoquinn[bot]` carries the implicit context that this is a code-focused agent, not a general-purpose one
+
+---
+
+## How it works: GitHub App identities
+
+Quinn and Ava each have their own GitHub App installation. Each app has an App ID and a private key (PKCS#1 PEM). The A2APlugin uses these to generate short-lived JWT tokens for GitHub API calls.
+
+When A2APlugin receives a response from Quinn:
+1. It looks up the GitHub context from the inbound `correlationId` (owner, repo, number)
+2. It generates a JWT using `QUINN_APP_ID` + `QUINN_APP_PRIVATE_KEY`
+3. It exchanges the JWT for a GitHub installation token
+4. It posts the comment via the GitHub API — the comment appears as `protoquinn[bot]`
+
+When Ava responds via a chain call (e.g., `bug_triage → ava/manage_feature`):
+1. The same lookup happens for the GitHub context
+2. Ava's comment is posted using `AVA_APP_ID` + `AVA_APP_PRIVATE_KEY`
+3. The comment appears as `protoava[bot]`
+
+If the GitHub App env vars are not set, comments fall back to the PAT (`GITHUB_TOKEN`), which posts as the PAT owner's account.
+
+---
+
+## Discord: single bot, multiple agents
+
+Unlike GitHub, Discord does not have the concept of "apps posting as different bots." All Discord responses go through the single `DISCORD_BOT_TOKEN`. The agent identity in Discord is conveyed through message content and formatting rather than the posting identity.
+
+The DiscordPlugin uses embed formatting to signal which agent responded. The agent name is included in the embed footer or prefix.
+
+---
+
+## Why Quinn handles Discord provisioning
+
+The `onboard_project` skill is owned by Ava, but the `provision_discord` skill that creates Discord channels is owned by Quinn. This is a chain: Ava calls Quinn via `chain[onboard_project]: quinn/provision_discord`.
+
+The reason is that Quinn has the Discord API client code and the knowledge of the standard channel structure (dev, alerts, releases). Ava handles the broader project provisioning logic (GitHub scaffold, Plane project creation, write-back to `projects.yaml`). The chain keeps these responsibilities separate.
+
+When the channel IDs come back from Discord, they are written to both `settings.json` in the target repo and `projects.yaml` in the protoWorkstacean repo. This makes the IDs available to both the agent running in the target repo context and the workstacean routing layer.
+
+---
+
+## The `contextId` in A2A calls
+
+Agent conversation memory is scoped by `contextId` in the JSON-RPC call:
+
+```json
+{
+  "params": {
+    "contextId": "workstacean-{channelId}"
+  }
+}
+```
+
+`contextId` is derived from the message channel. For Discord, it's the Discord channel ID. For GitHub, it's `{owner}/{repo}#{number}`. For Plane, it's the `correlationId` (`plane-{issueId}`).
+
+This means:
+- All messages in the same GitHub issue share a conversation thread in the agent's memory
+- All messages in the same Discord channel share a thread
+- The HITL resume flow (days later) uses the same `correlationId` as the original plan request — Ava's memory of the conversation is preserved across the approval gap
+
+---
+
+## Secrets management
+
+All per-agent secrets live in Infisical (AI project `11e172e0`). The workstacean container receives them via `infisical run` at deploy time. The homelab-iac `docker-compose.yml` is the canonical reference for which secrets map to which services.
+
+No secrets are stored in this repository. The `workspace/agents.yaml` file uses `apiKeyEnv` to reference the env var name (e.g., `AVA_API_KEY`), not the key value itself.
+
+---
+
+## Adding a new agent identity
+
+1. Create a GitHub App in the target org (or as the org owner's personal app)
+2. Generate a private key, download the PEM
+3. Store `APP_ID` and `APP_PRIVATE_KEY` in Infisical
+4. Add to `docker-compose.yml` as env vars for the `workstacean` service
+5. Add `appId` and `appPrivateKeyEnv` fields to the agent entry in `workspace/agents.yaml`
+6. Update the A2APlugin's comment posting logic to use the new app credentials for this agent's skill responses

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -1,0 +1,178 @@
+# Architecture — How protoWorkstacean Works
+
+_This is an explanation doc. It explains the design decisions, concepts, and how components connect — not how to use them._
+
+---
+
+## What protoWorkstacean is
+
+protoWorkstacean is a personal agent orchestration platform. It coordinates a fleet of specialized AI agents (Quinn, Ava, Frank, Jon, Cindi, Researcher) across GitHub, Discord, Plane, and Google Workspace. Every interaction — a GitHub PR, a Discord @mention, a scheduled cron, a Plane issue — enters the system as a message on the same in-process event bus.
+
+The key architectural decision is that **the bus is the only communication channel**. No plugin talks directly to another plugin. No plugin talks directly to an agent. Everything goes through the bus.
+
+---
+
+## The event bus
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                     EventBus (in-process)                │
+│           topic-based hierarchical pub/sub              │
+└───────────┬────────────────────────────────┬────────────┘
+            │                                │
+   ┌────────▼────────┐              ┌────────▼────────┐
+   │  Plugin Layer   │              │  Agent Layer    │
+   │  (lib/plugins/) │              │  (workspace/)   │
+   │                 │              │                 │
+   │ • GitHubPlugin  │              │ • Quinn (PR     │
+   │ • DiscordPlugin │              │   review, triage│
+   │ • PlanePlugin   │              │ • Ava (features)│
+   │ • A2APlugin     │              │ • Frank, Jon... │
+   │ • CeremonyPlugin│              └─────────────────┘
+   │ • GooglePlugin  │
+   └─────────────────┘
+```
+
+The bus is an in-process pub/sub system with MQTT-style hierarchical topic matching. `#` matches any number of path segments:
+
+- `message.inbound.#` catches everything entering the system
+- `message.inbound.discord.#` catches only Discord messages
+- `message.inbound.discord.1234567890` catches one specific channel
+
+This topic hierarchy is the routing backbone. Plugins subscribe narrowly — each plugin only sees the messages it cares about.
+
+---
+
+## The plugin layer
+
+Plugins are the adapters between the outside world and the bus. Each plugin:
+
+1. Listens for external events (GitHub webhooks, Discord gateway events, Plane webhooks, cron timers)
+2. Validates and normalizes the event into a `BusMessage`
+3. Publishes the `BusMessage` on the appropriate `message.inbound.*` topic
+
+And in the other direction:
+
+1. Subscribes to `message.outbound.*` topics
+2. Delivers the outbound message to the external service (posts a GitHub comment, sends a Discord message, patches a Plane issue)
+
+Plugins are symmetric — they bridge in both directions, but they don't process the content. They don't decide what to say. That's the agent's job.
+
+---
+
+## The A2A plugin
+
+The A2APlugin is the bridge between the bus and the agent fleet. It:
+
+1. Subscribes to `message.inbound.#` and `cron.#`
+2. Matches each message to a skill (explicit hint → keyword → default Ava)
+3. Calls the appropriate agent via JSON-RPC 2.0 (`message/send`)
+4. Publishes the agent's response to the appropriate `message.outbound.*` topic
+
+The agent fleet is defined in `workspace/agents.yaml`. The A2APlugin doesn't know anything about what agents do — it only knows which topics to route to which agents.
+
+---
+
+## Message flow: end-to-end
+
+```
+Discord @mention
+  ↓
+DiscordPlugin validates, publishes message.inbound.discord.{channelId}
+  ↓
+A2APlugin keyword-matches → routes to Ava (sitrep)
+  ↓
+callA2A(ava, content, contextId) — JSON-RPC 2.0 HTTP call
+  ↓
+Ava processes, returns response
+  ↓
+A2APlugin publishes message.outbound.discord.{channelId}
+  ↓
+DiscordPlugin sends Discord reply
+```
+
+This same pattern holds for every interface: GitHub → GitHubPlugin → bus → A2APlugin → agent → bus → GitHubPlugin → GitHub comment.
+
+---
+
+## Quinn's vector context pipeline
+
+Quinn extends this pattern with a multi-step retrieval pipeline before the LLM call:
+
+```
+PR opened/synchronize
+  → GitHubPlugin → message.inbound.github.*
+  → A2APlugin → Quinn (pr_review skill)
+  → runReviewPipeline(diff, repo, pr)
+      ├── parseDiff + extractSymbols
+      ├── Qdrant: retrieveAllPastPRDecisions (quinn-pr-history)
+      ├── Qdrant: findAllSimilarPatterns (quinn-code-patterns)
+      ├── formatCodebaseContext + applyTokenBudget (20% cap)
+      └── assembleReviewPrompt → LLM call
+```
+
+The Qdrant collections are populated as PRs are merged:
+
+```
+PR merged
+  → fetchPRDiff + fetchReviewDecision
+  → chunkDiff → embed → quinn-pr-history
+  → extractSymbols → fetchSymbolContexts → quinn-code-patterns
+```
+
+Developer dismissals are tracked in `quinn-review-learnings` and used to suppress low-signal comment patterns over time.
+
+---
+
+## The HITL gate
+
+The HITL (human-in-the-loop) gate is the approval checkpoint for the `plan` skill. It exists because plan execution has permanent side effects: board features, Plane state changes, Discord channel provisioning.
+
+The design principle: **the bus is dumb, interface plugins own rendering, Ava owns plan state**.
+
+- When Ava's `plan` skill finishes, it publishes an `HITLRequest` to the bus with the PRD summary and review scores
+- The originating interface plugin (Discord, Plane, API) receives the `HITLRequest` and renders it natively — Discord gets interactive buttons, Plane gets a comment
+- The human responds; the interface plugin publishes an `HITLResponse` on the bus
+- The A2APlugin routes to Ava's `plan_resume` skill, which restores the SQLite checkpoint and creates the board features
+
+Adding a new interface (Slack, voice, SMS) requires only implementing the renderer — no changes to Ava, the bus, or the HITL plugin.
+
+`correlationId` is the thread connecting every message in the plan lifecycle. Set once at the inbound message and stamped on every downstream artifact.
+
+---
+
+## Service layer
+
+Quinn's vector pipeline uses a dedicated service layer in `src/services/`:
+
+| Package | Responsibility |
+|---|---|
+| `qdrant/client.ts` | Qdrant REST API client (5s timeout, fallback on error) |
+| `embeddings/ollama-client.ts` | Ollama embedding API (nomic-embed-text) |
+| `diff/chunker.ts` | Parse unified diff, chunk large files |
+| `diff/symbol-extractor.ts` | Route to language-specific symbol extractors |
+| `reviews/review-pipeline.ts` | Orchestrate full context retrieval pipeline |
+| `reviews/context-formatter.ts` | Format the `CODEBASE CONTEXT` block |
+| `reviews/token-budgeter.ts` | Enforce 20% token budget cap |
+
+---
+
+## External services
+
+| Service | URL | Purpose |
+|---|---|---|
+| Qdrant | `http://qdrant:6333` | Vector search and storage |
+| Ollama | `http://ollama:11434` | Local LLM and embedding inference |
+| GitHub API | `https://api.github.com` | PR data, diffs, comments |
+| Plane | configured via `PLANE_API_URL` | Project management |
+| Discord | bot token | Team notifications |
+
+---
+
+## Design principles
+
+1. **Bus is dumb** — routes messages, no business logic
+2. **Plugins are thin** — validate, normalize, publish, deliver. No content decisions.
+3. **Agents are stateless from the bus's perspective** — state lives in SQLite (PlanStore), Qdrant, or the agent itself
+4. **`correlationId` is the spine** — threads any multi-hop flow without the bus needing to understand it
+5. **Adding a surface requires only a plugin** — new Discord slash commands, new render targets for HITL, new external webhooks — none require touching core routing logic

--- a/docs/explanation/plugin-lifecycle.md
+++ b/docs/explanation/plugin-lifecycle.md
@@ -1,0 +1,146 @@
+# Plugin Lifecycle — How Plugins Register, Subscribe, and Reload
+
+_This is an explanation doc. It explains how the plugin system works conceptually, not how to write a specific plugin._
+
+---
+
+## Two plugin systems, one codebase
+
+protoWorkstacean has two distinct plugin systems that serve different purposes:
+
+1. **Workspace bus plugins** (`workspace/plugins/`) — extend the message bus; restart-based
+2. **Pi SDK extensions** (`.pi/extensions/`) — extend the LLM tool set; runtime, no restart
+
+They operate independently. An agent can use both simultaneously.
+
+---
+
+## Workspace bus plugins
+
+### Startup loading
+
+On container start, `src/index.ts` runs `loadWorkspacePlugins()`:
+
+1. Scans `workspace/plugins/` for `.ts` and `.js` files
+2. Dynamically imports each file via `await import(filePath)`
+3. Checks that the default export satisfies the `Plugin` interface (`name`, `install`, `uninstall`)
+4. Calls `plugin.install(bus)` on each valid plugin
+
+The install order is non-deterministic (filesystem scan order). Plugins should not depend on each other's install order.
+
+### What happens in `install()`
+
+`install(bus)` is where a plugin wires itself to the bus:
+
+```typescript
+install(bus: EventBus): void {
+  // Subscribe to inbound messages
+  bus.subscribe("message.inbound.discord.#", this.name, this.handleInbound.bind(this));
+
+  // Start HTTP server for webhooks
+  this.server = Bun.serve({
+    port: 8082,
+    fetch: this.handleWebhook.bind(this),
+  });
+}
+```
+
+After `install()` returns, the plugin is live. It receives messages and can publish responses.
+
+### Graceful shutdown
+
+On `SIGTERM` or `SIGINT`, `src/index.ts` calls `plugin.uninstall()` on each installed plugin in reverse order. Plugins should close HTTP servers, cancel timers, and release any resources here.
+
+```typescript
+uninstall(): void {
+  this.server?.stop();
+  clearInterval(this.pollInterval);
+}
+```
+
+### Hot reload is not supported
+
+There is no hot-reload for workspace bus plugins. To pick up a new or modified plugin:
+
+```bash
+docker restart workstacean
+```
+
+The restart is fast (seconds) and is the intended workflow for plugin development.
+
+---
+
+## Pi SDK extensions
+
+### Runtime registration
+
+Pi SDK extensions load via the Pi SDK's extension discovery mechanism. They can register tools, commands, and shortcuts at runtime — no container restart required.
+
+```typescript
+// .pi/extensions/my-tool.ts
+pi.registerTool({
+  name: "my-tool",
+  // ...
+  async execute(toolCallId, params) {
+    return { content: [{ type: "text", text: "done" }] };
+  },
+});
+```
+
+After `pi.registerTool()` returns, the tool is immediately callable by the LLM in the current session.
+
+### Discovery locations
+
+| Path | Scope |
+|------|-------|
+| `~/.pi/agent/extensions/*.ts` | Global — loaded for all projects |
+| `.pi/extensions/*.ts` | Project-local — loaded only in this project |
+
+Extensions in `.pi/extensions/` are tied to the project directory. When the agent starts in the protoWorkstacean workspace, all extensions in this directory are loaded.
+
+### Extension lifecycle events
+
+Extensions can subscribe to lifecycle events:
+
+- `session_start` — fires when an agent session begins
+- `session_end` — fires when a session ends
+- `tool_call` — fires before each tool call (can intercept/block)
+- `agent_turn` — fires after each agent response
+
+These enable patterns like injecting context at session start, logging tool calls, or implementing dynamic tool enable/disable based on project state.
+
+---
+
+## SchedulerPlugin lifecycle
+
+The SchedulerPlugin has its own internal lifecycle for timers:
+
+1. On `install()`, it scans `data/crons/` for YAML files and creates Node.js timers for each enabled schedule
+2. On `command.schedule` action `add` — creates a timer immediately and writes the YAML file
+3. On `command.schedule` action `remove` — cancels the timer and deletes the YAML file
+4. On `command.schedule` action `pause/resume` — cancels/recreates the timer; updates `enabled` in the YAML
+5. On `uninstall()` — cancels all active timers
+
+**Missed fire recovery**: On startup, after loading all schedules, the plugin checks each `lastFired` timestamp. If a schedule was due between `lastFired` and now:
+- Missed by ≤ 24 hours → fires immediately once
+- Missed by > 24 hours → skipped; next regular fire applies
+
+---
+
+## Why plugins need restart but extensions don't
+
+Workspace bus plugins use Node.js dynamic imports (`import()`). The Node module loader caches imports. Replacing a cached module requires restarting the process — there is no safe way to hot-reload a module in a running Node/Bun process without risking stale closure references.
+
+Pi SDK extensions bypass this by using the Pi SDK's own extension runtime, which has first-class support for dynamic tool registration via `pi.registerTool()`. The Pi SDK is designed for interactive use where adding tools at runtime is a core feature.
+
+The two systems are complementary: use Pi SDK extensions when you need immediate availability without restart; use workspace plugins when you need to bridge external services at the transport layer (HTTP servers, gateway connections, polling loops).
+
+---
+
+## Plugin discovery failure modes
+
+If a workspace plugin file fails to import (syntax error, missing dependency), `loadWorkspacePlugins()` logs the error and skips that plugin. Other plugins continue to load. The server starts regardless.
+
+If a plugin's `install()` throws, the error is caught and logged. The plugin is not installed, but the server continues.
+
+This means a broken plugin in `workspace/plugins/` never prevents the server from starting — you can always connect and debug.

--- a/docs/how-to/configure-discord.md
+++ b/docs/how-to/configure-discord.md
@@ -1,0 +1,173 @@
+# How to Configure Discord
+
+_This is a how-to guide. It covers bot setup, `discord.yaml` configuration, slash commands, and autocomplete._
+
+---
+
+## 1. Create and configure the Discord bot
+
+### Bot permissions
+
+In the [Discord Developer Portal](https://discord.com/developers/applications), create an application and add a Bot. Set:
+
+**Scopes:** `bot`, `applications.commands`
+
+**Bot Permissions:**
+- Read Messages / View Channels
+- Send Messages
+- Create Public Threads
+- Add Reactions
+- Manage Messages (for spam deletion)
+- Read Message History
+- Manage Guild Members intent (if using welcome channel)
+
+**Privileged Gateway Intents** (enable in the Bot tab):
+- Message Content Intent
+- Server Members Intent (only if using `channels.welcome`)
+
+### Required environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DISCORD_BOT_TOKEN` | Yes | Bot token — enables the plugin |
+| `DISCORD_GUILD_ID` | Yes | Guild ID for slash command registration |
+| `DISCORD_DIGEST_CHANNEL` | No | Fallback channel ID for cron pushes |
+
+The plugin is **skipped** if `DISCORD_BOT_TOKEN` is not set.
+
+---
+
+## 2. Configure discord.yaml
+
+Place `discord.yaml` in your workspace directory (default: `workspace/discord.yaml`). If absent, the plugin starts with empty commands and default moderation settings.
+
+```yaml
+# workspace/discord.yaml
+
+channels:
+  digest: "1234567890123456789"   # channel for cron-triggered posts
+  welcome: ""                      # new member welcome messages (leave blank to disable)
+  modLog: ""                       # reserved for future moderation logging
+
+moderation:
+  rateLimit:
+    maxMessages: 5
+    windowSeconds: 10
+  spamPatterns:
+    - "free\\s*nitro"
+    - "discord\\.gift/"
+    - "@everyone.*https?://"
+    - "steamcommunity\\.com/gift"
+
+commands:
+  - name: mybot
+    description: "My bot — project status and reports"
+    subcommands:
+      - name: status
+        description: "Current project status"
+        content: "/status"
+        skillHint: qa_report
+
+      - name: report
+        description: "Generate a report for a version"
+        content: "/report {version}"
+        skillHint: qa_report
+        options:
+          - name: version
+            description: "Version tag (e.g. v1.2.0)"
+            type: string
+            required: false
+```
+
+### Channel fields
+
+| Field | Description |
+|-------|-------------|
+| `digest` | Receives `message.outbound.discord.push.*` and cron-triggered posts |
+| `welcome` | New member welcome messages |
+| `modLog` | Reserved — not currently active |
+
+### Rate limiting
+
+`rateLimit.maxMessages` and `rateLimit.windowSeconds` define a rolling per-user window. Users exceeding the limit are silently throttled.
+
+### Spam patterns
+
+Array of regex strings (YAML-escaped). Matched case-insensitively. Matching messages are silently deleted.
+
+---
+
+## 3. Define slash commands
+
+### Subcommand style (recommended for multi-action bots)
+
+```yaml
+commands:
+  - name: dev
+    description: "Dev team commands"
+    subcommands:
+      - name: sitrep
+        description: "Current sprint status"
+        content: "/sitrep"
+        skillHint: sitrep
+
+      - name: audit
+        description: "Board audit"
+        content: "/audit"
+        skillHint: board_audit
+```
+
+Users type `/dev sitrep` or `/dev audit`.
+
+### Flat command with autocomplete
+
+Use top-level `options` (no `subcommands`) when you want Discord's autocomplete UX:
+
+```yaml
+commands:
+  - name: report-bug
+    description: Report a bug against a project
+    options:
+      - name: project
+        description: Project to report against (start typing to filter)
+        type: string
+        required: true
+        autocomplete: true
+      - name: description
+        description: Brief description of the bug
+        type: string
+        required: true
+    content: "Bug report for {project}: {description}"
+    skillHint: bug_triage
+```
+
+When `project` is an autocomplete option, the plugin loads `projects.yaml` at interaction time and returns matching projects (filtered by slug or title) as Discord choices.
+
+On submission, the project slug is resolved to `devChannelId` and `projectRepo` which are added to the inbound bus payload:
+
+```typescript
+{
+  devChannelId?: string;   // discord.dev channel ID from projects.yaml
+  projectRepo?: string;    // GitHub full name, e.g. "protoLabsAI/protoUI"
+}
+```
+
+---
+
+## 4. Reload commands after changes
+
+Slash commands are registered to the guild on container startup. To reload after editing `discord.yaml`:
+
+```bash
+docker restart workstacean
+```
+
+Changes take effect within a few seconds in Discord (guild-scoped commands update faster than global commands).
+
+---
+
+## Related docs
+
+- [reference/bus-topics.md](../reference/bus-topics.md) — Discord bus topics
+- [reference/config-files.md](../reference/config-files.md) — full `discord.yaml` schema reference
+- [explanation/plugin-lifecycle.md](../explanation/plugin-lifecycle.md) — how the DiscordPlugin registers and subscribes

--- a/docs/how-to/create-a-ceremony.md
+++ b/docs/how-to/create-a-ceremony.md
@@ -1,0 +1,157 @@
+# How to Create a Ceremony (Scheduled Recurring Task)
+
+_This is a how-to guide. It covers creating cron schedules via YAML, the bus, and the Pi SDK tool._
+
+---
+
+A "ceremony" is a scheduled recurring event — a daily digest, a weekly board audit, a nightly cleanup. In Workstacean, ceremonies are YAML files in `workspace/crons/` that publish to the message bus on a schedule.
+
+---
+
+## Option A — Write the YAML directly
+
+Create a file in `workspace/crons/`:
+
+```yaml
+# workspace/crons/daily-digest.yaml
+id: daily-digest
+schedule: "0 14 * * *"         # 2pm UTC daily
+timezone: "America/New_York"
+topic: "cron.daily-digest"
+payload:
+  content: "Generate the daily QA digest"
+  skillHint: qa_report
+  channel: "1234567890123456789"  # Discord channel ID for push
+  sender: "cron"
+enabled: true
+```
+
+The SchedulerPlugin picks up the file on the next container start. No restart needed if you publish `command.schedule` (see Option B).
+
+### YAML fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | Unique identifier (kebab-case). Used as filename. |
+| `type` | No | `cron` or `once`. Auto-detected from schedule format. |
+| `schedule` | Yes | Cron expression for recurring, ISO datetime for one-shot. |
+| `timezone` | No | IANA timezone. Defaults to system TZ. |
+| `topic` | Yes | Bus topic to publish when the schedule fires. |
+| `payload.content` | Yes | Message the agent receives when this fires. |
+| `payload.sender` | No | Sender identifier. Default: `cron`. |
+| `payload.channel` | No | Reply channel (`signal`, `cli`, or Discord channel ID). |
+| `payload.skillHint` | No | Routes to a specific skill (e.g., `qa_report`, `board_audit`). |
+| `enabled` | No | Whether active. Default: `true`. |
+| `lastFired` | Auto | ISO timestamp updated by the scheduler on each fire. |
+
+---
+
+## Option B — Add via bus command at runtime
+
+No restart needed — publish `command.schedule` to register a schedule immediately:
+
+```bash
+curl -s -X POST http://workstacean:3000/publish \
+  -H "Content-Type: application/json" \
+  -d '{
+    "topic": "command.schedule",
+    "payload": {
+      "action": "add",
+      "id": "daily-digest",
+      "schedule": "0 14 * * *",
+      "timezone": "America/New_York",
+      "topic": "cron.daily-digest",
+      "payload": {
+        "content": "Generate the daily QA digest",
+        "skillHint": "qa_report",
+        "channel": "1234567890123456789",
+        "sender": "cron"
+      }
+    }
+  }'
+```
+
+The SchedulerPlugin creates the YAML file in `data/crons/` and activates the timer immediately.
+
+---
+
+## Option C — Ask the agent in natural language (Pi SDK tool)
+
+If the `schedule_task` Pi SDK tool is registered:
+
+```
+Schedule a daily QA digest at 2pm New York time to the #dev-alerts channel
+```
+
+The agent calls the tool with the right cron expression, writes the YAML, and publishes `command.schedule`. No manual YAML editing needed.
+
+---
+
+## Managing schedules
+
+### Pause a schedule
+
+```bash
+curl -s -X POST http://workstacean:3000/publish \
+  -H "Content-Type: application/json" \
+  -d '{"topic": "command.schedule", "payload": {"action": "pause", "id": "daily-digest"}}'
+```
+
+### Resume a schedule
+
+```bash
+curl -s -X POST http://workstacean:3000/publish \
+  -H "Content-Type: application/json" \
+  -d '{"topic": "command.schedule", "payload": {"action": "resume", "id": "daily-digest"}}'
+```
+
+### Remove a schedule
+
+```bash
+curl -s -X POST http://workstacean:3000/publish \
+  -H "Content-Type: application/json" \
+  -d '{"topic": "command.schedule", "payload": {"action": "remove", "id": "daily-digest"}}'
+```
+
+### List all schedules
+
+```bash
+curl -s -X POST http://workstacean:3000/publish \
+  -H "Content-Type: application/json" \
+  -d '{"topic": "command.schedule", "payload": {"action": "list"}}'
+```
+
+Response published to `schedule.list`.
+
+---
+
+## Create a one-shot ceremony
+
+Use an ISO datetime in `schedule` to fire once and self-delete:
+
+```yaml
+id: q1-kickoff-reminder
+schedule: "2026-04-01T09:00:00"
+timezone: "America/New_York"
+topic: "cron.q1-kickoff-reminder"
+payload:
+  content: "Remind the team about the Q1 kickoff meeting at 10am"
+  sender: "cron"
+  channel: "signal"
+```
+
+One-shot schedules are automatically deleted after firing.
+
+---
+
+## Missed fire behavior
+
+If the container was down when a schedule was due, it fires immediately on restart — once only. If the missed window is more than 24 hours, it is skipped entirely and the next scheduled time applies.
+
+---
+
+## Related docs
+
+- [reference/config-files.md](../reference/config-files.md) — full cron YAML schema
+- [reference/bus-topics.md](../reference/bus-topics.md) — cron and schedule command topics
+- [explanation/plugin-lifecycle.md](../explanation/plugin-lifecycle.md) — how SchedulerPlugin loads and manages timers

--- a/docs/how-to/onboard-a-project.md
+++ b/docs/how-to/onboard-a-project.md
@@ -1,0 +1,108 @@
+# How to Onboard a Project
+
+_This is a how-to guide. It assumes the workstacean container is running and you have Ava configured in `workspace/agents.yaml`._
+
+---
+
+Onboarding a project provisions it across every system protoLabs uses: GitHub (`.automaker/` scaffold), Plane (project created), and Discord (category + channels created). The `onboard_project` skill on Ava orchestrates the full chain.
+
+## Trigger options
+
+### Option A — Automatic (org webhook)
+
+If you have the GitHub org webhook registered (see [how-to/use-quinn-pr-review.md](use-quinn-pr-review.md) for webhook setup), any new repository created under the org automatically triggers onboarding. No manual action needed.
+
+### Option B — Discord slash command
+
+In any Discord channel the bot has access to:
+
+```
+/ava onboard
+```
+
+Or by @mention:
+
+```
+@YourBot onboard protoLabsAI/my-new-repo
+```
+
+### Option C — Bus injection (scripted/CI)
+
+```bash
+curl -s -X POST http://workstacean:3000/publish \
+  -H "Content-Type: application/json" \
+  -d '{
+    "topic": "message.inbound.test",
+    "payload": {
+      "sender": "ci",
+      "content": "onboard protoLabsAI/my-new-repo",
+      "skillHint": "onboard_project",
+      "channel": "cli"
+    }
+  }'
+```
+
+---
+
+## What the onboard chain does
+
+Ava's `onboard_project` skill runs these steps in sequence:
+
+1. **GitHub API** — fetches repo metadata (description, topics, visibility)
+2. **`.automaker/` scaffold** — writes `project.json` and `settings.json` into the target repo, commits and pushes
+3. **`.gitignore` + worktree init** — adds worktree paths to `.gitignore` in the target repo
+4. **Plane API** — creates a new Plane project, stores the returned `plane_project_id`
+5. **Discord provisioning** — calls Quinn's `provision_discord` skill (via chain), which creates a Discord category with three channels: `dev`, `alerts`, `releases`
+6. **Write-back** — stores Discord channel IDs in both `.automaker/settings.json` (in the target repo) and `workspace/projects.yaml` (in this repo)
+
+On completion, a summary message is sent to the originating interface (Discord channel or the bus outbound topic).
+
+---
+
+## Verifying the onboard completed
+
+Check `workspace/projects.yaml` for a new entry:
+
+```yaml
+- repo: protoLabsAI/my-new-repo
+  plane_project_id: "<uuid>"
+  discord:
+    dev: "<channel-id>"
+    alerts: "<channel-id>"
+    releases: "<channel-id>"
+```
+
+Check the target repo for a `.automaker/` directory:
+
+```bash
+gh api repos/protoLabsAI/my-new-repo/contents/.automaker/project.json
+```
+
+---
+
+## If provisioning fails partway through
+
+The onboard chain is not atomic. If Discord provisioning fails (e.g., bot permissions), the Plane project and `.automaker/` scaffold are still created. The error is logged and a partial-onboard notice is sent to the originating interface.
+
+To re-run Discord provisioning only:
+
+```bash
+curl -s -X POST http://workstacean:3000/publish \
+  -H "Content-Type: application/json" \
+  -d '{
+    "topic": "message.inbound.test",
+    "payload": {
+      "sender": "manual",
+      "content": "provision discord for protoLabsAI/my-new-repo",
+      "skillHint": "provision_discord"
+    }
+  }'
+```
+
+---
+
+## Related docs
+
+- [reference/agent-skills.md](../reference/agent-skills.md) — full skill registry including `onboard_project` parameters
+- [reference/config-files.md](../reference/config-files.md) — `projects.yaml` schema
+- [explanation/agent-identity.md](../explanation/agent-identity.md) — why Quinn handles Discord provisioning (not Ava)

--- a/docs/how-to/set-up-google-workspace.md
+++ b/docs/how-to/set-up-google-workspace.md
@@ -1,0 +1,145 @@
+# How to Set Up Google Workspace
+
+_This is a how-to guide. It covers OAuth2 credentials, the `google.yaml` configuration, and enabling Drive, Calendar, and Gmail integration._
+
+---
+
+The Google Workspace plugin (`lib/plugins/google.ts`) bridges Google Drive, Calendar, and Gmail to the Workstacean bus. Each service is independently optional — configure only the ones you need.
+
+---
+
+## 1. Create a Google Cloud project and OAuth2 credentials
+
+1. Go to [console.cloud.google.com](https://console.cloud.google.com) and create a project.
+2. Enable the APIs you need:
+   - **Google Drive API**
+   - **Google Calendar API**
+   - **Gmail API**
+3. Under **APIs & Services → Credentials**, create an **OAuth 2.0 Client ID** (type: Web application or Desktop app depending on your setup).
+4. Download the credentials JSON and store the relevant values as environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `GOOGLE_CLIENT_ID` | OAuth2 client ID |
+| `GOOGLE_CLIENT_SECRET` | OAuth2 client secret |
+| `GOOGLE_REFRESH_TOKEN` | Long-lived refresh token (obtained via OAuth2 flow) |
+
+The plugin is **skipped** if `GOOGLE_CLIENT_ID` is not set.
+
+### Obtaining the refresh token
+
+Run the OAuth2 authorization flow once to get a refresh token:
+
+```bash
+# Use the Google OAuth2 playground or a one-shot script:
+# https://developers.google.com/oauthplayground/
+```
+
+Store the refresh token in Infisical (AI project `11e172e0`) under `GOOGLE_REFRESH_TOKEN`. The plugin exchanges it for access tokens automatically.
+
+---
+
+## 2. Configure google.yaml
+
+Place `google.yaml` in your workspace directory (default: `workspace/google.yaml`):
+
+```yaml
+# workspace/google.yaml
+
+drive:
+  orgFolderId: ""         # root org Drive folder — shared across all projects
+  templateFolderId: ""    # per-project folder template (optional)
+
+calendar:
+  orgCalendarId: ""               # shared org calendar for milestones/deadlines
+  pollIntervalMinutes: 60         # how often to check for upcoming events
+
+gmail:
+  watchLabels: []                 # Gmail labels to monitor for inbound routing
+  pollIntervalMinutes: 5          # how often to poll for new messages
+  routingRules: []                # label → skillHint mappings
+  # Example routingRules:
+  # - label: "bug-report"
+  #   skillHint: bug_triage
+  # - label: "gtm-request"
+  #   skillHint: content_review
+```
+
+---
+
+## 3. Enable Drive integration
+
+Set `drive.orgFolderId` to the Google Drive folder ID you want to use as the org root. The folder ID is the last path component of the Drive URL:
+
+```
+https://drive.google.com/drive/folders/1ABC123XYZ
+                                        ^^^^^^^^^^^
+                                        this is the ID
+```
+
+The plugin will surface Drive events to the bus. Agents can read/write Drive files via the available Drive tools.
+
+---
+
+## 4. Enable Calendar integration
+
+Set `calendar.orgCalendarId` to your shared org calendar's ID (found in Google Calendar → Settings → Calendar Settings → Calendar ID — typically an email-like string).
+
+The plugin polls the calendar every `pollIntervalMinutes` for upcoming events and publishes them to:
+
+```
+google.calendar.event.upcoming
+```
+
+Agents subscribed to this topic can trigger reminders, board updates, or ceremony checks.
+
+---
+
+## 5. Enable Gmail routing
+
+Gmail routing turns labeled emails into bus messages routed to specific skills.
+
+```yaml
+gmail:
+  watchLabels:
+    - "bug-report"
+    - "gtm-request"
+  pollIntervalMinutes: 5
+  routingRules:
+    - label: "bug-report"
+      skillHint: bug_triage
+    - label: "gtm-request"
+      skillHint: content_review
+```
+
+The plugin polls Gmail every `pollIntervalMinutes`, finds messages with the specified labels, and publishes them to:
+
+```
+message.inbound.gmail.{label}
+```
+
+with `skillHint` set from `routingRules`. The A2APlugin routes these to the appropriate agent.
+
+---
+
+## 6. Restart to apply changes
+
+```bash
+docker restart workstacean
+```
+
+On startup, the plugin logs which services it activated:
+
+```
+[GooglePlugin] Drive enabled — orgFolderId: 1ABC123XYZ
+[GooglePlugin] Calendar enabled — polling every 60 minutes
+[GooglePlugin] Gmail enabled — watching labels: bug-report, gtm-request
+```
+
+---
+
+## Related docs
+
+- [reference/bus-topics.md](../reference/bus-topics.md) — Google bus topics
+- [reference/config-files.md](../reference/config-files.md) — full `google.yaml` schema
+- [explanation/plugin-lifecycle.md](../explanation/plugin-lifecycle.md) — plugin install/uninstall lifecycle

--- a/docs/how-to/use-quinn-pr-review.md
+++ b/docs/how-to/use-quinn-pr-review.md
@@ -1,0 +1,158 @@
+# How to Use Quinn for PR Review
+
+_This is a how-to guide. It covers webhook setup, triggering PR review, and understanding Quinn's vector context pipeline._
+
+---
+
+Quinn reviews pull requests and issues via GitHub webhook. It uses codebase-wide vector search (Qdrant + Ollama) to provide context-aware reviews informed by past PR decisions and code patterns.
+
+---
+
+## 1. Set environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GITHUB_TOKEN` | Yes | PAT — enables the GitHub plugin and posts comment replies |
+| `GITHUB_WEBHOOK_SECRET` | Recommended | Validates `X-Hub-Signature-256` on inbound payloads |
+| `GITHUB_WEBHOOK_PORT` | No | Webhook HTTP server port (default: `8082`) |
+| `QUINN_APP_ID` | For bot comments | GitHub App ID — Quinn posts as `protoquinn[bot]` |
+| `QUINN_APP_PRIVATE_KEY` | For bot comments | GitHub App private key (PKCS#1 PEM) |
+| `QDRANT_URL` | For vector context | `http://qdrant:6333` |
+| `OLLAMA_URL` | For embeddings | `http://ollama:11434` |
+| `OLLAMA_EMBED_MODEL` | For embeddings | `nomic-embed-text` |
+
+---
+
+## 2. Configure github.yaml
+
+```yaml
+# workspace/github.yaml
+mentionHandle: "@quinn"   # case-insensitive
+
+skillHints:
+  issue_comment: bug_triage              # @mention in a comment on an issue
+  issues: bug_triage                     # @mention in the body of a new issue
+  pull_request_review_comment: pr_review # @mention in a PR review comment
+  pull_request: pr_review                # @mention in a PR description
+```
+
+---
+
+## 3. Register the webhook in GitHub
+
+For a single repository: **Settings → Webhooks → Add webhook**
+
+| Field | Value |
+|-------|-------|
+| Payload URL | `https://hooks.proto-labs.ai/webhook/github` |
+| Content type | `application/json` |
+| Secret | Value of `GITHUB_WEBHOOK_SECRET` |
+| SSL verification | Enable |
+| Events | Issue comments, Issues, Pull request review comments, Pull requests |
+
+### Org-level webhook (recommended)
+
+Register once at the org level to cover all repos — including new ones automatically:
+
+```bash
+gh api orgs/protoLabsAI/hooks \
+  --method POST \
+  --field name=web \
+  --field "config[url]=https://hooks.proto-labs.ai/webhook/github" \
+  --field "config[content_type]=json" \
+  --field "config[secret]=$GITHUB_WEBHOOK_SECRET" \
+  --field "config[insecure_ssl]=0" \
+  --field "events[]=repository" \
+  --field "events[]=issues" \
+  --field "events[]=issue_comment" \
+  --field "events[]=pull_request" \
+  --field "events[]=pull_request_review_comment"
+```
+
+---
+
+## 4. Required GitHub token permissions
+
+Fine-grained PAT scoped to the target repo:
+
+| Permission | Level |
+|------------|-------|
+| Issues | Read & Write |
+| Pull requests | Read & Write |
+| Actions | Read |
+| Contents | Read |
+
+---
+
+## 5. Trigger a PR review
+
+### Automatic (recommended)
+
+When a PR is opened or synchronized, and `pull_request` is in the webhook event list, Quinn reviews it automatically — no @mention needed.
+
+### Manual via @mention
+
+Leave a comment on any issue or PR:
+
+```
+@quinn please review this PR — focus on the auth changes
+```
+
+Quinn responds with a review comment posted as `protoquinn[bot]`.
+
+### Manual via Discord slash command
+
+```
+/quinn review
+```
+
+With the `pr_review` skillHint, A2APlugin routes to Quinn's `pr_review` skill.
+
+---
+
+## 6. How Quinn's review works
+
+Quinn's review goes beyond the diff. For every PR:
+
+1. **Diff parsed** — file changes are chunked by `diff/chunker.ts`
+2. **Symbols extracted** — TypeScript, Python, and Go symbols identified from the diff
+3. **Vector search (parallel)**:
+   - `quinn-pr-history` collection: past PR decisions for the same files
+   - `quinn-code-patterns` collection: similar code patterns in the codebase
+4. **Token budget enforced** — codebase context capped at 20% of the total prompt token budget
+5. **Review prompt assembled** — diff + `CODEBASE CONTEXT` block + review instructions
+6. **LLM call** — Quinn generates the review
+7. **Comment posted** — as `protoquinn[bot]` on the PR
+
+### Learning loop
+
+When a developer dismisses a Quinn comment, the plugin records the dismissal in `quinn-review-learnings`. Over time, low-signal comment patterns are filtered out.
+
+### Fallback
+
+If Qdrant is unavailable, Quinn reviews from the diff alone (no vector context). The review still runs — no error is surfaced.
+
+---
+
+## 7. Bug triage flywheel
+
+Reacting to any GitHub issue comment with 📋 triggers `bug_triage`:
+
+```
+/quinn comment on GitHub issue
+  → Quinn (bug_triage): classifies bug, may file board item via file_bug tool
+    → posts triage comment to GitHub issue
+  → Chain: Ava (manage_feature): reviews Quinn's triage, verifies board state
+    → posts follow-up comment: feature link, close recommendation
+```
+
+Trigger by @mention: `@protoquinn <description>` (admin users only).
+
+---
+
+## Related docs
+
+- [reference/plugins.md](../reference/plugins.md) — GitHubPlugin API contract
+- [reference/bus-topics.md](../reference/bus-topics.md) — GitHub bus topics
+- [reference/agent-skills.md](../reference/agent-skills.md) — `pr_review` and `bug_triage` skill specs
+- [explanation/architecture.md](../explanation/architecture.md) — Quinn's vector context pipeline in detail

--- a/docs/reference/agent-skills.md
+++ b/docs/reference/agent-skills.md
@@ -1,0 +1,130 @@
+# Agent Skills Reference
+
+_This is a reference doc. It lists all skills in the agent registry, their routing keywords, and the agents that handle them._
+
+---
+
+Skills are declared in `workspace/agents.yaml`. On startup, the A2APlugin fetches each agent's `/.well-known/agent.json` and overwrites with live skills if available. The table below reflects the static registry.
+
+---
+
+## Skill routing
+
+Skills are matched in priority order:
+
+1. **Explicit hint** — `payload.skillHint` bypasses keyword matching (set by GitHubPlugin, DiscordPlugin, PlanePlugin)
+2. **Keyword match** — content scanned against the keyword table below
+3. **Default** — falls back to Ava
+
+---
+
+## Skill registry
+
+### Quinn (`http://quinn:7870/a2a`)
+
+| Skill | Keywords | Description |
+|-------|----------|-------------|
+| `bug_triage` | bug, issue, broken, crash, error, fail, exception, triage, TypeError, ReferenceError | Classify and triage a bug report; optionally file a board item via `file_bug` tool |
+| `qa_report` | report, qa, digest, quality, /report | Generate a QA status digest for a project or sprint |
+| `board_audit` | audit, board, backlog, sprint, features, /audit | Audit the project board for staleness and hygiene |
+| `pr_review` | pr, pull request, review, merge, ci, /review | Full PR review with vector context (past decisions + similar patterns) |
+| `provision_discord` | (chain only) | Create Discord category + channels for a new project; called by chain from `onboard_project` |
+
+**Chain:** `bug_triage → ava/manage_feature`
+
+After Quinn completes `bug_triage`, A2APlugin automatically calls Ava's `manage_feature` with Quinn's response + original context. One level deep only.
+
+---
+
+### Ava (`http://automaker-server:3008/a2a`)
+
+| Skill | Keywords | Description |
+|-------|----------|-------------|
+| `sitrep` | status, sitrep, situation, summary, /sitrep | Current sprint/project status summary |
+| `manage_feature` | create feature, new feature, unblock, assign, move to, add to board | Create or update a feature on the board |
+| `board_health` | blocked, stalled, stuck, health, unhealthy | Surface blocked or stalled features |
+| `auto_mode` | auto mode, start auto, stop auto, pause auto | Toggle autonomous background work mode |
+| `onboard_project` | onboard, new project, add project, /onboard | Full project onboarding chain (GitHub + Plane + Discord) |
+| `plan` | idea, plan, build, proposal, project idea, /plan | Generate SPARC PRD + antagonistic review + HITL gate |
+| `plan_resume` | (not keyword-matched) | Resume a plan after HITLResponse arrives on bus with matching `correlationId` |
+
+---
+
+### Frank (`http://frank:7880/a2a`)
+
+| Skill | Keywords | Description |
+|-------|----------|-------------|
+| `infra_health` | infra, deploy, monitoring, node, container | Infrastructure health check |
+| `deploy` | deploy | Deploy a service or artifact |
+| `monitoring` | monitoring | Check monitoring dashboards and alerts |
+
+---
+
+### Jon (GTM)
+
+| Skill | Keywords | Description |
+|-------|----------|-------------|
+| `market_review` | market, competition | Market landscape review |
+| `positioning` | positioning | Product positioning analysis |
+| `antagonistic_review` | (chain only) | Strategic lens review; called by Ava during `plan` skill |
+
+---
+
+### Cindi (GTM)
+
+| Skill | Keywords | Description |
+|-------|----------|-------------|
+| `blog` | blog, post | Write or review blog content |
+| `seo` | seo, search | SEO analysis |
+| `content_review` | content review | Review content for quality and messaging |
+
+---
+
+### Researcher (Knowledge)
+
+| Skill | Keywords | Description |
+|-------|----------|-------------|
+| `research` | research, investigate, deep dive, knowledge | Deep research with entity extraction |
+| `entity_extract` | entity, extract | Extract structured entities from text |
+
+---
+
+## Adding a new agent
+
+1. Add the agent to `workspace/agents.yaml`:
+
+```yaml
+agents:
+  - name: my-agent
+    team: dev
+    url: http://my-agent:PORT/a2a
+    apiKeyEnv: MY_AGENT_API_KEY
+    skills:
+      - my_skill
+```
+
+2. Add keyword entries to `SKILL_KEYWORDS` in `src/plugins/a2a.ts` for keyword routing.
+3. Optionally add `chain` entries for follow-up chains.
+4. Restart: `docker restart workstacean`
+
+The A2APlugin fetches `/.well-known/agent.json` from the agent URL on startup and merges live skills — so the `agents.yaml` entry only needs to be approximate.
+
+---
+
+## A2A protocol
+
+All agent calls use JSON-RPC 2.0 `message/send`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "<uuid>",
+  "method": "message/send",
+  "params": {
+    "message": { "role": "user", "parts": [{ "kind": "text", "text": "..." }] },
+    "contextId": "workstacean-{channel}"
+  }
+}
+```
+
+Timeout: 120s per agent call. `contextId` is derived from the message channel so conversation threads persist.

--- a/docs/reference/bus-topics.md
+++ b/docs/reference/bus-topics.md
@@ -1,0 +1,158 @@
+# Bus Topics Reference
+
+_This is a reference doc. It lists all bus topics published and subscribed across all plugins._
+
+---
+
+Topic patterns use `#` as a multi-segment wildcard (MQTT-style). `{variable}` denotes a dynamic segment.
+
+---
+
+## GitHub Plugin
+
+| Topic | Direction | Publisher | Description |
+|-------|-----------|-----------|-------------|
+| `message.inbound.github.{owner}.{repo}.{event}.{number}` | Inbound | GitHubPlugin | @mention received on issue or PR |
+| `message.inbound.onboard` | Inbound | GitHubPlugin | New repository created in org |
+| `message.outbound.github.{owner}.{repo}.{number}` | Outbound | A2APlugin | Reply to post as GitHub comment |
+
+**Inbound payload** (`message.inbound.github.*`):
+```typescript
+{
+  sender: string;       // GitHub username
+  channel: string;      // "{owner}/{repo}#{number}"
+  content: string;      // event header + title + body
+  skillHint?: string;   // from github.yaml skillHints
+  github: {
+    event: string; owner: string; repo: string;
+    number: number; title: string; url: string;
+  };
+}
+```
+
+---
+
+## Discord Plugin
+
+| Topic | Direction | Publisher | Description |
+|-------|-----------|-----------|-------------|
+| `message.inbound.discord.{channelId}` | Inbound | DiscordPlugin | @mention or DM |
+| `message.inbound.discord.slash.{interactionId}` | Inbound | DiscordPlugin | Slash command |
+| `message.outbound.discord.{channelId}` | Outbound | A2APlugin | Reply to @mention or DM |
+| `message.outbound.discord.slash.{interactionId}` | Outbound | A2APlugin | Reply to slash command |
+| `message.outbound.discord.push.{channelId}` | Outbound | A2APlugin | Unprompted push (cron, etc.) |
+
+Subscribe to `message.outbound.discord.#` to handle all outbound Discord delivery.
+
+**Inbound payload**:
+```typescript
+{
+  sender: string;       // Discord user ID
+  channel: string;      // Discord channel ID
+  content: string;      // cleaned message (mentions stripped)
+  skillHint?: string;   // set by slash commands and 📋 reactions
+  isReaction?: boolean;
+  isThread?: boolean;
+  guildId?: string;
+}
+```
+
+---
+
+## Plane Plugin
+
+| Topic | Direction | Publisher | Description |
+|-------|-----------|-----------|-------------|
+| `message.inbound.plane.issue.create` | Inbound | PlanePlugin | Issue created with `plan` or `auto` label |
+| `message.inbound.plane.issue.update` | Inbound | PlanePlugin | Issue updated (not currently routed) |
+| `plane.reply.{correlationId}` | Outbound | Ava | A2A reply — triggers Plane state PATCH + comment |
+
+---
+
+## A2A Plugin
+
+| Topic | Direction | Publisher | Description |
+|-------|-----------|-----------|-------------|
+| `message.inbound.#` | Subscribed | All interface plugins | All inbound messages — routed by skill |
+| `cron.#` | Subscribed | SchedulerPlugin | Cron events — routed by skill |
+| `message.outbound.*` | Published | A2APlugin | Agent responses |
+| `message.outbound.discord.push.{channel}` | Published | A2APlugin | Cron responses to Discord |
+
+---
+
+## HITL Plugin
+
+| Topic | Direction | Publisher | Subscriber | Description |
+|-------|-----------|-----------|------------|-------------|
+| `hitl.request.#` | Inbound | Ava | HITLPlugin | Approval request after SPARC PRD |
+| `hitl.response.#` | Inbound | Interface plugin | HITLPlugin | Human decision |
+| `hitl.pending.{correlationId}` | Outbound | HITLPlugin | API callers | Unrouted requests |
+| `hitl.expired.{correlationId}` | Outbound | HITLPlugin | Any | Request TTL exceeded (60s sweep) |
+
+---
+
+## Scheduler Plugin
+
+| Topic | Direction | Publisher | Description |
+|-------|-----------|-----------|-------------|
+| `command.schedule` | Inbound | Any | Runtime schedule management (add/remove/pause/resume/list) |
+| `schedule.list` | Outbound | SchedulerPlugin | Response to `action: list` |
+| `cron.{id}` | Outbound | SchedulerPlugin | Fired when a schedule triggers |
+
+**`command.schedule` payload**:
+```typescript
+{
+  action: "add" | "remove" | "pause" | "resume" | "list";
+  id?: string;
+  schedule?: string;    // cron expression or ISO datetime
+  timezone?: string;
+  topic?: string;
+  payload?: object;
+}
+```
+
+---
+
+## Google Plugin
+
+| Topic | Direction | Publisher | Description |
+|-------|-----------|-----------|-------------|
+| `message.inbound.gmail.{label}` | Inbound | GooglePlugin | Gmail message matching a watched label |
+| `google.calendar.event.upcoming` | Outbound | GooglePlugin | Upcoming calendar events (polled) |
+| `google.drive.file.created` | Outbound | GooglePlugin | New Drive file detected |
+
+---
+
+## Onboarding
+
+| Topic | Direction | Publisher | Description |
+|-------|-----------|-----------|-------------|
+| `message.inbound.onboard` | Inbound | GitHubPlugin | New repo created — triggers `onboard_project` |
+
+**Onboard payload**:
+```typescript
+{
+  event: "repository.created";
+  owner: string;
+  repo: string;
+  fullName: string;    // "owner/repo"
+  url: string;
+  description: string;
+  isPrivate: boolean;
+}
+```
+
+---
+
+## Topic naming conventions
+
+```
+message.inbound.{source}.{...context}   — messages arriving from external interfaces
+message.outbound.{dest}.{...context}    — messages to be delivered to external interfaces
+command.{verb}                          — imperative commands to plugins
+cron.{id}                               — scheduled event fires
+hitl.{stage}.{correlationId}            — human-in-the-loop lifecycle
+plane.reply.{correlationId}             — Plane sync-back events
+google.{service}.{event}                — Google Workspace events
+schedule.{action}                       — scheduler responses
+```

--- a/docs/reference/config-files.md
+++ b/docs/reference/config-files.md
@@ -1,0 +1,222 @@
+# Configuration Files Reference
+
+_This is a reference doc. It covers all `workspace/*.yaml` schemas and environment variables for each plugin._
+
+---
+
+## Environment variables
+
+### Core / A2A Plugin
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `AGENTS_YAML` | No | Path to agent registry (default: `/workspace/agents.yaml`) |
+| `AVA_API_KEY` | If using Ava | API key injected as `X-API-Key` header |
+| `AVA_APP_ID` | For chain comments | GitHub App ID — chain responses post as `protoava[bot]` |
+| `AVA_APP_PRIVATE_KEY` | For chain comments | GitHub App private key (PKCS#1 PEM) |
+
+### GitHub Plugin
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GITHUB_TOKEN` | Yes | PAT — enables the plugin; posts comment replies |
+| `GITHUB_WEBHOOK_SECRET` | Recommended | Validates `X-Hub-Signature-256` on inbound payloads |
+| `GITHUB_WEBHOOK_PORT` | No | Webhook HTTP server port (default: `8082`) |
+| `QUINN_APP_ID` | For bot comments | GitHub App ID — Quinn's responses post as `protoquinn[bot]` |
+| `QUINN_APP_PRIVATE_KEY` | For bot comments | GitHub App private key (PKCS#1 PEM) |
+
+### Discord Plugin
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DISCORD_BOT_TOKEN` | Yes | Bot token — enables the plugin |
+| `DISCORD_GUILD_ID` | Yes | Guild ID for slash command registration |
+| `DISCORD_DIGEST_CHANNEL` | No | Fallback channel ID for cron pushes (overridden by `discord.yaml`) |
+
+### Plane Plugin
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `PLANE_WEBHOOK_SECRET` | Yes | HMAC key for webhook signature validation |
+| `PLANE_API_KEY` | Yes | For `/api/v1/` reads and writes |
+| `PLANE_BASE_URL` | No | Defaults to `http://ava:3002` |
+| `PLANE_WORKSPACE_SLUG` | No | Defaults to `protolabsai` |
+
+### Google Plugin
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GOOGLE_CLIENT_ID` | Yes | OAuth2 client ID — enables the plugin |
+| `GOOGLE_CLIENT_SECRET` | Yes | OAuth2 client secret |
+| `GOOGLE_REFRESH_TOKEN` | Yes | Long-lived refresh token |
+
+### Quinn Vector Context Pipeline
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `QDRANT_URL` | Yes (for vector) | `http://qdrant:6333` |
+| `QDRANT_VECTOR_SIZE` | No | Embedding dimensions (default: `768`) |
+| `OLLAMA_URL` | Yes (for embeddings) | `http://ollama:11434` |
+| `OLLAMA_EMBED_MODEL` | No | Embedding model (default: `nomic-embed-text`) |
+
+### Scheduler Plugin
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `TZ` | No | System timezone (e.g., `America/New_York`). Affects default cron timezone. |
+
+---
+
+## workspace/agents.yaml
+
+Source of truth for the agent registry. The A2APlugin fetches `/.well-known/agent.json` from each agent URL on startup and merges live skills.
+
+```yaml
+agents:
+  - name: ava
+    team: dev
+    url: http://automaker-server:3008/a2a
+    apiKeyEnv: AVA_API_KEY       # env var holding the API key (not the key itself)
+    skills:
+      - sitrep
+      - manage_feature
+      - auto_mode
+      - board_health
+      - onboard_project
+      - plan
+      - plan_resume
+
+  - name: quinn
+    team: dev
+    url: http://quinn:7870/a2a
+    skills:
+      - qa_report
+      - board_audit
+      - bug_triage
+      - pr_review
+    chain:
+      bug_triage: ava            # after bug_triage, call ava/manage_feature
+
+  - name: frank
+    team: dev
+    url: http://frank:7880/a2a
+    skills:
+      - infra_health
+      - deploy
+      - monitoring
+```
+
+**`chain`** is optional. When `chain[skill]` is set, the named agent is called with the first agent's response as context. One level deep only.
+
+---
+
+## workspace/projects.yaml
+
+Source of truth for the project registry. Consumed by Quinn and protoMaker via `GET /api/projects`. Written to during `onboard_project`.
+
+```yaml
+projects:
+  - repo: protoLabsAI/my-repo
+    plane_project_id: "<uuid>"
+    discord:
+      dev: "<channel-id>"
+      alerts: "<channel-id>"
+      releases: "<channel-id>"
+    github:
+      owner: protoLabsAI
+      name: my-repo
+```
+
+---
+
+## workspace/discord.yaml
+
+```yaml
+channels:
+  digest: ""       # channel ID for cron-triggered posts and message.outbound.discord.push.*
+  welcome: ""      # new member welcome messages (blank = disabled)
+  modLog: ""       # reserved for future moderation logging
+
+moderation:
+  rateLimit:
+    maxMessages: 5       # max messages per user per window
+    windowSeconds: 10    # rolling window in seconds
+  spamPatterns:          # regex strings, case-insensitive, matched messages silently deleted
+    - "free\\s*nitro"
+    - "discord\\.gift/"
+
+commands:
+  - name: mybot
+    description: "Bot description shown in Discord"
+    subcommands:
+      - name: status
+        description: "Subcommand description"
+        content: "/status"              # text sent as payload.content
+        skillHint: qa_report           # optional — routes to specific A2A skill
+        options:
+          - name: version
+            description: "Option description"
+            type: string               # string | integer | boolean
+            required: false
+            autocomplete: false        # true enables live Discord filtering; project options load from projects.yaml
+```
+
+---
+
+## workspace/github.yaml
+
+```yaml
+mentionHandle: "@quinn"       # case-insensitive handle to watch for
+
+skillHints:
+  issue_comment: bug_triage              # comment @mention on issue
+  issues: bug_triage                     # new issue body @mention
+  pull_request_review_comment: pr_review # review comment @mention
+  pull_request: pr_review                # PR body @mention
+```
+
+---
+
+## workspace/google.yaml
+
+```yaml
+drive:
+  orgFolderId: ""             # root org Drive folder ID
+  templateFolderId: ""        # per-project template folder ID (optional)
+
+calendar:
+  orgCalendarId: ""           # shared org calendar ID (from Google Calendar settings)
+  pollIntervalMinutes: 60     # polling interval
+
+gmail:
+  watchLabels: []             # Gmail label names to monitor
+  pollIntervalMinutes: 5
+  routingRules:               # label → skillHint mappings
+    - label: "bug-report"
+      skillHint: bug_triage
+```
+
+---
+
+## workspace/crons/{id}.yaml
+
+```yaml
+id: daily-digest              # unique, kebab-case — used as filename
+type: cron                    # "cron" or "once" (auto-detected if omitted)
+schedule: "0 14 * * *"        # cron expression (recurring) or ISO datetime (one-shot)
+timezone: "America/New_York"  # IANA timezone (system default if omitted)
+topic: "cron.daily-digest"    # bus topic to publish on fire
+payload:
+  content: "Generate the daily QA digest"
+  sender: "cron"
+  channel: "signal"           # reply channel or Discord channel ID
+  skillHint: qa_report
+enabled: true
+lastFired: "2026-04-01T14:00:00.000Z"   # auto-updated by SchedulerPlugin
+```
+
+---
+
+## workspace/plugins/{name}.ts
+
+Workspace plugins are TypeScript/JavaScript files exporting a default object implementing the `Plugin` interface. Loaded on container startup. See [`reference/plugins.md`](plugins.md) for the full interface contract.

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -1,0 +1,197 @@
+# Plugin API Reference
+
+_This is a reference doc. It covers the Plugin interface contract and the two extension mechanisms available._
+
+---
+
+See also: [`explanation/plugin-lifecycle.md`](../explanation/plugin-lifecycle.md) for how plugins register, subscribe, and hot-reload.
+
+---
+
+## Plugin interface
+
+All workspace bus plugins must implement:
+
+```typescript
+interface Plugin {
+  readonly name: string;
+  readonly description: string;
+  readonly capabilities: string[];
+  install(bus: EventBus): void;
+  uninstall(): void;
+}
+```
+
+### `install(bus: EventBus)`
+
+Called once on container startup after the bus is created. Subscribe to topics and set up HTTP servers here.
+
+```typescript
+install(bus: EventBus): void {
+  bus.subscribe("message.inbound.#", this.name, (msg: BusMessage) => {
+    // handle message
+  });
+}
+```
+
+### `uninstall()`
+
+Called on graceful shutdown. Clean up timers, close HTTP servers, release resources.
+
+---
+
+## EventBus interface
+
+```typescript
+interface EventBus {
+  subscribe(topic: string, subscriberId: string, handler: (msg: BusMessage) => void): void;
+  publish(topic: string, message: BusMessage): void;
+  unsubscribe(subscriberId: string): void;
+}
+```
+
+Topic patterns use `#` as a wildcard matching any number of segments (MQTT-style):
+
+```
+message.inbound.#          matches message.inbound.github.owner.repo.event.123
+message.inbound.discord.#  matches message.inbound.discord.channelId
+```
+
+---
+
+## BusMessage shape
+
+```typescript
+interface BusMessage {
+  id: string;               // UUID
+  topic: string;            // the topic this message was published on
+  timestamp: number;        // Unix milliseconds
+  correlationId?: string;   // links request → response → chain
+  payload: {
+    sender?: string;
+    content?: string;
+    channel?: string;
+    skillHint?: string;
+    reply?: string;
+    [key: string]: unknown;
+  };
+  reply?: string;           // outbound topic for responses
+  source?: {
+    interface: string;      // "discord" | "github" | "plane" | "cron" | ...
+    channelId: string;
+    userId: string;
+  };
+}
+```
+
+---
+
+## Pi SDK Extensions (Runtime, No Restart)
+
+Pi SDK extensions extend the **LLM tool set** at runtime via `pi.registerTool()`. No container restart needed.
+
+```typescript
+// Inside a Pi SDK extension (e.g., .pi/extensions/my-tool.ts)
+pi.registerTool({
+  name: "deploy",
+  label: "Deploy",
+  description: "Deploy the application to an environment",
+  parameters: Type.Object({
+    env: StringEnum(["dev", "staging", "prod"]),
+  }),
+  async execute(toolCallId, params, signal, onUpdate, ctx) {
+    // ...
+    return { content: [{ type: "text", text: "Deployed" }], details: {} };
+  },
+});
+```
+
+### Extension discovery
+
+| Location | Scope |
+|----------|-------|
+| `~/.pi/agent/extensions/*.ts` | Global (all projects) |
+| `.pi/extensions/*.ts` | Project-local |
+
+### Pi SDK extension capabilities
+
+- `pi.registerTool()` — add LLM-callable tools
+- `pi.registerCommand()` — add slash commands
+- `pi.registerShortcut()` — add keyboard shortcuts
+- `pi.setActiveTools()` — enable/disable tools at runtime
+- `pi.getAllTools()` — list all registered tools
+- Subscribe to lifecycle events (tool calls, session start/end, agent turns)
+- Intercept/block tool calls before execution
+- Inject context or modify system prompts
+
+---
+
+## Workspace Bus Plugins (Restart-Based)
+
+Bus plugins extend the **message bus** and are loaded from `workspace/plugins/` on container startup.
+
+```typescript
+// workspace/plugins/my-plugin.ts
+import type { Plugin, EventBus, BusMessage } from "../../lib/types";
+
+export default {
+  name: "my-plugin",
+  description: "Does something useful on the bus",
+  capabilities: ["custom"],
+
+  install(bus: EventBus) {
+    bus.subscribe("message.inbound.#", "my-plugin", (msg: BusMessage) => {
+      bus.publish("message.outbound.custom", {
+        id: msg.id,
+        topic: "message.outbound.custom",
+        timestamp: Date.now(),
+        payload: { content: "Custom response" },
+      });
+    });
+  },
+
+  uninstall() {},
+} satisfies Plugin;
+```
+
+### Bus plugin capabilities
+
+- Subscribe to any bus topic
+- Publish messages to any topic
+- Bridge external services (APIs, webhooks, databases)
+- Transform or route messages between channels
+- Implement custom command handlers
+
+### Bus plugin limitations
+
+- Cannot register LLM-callable tools (use Pi SDK extensions)
+- Cannot modify the agent's system prompt
+- Cannot intercept tool calls
+
+---
+
+## When to use which
+
+| Goal | Use |
+|------|-----|
+| Add an LLM-callable tool | Pi SDK extension |
+| Add a slash command | Pi SDK extension |
+| React to bus messages | Workspace plugin |
+| Bridge an external service | Workspace plugin |
+| Intercept/block tool calls | Pi SDK extension |
+| Route messages between channels | Workspace plugin |
+| Add capabilities without restart | Pi SDK extension |
+
+---
+
+## MCP support
+
+Pi SDK **does not ship MCP support**. MCP bridges are possible via extensions: write a Pi SDK extension that connects to MCP servers and registers their tools via `pi.registerTool()`.
+
+---
+
+## References
+
+- [Pi SDK Extensions Docs](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/extensions.md)
+- [Pi SDK Docs](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/README.md)
+- Migrated from: [`extensions.md`](../extensions.md)

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,0 +1,165 @@
+# Getting Started with protoWorkstacean
+
+_This is a tutorial. It walks you step-by-step from a fresh clone to your first agent interaction on the bus._
+
+---
+
+## What you'll achieve
+
+By the end of this tutorial you will have:
+
+1. The workstacean container running locally
+2. A message published to the bus and routed to an agent
+3. A real reply arriving back via the configured output channel
+
+---
+
+## Prerequisites
+
+- Docker + Docker Compose
+- Access to Infisical (AI project `11e172e0`) **or** a `.env` file with the required secrets
+- A Discord bot token (for Discord output) **or** the ability to read replies from logs
+
+---
+
+## Step 1 — Clone and configure the workspace
+
+```bash
+git clone https://github.com/protoLabsAI/protoWorkstacean.git
+cd protoWorkstacean
+```
+
+The `workspace/` directory is the runtime configuration volume. It ships with example YAML files. Review:
+
+```
+workspace/
+  agents.yaml      # agent registry — URLs, skills, chains
+  projects.yaml    # project registry — repos, Discord channels, Plane IDs
+  discord.yaml     # Discord slash commands, channel IDs, moderation
+  github.yaml      # mention handle, skill hints per event type
+  google.yaml      # Google Workspace Drive/Calendar/Gmail config
+  crons/           # scheduled task YAML files
+  plugins/         # hot-loaded workspace plugins
+```
+
+---
+
+## Step 2 — Set environment variables
+
+Copy the example env file and fill in the required secrets:
+
+```bash
+cp .env.example .env
+```
+
+Minimum required secrets to start the server (no plugins enabled):
+
+```
+# Agent calls
+AVA_API_KEY=<key>
+
+# Optional: enable GitHub plugin
+GITHUB_TOKEN=<pat>
+GITHUB_WEBHOOK_SECRET=<secret>
+
+# Optional: enable Discord plugin
+DISCORD_BOT_TOKEN=<token>
+DISCORD_GUILD_ID=<guild-id>
+```
+
+For the full secret list, see [`docs/reference/config-files.md`](../reference/config-files.md).
+
+---
+
+## Step 3 — Start the container
+
+```bash
+docker compose up workstacean
+```
+
+Watch the startup log. You should see each plugin report whether it installed successfully:
+
+```
+[DiscordPlugin] installed — guild commands registered
+[GitHubPlugin] installed — webhook server on :8082
+[A2APlugin] installed — 6 agents loaded from agents.yaml
+[SchedulerPlugin] installed — 0 schedules loaded
+```
+
+If a plugin is skipped (missing env var), it logs:
+```
+[DiscordPlugin] skipped — DISCORD_BOT_TOKEN not set
+```
+
+That is expected and safe — the server starts regardless.
+
+---
+
+## Step 4 — Publish your first bus message
+
+The server exposes a `/publish` endpoint on port 3000 (Docker-internal only). From another container on the same network, or using `docker exec`:
+
+```bash
+docker exec workstacean curl -s -X POST http://localhost:3000/publish \
+  -H "Content-Type: application/json" \
+  -d '{
+    "topic": "message.inbound.test",
+    "payload": {
+      "sender": "tutorial",
+      "content": "What is the status of the dev board?",
+      "channel": "cli",
+      "skillHint": "sitrep"
+    }
+  }'
+```
+
+---
+
+## Step 5 — Observe the response
+
+Watch the container logs:
+
+```bash
+docker logs -f workstacean
+```
+
+You will see:
+
+1. `[A2APlugin] routing message.inbound.test → ava (sitrep)`
+2. The A2A call to Ava's `/a2a` endpoint
+3. `[A2APlugin] publishing message.outbound.discord.push.<channel>`
+
+If you have a Discord channel configured, the reply appears there. Otherwise it appears in the log output.
+
+---
+
+## Step 6 — Trigger a real workflow via Discord
+
+If the Discord plugin is running:
+
+1. In your Discord server, go to any channel the bot has access to
+2. Type `@YourBot` followed by your message, e.g.: `@YourBot sitrep`
+3. The bot adds 👀 (processing) then ✅ (done) and replies in-thread
+
+That's it — you've completed your first end-to-end flow:
+
+```
+Discord @mention
+  → DiscordPlugin → bus (message.inbound.discord.{channelId})
+    → A2APlugin → Ava (sitrep skill)
+      → Ava responds
+        → message.outbound.discord.{channelId}
+          → DiscordPlugin posts reply
+```
+
+---
+
+## Next steps
+
+| Goal | Where to go |
+|------|-------------|
+| Onboard a new project | [how-to/onboard-a-project.md](../how-to/onboard-a-project.md) |
+| Configure Discord commands | [how-to/configure-discord.md](../how-to/configure-discord.md) |
+| Schedule recurring tasks | [how-to/create-a-ceremony.md](../how-to/create-a-ceremony.md) |
+| Understand how the bus works | [explanation/architecture.md](../explanation/architecture.md) |
+| See all bus topics | [reference/bus-topics.md](../reference/bus-topics.md) |


### PR DESCRIPTION
## Summary

## Goal

Reorganize `docs/` from a flat list of plugin files into the Diátaxis 4-quadrant structure.

## Diátaxis structure to create

```
docs/
  README.md              # index with quadrant nav
  tutorials/
    getting-started.md   # install → first plugin running → first onboard
  how-to/
    onboard-a-project.md
    configure-discord.md
    set-up-google-workspace.md
    create-a-ceremony.md
    use-quinn-pr-review.md
  reference/
    plugins.md           # plugin API contract (existing cont...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured documentation with Diátaxis framework (Tutorials, How-to Guides, Reference, Explanation).
  * Added comprehensive getting-started tutorial and configuration guides for Discord, Google Workspace, and ceremony scheduling.
  * Added reference documentation for agent skills, bus topics, config files, and plugin contracts.
  * Added architectural explanations for agent identity, system architecture, and plugin lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->