### PR TITLE
docs: CeremonyPlugin — reference + how-to (YAML-defined recurring fleet rituals)

### DIFF
--- a/docs/how-to/create-a-ceremony.md
+++ b/docs/how-to/create-a-ceremony.md
@@ -1,157 +1,120 @@
-# How to Create a Ceremony (Scheduled Recurring Task)
+# How to Create a Ceremony
 
-_This is a how-to guide. It covers creating cron schedules via YAML, the bus, and the Pi SDK tool._
+Ceremonies are recurring scheduled rituals defined in YAML and powered by CeremonyPlugin. This guide walks through adding one to your workspace.
 
----
+## Step 1: Create a YAML file in `workspace/ceremonies/`
 
-A "ceremony" is a scheduled recurring event — a daily digest, a weekly board audit, a nightly cleanup. In Workstacean, ceremonies are YAML files in `workspace/crons/` that publish to the message bus on a schedule.
+Each ceremony lives in its own `.yaml` file. The filename doesn't matter — the `id` field is the identifier.
 
----
+```bash
+touch workspace/ceremonies/my-ceremony.yaml
+```
 
-## Option A — Write the YAML directly
+## Step 2: Define the ceremony
 
-Create a file in `workspace/crons/`:
+Open the file and add the required fields:
 
 ```yaml
-# workspace/crons/daily-digest.yaml
-id: daily-digest
-schedule: "0 14 * * *"         # 2pm UTC daily
-timezone: "America/New_York"
-topic: "cron.daily-digest"
-payload:
-  content: "Generate the daily QA digest"
-  skillHint: qa_report
-  channel: "1234567890123456789"  # Discord channel ID for push
-  sender: "cron"
-enabled: true
+id: my-ceremony             # unique identifier
+name: My Ceremony           # human-readable label
+schedule: "0 9 * * 1-5"    # cron expression (UTC)
+skill: my-skill             # agent skill to invoke
+targets:
+  - projects/my-project     # project path, or 'all' for all projects
 ```
 
-The SchedulerPlugin picks up the file on the next container start. No restart needed if you publish `command.schedule` (see Option B).
+That's the minimum. CeremonyPlugin polls for changes every 5 seconds — no restart needed.
 
