### PR TITLE
feat: Discord release notes — dev channel on merge, release channel on tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,3 +70,27 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Notify Discord — what shipped
+        if: env.DISCORD_DEV_WEBHOOK != ''
+        env:
+          DISCORD_DEV_WEBHOOK: ${{ secrets.DISCORD_DEV_WEBHOOK }}
+        run: |
+          SUBJECT=$(git log -1 --pretty=format:"%s")
+          BODY=$(git log -1 --pretty=format:"%b" | head -5)
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          REPO="${{ github.repository }}"
+          RUN_URL="https://github.com/${REPO}/commit/${{ github.sha }}"
+
+          DESCRIPTION="${SUBJECT}"
+          if [ -n "${BODY}" ]; then
+            DESCRIPTION="${SUBJECT}\n\n${BODY}"
+          fi
+
+          curl -s -X POST "$DISCORD_DEV_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+              --arg title "Shipped to main — ${SHORT_SHA}" \
+              --arg desc "${DESCRIPTION}" \
+              --arg url "${RUN_URL}" \
+              '{embeds:[{title:$title,description:$desc,url:$url,color:5763719,footer:{text:"protoWorkstacean CI"}}]}')"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release Notes
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  post-release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history for git log
+
+      - name: Post release notes to Discord
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          DISCORD_RELEASE_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+        run: node scripts/post-release-notes.mjs

--- a/scripts/post-release-notes.mjs
+++ b/scripts/post-release-notes.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * post-release-notes.mjs — Rewrite commits with Claude and post to Discord.
+ *
+ * Usage:
+ *   node scripts/post-release-notes.mjs [--from <ref>] [--to <ref>] [--title <string>]
+ *
+ * Env vars:
+ *   ANTHROPIC_API_KEY        — required (Claude Haiku for rewrite)
+ *   DISCORD_RELEASE_WEBHOOK  — required (Discord webhook URL)
+ *
+ * If --from is omitted, auto-detects the previous git tag.
+ * If no tags exist, falls back to the last 30 commits.
+ */
+
+import { execSync } from "node:child_process";
+import { parseArgs } from "node:util";
+
+// ── Args ──────────────────────────────────────────────────────────────────────
+
+const { values } = parseArgs({
+  options: {
+    from:  { type: "string" },
+    to:    { type: "string", default: "HEAD" },
+    title: { type: "string" },
+  },
+});
+
+const to = values.to || "HEAD";
+
+let from = values.from;
+if (!from) {
+  try {
+    // Previous tag (one before HEAD so we don't include the tag commit itself)
+    from = execSync("git describe --tags --abbrev=0 HEAD^", { encoding: "utf8" }).trim();
+    console.log(`Auto-detected range: ${from}..${to}`);
+  } catch {
+    // No previous tag — grab last 30 commits
+    from = execSync("git rev-list --max-count=30 HEAD | tail -1", { encoding: "utf8" }).trim();
+    console.log(`No previous tag found — using last 30 commits`);
+  }
+}
+
+// ── Commits ───────────────────────────────────────────────────────────────────
+
+const rawLog = execSync(
+  `git log ${from}..${to} --pretty=format:"%s" --no-merges`,
+  { encoding: "utf8" },
+).trim();
+
+const NOISE = /^(chore: release|Merge |promote:|docs: session handoff|Co-Authored)/i;
+
+const commits = rawLog
+  .split("\n")
+  .map(l => l.trim())
+  .filter(l => l.length > 0 && !NOISE.test(l));
+
+if (commits.length === 0) {
+  console.log("No notable commits in range — nothing to post.");
+  process.exit(0);
+}
+
+console.log(`${commits.length} commits to summarise.`);
+
+// ── Version / title ───────────────────────────────────────────────────────────
+
+let version = values.title;
+if (!version) {
+  try {
+    version = execSync("git describe --tags", { encoding: "utf8" }).trim();
+  } catch {
+    version = execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim();
+  }
+}
+
+// ── Claude rewrite ────────────────────────────────────────────────────────────
+
+const apiKey = process.env.ANTHROPIC_API_KEY;
+if (!apiKey) {
+  console.error("ANTHROPIC_API_KEY not set");
+  process.exit(1);
+}
+
+const SYSTEM_PROMPT = `\
+You are writing release notes for protoWorkstacean — an autonomous multi-agent orchestration engine \
+built on a typed event bus, YAML-driven world state, and a GOAP planner.
+
+Given raw git commit subjects, rewrite them as polished release notes.
+
+Rules:
+- Group into 2–4 themed sections relevant to: World Engine, Plugins, HTTP API, Bug Fixes
+- Each item is one sentence, present tense, outcome-focused (what it enables, not what changed)
+- Skip purely internal housekeeping (fixture edits, comment typos, test data only)
+- Use • for bullets. Use **Section Title** for headers. No emojis.
+- Max 280 words. Plain markdown only — no code blocks, no headers with ##.`;
+
+const resp = await fetch("https://api.anthropic.com/v1/messages", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "x-api-key": apiKey,
+    "anthropic-version": "2023-06-01",
+  },
+  body: JSON.stringify({
+    model: "claude-haiku-4-5-20251001",
+    max_tokens: 700,
+    system: SYSTEM_PROMPT,
+    messages: [{ role: "user", content: commits.join("\n") }],
+  }),
+});
+
+if (!resp.ok) {
+  console.error(`Claude API error: ${resp.status}`, await resp.text());
+  process.exit(1);
+}
+
+const data = await resp.json();
+let notes = data.content?.[0]?.text ?? commits.map(c => `• ${c}`).join("\n");
+
+// Discord embed description limit
+if (notes.length > 3900) notes = notes.slice(0, 3897) + "…";
+
+// ── Discord post ──────────────────────────────────────────────────────────────
+
+const webhookUrl = process.env.DISCORD_RELEASE_WEBHOOK;
+if (!webhookUrl) {
+  console.log("DISCORD_RELEASE_WEBHOOK not set — release notes preview:\n\n" + notes);
+  process.exit(0);
+}
+
+const embed = {
+  title: `protoWorkstacean ${version}`,
+  description: notes,
+  color: 0x7c3aed,  // protoLabs purple
+  timestamp: new Date().toISOString(),
+  footer: { text: "protoWorkstacean" },
+};
+
+const discordResp = await fetch(webhookUrl, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ embeds: [embed] }),
+});
+
+if (!discordResp.ok) {
+  const body = await discordResp.text();
+  console.error(`Discord post failed (${discordResp.status}): ${body}`);
+  process.exit(1);
+}
+
+console.log(`Posted release notes for ${version} to Discord.`);


