### PR TITLE
feat: implement real GOAP domain collectors, alert routing, and ceremony triggers

### DIFF
--- a/lib/plane-client.ts
+++ b/lib/plane-client.ts
@@ -36,6 +36,19 @@ export interface PlaneWebhook {
   [key: string]: unknown;
 }
 
+export interface PlaneIssue {
+  id: string;
+  name: string;
+  state: string;           // state UUID
+  state__group?: string;   // populated by some endpoints: "backlog" | "unstarted" | "started" | "completed" | "cancelled"
+  priority?: string;
+  label_ids: string[];
+  assignees?: string[];
+  updated_at?: string;
+  created_at?: string;
+  completed_at?: string | null;
+}
+
 import { withCircuitBreaker } from "./plugins/circuit-breaker.ts";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -176,6 +189,68 @@ export class PlaneClient {
       console.error("[plane-client] Error adding issue comment:", err);
       return false;
     }
+  }
+
+  /**
+   * Fetch state metadata for a project, returning Map<stateId, stateGroup>.
+   * Groups: "backlog" | "unstarted" | "started" | "completed" | "cancelled"
+   */
+  async fetchStateGroups(projectId: string): Promise<Map<string, string>> {
+    const groupMap = new Map<string, string>();
+    try {
+      const url = `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/projects/${projectId}/states/`;
+      const resp = await withCircuitBreaker("plane-api", () =>
+        fetch(url, { headers: this.headers(), signal: AbortSignal.timeout(10_000) }),
+      );
+      if (resp.ok) {
+        const data = (await resp.json()) as { results?: PlaneState[] };
+        for (const state of data.results ?? []) {
+          groupMap.set(state.id, state.group);
+        }
+      }
+    } catch (err) {
+      console.error("[plane-client] Error fetching state groups:", err);
+    }
+    return groupMap;
+  }
+
+  /**
+   * List work items for a project. Paginates automatically up to `maxIssues`.
+   */
+  async listIssues(
+    projectId: string,
+    options?: { pageSize?: number; maxIssues?: number },
+  ): Promise<PlaneIssue[]> {
+    const pageSize = options?.pageSize ?? 100;
+    const maxIssues = options?.maxIssues ?? 500;
+    const issues: PlaneIssue[] = [];
+
+    let cursor: string | null =
+      `${this.baseUrl}/api/v1/workspaces/${this.workspaceSlug}/projects/${projectId}/work-items/?page_size=${pageSize}`;
+
+    while (cursor && issues.length < maxIssues) {
+      try {
+        const resp = await withCircuitBreaker("plane-api", () =>
+          fetch(cursor!, { headers: this.headers(), signal: AbortSignal.timeout(15_000) }),
+        );
+        if (!resp.ok) {
+          console.warn(`[plane-client] listIssues HTTP ${resp.status} for project ${projectId}`);
+          break;
+        }
+        const data = (await resp.json()) as {
+          results?: PlaneIssue[];
+          next?: string | null;
+        };
+        const batch = data.results ?? [];
+        issues.push(...batch);
+        cursor = data.next ?? null;
+      } catch (err) {
+        console.error("[plane-client] Error listing issues:", err);
+        break;
+      }
+    }
+
+    return issues;
   }
 
   /** Invalidate cached labels/states for a project so they're re-fetched next time. */

