### PR TITLE
docs: OnboardingPlugin — reference + how-to (M1/M2/M3)

### DIFF
--- a/docs/how-to/onboard-a-project.md
+++ b/docs/how-to/onboard-a-project.md
@@ -1,108 +1,225 @@
 # How to Onboard a Project
 
-_This is a how-to guide. It assumes the workstacean container is running and you have Ava configured in `workspace/agents.yaml`._
+_This is a how-to guide. It covers prerequisites, the three ways to trigger onboarding, how to check onboard status, and how to re-run idempotently._
 
 ---
 
-Onboarding a project provisions it across every system protoLabs uses: GitHub (`.automaker/` scaffold), Plane (project created), and Discord (category + channels created). The `onboard_project` skill on Ava orchestrates the full chain.
+See also: [`reference/onboarding-plugin.md`](../reference/onboarding-plugin.md) for the full pipeline reference, `OnboardRequest` schema, and environment variable docs.
 
-## Trigger options
+---
 
-### Option A — Automatic (org webhook)
+## Prerequisites
 
-If you have the GitHub org webhook registered (see [how-to/use-quinn-pr-review.md](use-quinn-pr-review.md) for webhook setup), any new repository created under the org automatically triggers onboarding. No manual action needed.
+Before onboarding, have the following ready:
 
-### Option B — Discord slash command
+| Prerequisite | Why needed |
+|-------------|-----------|
+| A GitHub repository (`owner/repo`) | Required field — the pipeline registers a webhook on this repo |
+| A unique project `slug` | Used as the primary key in `projects.yaml` (e.g. `protolabsai-myproject`) |
+| A project `title` | Human-readable name written to `projects.yaml` |
+| Discord channel IDs (optional) | Passed in the `discord` field; `discord.dev` is written to `projects.yaml` |
 
-In any Discord channel the bot has access to:
+**Environment prerequisites** (see [`reference/onboarding-plugin.md`](../reference/onboarding-plugin.md) for full list):
+
+- `PLANE_API_KEY` — required for Plane project and webhook creation (steps 3–4 skip if absent)
+- `WORKSTACEAN_PUBLIC_URL` — required for webhook registration (steps 4–5 skip if absent)
+- GitHub auth (`QUINN_APP_ID`/`QUINN_APP_PRIVATE_KEY` or `GITHUB_TOKEN`) — required for GitHub webhook (step 5 skips if absent)
+- Google credentials — required for Drive folder creation (step 6 skips if absent)
+
+Missing env vars cause individual steps to be skipped, not the whole pipeline.
+
+---
+
+## Option A — Via Discord `/onboard` slash command (M2)
+
+In any Discord channel the bot has access to, use the `/onboard` slash command. The command is registered via `workspace/discord.yaml` and routes the interaction to `message.inbound.onboard` on the bus.
+
+Example (slash command with options):
 
 ```
-/ava onboard
+/onboard slug:protolabsai-myproject title:My Project github:protoLabsAI/my-project
 ```
 
-Or by @mention:
+The bot replies with a step-by-step summary once the pipeline completes (or an error if a step fails).
 
-```
-@YourBot onboard protoLabsAI/my-new-repo
-```
+---
 
-### Option C — Bus injection (scripted/CI)
+## Option B — Via HTTP `POST /api/onboard`
 
 ```bash
-curl -s -X POST http://workstacean:3000/publish \
+curl -s -X POST http://localhost:3000/api/onboard \
   -H "Content-Type: application/json" \
   -d '{
-    "topic": "message.inbound.test",
-    "payload": {
-      "sender": "ci",
-      "content": "onboard protoLabsAI/my-new-repo",
-      "skillHint": "onboard_project",
-      "channel": "cli"
+    "slug": "protolabsai-myproject",
+    "title": "My Project",
+    "github": "protoLabsAI/my-project"
+  }'
+```
+
+The endpoint waits up to 30 seconds for the pipeline to complete and returns the result:
+
+```json
+{
+  "success": true,
+  "step": "complete",
+  "status": "onboarded",
+  "slug": "protolabsai-myproject",
+  "github": "protoLabsAI/my-project",
+  "steps": {
+    "planeProject": "ok",
+    "planeWebhook": "ok",
+    "githubWebhook": "ok",
+    "driveFolder": "skip",
+    "projectsYaml": "ok"
+  }
+}
+```
+
+If the pipeline takes longer than 30s, the response is `{ "success": true, "status": "accepted" }` and onboarding continues in the background.
+
+**Full optional fields:**
+
+```bash
+curl -s -X POST http://localhost:3000/api/onboard \
+  -H "Content-Type: application/json" \
+  -d '{
+    "slug": "protolabsai-myproject",
+    "title": "My Project",
+    "github": "protoLabsAI/my-project",
+    "defaultBranch": "main",
+    "team": "dev",
+    "agents": ["ava", "quinn"],
+    "discord": {
+      "dev": "123456789012345678",
+      "alerts": "123456789012345679"
     }
   }'
 ```
 
 ---
 
