### PR TITLE
chore: add board ceremony YAMLs + fix daily-standup schedule field

### DIFF
--- a/workspace/ceremonies/board.cleanup.yaml
+++ b/workspace/ceremonies/board.cleanup.yaml
@@ -1,0 +1,8 @@
+id: board.cleanup
+name: Board Cleanup
+schedule: "0 8 * * *"
+skill: board_janitor
+targets:
+  - all
+notifyChannel: ""
+enabled: true

--- a/workspace/ceremonies/board.health.yaml
+++ b/workspace/ceremonies/board.health.yaml
@@ -1,0 +1,8 @@
+id: board.health
+name: Board Health Check
+schedule: "*/30 * * * *"
+skill: board_health
+targets:
+  - all
+notifyChannel: ""
+enabled: true

--- a/workspace/ceremonies/board.pr-audit.yaml
+++ b/workspace/ceremonies/board.pr-audit.yaml
@@ -1,0 +1,8 @@
+id: board.pr-audit
+name: PR Audit
+schedule: "0 */3 * * *"
+skill: pr_audit
+targets:
+  - all
+notifyChannel: ""
+enabled: true

--- a/workspace/ceremonies/board.retro.yaml
+++ b/workspace/ceremonies/board.retro.yaml
@@ -1,0 +1,8 @@
+id: board.retro
+name: Weekly Retrospective
+schedule: "0 9 * * 1"
+skill: pattern_mining
+targets:
+  - all
+notifyChannel: ""
+enabled: true

--- a/workspace/ceremonies/daily-standup.yaml
+++ b/workspace/ceremonies/daily-standup.yaml
@@ -1,9 +1,9 @@
 id: daily-standup
 name: "Daily Fleet Standup"
 description: "Morning ceremony: board summary, active ceremonies, open PRs"
-cron: "0 9 * * 1-5"   # 9am Mon-Fri
+schedule: "0 9 * * 1-5"
 skill: board_audit
 targets:
   - ava
-discord:
-  channel: "1469195643590541353"  # #ava channel
+notifyChannel: "1469195643590541353"
+enabled: true


### PR DESCRIPTION
## Summary
- Adds 4 new fleet ceremony definitions: `board.health`, `board.cleanup`, `board.pr-audit`, `board.retro`
- Fixes `daily-standup.yaml`: `cron` → `schedule`, `discord.channel` → `notifyChannel`, adds `enabled: true` — resolves ceremony-loader startup warning

## Test plan
- [ ] Container restart shows no ceremony-loader warnings for any YAML
- [ ] Board ceremonies appear in ceremony registry on startup
- [ ] Daily standup fires at 9am Mon-Fri per schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Four new automated ceremonies added: Board Cleanup (daily), Board Health Check (every 30 minutes), PR Audit (every 3 hours), and Weekly Retrospective (Mondays at 09:00)

* **Configuration Updates**
  * Updated Daily Standup ceremony notification configuration and scheduling structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->