### PR DESCRIPTION
## Summary

- **System 1** (`build.yml`): After every successful push to main, posts a lightweight "what shipped" embed to `DISCORD_DEV_WEBHOOK` — commit subject, body preview, SHA link, blue color
- **System 2** (`release.yml` + `scripts/post-release-notes.mjs`): On `v*` tag push, fetches commits since the previous tag, rewrites them with Claude Haiku into 2–4 themed sections, posts a purple embed to `DISCORD_RELEASE_WEBHOOK`
- Script is also runnable locally: `node scripts/post-release-notes.mjs [--from <ref>] [--to <ref>] [--title <string>]`

## Required GitHub secrets to add
- `DISCORD_DEV_WEBHOOK` — webhook URL for the dev channel (channel 1490974511783219311)
- `DISCORD_RELEASE_WEBHOOK` — webhook URL for the release channel
- `ANTHROPIC_API_KEY` — already present

## Test plan
- [ ] CI passes
- [ ] Add `DISCORD_DEV_WEBHOOK` secret → verify next main merge posts to dev channel
- [ ] Run `DISCORD_RELEASE_WEBHOOK=<url> ANTHROPIC_API_KEY=<key> node scripts/post-release-notes.mjs --title "v0.2.0-test"` locally to preview output
- [ ] Push a `v*` tag → verify release channel embed appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated build notifications with detailed commit information
  * Implemented automated release notes generation and distribution for tagged releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->