### PR TITLE
feat: world engine expansion — agent_health domain, HTTP API, frank CI wiring

### DIFF
--- a/lib/plugins/world-state-collector.ts
+++ b/lib/plugins/world-state-collector.ts
@@ -34,16 +34,19 @@ import type {
   PortfolioState,
   PortfolioProject,
   WorldStateSnapshot,
+  AgentHealthState,
+  AgentHealthEntry,
 } from "../types/world-state.ts";
 
 // ── Tick rates (ms) ───────────────────────────────────────────────────────────
 // Per-domain tick rates: services=30s, board=60s, CI=300s (5min), portfolio=900s (15min)
 
 const TICK_RATES = {
-  services: 30_000,    // 30s
-  board: 60_000,       // 60s
-  ci: 300_000,         // 5min (CI=300s)
-  portfolio: 900_000,  // 15min (portfolio=900s)
+  services: 30_000,      // 30s
+  board: 60_000,         // 60s
+  ci: 300_000,           // 5min (CI=300s)
+  portfolio: 900_000,    // 15min (portfolio=900s)
+  agent_health: 60_000,  // 60s
 } as const;
 
 type DomainName = keyof typeof TICK_RATES;
@@ -178,11 +181,12 @@ export class WorldStateCollectorPlugin implements Plugin {
     this.subscriptionIds.push(mcpSubId);
 
     // Start per-domain tick schedulers
-    // Per-domain tick rates: services=30s, board=60s, CI=300s (5min), portfolio=900s (15min)
+    // Per-domain tick rates: services=30s, board=60s, CI=300s (5min), portfolio=900s (15min), agent_health=60s
     this._startDomainTicker("services", TICK_RATES.services);
     this._startDomainTicker("board", TICK_RATES.board);
     this._startDomainTicker("ci", TICK_RATES.ci);
     this._startDomainTicker("portfolio", TICK_RATES.portfolio);
+    this._startDomainTicker("agent_health", TICK_RATES.agent_health);
 
     // Periodic knowledge.db snapshot
     this.snapshotTimer = setInterval(() => {
@@ -196,10 +200,11 @@ export class WorldStateCollectorPlugin implements Plugin {
     void this._collectDomain("board");
     void this._collectDomain("ci");
     void this._collectDomain("portfolio");
+    void this._collectDomain("agent_health");
 
     console.log(
       "[world-state-collector] Plugin installed — " +
-      "tickers: services=30s, board=60s, CI=300s, portfolio=900s",
+      "tickers: services=30s, board=60s, CI=300s, portfolio=900s, agent_health=60s",
     );
   }
 
@@ -430,6 +435,9 @@ export class WorldStateCollectorPlugin implements Plugin {
           break;
         case "portfolio":
           domainData = await this._collectPortfolio(tickNum);
+          break;
+        case "agent_health":
+          domainData = await this._collectAgentHealth(tickNum);
           break;
         default:
           throw new Error(`Unknown domain: ${String(domain)}`);
@@ -709,6 +717,61 @@ export class WorldStateCollectorPlugin implements Plugin {
       data,
       metadata: { collectedAt: Date.now(), domain: "portfolio", tickNumber: tickNum },
     });
+  }
+
+  private async _collectAgentHealth(tickNum: number): Promise<WorldStateDomain<AgentHealthState>> {
+    const agentsPath = join(this.workspaceDir, "agents.yaml");
+    const agentDefs: Array<{ name: string; url: string }> = [];
+
+    if (existsSync(agentsPath)) {
+      try {
+        const raw = readFileSync(agentsPath, "utf8");
+        const parsed = parseYaml(raw) as { agents?: Array<{ name: string; url: string }> };
+        for (const a of parsed.agents ?? []) {
+          if (a.name && a.url) agentDefs.push({ name: a.name, url: a.url });
+        }
+      } catch (err) {
+        console.warn("[world-state-collector] Failed to read agents.yaml for agent_health:", err);
+      }
+    }
+
+    const entries: AgentHealthEntry[] = await Promise.all(
+      agentDefs.map(async ({ name, url }): Promise<AgentHealthEntry> => {
+        const start = Date.now();
+        try {
+          // Probe /health on the agent's base URL (strip /a2a suffix if present)
+          const baseUrl = url.replace(/\/a2a$/, "");
+          const resp = await fetch(`${baseUrl}/health`, {
+            method: "GET",
+            signal: AbortSignal.timeout(5_000),
+          });
+          const latencyMs = Date.now() - start;
+          const reachable = resp.ok || resp.status === 401 || resp.status === 403;
+          return { name, url, reachable, latencyMs, lastChecked: Date.now() };
+        } catch (err) {
+          return {
+            name,
+            url,
+            reachable: false,
+            lastChecked: Date.now(),
+            error: err instanceof Error ? err.message : String(err),
+          };
+        }
+      }),
+    );
+
+    const unreachableAgents = entries.filter(e => !e.reachable).map(e => e.name);
+    const data: AgentHealthState = {
+      entries,
+      totalReachable: entries.filter(e => e.reachable).length,
+      totalUnreachable: unreachableAgents.length,
+      unreachableAgents,
+    };
+
+    return {
+      data,
+      metadata: { collectedAt: Date.now(), domain: "agent_health", tickNumber: tickNum },
+    };
   }
 
   // ── Service health checks ─────────────────────────────────────────────────

--- a/lib/types/world-state.ts
+++ b/lib/types/world-state.ts
@@ -91,6 +91,24 @@ export interface PortfolioState {
   projects: PortfolioProject[];
 }
 
+// ── Agent health state ────────────────────────────────────────────────────────
+
+export interface AgentHealthEntry {
+  name: string;
+  url: string;
+  reachable: boolean;
+  latencyMs?: number;
+  lastChecked: number;    // Unix timestamp ms
+  error?: string;
+}
+
+export interface AgentHealthState {
+  entries: AgentHealthEntry[];
+  totalReachable: number;
+  totalUnreachable: number;
+  unreachableAgents: string[];
+}
+
 // ── Generic extension mechanism ───────────────────────────────────────────────
 
 /** Arbitrary domain-specific extensions keyed by domain name or feature slug. */
@@ -118,6 +136,7 @@ export interface WorldState {
     board?: WorldStateDomain<BoardState>;
     ci?: WorldStateDomain<CIState>;
     portfolio?: WorldStateDomain<PortfolioState>;
+    agent_health?: WorldStateDomain<AgentHealthState>;
   };
   /** Generic extension mechanism for future domains or domain-specific data. */
   extensions: WorldStateExtensions;

--- a/src/index.ts
+++ b/src/index.ts
@@ -502,51 +502,50 @@ function handleGetAgentSkills(agentName: string): Response {
   }
 }
 
-// ── HTTP server ───────────────────────────────────────────────────────────────
+// ── HTTP router ───────────────────────────────────────────────────────────────
 
-type RouteHandler = (req: Request) => Response | Promise<Response>;
+type Params = Record<string, string>;
+type RouteHandler = (req: Request, params: Params) => Response | Promise<Response>;
 
-const routes = new Map<string, RouteHandler>([
-  ["GET /health",        () => Response.json({ status: "ok", timestamp: Date.now() })],
-  ["POST /publish",      handlePublish],
-  ["POST /api/onboard",  handleOnboard],
-  ["GET /api/projects",  () => serveWorkspaceYaml("projects.yaml", "projects")],
-  ["GET /api/agents",    () => serveWorkspaceYaml("agents.yaml", "agents")],
-]);
+/** Match a path against a pattern like "/api/foo/:id/run". Returns params or null. */
+function matchPath(pattern: string, path: string): Params | null {
+  const pp = pattern.split("/");
+  const sp = path.split("/");
+  if (pp.length !== sp.length) return null;
+  const params: Params = {};
+  for (let i = 0; i < pp.length; i++) {
+    if (pp[i].startsWith(":")) {
+      params[pp[i].slice(1)] = sp[i];
+    } else if (pp[i] !== sp[i]) {
+      return null;
+    }
+  }
+  return params;
+}
+
+const routes: Array<{ method: string; path: string; handler: RouteHandler }> = [
+  { method: "GET",  path: "/health",                    handler: () => Response.json({ status: "ok", timestamp: Date.now() }) },
+  { method: "POST", path: "/publish",                   handler: handlePublish },
+  { method: "POST", path: "/api/onboard",               handler: handleOnboard },
+  { method: "GET",  path: "/api/projects",              handler: () => serveWorkspaceYaml("projects.yaml", "projects") },
+  { method: "GET",  path: "/api/agents",                handler: () => serveWorkspaceYaml("agents.yaml", "agents") },
+  { method: "GET",  path: "/api/goals",                 handler: () => serveWorkspaceYaml("goals.yaml", "goals") },
+  { method: "GET",  path: "/api/world-state",           handler: () => handleGetWorldState() },
+  { method: "GET",  path: "/api/world-state/:domain",   handler: (_, p) => handleGetWorldState(p.domain) },
+  { method: "GET",  path: "/api/ceremonies",            handler: () => handleGetCeremonies() },
+  { method: "POST", path: "/api/ceremonies/:id/run",    handler: (req, p) => handleRunCeremony(req, p.id) },
+  { method: "GET",  path: "/api/skills/:agentName",     handler: (_, p) => handleGetAgentSkills(p.agentName) },
+];
 
 Bun.serve({
   port: HTTP_PORT,
   fetch: async (req) => {
     const { pathname } = new URL(req.url);
-    const key = `${req.method} ${pathname}`;
-
-    // Static routes (exact match)
-    const handler = routes.get(key);
-    if (handler) return handler(req);
-
-    // Dynamic routes
-    if (req.method === "GET" && pathname === "/api/world-state") {
-      return handleGetWorldState();
+    for (const route of routes) {
+      if (route.method !== req.method) continue;
+      const params = matchPath(route.path, pathname);
+      if (params) return route.handler(req, params);
     }
-    if (req.method === "GET" && pathname.startsWith("/api/world-state/")) {
-      const domain = pathname.slice("/api/world-state/".length);
-      return handleGetWorldState(domain);
-    }
-    if (req.method === "GET" && pathname === "/api/ceremonies") {
-      return handleGetCeremonies();
-    }
-    if (req.method === "POST" && pathname.startsWith("/api/ceremonies/") && pathname.endsWith("/run")) {
-      const ceremonyId = pathname.slice("/api/ceremonies/".length, -"/run".length);
-      return handleRunCeremony(req, ceremonyId);
-    }
-    if (req.method === "GET" && pathname === "/api/goals") {
-      return serveWorkspaceYaml("goals.yaml", "goals");
-    }
-    if (req.method === "GET" && pathname.startsWith("/api/skills/")) {
-      const agentName = pathname.slice("/api/skills/".length);
-      return handleGetAgentSkills(agentName);
-    }
-
     return Response.json({ success: false, error: "Not found" }, { status: 404 });
   },
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -432,6 +432,78 @@ async function handleOnboard(req: Request): Promise<Response> {
   return Response.json(result, { status: statusCode });
 }
 
+// ── World-state API helpers ────────────────────────────────────────────────────
+
+// Minimal interface so we can call getWorldState() without importing the full type
+interface WorldStateAPI {
+  getWorldState(opts?: { domain?: string; maxAgeMs?: number }): unknown;
+}
+
+// Resolved after plugins are loaded
+const worldStateCollector = registeredPlugins.find(p => p.name === "world-state-collector") as (WorldStateAPI & { name: string }) | undefined;
+
+function handleGetWorldState(domain?: string): Response {
+  if (!worldStateCollector) {
+    return Response.json({ success: false, error: "world-state-collector not available" }, { status: 503 });
+  }
+  const data = worldStateCollector.getWorldState(domain ? { domain, maxAgeMs: 120_000 } : { maxAgeMs: 120_000 });
+  return Response.json({ success: true, data });
+}
+
+function handleGetCeremonies(): Response {
+  const ceremoniesDir = join(workspaceDir, "ceremonies");
+  if (!existsSync(ceremoniesDir)) return Response.json({ success: true, data: [] });
+  const files = readdirSync(ceremoniesDir).filter(f => f.endsWith(".yaml") || f.endsWith(".yml"));
+  const ceremonies: unknown[] = [];
+  for (const file of files) {
+    try {
+      const parsed = parseYaml(readFileSync(join(ceremoniesDir, file), "utf8")) as Record<string, unknown>;
+      ceremonies.push(parsed);
+    } catch { /* skip malformed files */ }
+  }
+  return Response.json({ success: true, data: ceremonies });
+}
+
+async function handleRunCeremony(req: Request, ceremonyId: string): Promise<Response> {
+  if (API_KEY && req.headers.get("X-API-Key") !== API_KEY) {
+    return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+  // Sanitize ceremonyId — only allow alphanumeric, dash, dot, underscore
+  if (!/^[\w.\-]+$/.test(ceremonyId)) {
+    return Response.json({ success: false, error: "Invalid ceremony id" }, { status: 400 });
+  }
+  const topic = `ceremony.${ceremonyId}.execute`;
+  bus.publish(topic, {
+    id: crypto.randomUUID(),
+    correlationId: crypto.randomUUID(),
+    topic,
+    timestamp: Date.now(),
+    payload: { type: "manual.execute", triggeredBy: "api" },
+  });
+  return Response.json({ success: true, message: `Ceremony "${ceremonyId}" triggered` });
+}
+
+function handleGetAgentSkills(agentName: string): Response {
+  const agentsPath = join(workspaceDir, "agents.yaml");
+  if (!existsSync(agentsPath)) {
+    return Response.json({ success: false, error: "agents.yaml not found" }, { status: 404 });
+  }
+  try {
+    const parsed = parseYaml(readFileSync(agentsPath, "utf8")) as {
+      agents?: Array<{ name: string; skills?: unknown[] }>;
+    };
+    const agent = (parsed.agents ?? []).find(a => a.name === agentName);
+    if (!agent) {
+      return Response.json({ success: false, error: `Agent "${agentName}" not found` }, { status: 404 });
+    }
+    return Response.json({ success: true, data: { name: agent.name, skills: agent.skills ?? [] } });
+  } catch {
+    return Response.json({ success: false, error: "Failed to parse agents.yaml" }, { status: 500 });
+  }
+}
+
+// ── HTTP server ───────────────────────────────────────────────────────────────
+
 type RouteHandler = (req: Request) => Response | Promise<Response>;
 
 const routes = new Map<string, RouteHandler>([
@@ -446,10 +518,36 @@ Bun.serve({
   port: HTTP_PORT,
   fetch: async (req) => {
     const { pathname } = new URL(req.url);
-    const handler = routes.get(`${req.method} ${pathname}`);
-    return handler
-      ? handler(req)
-      : Response.json({ success: false, error: "Not found" }, { status: 404 });
+    const key = `${req.method} ${pathname}`;
+
+    // Static routes (exact match)
+    const handler = routes.get(key);
+    if (handler) return handler(req);
+
+    // Dynamic routes
+    if (req.method === "GET" && pathname === "/api/world-state") {
+      return handleGetWorldState();
+    }
+    if (req.method === "GET" && pathname.startsWith("/api/world-state/")) {
+      const domain = pathname.slice("/api/world-state/".length);
+      return handleGetWorldState(domain);
+    }
+    if (req.method === "GET" && pathname === "/api/ceremonies") {
+      return handleGetCeremonies();
+    }
+    if (req.method === "POST" && pathname.startsWith("/api/ceremonies/") && pathname.endsWith("/run")) {
+      const ceremonyId = pathname.slice("/api/ceremonies/".length, -"/run".length);
+      return handleRunCeremony(req, ceremonyId);
+    }
+    if (req.method === "GET" && pathname === "/api/goals") {
+      return serveWorkspaceYaml("goals.yaml", "goals");
+    }
+    if (req.method === "GET" && pathname.startsWith("/api/skills/")) {
+      const agentName = pathname.slice("/api/skills/".length);
+      return handleGetAgentSkills(agentName);
+    }
+
+    return Response.json({ success: false, error: "Not found" }, { status: 404 });
   },
 });
 

--- a/src/planner/types/action.ts
+++ b/src/planner/types/action.ts
@@ -48,6 +48,10 @@ export interface ActionMeta {
   timeout?: number;
   /** Arbitrary extra context passed through to the action handler. */
   context?: Record<string, unknown>;
+  /** If true, publish to topic then immediately complete as success (no outcome wait). */
+  fireAndForget?: boolean;
+  /** Hint for SkillBrokerPlugin: which skill to invoke. */
+  skillHint?: string;
 }
 
 export type ActionTier = "tier_0" | "tier_1" | "tier_2";

--- a/src/plugins/action-dispatcher-plugin.ts
+++ b/src/plugins/action-dispatcher-plugin.ts
@@ -158,7 +158,25 @@ export class ActionDispatcherPlugin implements Plugin {
         return;
       }
 
-      // For actions with a dispatch topic, publish and wait for outcome via timeout
+      // For tier_0 actions with a topic: fire-and-forget — publish then immediately succeed.
+      // Tier_0 means "deterministic/free"; waiting for an external outcome receipt is tier_1+.
+      if (action.tier === "tier_0") {
+        this.bus.publish(action.meta.topic, {
+          id: crypto.randomUUID(),
+          correlationId,
+          topic: action.meta.topic,
+          timestamp: Date.now(),
+          payload: {
+            actionId: action.id,
+            goalId: action.goalId,
+            meta: action.meta,
+          },
+        });
+        await this.completeAction(action, correlationId, parentCorrelationId, startedAt, true);
+        return;
+      }
+
+      // For tier_1+ actions with a dispatch topic, publish and wait for outcome via timeout
       const timeoutMs = action.meta.timeout ?? this.config.defaultTimeoutMs ?? 30_000;
 
       await new Promise<void>((resolve) => {

--- a/src/plugins/action-dispatcher-plugin.ts
+++ b/src/plugins/action-dispatcher-plugin.ts
@@ -158,9 +158,9 @@ export class ActionDispatcherPlugin implements Plugin {
         return;
       }
 
-      // For tier_0 actions with a topic: fire-and-forget — publish then immediately succeed.
-      // Tier_0 means "deterministic/free"; waiting for an external outcome receipt is tier_1+.
-      if (action.tier === "tier_0") {
+      // For fire-and-forget actions: publish to topic then immediately succeed.
+      // Use meta.fireAndForget for alerts, ceremony triggers, and other side-effect-only dispatches.
+      if (action.meta.fireAndForget) {
         this.bus.publish(action.meta.topic, {
           id: crypto.randomUUID(),
           correlationId,
@@ -176,7 +176,7 @@ export class ActionDispatcherPlugin implements Plugin {
         return;
       }
 
-      // For tier_1+ actions with a dispatch topic, publish and wait for outcome via timeout
+      // For actions with a dispatch topic, publish and wait for outcome via timeout
       const timeoutMs = action.meta.timeout ?? this.config.defaultTimeoutMs ?? 30_000;
 
       await new Promise<void>((resolve) => {

--- a/src/plugins/skill-broker-plugin.ts
+++ b/src/plugins/skill-broker-plugin.ts
@@ -133,21 +133,40 @@ export class SkillBrokerPlugin implements Plugin {
   }
 
   private async _handleSkillRequest(msg: BusMessage): Promise<void> {
+    // Handles two payload shapes:
+    //   CeremonyPlugin:       { skill, ceremonyId, ceremonyName, targets, runId }
+    //   ActionDispatcherPlugin: { actionId, goalId, meta: { skillHint, agentId } }
     const payload = msg.payload as {
-      skill: string;
-      ceremonyId: string;
-      ceremonyName: string;
-      targets: string[];
-      runId: string;
+      // CeremonyPlugin fields
+      skill?: string;
+      ceremonyId?: string;
+      ceremonyName?: string;
+      targets?: string[];
+      runId?: string;
       projectPaths?: string[];
+      // ActionDispatcher fields
+      actionId?: string;
+      goalId?: string;
+      meta?: { skillHint?: string; agentId?: string; topic?: string };
     };
 
-    const { skill, ceremonyId, ceremonyName, targets = [], runId } = payload;
+    const skill = payload.skill ?? payload.meta?.skillHint ?? "";
+    const targets = payload.targets ?? (payload.meta?.agentId ? [payload.meta.agentId] : []);
+    const runId = payload.runId ?? msg.correlationId;
+    const ceremonyId = payload.ceremonyId ?? payload.actionId ?? "action";
+    const ceremonyName = payload.ceremonyName ?? payload.goalId ?? "World Engine Action";
+
     const replyTopic = (msg as BusMessage & { reply?: { topic?: string } }).reply?.topic
       ?? `agent.skill.response.${runId}`;
 
     // Resolution: targets first (explicit agent names), then skill → registry lookup
     const agent = this._resolveAgent(skill, targets);
+
+    if (!skill) {
+      console.warn(`[skill-broker] Received skill request with no skill — dropping`);
+      this._publishResponse(replyTopic, runId, undefined, "No skill specified in request");
+      return;
+    }
 
     if (!agent) {
       const searched = targets.length > 0

--- a/workspace/actions.yaml
+++ b/workspace/actions.yaml
@@ -32,6 +32,37 @@ actions:
       topic: "message.outbound.discord.alert"
       agentId: ava
 
+  - id: alert.agent_unreachable
+    goalId: agents.all_reachable
+    tier: tier_0
+    priority: 10
+    cost: 1
+    name: "Alert when agents are unreachable"
+    preconditions:
+      - path: "domains.agent_health.data.totalUnreachable"
+        operator: gt
+        value: 0
+    effects: []
+    meta:
+      topic: "message.outbound.discord.alert"
+      agentId: ava
+
+  - id: ci.debug_failures
+    goalId: ci.success_rate_healthy
+    tier: tier_0
+    priority: 8
+    cost: 1
+    name: "Trigger CI debug when success rate drops"
+    preconditions:
+      - path: "domains.ci.data.successRate"
+        operator: lt
+        value: 0.70
+    effects: []
+    meta:
+      topic: "agent.skill.request"
+      skillHint: "ci_debug"
+      agentId: frank
+
   - id: ceremony.service_health_check
     goalId: services.all_healthy
     tier: tier_0

--- a/workspace/actions.yaml
+++ b/workspace/actions.yaml
@@ -16,6 +16,7 @@ actions:
     meta:
       topic: "message.outbound.discord.alert"
       agentId: ava
+      fireAndForget: true
 
   - id: alert.distribution_drift
     goalId: flow.distribution_balanced
@@ -31,6 +32,7 @@ actions:
     meta:
       topic: "message.outbound.discord.alert"
       agentId: ava
+      fireAndForget: true
 
   - id: alert.agent_unreachable
     goalId: agents.all_reachable
@@ -46,6 +48,7 @@ actions:
     meta:
       topic: "message.outbound.discord.alert"
       agentId: ava
+      fireAndForget: true
 
   - id: ci.debug_failures
     goalId: ci.success_rate_healthy
@@ -62,6 +65,7 @@ actions:
       topic: "agent.skill.request"
       skillHint: "ci_debug"
       agentId: frank
+      fireAndForget: true
 
   - id: ceremony.service_health_check
     goalId: services.all_healthy
@@ -79,3 +83,4 @@ actions:
         value: false
     meta:
       topic: "ceremony.health_check.execute"
+      fireAndForget: true

--- a/workspace/ceremonies/board.cleanup.yaml
+++ b/workspace/ceremonies/board.cleanup.yaml
@@ -1,7 +1,7 @@
 id: board.cleanup
 name: Board Cleanup
 schedule: "0 8 * * *"
-skill: board_janitor
+skill: board_audit
 targets:
   - all
 notifyChannel: ""

--- a/workspace/ceremonies/board.pr-audit.yaml
+++ b/workspace/ceremonies/board.pr-audit.yaml
@@ -1,7 +1,7 @@
 id: board.pr-audit
 name: PR Audit
 schedule: "0 */3 * * *"
-skill: pr_audit
+skill: pr_review
 targets:
   - all
 notifyChannel: ""

--- a/workspace/ceremonies/board.retro.yaml
+++ b/workspace/ceremonies/board.retro.yaml
@@ -1,7 +1,7 @@
 id: board.retro
 name: Weekly Retrospective
 schedule: "0 9 * * 1"
-skill: pattern_mining
+skill: pattern_analysis
 targets:
   - all
 notifyChannel: ""

--- a/workspace/goals.yaml
+++ b/workspace/goals.yaml
@@ -24,3 +24,17 @@ goals:
     selector: "domains.services.metadata.failed"
     operator: falsy
     description: "No service collection failures"
+
+  - id: agents.all_reachable
+    type: Invariant
+    severity: high
+    selector: "domains.agent_health.data.totalUnreachable"
+    operator: falsy
+    description: "All A2A agents must be reachable"
+
+  - id: ci.success_rate_healthy
+    type: Threshold
+    severity: high
+    selector: "domains.ci.data.successRate"
+    min: 0.70
+    description: "CI success rate must stay >= 70%"


### PR DESCRIPTION
## Summary

- **Fix 3 broken ceremonies**: `board_janitor`→`board_audit`, `pr_audit`→`pr_review`, `pattern_mining`→`pattern_analysis` — these were silently timing out every execution since no agent had those skills
- **`agent_health` domain** (60s tick): pings `/health` on every agent from `agents.yaml`, collects reachability + latency, publishes to world state
- **2 new goals**: `agents.all_reachable` (Invariant, triggers when any agent goes dark) + `ci.success_rate_healthy` (Threshold ≥ 70%)
- **2 new actions**: `alert.agent_unreachable` → Discord alert, `ci.debug_failures` → dispatches `ci_debug` to frank via SkillBroker
- **Fix ActionDispatcher**: tier_0 + topic actions now fire-and-forget (publish → immediate success) instead of always timing out after 30s — fixes alerts and ceremony triggers
- **Fix SkillBrokerPlugin**: now handles both payload shapes: CeremonyPlugin (`skill`, `targets`, `runId`) and ActionDispatcher (`meta.skillHint`, `meta.agentId`)
- **HTTP API** (`src/index.ts`): `GET /api/world-state`, `GET /api/world-state/:domain`, `GET /api/ceremonies`, `POST /api/ceremonies/:id/run`, `GET /api/goals`, `GET /api/skills/:agentName`

## Test plan
- [ ] CI passes (502 existing tests green)
- [ ] `GET /api/world-state` returns full world state snapshot
- [ ] `GET /api/world-state/agent_health` returns agent reachability data after first 60s tick
- [ ] `POST /api/ceremonies/board.cleanup/run` fires the ceremony and broker routes to quinn
- [ ] `GET /api/goals` returns goals including new agent_health + CI goals
- [ ] When CI success rate < 70%, action dispatcher triggers `ci_debug` → frank via broker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent health monitoring: per-agent reachability & latency collection with a new domain and aggregated state.
  * New APIs: world-state (global & per-domain), ceremonies listing and trigger, and agent skills lookup.
  * Action dispatch: supports fire-and-forget publishing for immediate completion.
  * Skill broker: accepts additional request shapes and derives skill/targets from hints.
  * Routing: dynamic path parameter support.

* **Chores**
  * Updated ceremony skill references, added agent/CI goals, and new actions tied to agent health and CI alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->