-## What the onboard chain does
+## Option C — Via bus message `message.inbound.onboard`
 
-Ava's `onboard_project` skill runs these steps in sequence:
+Publish directly to the bus (useful in CI or scripts):
 
-1. **GitHub API** — fetches repo metadata (description, topics, visibility)
-2. **`.automaker/` scaffold** — writes `project.json` and `settings.json` into the target repo, commits and pushes
-3. **`.gitignore` + worktree init** — adds worktree paths to `.gitignore` in the target repo
-4. **Plane API** — creates a new Plane project, stores the returned `plane_project_id`
-5. **Discord provisioning** — calls Quinn's `provision_discord` skill (via chain), which creates a Discord category with three channels: `dev`, `alerts`, `releases`
-6. **Write-back** — stores Discord channel IDs in both `.automaker/settings.json` (in the target repo) and `workspace/projects.yaml` (in this repo)
+```bash
+curl -s -X POST http://localhost:3000/publish \
+  -H "Content-Type: application/json" \
+  -d '{
+    "topic": "message.inbound.onboard",
+    "payload": {
+      "slug": "protolabsai-myproject",
+      "title": "My Project",
+      "github": "protoLabsAI/my-project"
+    }
+  }'
+```
 
-On completion, a summary message is sent to the originating interface (Discord channel or the bus outbound topic).
+This is fire-and-forget — no response is returned by the `/publish` endpoint. The pipeline runs asynchronously. To get a result, use the HTTP endpoint (Option B) instead, or subscribe to `message.inbound.onboard.complete` on the bus.
 
 ---
 
-## Verifying the onboard completed
+## Option D — Automatically via GitHub org webhook (M2)
 
-Check `workspace/projects.yaml` for a new entry:
+If the GitHub org webhook is registered, any new repository created under the org automatically triggers onboarding. No manual action needed.
+
+The `GithubPlugin` catches `repository.created` events and publishes to `message.inbound.onboard` with the repository's name, owner, and description as the payload. The slug is derived from the repository's `full_name`.
+
+---
+
+## How to check onboard status
+
+### Check `workspace/projects.yaml`
+
+After onboarding, the project appears in `workspace/projects.yaml`:
 
 ```yaml
-- repo: protoLabsAI/my-new-repo
-  plane_project_id: "<uuid>"
-  discord:
-    dev: "<channel-id>"
-    alerts: "<channel-id>"
-    releases: "<channel-id>"
+projects:
+  - slug: protolabsai-myproject
+    title: My Project
+    github: protoLabsAI/my-project
+    status: active
+    defaultBranch: main
+    team: dev
+    agents: [ava, quinn]
+    onboardedAt: "2026-04-08T12:00:00.000Z"
+    planeProjectId: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+    discord:
+      dev: ""
+    googleWorkspace:
+      driveFolderId: ""
+      sharedDocId: ""
+      calendarId: ""
 ```
 