--- a/lib/plugins/world-engine-alert.ts
+++ b/lib/plugins/world-engine-alert.ts
@@ -1,0 +1,100 @@
+/**
+ * WorldEngineAlertPlugin — routes world engine goal-violation alerts to Discord.
+ *
+ * Subscribes to: message.outbound.discord.alert
+ *
+ * When ActionDispatcher fires an action with meta.topic = "message.outbound.discord.alert",
+ * this plugin receives the event and POSTs an embed to the configured alerts webhook.
+ *
+ * Config (env vars):
+ *   DISCORD_WEBHOOK_ALERTS  — fleet-wide alerts channel webhook URL
+ */
+
+import type { Plugin, EventBus, BusMessage } from "../types.ts";
+
+const SEVERITY_COLORS: Record<string, number> = {
+  high: 0xED4245,    // Red
+  medium: 0xFF6B00,  // Orange
+  low: 0xFEE75C,     // Yellow
+};
+
+export class WorldEngineAlertPlugin implements Plugin {
+  readonly name = "world-engine-alert";
+  readonly description = "Routes world engine goal violations to the Discord alerts webhook";
+  readonly capabilities = ["discord-alerts"];
+
+  private bus?: EventBus;
+  private readonly subscriptionIds: string[] = [];
+
+  install(bus: EventBus): void {
+    this.bus = bus;
+
+    const subId = bus.subscribe("message.outbound.discord.alert", this.name, (msg: BusMessage) => {
+      void this._handleAlert(msg);
+    });
+    this.subscriptionIds.push(subId);
+
+    const webhookConfigured = !!process.env.DISCORD_WEBHOOK_ALERTS;
+    console.log(
+      `[world-engine-alert] Plugin installed — alerts webhook ${webhookConfigured ? "configured" : "NOT configured (set DISCORD_WEBHOOK_ALERTS)"}`,
+    );
+  }
+
+  uninstall(): void {
+    if (this.bus) {
+      for (const id of this.subscriptionIds) {
+        this.bus.unsubscribe(id);
+      }
+    }
+    this.subscriptionIds.length = 0;
+    this.bus = undefined;
+  }
+
+  private async _handleAlert(msg: BusMessage): Promise<void> {
+    const webhookUrl = process.env.DISCORD_WEBHOOK_ALERTS;
+    if (!webhookUrl) {
+      console.warn("[world-engine-alert] DISCORD_WEBHOOK_ALERTS not set — alert dropped");
+      return;
+    }
+
+    const payload = msg.payload as {
+      actionId?: string;
+      goalId?: string;
+      meta?: { agentId?: string; severity?: string };
+    };
+
+    const severity = payload.meta?.severity ?? "medium";
+    const color = SEVERITY_COLORS[severity] ?? SEVERITY_COLORS.medium;
+
+    const embed = {
+      title: "World Engine Alert",
+      description: `Goal \`${payload.goalId ?? "unknown"}\` violated — automated action dispatched`,
+      color,
+      fields: [
+        { name: "Action", value: payload.actionId ?? "unknown", inline: true },
+        { name: "Severity", value: severity, inline: true },
+        { name: "Agent", value: payload.meta?.agentId ?? "system", inline: true },
+      ],
+      timestamp: new Date().toISOString(),
+      footer: { text: "protoWorkstacean World Engine" },
+    };
+
+    try {
+      const resp = await fetch(webhookUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ embeds: [embed] }),
+        signal: AbortSignal.timeout(5_000),
+      });
+
+      if (!resp.ok) {
+        const text = await resp.text().catch(() => "(no body)");
+        console.error(`[world-engine-alert] Webhook POST failed: HTTP ${resp.status} — ${text}`);
+      } else {
+        console.log(`[world-engine-alert] Alert sent: goal=${payload.goalId} action=${payload.actionId}`);
+      }
+    } catch (err) {
+      console.error("[world-engine-alert] Failed to send alert:", err instanceof Error ? err.message : String(err));
+    }
+  }
+}

--- a/lib/plugins/world-state-collector.ts
+++ b/lib/plugins/world-state-collector.ts
@@ -19,16 +19,20 @@
  */
 
 import { Database } from "bun:sqlite";