-### YAML fields
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| `id` | Yes | Unique identifier (kebab-case). Used as filename. |
-| `type` | No | `cron` or `once`. Auto-detected from schedule format. |
-| `schedule` | Yes | Cron expression for recurring, ISO datetime for one-shot. |
-| `timezone` | No | IANA timezone. Defaults to system TZ. |
-| `topic` | Yes | Bus topic to publish when the schedule fires. |
-| `payload.content` | Yes | Message the agent receives when this fires. |
-| `payload.sender` | No | Sender identifier. Default: `cron`. |
-| `payload.channel` | No | Reply channel (`signal`, `cli`, or Discord channel ID). |
-| `payload.skillHint` | No | Routes to a specific skill (e.g., `qa_report`, `board_audit`). |
-| `enabled` | No | Whether active. Default: `true`. |
-| `lastFired` | Auto | ISO timestamp updated by the scheduler on each fire. |
-
----
-
-## Option B — Add via bus command at runtime
-
-No restart needed — publish `command.schedule` to register a schedule immediately:
-
-```bash
-curl -s -X POST http://workstacean:3000/publish \
-  -H "Content-Type: application/json" \
-  -d '{
-    "topic": "command.schedule",
-    "payload": {
-      "action": "add",
-      "id": "daily-digest",
-      "schedule": "0 14 * * *",
-      "timezone": "America/New_York",
-      "topic": "cron.daily-digest",
-      "payload": {
-        "content": "Generate the daily QA digest",
-        "skillHint": "qa_report",
-        "channel": "1234567890123456789",
-        "sender": "cron"
-      }
-    }
-  }'
-```
-
-The SchedulerPlugin creates the YAML file in `data/crons/` and activates the timer immediately.
-
----
-
-## Option C — Ask the agent in natural language (Pi SDK tool)
-
-If the `schedule_task` Pi SDK tool is registered:
-
-```
-Schedule a daily QA digest at 2pm New York time to the #dev-alerts channel
-```
-
-The agent calls the tool with the right cron expression, writes the YAML, and publishes `command.schedule`. No manual YAML editing needed.
-
----
-
-## Managing schedules
-
-### Pause a schedule
-
-```bash
-curl -s -X POST http://workstacean:3000/publish \
-  -H "Content-Type: application/json" \
-  -d '{"topic": "command.schedule", "payload": {"action": "pause", "id": "daily-digest"}}'
-```
-
-### Resume a schedule
-
-```bash
-curl -s -X POST http://workstacean:3000/publish \
-  -H "Content-Type: application/json" \
-  -d '{"topic": "command.schedule", "payload": {"action": "resume", "id": "daily-digest"}}'
-```
-
-### Remove a schedule
-
-```bash
-curl -s -X POST http://workstacean:3000/publish \
-  -H "Content-Type: application/json" \
-  -d '{"topic": "command.schedule", "payload": {"action": "remove", "id": "daily-digest"}}'
-```
-
-### List all schedules
-
-```bash
-curl -s -X POST http://workstacean:3000/publish \
-  -H "Content-Type: application/json" \
-  -d '{"topic": "command.schedule", "payload": {"action": "list"}}'
-```
-
-Response published to `schedule.list`.
-
----
-
-## Create a one-shot ceremony
-
-Use an ISO datetime in `schedule` to fire once and self-delete:
+## Example: Daily Board Health Check at 9am
 
 ```yaml
-id: q1-kickoff-reminder
-schedule: "2026-04-01T09:00:00"
-timezone: "America/New_York"
-topic: "cron.q1-kickoff-reminder"
-payload:
-  content: "Remind the team about the Q1 kickoff meeting at 10am"
-  sender: "cron"
-  channel: "signal"
+id: board.health-check
+name: Daily Board Health Check
+schedule: "0 9 * * 1-5"
+skill: board-health-check
+targets:
+  - all
+notifyChannel: eng-standup
 ```
 
-One-shot schedules are automatically deleted after firing.
+- Runs at 9:00 AM UTC, Monday through Friday
+- Invokes the `board-health-check` skill across all projects
+- Posts a summary to the `#eng-standup` Discord channel
 
----
+## Example: Weekly Sprint Review on Fridays
 
-## Missed fire behavior
+```yaml
+id: sprint.weekly-review
+name: Weekly Sprint Review
+schedule: "0 17 * * 5"
+skill: sprint-review
+targets:
+  - projects/alpha
+  - projects/beta
+notifyChannel: sprint-reviews
+```
 
-If the container was down when a schedule was due, it fires immediately on restart — once only. If the missed window is more than 24 hours, it is skipped entirely and the next scheduled time applies.
+- Runs at 5:00 PM UTC every Friday
+- Invokes `sprint-review` for `projects/alpha` and `projects/beta`
+- Posts results to `#sprint-reviews`
 
----
+## Optional Fields
 
-## Related docs
+```yaml
+notifyChannel: my-channel   # Discord channel slug — omit to skip notifications
+enabled: false              # set to false to temporarily pause without deleting
+```
 
