### PR TITLE
fix: wire WorldStateCollector and ActionDispatcher into GOAP flow

### DIFF
--- a/lib/plugins/world-state-collector.ts
+++ b/lib/plugins/world-state-collector.ts
@@ -426,6 +426,26 @@ export class WorldStateCollectorPlugin implements Plugin {
       const redisLatencyMs = Date.now() - redisWriteStart;
       const durationMs = Date.now() - startTs;
 
+      // Publish to event bus so GoalEvaluatorPlugin can evaluate goals (world.state.# wildcard)
+      if (this.bus) {
+        const domainTopic = `world.state.${domain}`;
+        this.bus.publish(domainTopic, {
+          id: crypto.randomUUID(),
+          correlationId: crypto.randomUUID(),
+          topic: domainTopic,
+          timestamp: Date.now(),
+          payload: { domain, tickNumber: tickNum, state: this.worldState },
+        });
+        // Also publish world.state.updated with full WorldState so ActionDispatcherPlugin stays in sync
+        this.bus.publish("world.state.updated", {
+          id: crypto.randomUUID(),
+          correlationId: crypto.randomUUID(),
+          topic: "world.state.updated",
+          timestamp: Date.now(),
+          payload: this.worldState,
+        });
+      }
+
       span.end({
         domain,
         tickNumber: tickNum,

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,6 +205,22 @@ const pluginRegistry: PluginRegistryEntry[] = [
     },
   },
   {
+    name: "world-state-collector",
+    condition: () => true,
+    factory: async () => {
+      const { WorldStateCollectorPlugin } = await import("../lib/plugins/world-state-collector.js");
+      return new WorldStateCollectorPlugin({ knowledgeDbPath: `${dataDir}/knowledge.db` });
+    },
+  },
+  {
+    name: "action-dispatcher",
+    condition: () => true,
+    factory: async () => {
+      const { ActionDispatcherPlugin } = await import("./plugins/action-dispatcher-plugin.js");
+      return new ActionDispatcherPlugin({ wipLimit: 5 });
+    },
+  },
+  {
     name: "flow-monitor",
     condition: () => true,
     factory: async () => {


### PR DESCRIPTION
## Summary
- Registers `WorldStateCollectorPlugin` in the plugin registry — it existed but was never instantiated, leaving the entire world state collection dead
- Registers `ActionDispatcherPlugin` in the plugin registry — same issue, the WIP-limited action executor was never running
- Adds `bus.publish()` calls in `_collectDomain()` after each domain tick: publishes `world.state.{domain}` (consumed by GoalEvaluatorPlugin via `world.state.#` wildcard) and `world.state.updated` (consumed by ActionDispatcherPlugin for state sync)

These two fixes unlock the full GOAP cascade: WorldState → GoalEvaluator → PlannerL0 → ActionDispatcher → action topic dispatch.

## Test plan
- [ ] CI passes
- [ ] Restart workstacean and confirm `[world-state-collector] Plugin installed` appears in logs
- [ ] Confirm `[goal-evaluator] Plugin installed` appears and `world.state.services` events are flowing
- [ ] Confirm `[action-dispatcher]` installs and receives dispatch events when goals are violated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * World state updates now automatically publish events for enhanced system observability and real-time state synchronization across domains.
  * World state collection and action dispatching capabilities are now enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->