### PR TITLE
bug: projects.yaml file watcher fires 14+ times — no debounce on watcher callbacks

### DIFF
--- a/lib/plugins/a2a.ts
+++ b/lib/plugins/a2a.ts
@@ -122,9 +122,13 @@ export class A2APlugin implements Plugin {
 
     // Re-index on file change so the process can pick up new entries without restart.
     if (existsSync(projectsPath)) {
+      let debounceTimer: ReturnType<typeof setTimeout> | null = null;
       watchFile(projectsPath, { interval: 5_000 }, () => {
-        this.index = buildIndex(projectsPath);
-        console.log(`[a2a] projects.yaml changed — reloaded ${this.index.size} project(s)`);
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => {
+          this.index = buildIndex(projectsPath);
+          console.log(`[a2a] projects.yaml changed — reloaded ${this.index.size} project(s)`);
+        }, 300);
       });
     }
 

--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -230,10 +230,14 @@ export class GitHubPlugin implements Plugin {
     const configPath = join(this.workspaceDir, "github.yaml");
     const projectsPath = join(this.workspaceDir, "projects.yaml");
 
+    let reloadDebounceTimer: ReturnType<typeof setTimeout> | null = null;
     const reloadConfig = () => {
-      this.config = loadConfig(this.workspaceDir);
-      const repoCount = this.config.autoTriage?.monitoredRepos?.length ?? 0;
-      console.log(`[github] Config reloaded — ${repoCount} monitored repo(s)`);
+      if (reloadDebounceTimer) clearTimeout(reloadDebounceTimer);
+      reloadDebounceTimer = setTimeout(() => {
+        this.config = loadConfig(this.workspaceDir);
+        const repoCount = this.config.autoTriage?.monitoredRepos?.length ?? 0;
+        console.log(`[github] Config reloaded — ${repoCount} monitored repo(s)`);
+      }, 300);
     };
 
     // watchFile works even if the file doesn't exist yet — it will fire on creation.


### PR DESCRIPTION
## Summary

**Root cause (QA smoke test finding):** The `projects.yaml changed` log line fired 14 times over 5 hours. Both `feature-notifier` and `plane-hitl` reload on every watcher event. The file watcher has no debounce — editor saves, rclone syncs, or other processes writing to `projects.yaml` trigger N rapid re-reads.

**Fix:** Add a debounce (200-500ms) to the `watchFile` callbacks in any plugin that watches `projects.yaml`. Pattern already exists in other plugins with `watchFile`; just add:
```ts
let...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized file monitoring and configuration reloading with debouncing. During rapid successive file changes, processing is now deferred to eliminate redundant operations, improving system efficiency and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->