### PR TITLE
feat: wire world.goal.violated → L0 planner cascade + register CeremonyPlugin + FlowMonitorPlugin

### DIFF
--- a/src/config/goals_config.ts
+++ b/src/config/goals_config.ts
@@ -10,7 +10,7 @@ export interface GoalsConfig {
 }
 
 export const DEFAULT_GOALS_CONFIG: GoalsConfig = {
-  observeOnly: true,
+  observeOnly: false,
   workspaceDir: "workspace",
   evaluationIntervalMs: 0,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,9 @@ import { LoggerPlugin } from "../lib/plugins/logger";
 import { CLIPlugin } from "../lib/plugins/cli";
 import { SignalPlugin } from "../lib/plugins/signal";
 import { SchedulerPlugin } from "../lib/plugins/scheduler";
+import { ActionRegistry } from "./planner/action-registry";
 import type { Plugin, BusMessage } from "../lib/types";
+import type { Action } from "./planner/types/action";
 
 // --- Workspace config ---
 const workspaceDir = resolve(
@@ -22,6 +24,53 @@ const dataDir = resolve(
 );
 
 const bus = new InMemoryEventBus();
+
+// --- Shared ActionRegistry — populated from workspace/actions.yaml ---
+const actionRegistry = new ActionRegistry();
+
+function loadActionsYaml(): void {
+  const actionsPath = join(workspaceDir, "actions.yaml");
+  if (!existsSync(actionsPath)) return;
+  try {
+    const raw = parseYaml(readFileSync(actionsPath, "utf8")) as { actions?: Record<string, unknown>[] };
+    const actionsData = raw?.actions ?? [];
+    for (const a of actionsData) {
+      try {
+        const action: Action = {
+          id: a.id as string,
+          name: a.name as string,
+          description: (a.description as string) ?? "",
+          goalId: a.goalId as string,
+          tier: a.tier as Action["tier"],
+          priority: typeof a.priority === "number" ? a.priority : 0,
+          cost: typeof a.cost === "number" ? a.cost : 0,
+          preconditions: Array.isArray(a.preconditions)
+            ? (a.preconditions as Array<{ path: string; operator: string; value?: unknown }>).map((p) => ({
+                path: p.path,
+                operator: p.operator as Action["preconditions"][number]["operator"],
+                value: p.value,
+              }))
+            : [],
+          effects: Array.isArray(a.effects)
+            ? (a.effects as Array<{ path: string; op?: string; operation?: string; value?: unknown }>).map((e) => ({
+                path: e.path,
+                operation: ((e.operation ?? e.op) as Action["effects"][number]["operation"]),
+                value: e.value,
+              }))
+            : [],
+          meta: typeof a.meta === "object" && a.meta !== null ? (a.meta as Action["meta"]) : {},
+        };
+        actionRegistry.upsert(action);
+      } catch (err) {
+        console.warn(`[actions-loader] Skipping invalid action '${a.id}':`, err);
+      }
+    }
+    console.info(`[actions-loader] Loaded ${actionRegistry.size} action(s) from workspace/actions.yaml`);
+  } catch (err) {
+    console.error("[actions-loader] Failed to parse workspace/actions.yaml:", err);
+  }
+}
+loadActionsYaml();
 
 // Core plugins — always loaded, statically imported (no dynamic overhead needed)
 const debugPlugin = new DebugPlugin();
@@ -121,6 +170,38 @@ const pluginRegistry: PluginRegistryEntry[] = [
     factory: async () => {
       const { EventViewerPlugin } = await import("../lib/plugins/event-viewer");
       return new EventViewerPlugin();
+    },
+  },
+  {
+    name: "goal-evaluator",
+    condition: () => true,
+    factory: async () => {
+      const { GoalEvaluatorPlugin } = await import("./plugins/goal_evaluator_plugin.js");
+      return new GoalEvaluatorPlugin({ workspaceDir });
+    },
+  },
+  {
+    name: "planner-l0",
+    condition: () => true,
+    factory: async () => {
+      const { PlannerPluginL0 } = await import("./plugins/planner-plugin-l0.js");
+      return new PlannerPluginL0(actionRegistry);
+    },
+  },
+  {
+    name: "ceremony",
+    condition: () => true,
+    factory: async () => {
+      const { CeremonyPlugin } = await import("./plugins/CeremonyPlugin.js");
+      return new CeremonyPlugin({ workspaceDir });
+    },
+  },
+  {
+    name: "flow-monitor",
+    condition: () => true,
+    factory: async () => {
+      const { FlowMonitorPlugin } = await import("../lib/plugins/flow-monitor.js");
+      return new FlowMonitorPlugin();
     },
   },
   // Built-ins: opt-in via ENABLED_PLUGINS=echo,...

--- a/src/plugins/goal_evaluator_plugin.ts
+++ b/src/plugins/goal_evaluator_plugin.ts
@@ -26,8 +26,7 @@ export class GoalEvaluatorPlugin implements Plugin, IGoalEvaluatorPlugin {
   readonly description = "Observe-only goal registry evaluator — diffs world state against goals and emits violations";
   readonly capabilities = ["goals", "evaluation", "observe-only"];
 
-  /** observeOnly: always true — planner actions are not supported in this milestone */
-  private readonly observeOnly: boolean = true;
+  private readonly observeOnly: boolean;
 
   private config: GoalsConfig;
   private loader: GoalsLoader;
@@ -48,6 +47,7 @@ export class GoalEvaluatorPlugin implements Plugin, IGoalEvaluatorPlugin {
 
   constructor(config?: Partial<GoalsConfig>) {
     this.config = { ...DEFAULT_GOALS_CONFIG, ...config };
+    this.observeOnly = this.config.observeOnly;
     this.loader = new GoalsLoader(this.config.workspaceDir, this.config.projectsBaseDir);
     this.langfuse = new LangfuseLogger();
     this.discord = new DiscordLogger();
@@ -158,9 +158,9 @@ export class GoalEvaluatorPlugin implements Plugin, IGoalEvaluatorPlugin {
       return;
     }
 
-    // Safety guard: never trigger planner actions in observe-only mode
-    if (!this.observeOnly) {
-      console.warn("[goal-evaluator] Planner action requested — feature not yet supported; dropping request");
+    // Safety guard: in observe-only mode, log but do not emit to bus
+    if (this.observeOnly) {
+      console.info(`[goal-evaluator] OBSERVE-ONLY VIOLATION [${violation.severity.toUpperCase()}] goal="${violation.goalId}" — ${violation.message}`);
       return;
     }
 

--- a/src/plugins/planner-plugin-l0.ts
+++ b/src/plugins/planner-plugin-l0.ts
@@ -20,6 +20,7 @@ import type {
   ActionOscillationPayload,
   PlannerEscalatePayload,
 } from "../event-bus/action-events.ts";
+import type { GoalViolatedEventPayload } from "../types/events.ts";
 import { TOPICS } from "../event-bus/topics.ts";
 import { ActionRegistry } from "../planner/action-registry.ts";
 import { matchActions } from "../planner/pattern-matcher.ts";
@@ -85,6 +86,28 @@ export class PlannerPluginL0 implements Plugin {
       }
     );
     this.subscriptionIds.push(outcomeId);
+
+    // React to goal violations by dispatching matching tier_0 actions
+    const violationSubId = bus.subscribe(
+      "world.goal.violated",
+      this.name,
+      async (msg: BusMessage) => {
+        const payload = msg.payload as GoalViolatedEventPayload;
+        const violation = payload.violation;
+        const matchingActions = this.registry.getByGoal(violation.goalId);
+        for (const action of matchingActions) {
+          if (this.inFlightGoals.has(action.goalId)) continue;
+          if (this.cooldownManager.isOnCooldown(action.goalId, action.id)) continue;
+          if (this.loopDetector.isOscillating(action.goalId, action.id)) {
+            this.handleOscillation(action.goalId, action.id, msg.correlationId);
+            continue;
+          }
+          this.inFlightGoals.add(action.goalId);
+          this.dispatchAction(action, {} as WorldState, msg.correlationId);
+        }
+      }
+    );
+    this.subscriptionIds.push(violationSubId);
   }
 
   uninstall(): void {

--- a/workspace/actions.yaml
+++ b/workspace/actions.yaml
@@ -1,0 +1,50 @@
+# World Engine Actions — mapped to goals by goalId
+# Tier 0 = deterministic/free, Tier 1 = A* planned, Tier 2 = Ava LLM
+
+actions:
+  - id: alert.efficiency_low
+    goalId: flow.efficiency_healthy
+    tier: tier_0
+    priority: 10
+    cost: 1
+    name: "Alert on low flow efficiency"
+    preconditions:
+      - path: "domains.board.data.efficiency"
+        operator: lt
+        value: 0.35
+    effects: []
+    meta:
+      topic: "message.outbound.discord.alert"
+      agentId: ava
+
+  - id: alert.distribution_drift
+    goalId: flow.distribution_balanced
+    tier: tier_0
+    priority: 10
+    cost: 1
+    name: "Alert on board distribution drift"
+    preconditions:
+      - path: "domains.board.data.distribution.feature"
+        operator: lt
+        value: 0.40
+    effects: []
+    meta:
+      topic: "message.outbound.discord.alert"
+      agentId: ava
+
+  - id: ceremony.service_health_check
+    goalId: services.all_healthy
+    tier: tier_0
+    priority: 5
+    cost: 1
+    name: "Trigger service health check ceremony"
+    preconditions:
+      - path: "domains.services.metadata.failed"
+        operator: eq
+        value: true
+    effects:
+      - path: "domains.services.metadata.failed"
+        operation: set
+        value: false
+    meta:
+      topic: "ceremony.health_check.execute"

--- a/workspace/ceremonies/daily-standup.yaml
+++ b/workspace/ceremonies/daily-standup.yaml
@@ -1,0 +1,9 @@
+id: daily-standup
+name: "Daily Fleet Standup"
+description: "Morning ceremony: board summary, active ceremonies, open PRs"
+cron: "0 9 * * 1-5"   # 9am Mon-Fri
+skill: board_audit
+targets:
+  - ava
+discord:
+  channel: "1469195643590541353"  # #ava channel

--- a/workspace/goals.yaml
+++ b/workspace/goals.yaml
@@ -1,0 +1,26 @@
+# World Engine Goals — Global
+# Per-project overrides: .automaker/projects/{slug}/goals.yaml
+
+goals:
+  - id: flow.efficiency_healthy
+    type: Threshold
+    severity: medium
+    selector: "domains.board.data.efficiency"
+    min: 0.35
+    description: "Flow efficiency must stay >= 35%"
+
+  - id: flow.distribution_balanced
+    type: Distribution
+    severity: medium
+    description: "Board must have >= 40% features, <= 30% defects"
+    distribution:
+      feature: 0.40
+      defect: 0.30
+    tolerance: 0.10
+
+  - id: services.all_healthy
+    type: Invariant
+    severity: high
+    selector: "domains.services.metadata.failed"
+    operator: falsy
+    description: "No service collection failures"


### PR DESCRIPTION
## Summary

**Goal:** Complete the World Engine's self-correcting loop. Right now `GoalEvaluatorPlugin` emits `world.goal.violated` but nothing listens to it — the cascade stops there. Wire the full loop:

```
world.state.updated → GoalEvaluatorPlugin → world.goal.violated
                                                    ↓
                                          PlannerPluginL0 (NEW subscription)
                                                    ↓
                                          world.actio...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled planner actions by default; previously the system operated in observe-only mode.
  * Added automatic goal-violation response handling with reactive event detection.
  * Introduced workspace goal definitions for efficiency monitoring, distribution balancing, and service health checks.
  * Added configurable action and ceremony scheduling support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->