### PR TITLE
refactor: update projects.yaml discord schema — dev/release channels with channelId + webhook

### DIFF
--- a/workspace/projects.yaml
+++ b/workspace/projects.yaml
@@ -12,11 +12,11 @@ projects:
     agents: [ava, quinn, frank, matt, kai]
     discord:
       dev:
-        channelId: ""
-        webhook: ""
+        channelId: "1469080556720623699"
+        webhook: "https://discord.com/api/webhooks/1491330030536491011/bvMRTUuSjEwdESR61dpPf51UGqzk8nk4DVApd89Csj0-9Hsx3nljQpoiM5r9TaaRpYBK"
       release:
-        channelId: ""
-        webhook: ""
+        channelId: "1490893509337550859"
+        webhook: "https://discord.com/api/webhooks/1491330034361696277/b03iV5EAJdhj3m0_OlM1mCr5I20FDQ_2-4WYy7zMqHwT4ACQmqqwSq_SJLUpRLh8zjqb"
 
   - slug: protolabsai-quinn
     title: Quinn
@@ -27,11 +27,11 @@ projects:
     agents: [ava, quinn]
     discord:
       dev:
-        channelId: ""
-        webhook: ""
+        channelId: "1490974550169485413"
+        webhook: "https://discord.com/api/webhooks/1491330039483076720/sKLq-s2vGGaJe_zuDsniroo-Lg5Jclrp8WjkwsIwl1akH8bMlBd4QAQBnLTV_yDUJ9_N"
       release:
-        channelId: ""
-        webhook: ""
+        channelId: "1490974552161783828"
+        webhook: "https://discord.com/api/webhooks/1491330041152405524/Ymmu2XDalam4Ynh5YimDvIxAA2XMBovfXLSvWhZ4dTlxQLcBS_Kd1zeiYcqt5oSIvfru"
 
   - slug: protolabsai-protoui
     title: protoUI
@@ -43,10 +43,10 @@ projects:
     discord:
       dev:
         channelId: "1490601620927418428"
-        webhook: ""
+        webhook: "https://discord.com/api/webhooks/1491330063830876231/nlwSd20_invzQAYHt8jikmncpDVnTqw4qCTuCISA_0h632DzA-1Bmt_BYFEiuWJf4KR3"
       release:
-        channelId: "1490601619300286525"
-        webhook: ""
+        channelId: "1490895075759095910"
+        webhook: "https://discord.com/api/webhooks/1491330066259644416/5x15zi_cif-WIR_R1bnH0r1P3xAsvCHnLF2aiWG01eZ0J0GZQk-SuRAbQjCJqu3YUH4t"
 
   - slug: protolabsai-protocontent
     title: protoContent
@@ -72,8 +72,8 @@ projects:
     agents: [ava, quinn, frank, kai]
     discord:
       dev:
-        channelId: ""
-        webhook: ""
+        channelId: "1490978896911405208"
+        webhook: "https://discord.com/api/webhooks/1491330067756875848/yWZXujCFJUfzz4t97MpLZJ9mMXsTdXmQNlqIAVHXkO6sufNbFugZ4PDG3pmk6KyXOi-c"
       release:
-        channelId: ""
-        webhook: ""
+        channelId: "1490978898568286329"
+        webhook: "https://discord.com/api/webhooks/1491330070298492990/nj70huK2hButyWpfyzTnMC8eUdaHmbi-5Ms7_3oX4yO8n_xkLKsifJeo-Udk0d_sqpVx"

--- a/workspace/projects.yaml
+++ b/workspace/projects.yaml
@@ -11,9 +11,12 @@ projects:
     status: active
     agents: [ava, quinn, frank, matt, kai]
     discord:
-      general: ""
-      updates: ""
-      dev: ""
+      dev:
+        channelId: ""
+        webhook: ""
+      release:
+        channelId: ""
+        webhook: ""
 
   - slug: protolabsai-quinn
     title: Quinn
@@ -23,8 +26,12 @@ projects:
     status: active
     agents: [ava, quinn]
     discord:
-      general: ""
-      dev: ""
+      dev:
+        channelId: ""
+        webhook: ""
+      release:
+        channelId: ""
+        webhook: ""
 
   - slug: protolabsai-protoui
     title: protoUI
@@ -34,9 +41,12 @@ projects:
     status: active
     agents: [ava, quinn, matt]
     discord:
-      general: "1490601617567912050"
-      updates: "1490601619300286525"
-      dev: "1490601620927418428"
+      dev:
+        channelId: "1490601620927418428"
+        webhook: ""
+      release:
+        channelId: "1490601619300286525"
+        webhook: ""
 
   - slug: protolabsai-protocontent
     title: protoContent
@@ -46,8 +56,12 @@ projects:
     status: active
     agents: [jon, cindi]
     discord:
-      general: ""
-      dev: ""
+      dev:
+        channelId: ""
+        webhook: ""
+      release:
+        channelId: ""
+        webhook: ""
 
   - slug: protolabsai-protoworkstacean
     title: protoWorkstacean
@@ -57,5 +71,9 @@ projects:
     status: active
     agents: [ava, quinn, frank, kai]
     discord:
-      general: ""
-      dev: ""
+      dev:
+        channelId: ""
+        webhook: ""
+      release:
+        channelId: ""
+        webhook: ""

--- a/workspace/projects.yaml
+++ b/workspace/projects.yaml
@@ -7,6 +7,7 @@ projects:
     title: protoMaker
     team: dev
     github: protoLabsAI/protoMaker
+    repoUrl: "https://github.com/protoLabsAI/protoMaker"
     defaultBranch: main
     status: active
     agents: [ava, quinn, frank, matt, kai]
@@ -22,6 +23,7 @@ projects:
     title: Quinn
     team: dev
     github: protoLabsAI/quinn
+    repoUrl: "https://github.com/protoLabsAI/quinn"
     defaultBranch: main
     status: active
     agents: [ava, quinn]
@@ -37,6 +39,7 @@ projects:
     title: protoUI
     team: dev
     github: protoLabsAI/protoUI
+    repoUrl: "https://github.com/protoLabsAI/protoUI"
     defaultBranch: main
     status: active
     agents: [ava, quinn, matt]
@@ -52,6 +55,7 @@ projects:
     title: protoContent
     team: gtm
     github: protoLabsAI/protoContent
+    repoUrl: "https://github.com/protoLabsAI/protoContent"
     defaultBranch: main
     status: active
     agents: [jon, cindi]
@@ -67,6 +71,7 @@ projects:
     title: protoWorkstacean
     team: dev
     github: protoLabsAI/protoWorkstacean
+    repoUrl: "https://github.com/protoLabsAI/protoWorkstacean"
     defaultBranch: main
     status: active
     agents: [ava, quinn, frank, kai]


### PR DESCRIPTION
## Summary
- Replaces flat \`general/updates/dev\` channel ID fields with structured \`dev\`/\`release\` blocks
- Each channel block carries \`channelId\` and \`webhook\` URL
- protoUI's existing channel IDs carried forward into the new schema
- Aligns with protoMaker's project-scoped webhook architecture

## Test plan
- [ ] Workstacean serves updated schema via \`GET /api/projects\`
- [ ] protoMaker \`ProjectRegistryService\` correctly deserializes \`discord.dev.webhook\` and \`discord.release.webhook\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project configuration with repository URLs.
  * Restructured Discord integration configuration for improved organization and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->