### PR TITLE
bug: no circuit breaker on external API calls — Google/Plane/GitHub will spam retries on outage

### DIFF
--- a/lib/plane-client.ts
+++ b/lib/plane-client.ts
@@ -36,6 +36,8 @@ export interface PlaneWebhook {
   [key: string]: unknown;
 }
 
+import { withCircuitBreaker } from "./plugins/circuit-breaker.ts";
+
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
 /** Escape HTML entities to prevent XSS when embedding text in comment_html. */
@@ -81,7 +83,9 @@ export class PlaneClient {
     const map = new Map<string, string>();
     try {
       const url = `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/projects/${projectId}/labels/`;
-      const resp = await fetch(url, { headers: this.headers(), signal: AbortSignal.timeout(10_000) });
+      const resp = await withCircuitBreaker("plane-api", () =>
+        fetch(url, { headers: this.headers(), signal: AbortSignal.timeout(10_000) }),
+      );
       if (resp.ok) {
         const data = (await resp.json()) as { results?: PlaneLabel[] };
         for (const label of data.results ?? []) {
@@ -103,7 +107,9 @@ export class PlaneClient {
     const map = new Map<string, string>();
     try {
       const url = `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/projects/${projectId}/states/`;
-      const resp = await fetch(url, { headers: this.headers(), signal: AbortSignal.timeout(10_000) });
+      const resp = await withCircuitBreaker("plane-api", () =>
+        fetch(url, { headers: this.headers(), signal: AbortSignal.timeout(10_000) }),
+      );
       if (resp.ok) {
         const data = (await resp.json()) as { results?: PlaneState[] };
         for (const state of data.results ?? []) {
@@ -131,12 +137,14 @@ export class PlaneClient {
   async patchIssueState(projectId: string, issueId: string, stateUUID: string): Promise<boolean> {
     try {
       const url = `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/projects/${projectId}/work-items/${issueId}/`;
-      const resp = await fetch(url, {
-        method: "PATCH",
-        headers: this.headers(),
-        body: JSON.stringify({ state: stateUUID }),
-        signal: AbortSignal.timeout(10_000),
-      });
+      const resp = await withCircuitBreaker("plane-api", () =>
+        fetch(url, {
+          method: "PATCH",
+          headers: this.headers(),
+          body: JSON.stringify({ state: stateUUID }),
+          signal: AbortSignal.timeout(10_000),
+        }),
+      );
       if (!resp.ok) {
         console.error(`[plane-client] PATCH issue state failed: ${resp.status} ${await resp.text()}`);
         return false;
@@ -151,12 +159,14 @@ export class PlaneClient {
   async addIssueComment(projectId: string, issueId: string, comment: string): Promise<boolean> {
     try {
       const url = `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/projects/${projectId}/work-items/${issueId}/comments/`;
-      const resp = await fetch(url, {
-        method: "POST",
-        headers: this.headers(),
-        body: JSON.stringify({ comment_html: `<p>${escapeHtml(comment)}</p>` }),
-        signal: AbortSignal.timeout(10_000),
-      });
+      const resp = await withCircuitBreaker("plane-api", () =>
+        fetch(url, {
+          method: "POST",
+          headers: this.headers(),
+          body: JSON.stringify({ comment_html: `<p>${escapeHtml(comment)}</p>` }),
+          signal: AbortSignal.timeout(10_000),
+        }),
+      );
       if (!resp.ok) {
         console.error(`[plane-client] POST issue comment failed: ${resp.status} ${await resp.text()}`);
         return false;
@@ -180,7 +190,9 @@ export class PlaneClient {
   async listProjects(): Promise<PlanePlaneProject[]> {
     try {
       const url = `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/projects/`;
-      const resp = await fetch(url, { headers: this.headers(), signal: AbortSignal.timeout(10_000) });
+      const resp = await withCircuitBreaker("plane-api", () =>
+        fetch(url, { headers: this.headers(), signal: AbortSignal.timeout(10_000) }),
+      );
       if (!resp.ok) {
         console.warn(`[plane-client] Failed to list projects: ${resp.status}`);
         return [];
@@ -216,12 +228,14 @@ export class PlaneClient {
       const body: Record<string, unknown> = { name, identifier };
       if (description) body.description = description;
 
-      const resp = await fetch(url, {
-        method: "POST",
-        headers: this.headers(),
-        body: JSON.stringify(body),
-        signal: AbortSignal.timeout(15_000),
-      });
+      const resp = await withCircuitBreaker("plane-api", () =>
+        fetch(url, {
+          method: "POST",
+          headers: this.headers(),
+          body: JSON.stringify(body),
+          signal: AbortSignal.timeout(15_000),
+        }),
+      );
 
       if (!resp.ok) {
         const text = await resp.text();
@@ -239,7 +253,9 @@ export class PlaneClient {
   async listWebhooks(): Promise<PlaneWebhook[]> {
     try {
       const url = `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/webhooks/`;
-      const resp = await fetch(url, { headers: this.headers(), signal: AbortSignal.timeout(10_000) });
+      const resp = await withCircuitBreaker("plane-api", () =>
+        fetch(url, { headers: this.headers(), signal: AbortSignal.timeout(10_000) }),
+      );
       if (!resp.ok) return [];
       const data = (await resp.json()) as { results?: PlaneWebhook[] } | PlaneWebhook[];
       return Array.isArray(data) ? data : (data.results ?? []);
@@ -273,12 +289,14 @@ export class PlaneClient {
       };
       if (secret) body.secret = secret;
 
-      const resp = await fetch(url, {
-        method: "POST",
-        headers: this.headers(),
-        body: JSON.stringify(body),
-        signal: AbortSignal.timeout(15_000),
-      });
+      const resp = await withCircuitBreaker("plane-api", () =>
+        fetch(url, {
+          method: "POST",
+          headers: this.headers(),
+          body: JSON.stringify(body),
+          signal: AbortSignal.timeout(15_000),
+        }),
+      );
 
       if (!resp.ok) {
         const text = await resp.text();

--- a/lib/plugins/circuit-breaker.ts
+++ b/lib/plugins/circuit-breaker.ts
@@ -186,3 +186,49 @@ export class CircuitBreaker {
     return [...this.circuits.values()].map((c) => ({ ...c }));
   }
 }
+
+// ── External API circuit breaker utility ──────────────────────────────────────
+
+/** Module-level singleton circuit breaker for external service calls. */
+const _apiBreaker = new CircuitBreaker({
+  failureThreshold: 5,
+  recoveryWindowMs: 60_000, // 1 minute
+  successThreshold: 1,
+});
+
+/**
+ * Wraps an async external API call with a named circuit breaker.
+ *
+ * - CLOSED    → call executes normally
+ * - OPEN      → throws immediately without executing fn (circuit open)
+ * - HALF_OPEN → one test call is allowed through
+ *
+ * On network-level failure (fn throws): records the failure, may open the circuit.
+ * On success: records the success, may close a HALF_OPEN circuit.
+ *
+ * @param name  Unique circuit name, e.g. "plane-api", "google-api", "github-api"
+ * @param fn    The async function to guard
+ */
+export async function withCircuitBreaker<T>(
+  name: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (!_apiBreaker.isAllowed(name, "api")) {
+    const msg = `[circuit-breaker] ${name}: circuit OPEN — call rejected`;
+    console.warn(msg);
+    throw new Error(msg);
+  }
+  try {
+    const result = await fn();
+    _apiBreaker.recordSuccess(name, "api");
+    return result;
+  } catch (err) {
+    _apiBreaker.recordFailure(name, "api");
+    throw err;
+  }
+}
+
+/** Expose the internal breaker for testing/monitoring. */
+export function getApiBreaker(): CircuitBreaker {
+  return _apiBreaker;
+}

--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -26,6 +26,7 @@ import type { EventBus, BusMessage, Plugin } from "../types.ts";
 import { sanitizeIssueBody } from "../sanitize.ts";
 import type { SanitizationConfig } from "../sanitize.ts";
 import { makeGitHubAuth } from "../github-auth.ts";
+import { withCircuitBreaker } from "./circuit-breaker.ts";
 
 // ── Config types ──────────────────────────────────────────────────────────────
 
@@ -381,16 +382,18 @@ export class GitHubPlugin implements Plugin {
       } else {
         url = `https://api.github.com/repos/${ctx.owner}/${ctx.repo}/issues/${ctx.number}/reactions`;
       }
-      const res = await fetch(url, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-          "User-Agent": "protoWorkstacean/1.0",
-          "X-GitHub-Api-Version": "2022-11-28",
-        },
-        body: JSON.stringify({ content: "eyes" }),
-      });
+      const res = await withCircuitBreaker("github-api", () =>
+        fetch(url, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+            "User-Agent": "protoWorkstacean/1.0",
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+          body: JSON.stringify({ content: "eyes" }),
+        }),
+      );
       if (!res.ok) console.error(`[github] reaction failed ${res.status}: ${await res.text()}`);
     })().catch(err => console.error("[github] reaction error:", err));
 
@@ -529,15 +532,17 @@ export class GitHubPlugin implements Plugin {
     token: string,
   ): Promise<boolean> {
     try {
-      const res = await fetch(
-        `https://api.github.com/orgs/${orgName}/members/${username}`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "User-Agent": "protoWorkstacean/1.0",
-            "X-GitHub-Api-Version": "2022-11-28",
+      const res = await withCircuitBreaker("github-api", () =>
+        fetch(
+          `https://api.github.com/orgs/${orgName}/members/${username}`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+              "User-Agent": "protoWorkstacean/1.0",
+              "X-GitHub-Api-Version": "2022-11-28",
+            },
           },
-        },
+        ),
       );
       // 204 = member, 302/404 = not a member or org is private
       return res.status === 204;
@@ -564,14 +569,18 @@ export class GitHubPlugin implements Plugin {
       "that violates our submission guidelines. If you believe this is an error, please " +
       "open a new issue without the flagged content.";
 
-    await fetch(
-      `https://api.github.com/repos/${owner}/${repo}/issues/${number}/comments`,
-      { method: "POST", headers, body: JSON.stringify({ body: commentBody }) },
+    await withCircuitBreaker("github-api", () =>
+      fetch(
+        `https://api.github.com/repos/${owner}/${repo}/issues/${number}/comments`,
+        { method: "POST", headers, body: JSON.stringify({ body: commentBody }) },
+      ),
     );
 
-    await fetch(
-      `https://api.github.com/repos/${owner}/${repo}/issues/${number}`,
-      { method: "PATCH", headers, body: JSON.stringify({ state: "closed", state_reason: "not_planned" }) },
+    await withCircuitBreaker("github-api", () =>
+      fetch(
+        `https://api.github.com/repos/${owner}/${repo}/issues/${number}`,
+        { method: "PATCH", headers, body: JSON.stringify({ state: "closed", state_reason: "not_planned" }) },
+      ),
     );
   }
 
@@ -583,16 +592,18 @@ export class GitHubPlugin implements Plugin {
     try {
       const token = await getToken(ctx.owner, ctx.repo);
       const url = `https://api.github.com/repos/${ctx.owner}/${ctx.repo}/issues/${ctx.number}/comments`;
-      const res = await fetch(url, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-          "User-Agent": "protoWorkstacean/1.0",
-          "X-GitHub-Api-Version": "2022-11-28",
-        },
-        body: JSON.stringify({ body }),
-      });
+      const res = await withCircuitBreaker("github-api", () =>
+        fetch(url, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+            "User-Agent": "protoWorkstacean/1.0",
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+          body: JSON.stringify({ body }),
+        }),
+      );
       if (!res.ok) {
         console.error(`[github] Failed to post comment: ${res.status} ${await res.text()}`);
       } else {

--- a/lib/plugins/google.ts
+++ b/lib/plugins/google.ts
@@ -22,6 +22,7 @@ import { readFileSync, existsSync, watchFile, unwatchFile } from "node:fs";
 import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
 import type { EventBus, BusMessage, Plugin } from "../types.ts";
+import { withCircuitBreaker } from "./circuit-breaker.ts";
 
 // ── Config types ──────────────────────────────────────────────────────────────
 
@@ -163,19 +164,21 @@ export async function createDriveFolder(
   }
 
   try {
-    const resp = await fetch("https://www.googleapis.com/drive/v3/files", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        name,
-        mimeType: "application/vnd.google-apps.folder",
-        parents: [parentId],
+    const resp = await withCircuitBreaker("google-api", () =>
+      fetch("https://www.googleapis.com/drive/v3/files", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name,
+          mimeType: "application/vnd.google-apps.folder",
+          parents: [parentId],
+        }),
+        signal: AbortSignal.timeout(15_000),
       }),
-      signal: AbortSignal.timeout(15_000),
-    });
+    );
 
     if (!resp.ok) {
       const errBody = await resp.text().catch(() => "");
@@ -345,17 +348,19 @@ export class GooglePlugin implements Plugin {
         content +
         `\r\n--${boundary}--`;
 
-      const resp = await fetch(
-        "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart",
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": `multipart/related; boundary="${boundary}"`,
+      const resp = await withCircuitBreaker("google-api", () =>
+        fetch(
+          "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart",
+          {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${token}`,
+              "Content-Type": `multipart/related; boundary="${boundary}"`,
+            },
+            body,
+            signal: AbortSignal.timeout(30_000),
           },
-          body,
-          signal: AbortSignal.timeout(30_000),
-        },
+        ),
       );
 
       if (!resp.ok) {
@@ -367,15 +372,17 @@ export class GooglePlugin implements Plugin {
     }
 
     // Metadata-only create (folder, or file without content)
-    const resp = await fetch("https://www.googleapis.com/drive/v3/files", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(metadata),
-      signal: AbortSignal.timeout(15_000),
-    });
+    const resp = await withCircuitBreaker("google-api", () =>
+      fetch("https://www.googleapis.com/drive/v3/files", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(metadata),
+        signal: AbortSignal.timeout(15_000),
+      }),
+    );
 
     if (!resp.ok) {
       const errBody = await resp.text().catch(() => "");
@@ -398,9 +405,11 @@ export class GooglePlugin implements Plugin {
 
     let body = content;
     if (append) {
-      const fetchResp = await fetch(
-        `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`,
-        { headers: { Authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(15_000) },
+      const fetchResp = await withCircuitBreaker("google-api", () =>
+        fetch(
+          `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`,
+          { headers: { Authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(15_000) },
+        ),
       );
       if (fetchResp.ok) {
         const existing = await fetchResp.text();
@@ -408,17 +417,19 @@ export class GooglePlugin implements Plugin {
       }
     }
 
-    const resp = await fetch(
-      `https://www.googleapis.com/upload/drive/v3/files/${fileId}?uploadType=media`,
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "text/plain",
+    const resp = await withCircuitBreaker("google-api", () =>
+      fetch(
+        `https://www.googleapis.com/upload/drive/v3/files/${fileId}?uploadType=media`,
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "text/plain",
+          },
+          body,
+          signal: AbortSignal.timeout(30_000),
         },
-        body,
-        signal: AbortSignal.timeout(30_000),
-      },
+      ),
     );
 
     if (!resp.ok) {
@@ -464,15 +475,17 @@ export class GooglePlugin implements Plugin {
   ): Promise<Record<string, unknown>> {
     const title = String(payload.title ?? "Untitled Document");
 
-    const resp = await fetch("https://docs.googleapis.com/v1/documents", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ title }),
-      signal: AbortSignal.timeout(15_000),
-    });
+    const resp = await withCircuitBreaker("google-api", () =>
+      fetch("https://docs.googleapis.com/v1/documents", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ title }),
+        signal: AbortSignal.timeout(15_000),
+      }),
+    );
 
     if (!resp.ok) {
       const errBody = await resp.text().catch(() => "");
@@ -501,19 +514,21 @@ export class GooglePlugin implements Plugin {
     const content = String(payload.content ?? "");
     const index = typeof payload.index === "number" ? payload.index : 1;
 
-    const resp = await fetch(
-      `https://docs.googleapis.com/v1/documents/${documentId}:batchUpdate`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
+    const resp = await withCircuitBreaker("google-api", () =>
+      fetch(
+        `https://docs.googleapis.com/v1/documents/${documentId}:batchUpdate`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            requests: [{ insertText: { location: { index }, text: content } }],
+          }),
+          signal: AbortSignal.timeout(15_000),
         },
-        body: JSON.stringify({
-          requests: [{ insertText: { location: { index }, text: content } }],
-        }),
-        signal: AbortSignal.timeout(15_000),
-      },
+      ),
     );
 
     if (!resp.ok) {
@@ -569,10 +584,12 @@ export class GooglePlugin implements Plugin {
         url.searchParams.set("q", query);
         url.searchParams.set("maxResults", "10");
 
-        const listResp = await fetch(url.toString(), {
-          headers: { Authorization: `Bearer ${token}` },
-          signal: AbortSignal.timeout(15_000),
-        });
+        const listResp = await withCircuitBreaker("google-api", () =>
+          fetch(url.toString(), {
+            headers: { Authorization: `Bearer ${token}` },
+            signal: AbortSignal.timeout(15_000),
+          }),
+        );
 
         if (!listResp.ok) {
           console.warn(`[google] Gmail list failed for label "${label}": ${listResp.status}`);
@@ -585,9 +602,11 @@ export class GooglePlugin implements Plugin {
         for (const rawMsg of messages) {
           if (this.processedGmailIds.has(rawMsg.id)) continue;
 
-          const msgResp = await fetch(
-            `https://gmail.googleapis.com/gmail/v1/users/me/messages/${rawMsg.id}`,
-            { headers: { Authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(15_000) },
+          const msgResp = await withCircuitBreaker("google-api", () =>
+            fetch(
+              `https://gmail.googleapis.com/gmail/v1/users/me/messages/${rawMsg.id}`,
+              { headers: { Authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(15_000) },
+            ),
           );
           if (!msgResp.ok) continue;
 
@@ -702,10 +721,12 @@ export class GooglePlugin implements Plugin {
       url.searchParams.set("orderBy", "startTime");
       url.searchParams.set("maxResults", "20");
 
-      const resp = await fetch(url.toString(), {
-        headers: { Authorization: `Bearer ${token}` },
-        signal: AbortSignal.timeout(15_000),
-      });
+      const resp = await withCircuitBreaker("google-api", () =>
+        fetch(url.toString(), {
+          headers: { Authorization: `Bearer ${token}` },
+          signal: AbortSignal.timeout(15_000),
+        }),
+      );
 
       if (!resp.ok) {
         console.warn(`[google] Calendar list failed: ${resp.status}`);


### PR DESCRIPTION
## Summary

**Root cause:** `lib/plugins/google.ts`, `lib/plugins/plane.ts`, and `lib/plugins/github.ts` make outbound API calls (Drive, Calendar, Gmail, Plane REST, GitHub REST) with no circuit breaker. A downstream outage causes unbounded retries/error logging with no back-off, potentially exhausting rate limits or flooding logs.

**Fix:** Wrap outbound API calls in the existing `CircuitBreakerPlugin` (or a shared `withCircuitBreaker(name, fn)` utility). Apply to:
- `google.ts` Drive upload, Calendar poll...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved stability and resilience of external integrations (Google, GitHub, and Planner services) by adding a centralized circuit-breaker around outbound API requests to reduce failures and transient outages.
  * Exposed a mechanism to inspect the shared circuit state for monitoring and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->