### PR TITLE
docs: Google Workspace Plugin — reference + how-to

### DIFF
--- a/docs/how-to/set-up-google-workspace.md
+++ b/docs/how-to/set-up-google-workspace.md
@@ -4,48 +4,93 @@ _This is a how-to guide. It covers OAuth2 credentials, the `google.yaml` configu
 
 ---
 
-The Google Workspace plugin (`lib/plugins/google.ts`) bridges Google Drive, Calendar, and Gmail to the Workstacean bus. Each service is independently optional — configure only the ones you need.
+The Google Workspace plugin (`lib/plugins/google.ts`) bridges Google Drive, Calendar, Gmail, and Docs to the Workstacean bus. Each service is independently optional — configure only the ones you need.
 
 ---
 
 ## 1. Create a Google Cloud project and OAuth2 credentials
 
-1. Go to [console.cloud.google.com](https://console.cloud.google.com) and create a project.
-2. Enable the APIs you need:
+1. Go to [console.cloud.google.com](https://console.cloud.google.com) and create or select a project.
+2. Enable the APIs you need under **APIs & Services → Library**:
    - **Google Drive API**
    - **Google Calendar API**
    - **Gmail API**
-3. Under **APIs & Services → Credentials**, create an **OAuth 2.0 Client ID** (type: Web application or Desktop app depending on your setup).
-4. Download the credentials JSON and store the relevant values as environment variables:
-
-| Variable | Description |
-|----------|-------------|
-| `GOOGLE_CLIENT_ID` | OAuth2 client ID |
-| `GOOGLE_CLIENT_SECRET` | OAuth2 client secret |
-| `GOOGLE_REFRESH_TOKEN` | Long-lived refresh token (obtained via OAuth2 flow) |
-
-The plugin is **skipped** if `GOOGLE_CLIENT_ID` is not set.
-
-### Obtaining the refresh token
-
-Run the OAuth2 authorization flow once to get a refresh token:
-
-```bash
-# Use the Google OAuth2 playground or a one-shot script:
-# https://developers.google.com/oauthplayground/
-```
-
-Store the refresh token in Infisical (AI project `11e172e0`) under `GOOGLE_REFRESH_TOKEN`. The plugin exchanges it for access tokens automatically.
+   - **Google Docs API**
+3. Under **APIs & Services → Credentials**, create an **OAuth 2.0 Client ID**.
+   - Choose **Web application** as the type.
+   - Add `http://localhost:8765` as an authorized redirect URI.
+4. Note the **Client ID** and **Client Secret**.
 
 ---
 
-## 2. Configure google.yaml
+## 2. Obtain a refresh token
+
+Run the OAuth2 authorization flow once to obtain a long-lived refresh token.
+
+**Option A — Google OAuth2 Playground**
+
+1. Visit [developers.google.com/oauthplayground](https://developers.google.com/oauthplayground).
+2. In Settings (gear icon), check **Use your own OAuth credentials** and enter your Client ID and Client Secret.
+3. Select the following scopes:
+   - `https://www.googleapis.com/auth/drive`
+   - `https://www.googleapis.com/auth/calendar`
+   - `https://www.googleapis.com/auth/gmail.modify`
+   - `https://www.googleapis.com/auth/documents`
+4. Authorize, then exchange the authorization code for tokens.
+5. Copy the **refresh token** from the response.
+
+**Option B — manual curl flow**
+
+```bash
+# Step 1: Visit this URL in a browser and authorize
+# Replace CLIENT_ID with yours
+https://accounts.google.com/o/oauth2/v2/auth?\
+  client_id=CLIENT_ID&\
+  redirect_uri=http%3A%2F%2Flocalhost%3A8765&\
+  response_type=code&\
+  scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive+\
+        https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar+\
+        https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.modify+\
+        https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdocuments&\
+  access_type=offline&\
+  prompt=consent
+
+# Step 2: Exchange the code for a refresh token
+curl -s -X POST https://oauth2.googleapis.com/token \
+  -d "code=CODE&\
+      client_id=CLIENT_ID&\
+      client_secret=CLIENT_SECRET&\
+      redirect_uri=http://localhost:8765&\
+      grant_type=authorization_code"
+```
+
+Copy the `refresh_token` value from the JSON response.
+
+---
+
+## 3. Store credentials in Infisical
+
+Store all three values in Infisical (project `11e172e0-a1f6-41d5-9464-df72779a7063`, env `prod`):
+
+| Infisical key | Value |
+|---------------|-------|
+| `GOOGLE_CLIENT_ID` | OAuth2 client ID |
+| `GOOGLE_CLIENT_SECRET` | OAuth2 client secret |
+| `GOOGLE_REFRESH_TOKEN` | Refresh token from step 2 |
+
+The plugin reads these at startup. If any are missing, the plugin logs a message and disables itself:
+
+```
+[google] GOOGLE_CLIENT_ID/SECRET/REFRESH_TOKEN not set — plugin disabled
+```
+
+---
+
+## 4. Configure `workspace/google.yaml`
 
 Place `google.yaml` in your workspace directory (default: `workspace/google.yaml`):
 
 ```yaml
-# workspace/google.yaml
-
 drive:
   orgFolderId: ""         # root org Drive folder — shared across all projects
   templateFolderId: ""    # per-project folder template (optional)
@@ -62,14 +107,12 @@ gmail:
   # - label: "bug-report"
   #   skillHint: bug_triage
   # - label: "gtm-request"
-  #   skillHint: content_review
+  #   skillHint: content_strategy
 ```
 
----
+### Setting `drive.orgFolderId`
 
-## 3. Enable Drive integration
-
-Set `drive.orgFolderId` to the Google Drive folder ID you want to use as the org root. The folder ID is the last path component of the Drive URL:
+The folder ID is the last path segment of the Drive folder URL:
 
 ```
 https://drive.google.com/drive/folders/1ABC123XYZ
@@ -77,27 +120,13 @@ https://drive.google.com/drive/folders/1ABC123XYZ
                                         this is the ID
 ```
 
-The plugin will surface Drive events to the bus. Agents can read/write Drive files via the available Drive tools.
+### Setting `calendar.orgCalendarId`
 
----
+Find this in Google Calendar → Settings → the calendar → **Calendar ID**. It usually looks like an email address (`team@example.com` or a long `@group.calendar.google.com` string).
 
-## 4. Enable Calendar integration
+### Configuring Gmail routing
 
-Set `calendar.orgCalendarId` to your shared org calendar's ID (found in Google Calendar → Settings → Calendar Settings → Calendar ID — typically an email-like string).
-
-The plugin polls the calendar every `pollIntervalMinutes` for upcoming events and publishes them to:
-
-```
-google.calendar.event.upcoming
-```
-
-Agents subscribed to this topic can trigger reminders, board updates, or ceremony checks.
-
----
-
-## 5. Enable Gmail routing
-
-Gmail routing turns labeled emails into bus messages routed to specific skills.
+Gmail routing turns labeled emails into bus messages routed to specific skills:
 
 ```yaml
 gmail:
@@ -109,37 +138,35 @@ gmail:
     - label: "bug-report"
       skillHint: bug_triage
     - label: "gtm-request"
-      skillHint: content_review
+      skillHint: content_strategy
 ```
 
-The plugin polls Gmail every `pollIntervalMinutes`, finds messages with the specified labels, and publishes them to:
-
-```
-message.inbound.gmail.{label}
-```
-
-with `skillHint` set from `routingRules`. The A2APlugin routes these to the appropriate agent.
+The plugin polls Gmail every `pollIntervalMinutes`, finds unread messages with the specified labels, and publishes them to `message.inbound.google.gmail` with `skillHint` set from `routingRules`.
 
 ---
 
-## 6. Restart to apply changes
+## 5. Verify the plugin started
 
-```bash
-docker restart workstacean
-```
-
-On startup, the plugin logs which services it activated:
+After setting credentials and restarting the container, look for these log lines:
 
 ```
-[GooglePlugin] Drive enabled — orgFolderId: 1ABC123XYZ
-[GooglePlugin] Calendar enabled — polling every 60 minutes
-[GooglePlugin] Gmail enabled — watching labels: bug-report, gtm-request
+[google] Access token refreshed (expires in 3599s)
+[google] Gmail poller started (interval: 5m, labels: bug-report, gtm-request)
+[google] Calendar poller started (interval: 60m)
+[google] Plugin installed — Drive, Docs, Gmail, Calendar active
+```
+
+If a service is skipped due to missing config, it logs a message explaining why:
+
+```
+[google] Gmail polling skipped — no watchLabels configured
+[google] Calendar polling skipped — no orgCalendarId configured
 ```
 
 ---
 
 ## Related docs
 
-- [reference/bus-topics.md](../reference/bus-topics.md) — Google bus topics
-- [reference/config-files.md](../reference/config-files.md) — full `google.yaml` schema
-- [explanation/plugin-lifecycle.md](../explanation/plugin-lifecycle.md) — plugin install/uninstall lifecycle
+- [reference/google-workspace.md](../reference/google-workspace.md) — full config schema, bus topics, and agent reference
+- [reference/bus-topics.md](../reference/bus-topics.md) — complete bus topic catalogue
+- [reference/config-files.md](../reference/config-files.md) — all workspace config files

--- a/docs/reference/google-workspace.md
+++ b/docs/reference/google-workspace.md
@@ -1,0 +1,176 @@
+# Google Workspace Plugin Reference
+
+_This is a reference doc. It covers the plugin overview, configuration schema, bus topics, credentials, and agent usage._
+
+---
+
+## Overview
+
+The Google Workspace plugin (`lib/plugins/google.ts`) bridges four Google services to the Workstacean bus:
+
+| Service | Direction | What it does |
+|---------|-----------|--------------|
+| **Gmail** | Inbound (polling) | Watches configured labels; publishes unread messages to the bus |
+| **Calendar** | Inbound (polling) | Fetches upcoming events in the next 7 days; publishes to the bus |
+| **Drive** | Outbound (subscription) | Handles file create, update, and append operations |
+| **Docs** | Outbound (subscription) | Handles document create and text-insert operations |
+
+The plugin is **disabled entirely** if any of `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, or `GOOGLE_REFRESH_TOKEN` are missing. All three must be set.
+
+`workspace/google.yaml` is **hot-reloaded** — changes apply without restarting the container. Polling intervals and label lists are restarted automatically when they change.
+
+---
+
+## Configuration schema — `workspace/google.yaml`
+
+```yaml
+drive:
+  orgFolderId: ""        # Google Drive folder ID for the org root (shared across projects)
+  templateFolderId: ""   # Per-project folder template (optional)
+
+calendar:
+  orgCalendarId: ""              # Calendar ID for the shared org calendar
+  pollIntervalMinutes: 60        # How often to poll for upcoming events (default: 60)
+
+gmail:
+  watchLabels: []                # Gmail labels to watch for inbound messages
+  pollIntervalMinutes: 5         # How often to poll each label (default: 5)
+  routingRules: []               # Label → skillHint mappings
+  # Example:
+  # - label: "bug-report"
+  #   skillHint: bug_triage
+  # - label: "gtm-request"
+  #   skillHint: content_strategy
+```
+
+### Field reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `drive.orgFolderId` | string | `""` | Root org Drive folder ID. Required for Drive operations. |
+| `drive.templateFolderId` | string | `""` | Template folder for new project folders (optional). |
+| `calendar.orgCalendarId` | string | `""` | Google Calendar ID (e.g. `user@example.com`). Required for Calendar polling. |
+| `calendar.pollIntervalMinutes` | number | `60` | Polling interval for calendar events. |
+| `gmail.watchLabels` | string[] | `[]` | Gmail label names to watch. Gmail polling is skipped if empty. |
+| `gmail.pollIntervalMinutes` | number | `5` | Polling interval per label. |
+| `gmail.routingRules` | RoutingRule[] | `[]` | Maps a label to a `skillHint` attached to the published bus message. |
+
+#### `RoutingRule`
+
+```yaml
+- label: "bug-report"    # Gmail label name (case-insensitive)
+  skillHint: bug_triage  # Skill hint attached to the published message payload
+```
+
+---
+
+## `projects.yaml` extensions
+
+Per-project Google Workspace overrides can be added to each project entry in `workspace/projects.yaml`:
+
+```yaml
+projects:
+  - slug: my-project
+    # ...
+    googleWorkspace:
+      driveFolderId: "1ABC123XYZ"   # Project-specific Drive folder
+      sharedDocId: "1DEF456UVW"     # Shared Google Doc for this project
+      calendarId: "team@example.com" # Project-specific calendar (overrides org default)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `googleWorkspace.driveFolderId` | string | Project Drive folder ID. Used by Cindi when creating project files. |
+| `googleWorkspace.sharedDocId` | string | Shared Google Doc ID. Used by Jon and Quinn for running notes. |
+| `googleWorkspace.calendarId` | string | Project calendar ID. Overrides `calendar.orgCalendarId` for this project. |
+
+---
+
+## Bus topics
+
+### Inbound topics (published by the plugin)
+
+| Topic | Trigger | Payload fields |
+|-------|---------|----------------|
+| `message.inbound.google.gmail` | New unread message found matching a watched label | `messageId`, `threadId`, `label`, `from`, `to`, `subject`, `date`, `body` (≤4000 chars), `skillHint` (if routing rule matched) |
+| `message.inbound.google.calendar` | Calendar poll found upcoming events | `events[]` (id, title, description, start, end, attendees, link), `window` (from, to) |
+
+### Outbound topics (subscribed by the plugin)
+
+Publish to these topics to trigger Drive or Docs operations. Set `reply.topic` on your message to receive the result.
+
+#### `message.outbound.google.drive`
+
+| `operation` | Required fields | Optional fields | Returns |
+|-------------|----------------|-----------------|---------|
+| `create` | `name`, `mimeType` | `parentId`, `content` | `fileId`, `name`, `webViewLink` |
+| `update` | `fileId`, `content` | — | `fileId`, `name` |
+| `append` | `fileId`, `content` | — | `fileId`, `name` |
+
+Example:
+```json
+{
+  "operation": "create",
+  "name": "Project Brief",
+  "mimeType": "text/plain",
+  "parentId": "1ABC123XYZ",
+  "content": "Initial content here"
+}
+```
+
+#### `message.outbound.google.docs`
+
+| `operation` | Required fields | Optional fields | Returns |
+|-------------|----------------|-----------------|---------|
+| `create` | `title` | `content` | `documentId`, `title`, `link` |
+| `insert` | `documentId`, `content` | `index` (default: 1) | `documentId`, `link` |
+| `update` | `documentId`, `content` | `index` (default: 1) | `documentId`, `link` |
+
+Example:
+```json
+{
+  "operation": "create",
+  "title": "Sprint Retro — 2026-Q1",
+  "content": "## Summary\n\n..."
+}
+```
+
+### System topics
+
+| Topic | When | Payload |
+|-------|------|---------|
+| `auth.token_refresh_failed` | Access token refresh failed after 3 retries | `{ plugin: "google", reason: string }` |
+| `config.updated` | `google.yaml` was hot-reloaded | `{ plugin: "google", config: "google.yaml" }` |
+
+---
+
+## Credentials
+
+All three secrets must be injected at runtime (from Infisical, project `11e172e0-a1f6-41d5-9464-df72779a7063`, env `prod`):
+
+| Secret | Infisical key | Description |
+|--------|---------------|-------------|
+| OAuth2 client ID | `GOOGLE_CLIENT_ID` | Created in Google Cloud Console → APIs & Services → Credentials |
+| OAuth2 client secret | `GOOGLE_CLIENT_SECRET` | Paired with the client ID |
+| OAuth2 refresh token | `GOOGLE_REFRESH_TOKEN` | Long-lived token; exchanged for short-lived access tokens automatically |
+
+The plugin refreshes the access token automatically. Tokens are cached in memory with a 5-minute safety buffer. A background job proactively refreshes when fewer than 10 minutes remain.
+
+---
+
+## Agents that use this plugin
+
+| Agent | Services used | How |
+|-------|--------------|-----|
+| **Jon** | Docs | Creates and updates Google Docs for project artefacts |
+| **Cindi** | Drive | Creates per-project folders; uploads files to Drive |
+| **Ava** | Calendar | Reads upcoming events via `message.inbound.google.calendar` to signal deadlines |
+| **Quinn** | Docs | Reads and writes shared Docs for portfolio summaries and PR reviews |
+
+---
+
+## See also
+
+- [`docs/how-to/set-up-google-workspace.md`](../how-to/set-up-google-workspace.md) — step-by-step OAuth2 setup
+- [`docs/reference/bus-topics.md`](bus-topics.md) — full bus topic catalogue
+- [`docs/reference/config-files.md`](config-files.md) — all workspace config files


### PR DESCRIPTION
Cherry-pick of the Google Workspace docs commit onto current main (original PR #28 was conflicting due to squash merge history).

Adds `docs/reference/google-workspace.md` — OAuth2 setup, plugin config, workspace/google.yaml reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Google Workspace setup guide to support Docs alongside Drive, Calendar, and Gmail
  * Streamlined OAuth credential configuration and refresh token acquisition processes
  * Added comprehensive reference documentation for Google Workspace plugin configuration and operations
  * Improved credential requirement validation and plugin startup verification procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->