-Check the target repo for a `.automaker/` directory:
+### Check via HTTP
 
 ```bash
-gh api repos/protoLabsAI/my-new-repo/contents/.automaker/project.json
+curl -s http://localhost:3000/api/projects | jq '.projects[] | select(.slug == "protolabsai-myproject")'
+```
+
+### Check container logs
+
+```bash
+docker logs workstacean 2>&1 | grep "onboarding.*protolabsai-myproject"
+```
+
+Each pipeline step logs its outcome:
+
+```
+[onboarding] Starting pipeline for "protolabsai-myproject" (protoLabsAI/my-project)
+[onboarding] Step 3 plane_project: ok — Created Plane project "My Project" (uuid)
+[onboarding] Step 4 plane_webhook: ok — Plane webhook registered → https://ws.example.com/webhooks/plane
+[onboarding] Step 5 github_webhook: ok — GitHub webhook registered on protoLabsAI/my-project
+[onboarding] Step 6 drive_folder: skip — Google credentials not set
+[onboarding] Step 7 projects_yaml: ok — Appended "protolabsai-myproject" to projects.yaml
+[onboarding] Step 8 bus_notify: ok — published message.inbound.onboard.complete
+[onboarding] Step 9 reply: ok — protolabsai-myproject onboarded
 ```
 
 ---
 
-## If provisioning fails partway through
+## How to re-run idempotently
 
-The onboard chain is not atomic. If Discord provisioning fails (e.g., bot permissions), the Plane project and `.automaker/` scaffold are still created. The error is logged and a partial-onboard notice is sent to the originating interface.
+Re-running the pipeline for an already-onboarded project is safe. Step 2 (idempotency check) reads `projects.yaml`, finds the slug, and returns immediately:
 
-To re-run Discord provisioning only:
+```json
+{
+  "success": true,
+  "step": "idempotency",
+  "status": "already_onboarded",
+  "slug": "protolabsai-myproject",
+  "message": "Project \"protolabsai-myproject\" is already registered in projects.yaml"
+}
+```
+
+No external API calls are made during an idempotency-skip run.
+
+**To force re-onboarding** (e.g., to re-register webhooks or recreate a Plane project after deletion):
+
+1. Remove or rename the entry in `workspace/projects.yaml`
+2. Re-run any trigger from Options A–D above
+
+---
+
+## Backfilling existing projects (M3)
+
+For projects added to `projects.yaml` manually (before the OnboardingPlugin, or via direct YAML edit), use the backfill script to create the missing Plane projects and seed standard states/labels:
 
 ```bash
-curl -s -X POST http://workstacean:3000/publish \
-  -H "Content-Type: application/json" \
-  -d '{
-    "topic": "message.inbound.test",
-    "payload": {
-      "sender": "manual",
-      "content": "provision discord for protoLabsAI/my-new-repo",
-      "skillHint": "provision_discord"
-    }
-  }'
+# Preview what would change
+bun scripts/backfill-plane.ts --dry-run
+
+# Apply
+bun scripts/backfill-plane.ts
 ```
+
+The script is idempotent — safe to re-run. It only acts on entries missing a `planeProjectId`.
 
 ---
 
 ## Related docs
 
-- [reference/agent-skills.md](../reference/agent-skills.md) — full skill registry including `onboard_project` parameters
-- [reference/config-files.md](../reference/config-files.md) — `projects.yaml` schema
-- [explanation/agent-identity.md](../explanation/agent-identity.md) — why Quinn handles Discord provisioning (not Ava)
+- [`reference/onboarding-plugin.md`](../reference/onboarding-plugin.md) — full pipeline reference, OnboardRequest schema, env vars
+- [`reference/bus-topics.md`](../reference/bus-topics.md) — full bus topic registry
+- [`reference/config-files.md`](../reference/config-files.md) — `projects.yaml` and workspace config file reference