-- [reference/config-files.md](../reference/config-files.md) — full cron YAML schema
-- [reference/bus-topics.md](../reference/bus-topics.md) — cron and schedule command topics
-- [explanation/plugin-lifecycle.md](../explanation/plugin-lifecycle.md) — how SchedulerPlugin loads and manages timers
+## Project-Scoped Overrides
+
+To override a global ceremony for a specific project, create a file with the same `id` at:
+
+```
+.automaker/projects/{project-slug}/ceremonies/my-ceremony.yaml
+```
+
+The project-level definition takes precedence over the global one. All other global ceremonies are inherited unchanged.
+
+## How to Test a Ceremony Manually
+
+To trigger a ceremony immediately without waiting for its cron schedule, publish a `ceremony.{id}.execute` event directly on the EventBus:
+
+```typescript
+const runId = crypto.randomUUID();
+const ceremonyId = "board.health-check";
+
+bus.publish(`ceremony.${ceremonyId}.execute`, {
+  id: crypto.randomUUID(),
+  correlationId: runId,
+  topic: `ceremony.${ceremonyId}.execute`,
+  timestamp: Date.now(),
+  payload: {
+    type: "ceremony.execute",
+    context: {
+      runId,
+      ceremonyId,
+      projectPaths: ["projects/my-project"],
+      startedAt: Date.now(),
+    },
+    skill: "board-health-check",
+    ceremonyName: "Daily Board Health Check",
+  },
+});
+```
+
+Listen on `ceremony.{id}.completed` to see the outcome:
+
+```typescript
+bus.subscribe(`ceremony.${ceremonyId}.completed`, "test", (msg) => {
+  const { outcome } = msg.payload;
+  console.log(`Status: ${outcome.status}, duration: ${outcome.duration}ms`);
+  if (outcome.result) console.log("Result:", outcome.result);
+  if (outcome.error) console.log("Error:", outcome.error);
+});
+```
+
+The plugin dispatches the skill via `agent.skill.request` and waits up to 120 seconds for a response on `agent.skill.response.{runId}`. If no response arrives, the run is marked `timeout`.
+
+## Related Docs
+
+- [reference/ceremony-plugin.md](../reference/ceremony-plugin.md) — full schema, bus topics, and internals