-import { mkdirSync, existsSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { mkdirSync, existsSync, readFileSync } from "node:fs";
+import { dirname, resolve, join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { PlaneClient } from "../plane-client.ts";
 import type { Plugin, EventBus, BusMessage } from "../types.ts";
 import type {
   WorldState,
   WorldStateDomain,
   ServiceState,
+  ServiceInstance,
   BoardState,
   CIState,
   PortfolioState,
+  PortfolioProject,
   WorldStateSnapshot,
 } from "../types/world-state.ts";
 
@@ -100,6 +104,23 @@ export interface MCPTool {
   handler: (input: Record<string, unknown>) => Promise<unknown>;
 }
 
+// ── Issue type classification helper ─────────────────────────────────────────
+
+/**
+ * Classify a Plane work item as feature/defect/risk/debt based on its label names.
+ * Defaults to "feature" when no labels match.
+ */
+function _classifyIssueType(
+  labelIds: string[],
+  labelMap: Map<string, string>,
+): "feature" | "defect" | "risk" | "debt" {
+  const names = labelIds.map(id => labelMap.get(id)?.toLowerCase() ?? "").filter(Boolean);
+  if (names.some(n => /bug|defect|fix/.test(n))) return "defect";
+  if (names.some(n => /risk|security|vuln/.test(n))) return "risk";
+  if (names.some(n => /debt|tech.?debt|refactor|cleanup/.test(n))) return "debt";
+  return "feature";
+}
+
 // ── Plugin ────────────────────────────────────────────────────────────────────
 
 export class WorldStateCollectorPlugin implements Plugin {
@@ -127,11 +148,13 @@ export class WorldStateCollectorPlugin implements Plugin {
 
   private readonly knowledgeDbPath: string;
   private readonly snapshotIntervalMs: number;
+  private readonly workspaceDir: string;
   private snapshotTimer?: ReturnType<typeof setInterval>;
 
-  constructor(options?: { knowledgeDbPath?: string; snapshotIntervalMs?: number }) {
+  constructor(options?: { knowledgeDbPath?: string; snapshotIntervalMs?: number; workspaceDir?: string }) {
     this.knowledgeDbPath = resolve(options?.knowledgeDbPath ?? "data/knowledge.db");
     this.snapshotIntervalMs = options?.snapshotIntervalMs ?? 300_000; // default 5min
+    this.workspaceDir = resolve(options?.workspaceDir ?? process.env.WORKSPACE_DIR ?? "workspace");
   }
 
   install(bus: EventBus): void {
@@ -489,47 +512,273 @@ export class WorldStateCollectorPlugin implements Plugin {
   }
 
   private async _collectBoard(tickNum: number): Promise<WorldStateDomain<BoardState>> {
+    const workspaceSlug = process.env.PLANE_WORKSPACE_SLUG ?? "protolabsai";
+    const apiKey = process.env.PLANE_API_KEY ?? "";
+    const baseUrl = process.env.PLANE_BASE_URL ?? "http://ava:3002";
+
+    // Without an API key we can't fetch — return zeroed state without throwing
+    if (!apiKey) {
+      console.warn("[world-state-collector] PLANE_API_KEY not set — board domain will be empty");
+      const data: BoardState = {
+        projectSlug: workspaceSlug,
+        openIssues: 0, inProgress: 0, done: 0, issues: [],
+        efficiency: 0,
+        distribution: { feature: 0, defect: 0, risk: 0, debt: 0 },
+      };
+      return { data, metadata: { collectedAt: Date.now(), domain: "board", tickNumber: tickNum } };
+    }
+
+    const client = new PlaneClient(baseUrl, workspaceSlug, apiKey);
+    const projects = await client.listProjects();
+
+    let totalOpen = 0, totalInProgress = 0, totalDone = 0;
+    let totalFeature = 0, totalDefect = 0, totalRisk = 0, totalDebt = 0;
+    const allIssues: BoardState["issues"] = [];
+
+    for (const project of projects) {
+      const [stateGroups, labelMap, issues] = await Promise.all([
+        client.fetchStateGroups(project.id),
+        client.fetchLabels(project.id),
+        client.listIssues(project.id, { pageSize: 100, maxIssues: 500 }),
+      ]);
+
+      for (const issue of issues) {
+        const group = stateGroups.get(issue.state) ?? "unstarted";
+
+        if (group === "started") {
+          totalInProgress++;
+        } else if (group === "completed") {
+          totalDone++;
+        } else if (group !== "cancelled") {
+          totalOpen++; // backlog + unstarted
+        }
+
+        const issueType = _classifyIssueType(issue.label_ids, labelMap);
+        if (issueType === "defect") totalDefect++;
+        else if (issueType === "risk") totalRisk++;
+        else if (issueType === "debt") totalDebt++;
+        else totalFeature++;
+
+        allIssues.push({
+          id: issue.id,
+          title: issue.name,
+          status: group,
+          priority: issue.priority,
+          assignee: issue.assignees?.[0],
+          updatedAt: issue.updated_at,
+        });
+      }
+    }
+
+    const waitingCount = totalOpen + totalInProgress;
+    const efficiency = waitingCount > 0 ? totalInProgress / waitingCount : 0;
+
+    const typeTotal = totalFeature + totalDefect + totalRisk + totalDebt || 1;
+    const distribution = {
+      feature: totalFeature / typeTotal,
+      defect: totalDefect / typeTotal,
+      risk: totalRisk / typeTotal,
+      debt: totalDebt / typeTotal,
+    };
+
     const data: BoardState = {
-      projectSlug: process.env.PLANE_WORKSPACE_SLUG ?? "protolabsai",
-      openIssues: 0,
-      inProgress: 0,
-      done: 0,
-      issues: [],
+      projectSlug: workspaceSlug,
+      openIssues: totalOpen,
+      inProgress: totalInProgress,
+      done: totalDone,
+      issues: allIssues.slice(0, 100),
+      efficiency,
+      distribution,
     };
-    return {
-      data,
-      metadata: { collectedAt: Date.now(), domain: "board", tickNumber: tickNum },
-    };
+
+    return { data, metadata: { collectedAt: Date.now(), domain: "board", tickNumber: tickNum } };
   }
 
   private async _collectCI(tickNum: number): Promise<WorldStateDomain<CIState>> {
+    const token = process.env.GITHUB_TOKEN;
+
+    // Derive repo list from projects.yaml
+    const repos = this._readReposFromPortfolio();
+    if (repos.length === 0 && process.env.GITHUB_REPOSITORY) {
+      repos.push(process.env.GITHUB_REPOSITORY);
+    }
+
+    if (!token || repos.length === 0) {
+      const data: CIState = { repository: repos[0] ?? "", runs: [], successRate: undefined };
+      return { data, metadata: { collectedAt: Date.now(), domain: "ci", tickNumber: tickNum } };
+    }
+
+    const allRuns: CIState["runs"] = [];
+
+    for (const repo of repos.slice(0, 5)) {
+      try {
+        const resp = await fetch(
+          `https://api.github.com/repos/${repo}/actions/runs?per_page=10`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+              Accept: "application/vnd.github+json",
+              "User-Agent": "protoWorkstacean",
+            },
+            signal: AbortSignal.timeout(8_000),
+          },
+        );
+        if (!resp.ok) continue;
+
+        const body = (await resp.json()) as {
+          workflow_runs?: Array<{
+            id: number;
+            name: string;
+            status: string;
+            conclusion: string | null;
+            head_branch: string;
+            run_started_at?: string;
+            updated_at?: string;
+            html_url: string;
+          }>;
+        };
+
+        for (const run of body.workflow_runs ?? []) {
+          allRuns.push({
+            id: String(run.id),
+            name: `${repo} / ${run.name}`,
+            status: run.conclusion ?? run.status,
+            branch: run.head_branch,
+            startedAt: run.run_started_at,
+            finishedAt: run.updated_at,
+            url: run.html_url,
+          });
+        }
+      } catch {
+        // Skip this repo; continue with others
+      }
+    }
+
+    const completed = allRuns.filter(r => r.status === "success" || r.status === "failure");
+    const successRate = completed.length > 0
+      ? completed.filter(r => r.status === "success").length / completed.length
+      : undefined;
+
     const data: CIState = {
-      repository: process.env.GITHUB_REPOSITORY ?? "",
-      runs: [],
-      successRate: undefined,
+      repository: repos.join(", "),
+      runs: allRuns.slice(0, 50),
+      successRate,
     };
-    return {
-      data,
-      metadata: { collectedAt: Date.now(), domain: "ci", tickNumber: tickNum },
-    };
+    return { data, metadata: { collectedAt: Date.now(), domain: "ci", tickNumber: tickNum } };
   }
 
-  private async _collectPortfolio(tickNum: number): Promise<WorldStateDomain<PortfolioState>> {
+  private _collectPortfolio(tickNum: number): Promise<WorldStateDomain<PortfolioState>> {
+    const projectsPath = join(this.workspaceDir, "projects.yaml");
+    const projects: PortfolioProject[] = [];
+
+    if (existsSync(projectsPath)) {
+      try {
+        const raw = readFileSync(projectsPath, "utf8");
+        const parsed = parseYaml(raw) as {
+          projects?: Array<{
+            slug?: string;
+            title?: string;
+            github?: string;
+            status?: string;
+            agents?: string[];
+          }>;
+        };
+
+        for (const p of parsed.projects ?? []) {
+          if (!p.slug) continue;
+          projects.push({
+            slug: p.slug,
+            title: p.title ?? p.slug,
+            github: p.github ?? "",
+            status: (p.status ?? "active") as PortfolioProject["status"],
+            agents: p.agents ?? [],
+          });
+        }
+      } catch (err) {
+        console.warn("[world-state-collector] Failed to read projects.yaml for portfolio:", err);
+      }
+    }
+
     const data: PortfolioState = {
-      totalProjects: 0,
-      activeProjects: 0,
-      projects: [],
+      totalProjects: projects.length,
+      activeProjects: projects.filter(p => p.status === "active").length,
+      projects,
     };
-    return {
+
+    return Promise.resolve({
       data,
       metadata: { collectedAt: Date.now(), domain: "portfolio", tickNumber: tickNum },
-    };
+    });
   }
 
-  // ── Service health stub (replace with real health checks in production) ────
+  // ── Service health checks ─────────────────────────────────────────────────
 
-  private async _fetchServiceHealth(): Promise<ServiceState["instances"]> {
-    return [];
+  private async _fetchServiceHealth(): Promise<ServiceInstance[]> {
+    type ServiceCheck = { name: string; url: string; headers?: Record<string, string> };
+
+    const planeKey = process.env.PLANE_API_KEY;
+    const ghToken = process.env.GITHUB_TOKEN;
+
+    const checks: ServiceCheck[] = [
+      {
+        name: "plane",
+        url: `${process.env.PLANE_BASE_URL ?? "http://ava:3002"}/api/v1/workspaces/${process.env.PLANE_WORKSPACE_SLUG ?? "protolabsai"}/projects/`,
+        headers: planeKey ? { "X-Api-Key": planeKey } : undefined,
+      },
+      {
+        name: "github",
+        url: "https://api.github.com/rate_limit",
+        headers: ghToken ? { Authorization: `Bearer ${ghToken}` } : undefined,
+      },
+      {
+        name: "discord",
+        url: "https://discord.com/api/v10/gateway",
+      },
+    ];
+
+    return Promise.all(
+      checks.map(async ({ name, url, headers }): Promise<ServiceInstance> => {
+        const start = Date.now();
+        try {
+          const resp = await fetch(url, {
+            method: "GET",
+            headers,
+            signal: AbortSignal.timeout(5_000),
+          });
+          const latencyMs = Date.now() - start;
+          // 401/403 counts as reachable (auth issues, not outages)
+          const reachable = resp.ok || resp.status === 401 || resp.status === 403;
+          return {
+            name,
+            status: reachable ? "healthy" : "degraded",
+            lastChecked: Date.now(),
+            meta: { statusCode: resp.status, latencyMs },
+          };
+        } catch (err) {
+          return {
+            name,
+            status: "down",
+            lastChecked: Date.now(),
+            meta: { error: err instanceof Error ? err.message : String(err) },
+          };
+        }
+      }),
+    );
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  /** Read github repo slugs from projects.yaml for CI collection. */
+  private _readReposFromPortfolio(): string[] {
+    const projectsPath = join(this.workspaceDir, "projects.yaml");
+    if (!existsSync(projectsPath)) return [];
+    try {
+      const raw = readFileSync(projectsPath, "utf8");
+      const parsed = parseYaml(raw) as { projects?: Array<{ github?: string }> };
+      return (parsed.projects ?? []).map(p => p.github).filter((g): g is string => !!g);
+    } catch {
+      return [];
+    }
   }
 
   // ── Redis fast-path write ──────────────────────────────────────────────────

--- a/lib/types/world-state.ts
+++ b/lib/types/world-state.ts
@@ -45,6 +45,15 @@ export interface BoardState {
   inProgress: number;
   done: number;
   issues: BoardIssue[];
+  /** Flow efficiency: in-progress / (in-progress + open-backlog). Target >= 0.35. */
+  efficiency: number;
+  /** Distribution of work by type across all active issues. */
+  distribution: {
+    feature: number;  // 0.0 – 1.0
+    defect: number;
+    risk: number;
+    debt: number;
+  };
 }
 
 // ── CI state ──────────────────────────────────────────────────────────────────

--- a/src/goals/board/auto-mode-running.goal.test.ts
+++ b/src/goals/board/auto-mode-running.goal.test.ts
@@ -29,6 +29,8 @@ const worldStateWithBoard: WorldState = makeWorldState({
         inProgress: 1,
         done: 0,
         issues: [],
+        efficiency: 0.25,
+        distribution: { feature: 1, defect: 0, risk: 0, debt: 0 },
       },
       metadata: {
         collectedAt: Date.now(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,7 +209,7 @@ const pluginRegistry: PluginRegistryEntry[] = [
     condition: () => true,
     factory: async () => {
       const { WorldStateCollectorPlugin } = await import("../lib/plugins/world-state-collector.js");
-      return new WorldStateCollectorPlugin({ knowledgeDbPath: `${dataDir}/knowledge.db` });
+      return new WorldStateCollectorPlugin({ knowledgeDbPath: `${dataDir}/knowledge.db`, workspaceDir });
     },
   },
   {
@@ -218,6 +218,14 @@ const pluginRegistry: PluginRegistryEntry[] = [
     factory: async () => {
       const { ActionDispatcherPlugin } = await import("./plugins/action-dispatcher-plugin.js");
       return new ActionDispatcherPlugin({ wipLimit: 5 });
+    },
+  },
+  {
+    name: "world-engine-alert",
+    condition: () => true,
+    factory: async () => {
+      const { WorldEngineAlertPlugin } = await import("../lib/plugins/world-engine-alert.js");
+      return new WorldEngineAlertPlugin();
     },
   },
   {

--- a/src/plugins/CeremonyPlugin.ts
+++ b/src/plugins/CeremonyPlugin.ts
@@ -104,12 +104,32 @@ export class CeremonyPlugin implements Plugin {
     // Install state extension (listens for completed events)
     this.stateExtension.install(bus);
 
-    // Subscribe to ceremony.# to handle completed events for persistence/notification
+    // Subscribe to ceremony.# to handle completed events for persistence/notification,
+    // and to handle external execute triggers from the world engine / ActionDispatcher.
     const subId = bus.subscribe("ceremony.#", this.name, (msg: BusMessage) => {
       if (msg.topic.endsWith(".completed")) {
         this._onCeremonyCompleted(msg).catch((err) => {
           console.error("[ceremony] Error handling completed event:", err);
         });
+      } else if (msg.topic.endsWith(".execute")) {
+        // External trigger (e.g. from ActionDispatcher via world engine).
+        // Internal cron fires set payload.type = "ceremony.execute" — skip those
+        // to avoid double-firing.
+        const payload = msg.payload as Record<string, unknown> | null;
+        if (payload?.type === "ceremony.execute") return;
+
+        // Extract ceremony ID from topic: ceremony.{id}.execute
+        const parts = msg.topic.split(".");
+        if (parts.length >= 3) {
+          const ceremonyId = parts.slice(1, -1).join(".");
+          const ceremony = this.ceremonies.get(ceremonyId);
+          if (ceremony) {
+            console.log(`[ceremony] External trigger received for: ${ceremonyId}`);
+            this._fireCeremony(ceremony);
+          } else {
+            console.warn(`[ceremony] External trigger for unknown ceremony: ${ceremonyId}`);
+          }
+        }
       }
     });
     this.subscriptionIds.push(subId);

--- a/src/plugins/planner-plugin-l0.test.ts
+++ b/src/plugins/planner-plugin-l0.test.ts
@@ -115,6 +115,8 @@ describe("PlannerPluginL0", () => {
             inProgress: 1,
             done: 0,
             issues: [],
+            efficiency: 0.5,
+            distribution: { feature: 1, defect: 0, risk: 0, debt: 0 },
           },
           metadata: {
             collectedAt: Date.now(),

--- a/workspace/ceremonies/health-check.yaml
+++ b/workspace/ceremonies/health-check.yaml
@@ -1,0 +1,9 @@
+id: health_check
+name: "Service Health Check"
+description: "Triggered by world engine when a service domain collection fails. Investigates and reports the health status of fleet infrastructure dependencies."
+schedule: "0 */6 * * *"
+skill: board_audit
+targets:
+  - ava
+notifyChannel: ""
+enabled: true


### PR DESCRIPTION
## Summary
- Replaces all 4 stub domain collectors in \`WorldStateCollectorPlugin\` with real implementations: Plane API board data (with flow efficiency + work-type distribution), projects.yaml portfolio, GitHub Actions CI runs, and live service health pings (Plane/GitHub/Discord)
- Wires \`WorldEngineAlertPlugin\` (new) to handle \`message.outbound.discord.alert\` — previously world engine alerts had no subscriber and were silently dropped; now POSTs a Discord embed to \`DISCORD_WEBHOOK_ALERTS\`
- Extends \`CeremonyPlugin\` to handle external \`ceremony.{id}.execute\` events from ActionDispatcher, enabling world-engine-triggered ceremonies alongside scheduled cron fires
- Adds \`PlaneIssue\`, \`fetchStateGroups()\`, and \`listIssues()\` to \`PlaneClient\`; adds \`efficiency\` + \`distribution\` fields to \`BoardState\` so goals.yaml selectors resolve correctly; adds \`health-check.yaml\` ceremony consumed by the \`ceremony.service_health_check\` action

## Test plan
- [ ] CI passes
- [ ] Restart workstacean — confirm \`[world-state-collector]\`, \`[world-engine-alert]\` logs appear on startup
- [ ] Confirm board domain ticks with real Plane data after 60s (check \`world.state.board\` bus events)
- [ ] Confirm portfolio domain returns 5 projects from projects.yaml after 15min (or force tick)
- [ ] Set \`DISCORD_WEBHOOK_ALERTS\` and confirm alerts route to Discord when a goal violation fires
- [ ] Trigger a ceremony externally via \`ceremony.health_check.execute\` bus event and confirm \`_fireCeremony\` runs without double-firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Plane for centralized work item and project state tracking
  * Added Discord alert notifications for goal violations
  * Added service health monitoring with real-time status checks for integrated services
  * Enhanced board metrics with efficiency tracking and work distribution by type
  * Extended ceremony execution to support external triggers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->