--- a/docs/reference/onboarding-plugin.md
+++ b/docs/reference/onboarding-plugin.md
@@ -1,0 +1,215 @@
+# OnboardingPlugin Reference
+
+_This is a reference doc. It covers the OnboardingPlugin pipeline, request schema, idempotency guarantees, trigger sources, and related tooling._
+
+---
+
+See also: [`how-to/onboard-a-project.md`](../how-to/onboard-a-project.md) for step-by-step operational procedures.
+
+---
+
+## Overview
+
+`OnboardingPlugin` (`lib/plugins/onboarding.ts`) implements a deterministic, idempotent 9-step project provisioning pipeline. When triggered, it registers a project across Plane, GitHub, and Google Drive, then writes the project's metadata to `workspace/projects.yaml` and notifies downstream consumers.
+
+---
+
+## The 9-step pipeline
+
+Steps run in sequence. Each step is individually idempotent — re-running the full pipeline for the same slug is safe.
+
+| # | Step | What it does | Skip condition |
+|---|------|-------------|----------------|
+| 1 | **validate** | Checks `slug`, `title`, and `github` are present; validates `github` is `owner/repo` format; rejects duplicate in-flight runs | Missing required fields or invalid format |
+| 2 | **idempotency** | Reads `workspace/projects.yaml` and exits early (success) if the slug is already registered | Slug already in `projects.yaml` |
+| 3 | **plane_project** | Creates a Plane project with a derived identifier (max 12 chars, uppercase, alphanumeric) | `PLANE_API_KEY` not set |
+| 4 | **plane_webhook** | Registers a Plane webhook pointing at `$WORKSTACEAN_PUBLIC_URL/webhooks/plane` | `PLANE_API_KEY` or `WORKSTACEAN_PUBLIC_URL` not set |
+| 5 | **github_webhook** | Registers a GitHub repo webhook for `issues`, `issue_comment`, `pull_request`, `pull_request_review_comment` events; skips if webhook URL already registered | No GitHub auth (`QUINN_APP_ID` or `GITHUB_TOKEN`), or `WORKSTACEAN_PUBLIC_URL` not set, or webhook already exists |
+| 6 | **drive_folder** | Creates a Google Drive folder under the org root folder (`drive.orgFolderId` in `workspace/google.yaml`) | Google credentials not set, `google.yaml` missing, or `drive.orgFolderId` empty |
+| 7 | **projects_yaml** | Upserts the project entry into `workspace/projects.yaml` under a write lock; validates entry against `ProjectEntrySchema` before writing; preserves file header comments | Slug already present (double-checked under lock) |
+| 8 | **bus_notify** | Publishes `message.inbound.onboard.complete` with project metadata and step outcomes | Never skipped |
+| 9 | **reply** | Sends a confirmation message (or error) to the reply topic | No reply topic in the inbound message |
+
+Steps 3–6 are non-fatal: an error in one step is logged, and the pipeline continues to `projects_yaml`. The pipeline aborts only if `projects_yaml` (step 7) fails.
+
+---
+
+## `OnboardRequest` schema
+
+Sent as the `payload` of a `message.inbound.onboard` bus message (or the JSON body of `POST /api/onboard`):
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `slug` | `string` | ✅ | — | Unique project identifier, e.g. `"protolabsai-myproject"` |
+| `title` | `string` | ✅ | — | Human-readable project name |
+| `github` | `string` | ✅ | — | Repository in `"owner/repo"` format |
+| `defaultBranch` | `string` | | `"main"` | Default git branch |
+| `team` | `string` | | `"dev"` | Team assignment: `"dev"`, `"gtm"`, etc. |
+| `agents` | `string[]` | | `["ava", "quinn"]` | Agent identifiers to associate |
+| `discord` | `object` | | `{}` | Discord channel IDs (`general`, `updates`, `dev`, `alerts`, `releases`) |
+
+---
+
+## `lib/project-schema.ts` — Zod schema
+
+`lib/project-schema.ts` defines the Zod schema for `workspace/projects.yaml` entries. It is used by:
+
+- `lib/plugins/onboarding.ts` — validates each new entry before writing (step 7 fails if validation fails)
+- `lib/plugins/a2a.ts` — validates on load (warns and skips invalid entries)
+
+### `ProjectEntrySchema` fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `slug` | ✅ | Unique project slug |
+| `github` | ✅ | `"owner/repo"` format |
+| `status` | ✅ | Project status string |
+| `discord.dev` | ✅ | Dev channel ID (may be empty string until channel is created) |
+| `title` | | Human-readable name |
+| `defaultBranch` | | Git default branch |
+| `team` | | Team assignment |
+| `agents` | | List of agent identifiers |
+| `planeProjectId` | | UUID of the corresponding Plane project |
+| `onboardedAt` | | ISO 8601 timestamp of onboarding |
+| `onboardingState` | | Per-step status tracking (`ok` \| `skip` \| `error`) |
+| `googleWorkspace.driveFolderId` | | Google Drive folder ID created during onboarding |
+| `googleWorkspace.sharedDocId` | | Project spec/brief Google Doc ID |
+| `googleWorkspace.calendarId` | | Project-scoped calendar ID |
+
+### Validation helpers
+
+```typescript
+// Validate a single raw entry
+validateProjectEntry(raw: unknown): { ok: true; entry: ProjectEntry } | { ok: false; errors: string[] }
+
+// Parse and validate the full projects.yaml structure (throws on invalid)
+parseProjectsYaml(raw: unknown): ProjectsYaml
+```
+
+---
+
+## Idempotency guarantees
+
+The pipeline is safe to re-run for the same project slug:
+
+1. **Step 2 (idempotency check)** exits early with `status: "already_onboarded"` if the slug is already in `projects.yaml`. No external API calls are made.
+2. **Step 5 (github_webhook)** lists existing webhooks before creating; skips if the target URL is already registered.
+3. **Step 7 (projects_yaml)** double-checks for the slug under a write lock before appending.
+4. **In-flight guard** — concurrent requests for the same slug are rejected with an error while the first run is in progress.
+
+---
+
+## Inbound triggers
+
+### Bus topic (primary)
+
+```
+message.inbound.onboard
+```
+
+Any subscriber can publish to this topic to trigger onboarding. The payload must match the `OnboardRequest` schema above.
+
+### HTTP endpoint
+
+```
+POST /api/onboard
+Content-Type: application/json
+
+{
+  "slug": "protolabsai-myproject",
+  "title": "My Project",
+  "github": "protoLabsAI/my-project"
+}
+```
+
+The HTTP handler waits up to 30 seconds for the pipeline to complete and returns the result synchronously. If the pipeline takes longer than 30s, it returns `{ success: true, status: "accepted" }` immediately and the pipeline continues in the background.
+
+### Discord `/onboard` slash command (M2)
+
+The Discord plugin routes slash commands to `message.inbound.discord.slash.{interactionId}` via the command config in `workspace/discord.yaml`. An `/onboard` command configured in `discord.yaml` can pass the project fields as options and publish to `message.inbound.onboard`. Autocomplete for project fields can be configured via the `choices` option in the command spec.
+
+### GitHub org webhook: `repository.created` (M2)
+
+When the GitHub org webhook is registered and a new repository is created under the org, `lib/plugins/github.ts` catches the `repository` + `action: created` event and publishes to `message.inbound.onboard` automatically. The payload uses the repository's `full_name`, `name`, `owner.login`, `description`, and visibility.
+
+---
+
+## Outbound topics
+
+| Topic | When published | Payload highlights |
+|-------|---------------|-------------------|
+| `message.inbound.onboard.complete` | After `projects_yaml` step succeeds | `slug`, `github`, `planeProjectId`, `driveFolderId`, per-step `status` |
+| `{msg.reply.topic}` | After pipeline finishes (success or error) | Full result with `success`, `step`, human-readable `content` |
+
+---
+
+## Environment variables
+
+| Variable | Required by | Default | Purpose |
+|----------|-------------|---------|---------|
+| `PLANE_API_KEY` | Steps 3, 4 | — | Enables Plane project and webhook creation |
+| `PLANE_BASE_URL` | Steps 3, 4 | `http://ava:3002` | Plane instance URL |
+| `PLANE_WORKSPACE_SLUG` | Steps 3, 4 | `protolabsai` | Plane workspace slug |
+| `PLANE_WEBHOOK_SECRET` | Step 4 | — | Optional HMAC secret for Plane webhooks |
+| `WORKSTACEAN_PUBLIC_URL` | Steps 4, 5 | — | Base URL for webhook registration (e.g. `https://ws.example.com`) |
+| `QUINN_APP_ID` | Step 5 | — | GitHub App ID for auth (used by `makeGitHubAuth`) |
+| `QUINN_APP_PRIVATE_KEY` | Step 5 | — | GitHub App private key |
+| `GITHUB_TOKEN` | Step 5 | — | Alternative GitHub PAT for webhook registration |
+| `GITHUB_WEBHOOK_SECRET` | Step 5 | — | Optional HMAC secret for GitHub webhooks |
+| `GOOGLE_CLIENT_ID` | Step 6 | — | Google OAuth client ID |
+| `GOOGLE_CLIENT_SECRET` | Step 6 | — | Google OAuth client secret |
+| `GOOGLE_REFRESH_TOKEN` | Step 6 | — | Google OAuth refresh token |
+
+---
+
+## Config hot-reload
+
+The following workspace config files are watched at runtime (polled every 5 seconds by Node's `watchFile`). Changes take effect without a container restart:
+
+| File | Watched by | What reloads |
+|------|-----------|-------------|
+| `workspace/github.yaml` | `GithubPlugin` | Monitored repos, org webhook config, mention handle, auto-triage settings |
+| `workspace/projects.yaml` | `GithubPlugin`, `A2aPlugin` | Monitored repo list (GithubPlugin), project routing table (A2aPlugin) |
+| `workspace/discord.yaml` | `DiscordPlugin` | Channel config, slash command list (re-registers commands on change) |
+| `workspace/agents.yaml` | `DiscordPlugin` | Agent identity list (bot → agent mapping) |
+
+---
+
+## `scripts/backfill-plane.ts` (M3)
+
+A one-shot maintenance script that creates Plane projects for all entries in `workspace/projects.yaml` that are missing a `planeProjectId`, then seeds standard workflow states and labels.
+
+**When to run:** After migrating existing projects into `projects.yaml` manually (i.e., projects that pre-date the OnboardingPlugin or were added without going through the pipeline).
+
+**Standard states seeded:** Todo (default), In Progress, In Review, Done, Cancelled
+
+**Standard labels seeded:** `bug`, `feature`, `chore`
+
+The script is fully idempotent — safe to re-run. Projects that already have a `planeProjectId` are skipped. State and label creation skips items that already exist.
+
+```bash
+# Preview changes without writing anything
+bun scripts/backfill-plane.ts --dry-run
+
+# Run for real
+bun scripts/backfill-plane.ts
+```
+
+**Required env vars:** `PLANE_API_KEY`
+
+**Optional env vars:**
+- `PLANE_BASE_URL` (default: `http://ava:3002`)
+- `PLANE_WORKSPACE_SLUG` (default: `protolabsai`)
+- `PROJECTS_YAML_PATH` (default: `workspace/projects.yaml` relative to cwd)
+
+---
+
+## References
+
+- [`lib/plugins/onboarding.ts`](../../lib/plugins/onboarding.ts) — plugin implementation
+- [`lib/project-schema.ts`](../../lib/project-schema.ts) — Zod schema for `projects.yaml` entries
+- [`lib/plane-client.ts`](../../lib/plane-client.ts) — Plane REST API client
+- [`scripts/backfill-plane.ts`](../../scripts/backfill-plane.ts) — Plane backfill script
+- [`how-to/onboard-a-project.md`](../how-to/onboard-a-project.md) — operational how-to
+- [`reference/bus-topics.md`](bus-topics.md) — full bus topic registry
+- [`reference/config-files.md`](config-files.md) — workspace config file reference


### PR DESCRIPTION
## Summary

## Goal

Write docs for the OnboardingPlugin pipeline (M1–M3 work).

## Files to create

**`docs/reference/onboarding-plugin.md`**

- What the onboarding pipeline does (9-step deterministic flow)
- All 9 steps: Plane project, Plane webhook, GitHub webhook, Drive folder, projects.yaml write, bus notify, reply
- `OnboardRequest` schema
- Idempotency guarantees (safe to re-run)
- `lib/project-schema.ts` — Zod schema for all required/optional project fields
- Discord `/onboard` slash command and aut...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced onboarding guide with prerequisites, multiple trigger mechanisms (Discord slash command, HTTP endpoint, bus publish, GitHub webhook), and status verification instructions.
  * Added comprehensive reference documentation for the onboarding plugin, including the 9-step pipeline sequence, supported triggers, configuration, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->