--- a/docs/reference/ceremony-plugin.md
+++ b/docs/reference/ceremony-plugin.md
@@ -1,0 +1,142 @@
+# CeremonyPlugin Reference
+
+CeremonyPlugin replaces hardcoded cron tasks with configurable, observable, and hot-reloadable YAML-defined ceremonies. A **ceremony** is a recurring scheduled ritual — for example, a daily board health check, PR triage, or weekly sprint review.
+
+## What is a Ceremony?
+
+A ceremony is a named, cron-scheduled task that:
+
+- Fires on a cron schedule (e.g. every morning at 9am, every Friday at 5pm)
+- Invokes an agent skill against one or more project targets
+- Publishes lifecycle events on the EventBus
+- Persists execution outcomes to `knowledge.db`
+- Optionally notifies a Discord channel on completion
+
+Ceremonies are defined in YAML files placed in `workspace/ceremonies/`. They are loaded at startup and hot-reloaded every 5 seconds when files change, with no restart required.
+
+## YAML Schema
+
+Each ceremony is defined in its own `.yaml` file inside `workspace/ceremonies/`.
+
+```yaml
+id: board.pr-audit          # required — unique ceremony identifier
+name: PR Audit              # required — human-readable name
+schedule: "0 9 * * 1-5"    # required — cron expression (UTC)
+skill: audit-prs            # required — agent skill to invoke
+targets:                    # required — project paths or ['all']
+  - projects/my-project
+notifyChannel: eng-standup  # optional — Discord channel slug for notifications
+enabled: true               # optional — defaults to true; set false to pause
+```
+
+### Field Reference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | yes | Unique identifier, e.g. `board.pr-audit`. Used in bus topics. |
+| `name` | string | yes | Human-readable name shown in logs and notifications. |
+| `schedule` | string | yes | Standard 5-field cron expression (UTC). |
+| `skill` | string | yes | Agent skill invoked when the ceremony fires. |
+| `targets` | string[] | yes | Non-empty list of project paths, or `['all']` to target all projects. |
+| `notifyChannel` | string | no | Discord channel slug for outcome notifications. |
+| `enabled` | boolean | no | Whether this ceremony is active. Defaults to `true`. |
+
+### Cron Expression Examples
+
+| Expression | Meaning |
+|------------|---------|
+| `0 9 * * 1-5` | 9:00 AM UTC, Monday–Friday |
+| `0 17 * * 5` | 5:00 PM UTC on Fridays |
+| `0 */3 * * *` | Every 3 hours |
+| `0 8 * * 1` | 8:00 AM UTC every Monday |
+
+## File Layout
+
+```
+workspace/
+  ceremonies/                        # global ceremonies (all projects)
+    board-pr-audit.yaml
+    weekly-sprint-review.yaml
+
+.automaker/
+  projects/
+    {project-slug}/
+      ceremonies/                    # project-scoped overrides
+        board-pr-audit.yaml          # overrides global ceremony with same id
+```
+
+Project-level ceremonies with the same `id` override global ones. All other global ceremonies are inherited unchanged.
+
+## How CeremonyPlugin Integrates with the Scheduler and Bus
+
+At startup, `CeremonyPlugin.install(bus)`:
+
+1. Loads all ceremony YAML files via `CeremonyYamlLoader`
+2. Schedules a cron timer for each enabled ceremony
+3. Starts a 5-second hot-reload polling loop
+
+When a ceremony fires:
+
+1. Publishes `ceremony.{id}.execute` on the EventBus
+2. Publishes `agent.skill.request` to dispatch the skill to an agent
+3. Waits up to 120 seconds for `agent.skill.response.{runId}`
+4. Publishes `ceremony.{id}.completed` with the outcome
+5. Persists the outcome to `knowledge.db` (capped at 500 entries per ceremony)
+6. Sends a Discord notification if `notifyChannel` is set
+
+## Bus Topics
+
+| Topic | Direction | Description |
+|-------|-----------|-------------|
+| `ceremony.{id}.execute` | published | Fired when a ceremony's cron triggers |
+| `ceremony.{id}.completed` | published | Fired after a ceremony run finishes |
+| `agent.skill.request` | published | Dispatches the skill to an agent for execution |
+| `agent.skill.response.{runId}` | subscribed | Result from the agent skill execution |
+| `ceremony.#` | subscribed | Wildcard — used internally to intercept completed events |
+| `world.state.snapshot` | published | Ceremony state update via `CeremonyStateExtension` |
+
+### Execute Payload (`ceremony.{id}.execute`)
+
+```typescript
+{
+  type: "ceremony.execute",
+  context: {
+    runId: string,          // UUID for this run
+    ceremonyId: string,
+    projectPaths: string[], // resolved targets
+    startedAt: number,      // Unix ms
+  },
+  skill: string,
+  ceremonyName: string,
+}
+```
+
+### Completed Payload (`ceremony.{id}.completed`)
+
+```typescript
+{
+  type: "ceremony.completed",
+  outcome: {
+    runId: string,
+    ceremonyId: string,
+    skill: string,
+    status: "success" | "failure" | "timeout",
+    duration: number,       // ms
+    targets: string[],
+    startedAt: number,
+    completedAt: number,
+    result?: string,        // optional summary from skill
+    error?: string,         // set on failure or timeout
+  }
+}
+```
+
+## Built-in vs Custom Ceremonies
+
+**Built-in ceremonies** ship as default YAML files in `src/plugins/ceremonies/defaults/`. On first run, CeremonyPlugin copies any missing defaults into `workspace/ceremonies/`. You can edit these files to customize them — they will not be overwritten on subsequent runs.
+
+**Custom ceremonies** are any YAML files you add to `workspace/ceremonies/` or `.automaker/projects/{slug}/ceremonies/`. There is no registration step — just drop the file and it will be picked up within 5 seconds.
+
+## Outcome Persistence
+
+Ceremony outcomes are stored in `knowledge.db` using `CeremonyOutcomesRepository`. Each ceremony retains up to 500 historical outcomes; older entries are pruned automatically. Status values are `success`, `failure`, and `timeout` (after 120 seconds with no skill response).


### PR DESCRIPTION
## Summary

## Goal

Write docs for CeremonyPlugin — recurring scheduled rituals defined in YAML.

## Files to create

**`docs/reference/ceremony-plugin.md`**

- What a ceremony is (scheduled ritual: board health check, PR triage, sprint review)
- `workspace/ceremonies.yaml` schema: name, cron, trigger, agent, skill
- How ceremonies integrate with the scheduler and bus
- Built-in ceremony types vs custom
- All bus topics

**`docs/how-to/create-a-ceremony.md`**

- Step-by-step: add a ceremony to `workspace/c...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-08T02:58:19.564Z -->