### PR TITLE
feat: protoWorkstacean MCP server — Claude Code bus integration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,10 +7,12 @@
       "dependencies": {
         "@makeplane/plane-node-sdk": "^0.2.9",
         "@mariozechner/pi-coding-agent": "^0.64.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "cron-parser": "^5.5.0",
         "discord.js": "^14.0.0",
         "openai": "^4.77.0",
         "yaml": "^2.8.3",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -181,6 +183,8 @@
 
     "@google/genai": ["@google/genai@1.48.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-plonYK4ML2PrxsRD9SeqmFt76eREWkQdPCglOA6aYDzL1AAbE+7PUnT54SvpWGfws13L0AZEqGSpL7+1IPnTxQ=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
+
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
     "@istanbuljs/load-nyc-config": ["@istanbuljs/load-nyc-config@1.1.0", "", { "dependencies": { "camelcase": "^5.3.1", "find-up": "^4.1.0", "get-package-type": "^0.1.0", "js-yaml": "^3.13.1", "resolve-from": "^5.0.0" } }, "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ=="],
@@ -268,6 +272,8 @@
     "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.64.0", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-W1qLry9MAuN/V3YJmMv/BJa0VaYv721NkXPg/DGItdqWxuDc+1VdNbyAnRwxblNkIpXVUWL26x64BlyFXpxmkg=="],
 
     "@mistralai/mistralai": ["@mistralai/mistralai@1.14.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.24.1" } }, "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
@@ -483,6 +489,8 @@
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
@@ -529,6 +537,8 @@
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
@@ -547,11 +557,15 @@
 
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
-    "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+    "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001786", "", {}, "sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA=="],
 
@@ -579,7 +593,17 @@
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cron-parser": ["cron-parser@5.5.0", "", { "dependencies": { "luxon": "^3.7.1" } }, "sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww=="],
 
@@ -597,6 +621,8 @@
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "detect-newline": ["detect-newline@3.1.0", "", {}, "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="],
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
@@ -611,11 +637,15 @@
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.331", "", {}, "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q=="],
 
     "emittery": ["emittery@0.13.1", "", {}, "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
@@ -631,6 +661,8 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
     "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
@@ -641,13 +673,23 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
     "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
 
     "exit-x": ["exit-x@0.2.2", "", {}, "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ=="],
 
     "expect": ["expect@30.3.0", "", { "dependencies": { "@jest/expect-utils": "30.3.0", "@jest/get-type": "30.1.0", "jest-matcher-utils": "30.3.0", "jest-message-util": "30.3.0", "jest-mock": "30.3.0", "jest-util": "30.3.0" } }, "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
@@ -671,6 +713,8 @@
 
     "file-type": ["file-type@21.3.4", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
@@ -684,6 +728,10 @@
     "formdata-node": ["formdata-node@4.4.1", "", { "dependencies": { "node-domexception": "1.0.0", "web-streams-polyfill": "4.0.0-beta.3" } }, "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ=="],
 
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
@@ -733,9 +781,13 @@
 
     "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
 
+    "hono": ["hono@4.12.12", "", {}, "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="],
+
     "hosted-git-info": ["hosted-git-info@9.0.2", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
@@ -744,6 +796,8 @@
     "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
 
     "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
@@ -759,11 +813,15 @@
 
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-generator-fn": ["is-generator-fn@2.1.0", "", {}, "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
@@ -831,6 +889,8 @@
 
     "jest-worker": ["jest-worker@30.3.0", "", { "dependencies": { "@types/node": "*", "@ungap/structured-clone": "^1.3.0", "jest-util": "30.3.0", "merge-stream": "^2.0.0", "supports-color": "^8.1.1" } }, "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ=="],
 
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
@@ -844,6 +904,8 @@
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
@@ -883,6 +945,10 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
@@ -905,6 +971,8 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
     "netmask": ["netmask@2.0.2", "", {}, "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="],
@@ -922,6 +990,10 @@
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
@@ -949,6 +1021,8 @@
 
     "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
@@ -961,6 +1035,8 @@
 
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
@@ -968,6 +1044,8 @@
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
@@ -977,6 +1055,8 @@
 
     "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
     "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
@@ -984,6 +1064,12 @@
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "pure-rand": ["pure-rand@7.0.1", "", {}, "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ=="],
+
+    "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
@@ -997,13 +1083,31 @@
 
     "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
@@ -1022,6 +1126,8 @@
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
@@ -1057,6 +1163,8 @@
 
     "tmpl": ["tmpl@1.0.5", "", {}, "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
@@ -1073,6 +1181,8 @@
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
@@ -1083,11 +1193,15 @@
 
     "undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "unrs-resolver": ["unrs-resolver@1.11.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.11.1", "@unrs/resolver-binding-android-arm64": "1.11.1", "@unrs/resolver-binding-darwin-arm64": "1.11.1", "@unrs/resolver-binding-darwin-x64": "1.11.1", "@unrs/resolver-binding-freebsd-x64": "1.11.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1", "@unrs/resolver-binding-linux-arm64-musl": "1.11.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-musl": "1.11.1", "@unrs/resolver-binding-wasm32-wasi": "1.11.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1", "@unrs/resolver-binding-win32-x64-msvc": "1.11.1" } }, "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "v8-to-istanbul": ["v8-to-istanbul@9.3.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.12", "@types/istanbul-lib-coverage": "^2.0.1", "convert-source-map": "^2.0.0" } }, "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "walker": ["walker@1.0.8", "", { "dependencies": { "makeerror": "1.0.12" } }, "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ=="],
 
@@ -1152,8 +1266,6 @@
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
-
-    "@istanbuljs/load-nyc-config/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "@jest/console/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -1222,6 +1334,8 @@
     "jest-snapshot/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-util/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "jest-validate/camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
 
     "jest-validate/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,124 +1,193 @@
 # Architecture — protoWorkstacean
 
-protoWorkstacean is a personal agent orchestration platform built on a hierarchical topic-based pub/sub message bus. It coordinates a fleet of specialized AI agents (Quinn, Ava, Frank, Jon, etc.) across GitHub, Discord, and Plane.
+protoWorkstacean is a homeostatic agent orchestration platform. It coordinates a fleet of AI agents across GitHub, Discord, Plane, and Google Workspace — and continuously monitors its own world state, acting autonomously to correct deviations from declared goals.
 
-## Core Architecture
+---
 
+## System overview
+
+```mermaid
+flowchart TD
+    subgraph Surfaces["External Surfaces"]
+        GH[GitHub webhooks]
+        DC[Discord gateway]
+        PL[Plane webhooks]
+        GG[Google Workspace]
+    end
+
+    subgraph Entry["Entry Points"]
+        HTTP["HTTP API :3000\n/publish · /api/incidents\n/api/ceremonies/:id/run\n/api/world-state"]
+        MCP["MCP Server\nmcp/server.ts\n(Claude Code agents)"]
+    end
+
+    BUS[("Event Bus\nin-process pub/sub\nhierarchical topics")]
+
+    subgraph Adapters["Interface Plugins"]
+        GHP[GitHubPlugin]
+        DCP[DiscordPlugin]
+        PLP[PlanePlugin]
+        GGP[GooglePlugin]
+        A2A[A2APlugin]
+    end
+
+    subgraph WorldEngine["World Engine"]
+        WSC["WorldStateCollector\nservices · board · CI\nportfolio · security · agent_health"]
+        GEP["GoalEvaluatorPlugin\ngoals.yaml"]
+        PL0["PlannerPluginL0\nactions.yaml"]
+        ADP["ActionDispatcherPlugin\nWIP limit: 5  fireAndForget"]
+    end
+
+    subgraph Ceremonies["Ceremony Pipeline"]
+        CRP["CeremonyPlugin\nworkspace/ceremonies/*.yaml"]
+        SKB["SkillBrokerPlugin"]
+    end
+
+    subgraph Agents["Agent Fleet (A2A / JSON-RPC 2.0)"]
+        AVA[Ava]
+        QNN[Quinn]
+        FRK[Frank]
+        JON[Jon / Cindi]
+        RSR[Researcher]
+    end
+
+    GH --> GHP
+    DC --> DCP
+    PL --> PLP
+    GG --> GGP
+    MCP --> HTTP
+    HTTP --> BUS
+
+    GHP <--> BUS
+    DCP <--> BUS
+    PLP <--> BUS
+    GGP <--> BUS
+    A2A <--> BUS
+
+    WSC -- "world.state.updated" --> GEP
+    GEP -- "world.goal.violated" --> BUS
+    BUS -- "world.goal.violated" --> PL0
+    PL0 -- "world.action.plan" --> BUS
+    BUS -- "world.action.plan" --> ADP
+    ADP -- "message.outbound.discord.alert\nceremony.*.execute\nagent.skill.request" --> BUS
+
+    BUS -- "ceremony.*.execute" --> CRP
+    CRP -- "agent.skill.request" --> BUS
+    BUS -- "agent.skill.request" --> SKB
+    SKB --> A2A
+
+    A2A --> AVA & QNN & FRK & JON & RSR
 ```
-┌─────────────────────────────────────────────────────────┐
-│                     EventBus (in-process)                │
-│           topic-based hierarchical pub/sub              │
-└───────────┬────────────────────────────────┬────────────┘
-            │                                │
-   ┌────────▼────────┐              ┌────────▼────────┐
-   │  Plugin Layer   │              │  Agent Layer    │
-   │  (lib/plugins/) │              │  (workspace/)   │
-   │                 │              │                 │
-   │ • GitHubPlugin  │              │ • Quinn (PR     │
-   │ • DiscordPlugin │              │   review, triage│
-   │ • PlanePlugin   │              │ • Ava (features)│
-   │ • A2APlugin     │              │ • Frank, Jon... │
-   │ • CeremonyPlugin│              └─────────────────┘
-   └─────────────────┘
+
+---
+
+## World Engine — GOAP homeostatic loop
+
+The World Engine continuously monitors system state and autonomously closes deviations from declared goals. No human in the loop for routine corrections.
+
+```mermaid
+flowchart LR
+    subgraph Collectors["WorldStateCollector (per-domain tickers)"]
+        SVC["services\n30s"]
+        BRD["board\n60s"]
+        CI["CI\n5min"]
+        PRT["portfolio\n15min"]
+        SEC["security\n30s"]
+        AGH["agent_health\n60s"]
+    end
+
+    subgraph Goals["goals.yaml"]
+        G1["flow.efficiency_healthy\nThreshold ≥ 0.35"]
+        G2["security.no_open_incidents\nInvariant · critical"]
+        G3["agents.all_reachable\nInvariant · high"]
+        G4["ci.success_rate_healthy\nThreshold ≥ 0.70"]
+        G5["services.all_healthy\nInvariant · high"]
+    end
+
+    subgraph Actions["actions.yaml (tier_0 · fireAndForget)"]
+        A1["alert.security_incident\nprio 100 → Discord alert"]
+        A2["ceremony.security_triage\nprio 90 → quinn bug_triage"]
+        A3["alert.agent_unreachable\n→ Discord alert"]
+        A4["ci.debug_failures\n→ frank ci_debug"]
+        A5["ceremony.service_health_check\n→ health_check ceremony"]
+    end
+
+    Collectors --> GEP["GoalEvaluatorPlugin\nevaluates all goals\nagainst current world state"]
+    GEP -- "violation detected" --> PL0["PlannerPluginL0\nselects highest-priority\napplicable actions"]
+    PL0 --> ADP["ActionDispatcherPlugin\nWIP limit: 5\npublishes to action topic"]
+    ADP --> A1 & A2 & A3 & A4 & A5
+
+    SEC -. "security.incident.reported\n(immediate re-collect)" .-> SEC
 ```
 
-## Plugin System
+---
 
-Plugins are instantiated with a `workspaceDir` and install themselves onto the EventBus:
+## Incident pipeline
 
-```typescript
-export class MyPlugin implements Plugin {
-  readonly name = "my-plugin";
-  install(bus: EventBus): void { /* subscribe + serve */ }
-  uninstall(): void { /* cleanup */ }
-}
+When a security or operational incident is reported — via the MCP server, HTTP API, or a Claude Code agent — it flows through the full GOAP pipeline:
+
+```mermaid
+sequenceDiagram
+    participant U as User / Claude Code
+    participant MCP as MCP Server
+    participant API as HTTP API
+    participant BUS as Event Bus
+    participant WSC as WorldStateCollector
+    participant GOAP as Goal → Planner → Dispatcher
+    participant DC as Discord
+    participant Q as Quinn (bug_triage)
+
+    U->>MCP: report_incident(title, severity, projectSlug)
+    MCP->>API: POST /api/incidents
+    API->>BUS: security.incident.reported
+    BUS->>WSC: immediate re-collect security domain
+    WSC-->>GOAP: openIncidents > 0 → goal violated
+    GOAP->>BUS: alert.security_incident (prio 100)
+    GOAP->>BUS: ceremony.security_triage (prio 90)
+    BUS->>DC: Discord alert embed
+    BUS->>Q: bug_triage skill → triage + board issue
 ```
 
-Plugins use `Bun.serve()` for HTTP endpoints and `bus.subscribe()` / `bus.publish()` for internal routing.
+---
 
-## Quinn Vector Context Pipeline
-
-Quinn's PR review pipeline extends beyond the diff with codebase-wide vector search via Qdrant:
-
-```
-PR opened/synchronize
-  → GitHubPlugin → bus (message.inbound.github.*)
-  → A2APlugin → Quinn agent (pr_review skill)
-  → runReviewPipeline(diff, repo, pr)
-      ├── parseDiff + extractSymbols
-      ├── Qdrant: retrieveAllPastPRDecisions (quinn-pr-history)
-      ├── Qdrant: findAllSimilarPatterns (quinn-code-patterns)
-      ├── formatCodebaseContext + applyTokenBudget
-      └── assembleReviewPrompt → LLM call
-
-PR merged
-  → GitHubPlugin → parsePRMergePayload → handlePRMerge
-      ├── fetchPRDiff + fetchReviewDecision
-      ├── chunkDiff → embed → quinn-pr-history
-      └── extractSymbols → fetchSymbolContexts → quinn-code-patterns
-
-Developer dismisses Quinn comment
-  → GitHubPlugin → parseCommentResponsePayload
-  → handleCommentResponse → trackCommentResponse
-  → recordDismissalEvent → quinn-review-learnings
-```
-
-## Service Layer (`src/services/`)
-
-| Package | Responsibility |
-|---|---|
-| `qdrant/client.ts` | Qdrant REST API client (5s timeout, fallback on error) |
-| `qdrant/collections.ts` | Collection initialization (quinn-pr-history, quinn-code-patterns, quinn-review-learnings) |
-| `qdrant/pr-history-indexer.ts` | Index PR diff chunks |
-| `qdrant/code-patterns-indexer.ts` | Index symbol definitions |
-| `qdrant/pattern-searcher.ts` | Search for similar code patterns |
-| `qdrant/past-pr-retriever.ts` | Retrieve past PR decisions for a file |
-| `qdrant/review-learnings-indexer.ts` | Store/update dismissed comment patterns |
-| `embeddings/ollama-client.ts` | Ollama embedding API (nomic-embed-text) |
-| `diff/chunker.ts` | Parse unified diff, chunk large files |
-| `diff/symbol-extractor.ts` | Route to language-specific symbol extractors |
-| `diff/symbols/typescript.ts` | TypeScript symbol extraction via regex |
-| `diff/symbols/python.ts` | Python symbol extraction via regex |
-| `diff/symbols/go.ts` | Go symbol extraction via regex |
-| `github/diff-fetcher.ts` | Fetch PR diff, comments, and decision via GitHub API |
-| `codebase/symbol-fetcher.ts` | Fetch symbol context via GitHub raw content API |
-| `reviews/context-formatter.ts` | Format CODEBASE CONTEXT block |
-| `reviews/token-budgeter.ts` | Enforce 20% token budget cap |
-| `reviews/quinn-review-prompt.ts` | Assemble final review prompt |
-| `reviews/review-pipeline.ts` | Orchestrate full context retrieval pipeline |
-| `reviews/dismissal-tracker.ts` | Track developer responses to Quinn comments |
-| `reviews/low-signal-filter.ts` | Filter low-signal comment patterns |
-
-## External Services
-
-| Service | URL | Purpose |
-|---|---|---|
-| Qdrant | `http://qdrant:6333` | Vector search and storage |
-| Ollama | `http://ollama:11434` | Local LLM and embedding inference |
-| GitHub API | `https://api.github.com` | PR data, diffs, comments |
-| Plane | configured via `PLANE_API_URL` | Project management integration |
-| Discord | bot token | Team notifications |
-
-## Topic Conventions
+## Message routing conventions
 
 ```
 message.inbound.github.<owner>.<repo>.<event>.<number>   — inbound from GitHub
-message.outbound.github.<owner>.<repo>.<number>          — outbound to GitHub
-message.inbound.discord.<channel>                        — inbound from Discord
-message.outbound.discord.<channel>                       — outbound to Discord
+message.outbound.github.<owner>.<repo>.<number>          — outbound to GitHub comment
+message.inbound.discord.<channelId>                      — inbound from Discord
+message.outbound.discord.<channelId>                     — outbound to Discord channel
+agent.skill.request                                      — route to agent via SkillBroker
+ceremony.<id>.execute                                    — trigger named ceremony
+world.goal.violated                                      — GOAP goal deviation detected
+world.action.plan                                        — planner output ready for dispatch
+security.incident.reported                               — immediate security domain recollect
 ```
 
-## Configuration
+---
 
-All configuration is via environment variables. See `docs/CONFIGURATION_REFERENCE.md` for the full list.
-Key variables for the Quinn vector context pipeline:
+## Workspace config — tracked vs gitignored
 
-```
-QDRANT_URL=http://qdrant:6333
-QDRANT_VECTOR_SIZE=768
-OLLAMA_URL=http://ollama:11434
-OLLAMA_EMBED_MODEL=nomic-embed-text
-GITHUB_WEBHOOK_SECRET=<secret>
-QUINN_APP_ID=<github-app-id>
-QUINN_APP_PRIVATE_KEY=<pem-contents>
-```
+| File | Purpose | Git |
+|------|---------|-----|
+| `workspace/actions.yaml` | GOAP action rules | tracked |
+| `workspace/goals.yaml` | GOAP goal definitions | tracked |
+| `workspace/ceremonies/*.yaml` | ceremony schedules + skill routing | tracked |
+| `workspace/agents.yaml` | agent fleet URLs, skills, chains | **gitignored** |
+| `workspace/projects.yaml` | project registry, Discord channels | **gitignored** |
+| `workspace/discord.yaml` | bot config, slash commands | **gitignored** |
+| `workspace/google.yaml` | Google Workspace config | **gitignored** |
+| `workspace/incidents.yaml` | live security incident state | **gitignored** |
+
+Copy `*.example` counterparts to bootstrap a new deployment.
+
+---
+
+## External services
+
+| Service | Default URL | Purpose |
+|---------|------------|---------|
+| Qdrant | `http://qdrant:6333` | Vector search (Quinn PR review) |
+| Ollama | `http://ollama:11434` | Local embeddings |
+| GitHub API | `https://api.github.com` | PRs, diffs, comments |
+| Plane | `PLANE_BASE_URL` | Project board |
+| Discord | bot token | Notifications, slash commands |

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -14,23 +14,27 @@ The key architectural decision is that **the bus is the only communication chann
 
 ## The event bus
 
-```
-┌─────────────────────────────────────────────────────────┐
-│                     EventBus (in-process)                │
-│           topic-based hierarchical pub/sub              │
-└───────────┬────────────────────────────────┬────────────┘
-            │                                │
-   ┌────────▼────────┐              ┌────────▼────────┐
-   │  Plugin Layer   │              │  Agent Layer    │
-   │  (lib/plugins/) │              │  (workspace/)   │
-   │                 │              │                 │
-   │ • GitHubPlugin  │              │ • Quinn (PR     │
-   │ • DiscordPlugin │              │   review, triage│
-   │ • PlanePlugin   │              │ • Ava (features)│
-   │ • A2APlugin     │              │ • Frank, Jon... │
-   │ • CeremonyPlugin│              └─────────────────┘
-   │ • GooglePlugin  │
-   └─────────────────┘
+```mermaid
+flowchart LR
+    subgraph In["Inbound"]
+        GH[GitHub]
+        DC[Discord]
+        PL[Plane]
+        GG[Google]
+        HTTP[HTTP API\n+ MCP Server]
+    end
+
+    BUS[("Event Bus\npub/sub · hierarchical topics")]
+
+    subgraph Out["Processing"]
+        A2A[A2APlugin\n→ agent fleet]
+        WE[World Engine\nGOAP pipeline]
+        CER[CeremonyPlugin\n→ scheduled skills]
+    end
+
+    In --> BUS
+    BUS --> Out
+    Out --> BUS
 ```
 
 The bus is an in-process pub/sub system with MQTT-style hierarchical topic matching. `#` matches any number of path segments:
@@ -121,6 +125,48 @@ PR merged
 ```
 
 Developer dismissals are tracked in `quinn-review-learnings` and used to suppress low-signal comment patterns over time.
+
+---
+
+## The World Engine
+
+The World Engine is a second major system alongside the A2A routing pipeline. Where A2A is reactive (respond to an event), the World Engine is **homeostatic** — it continuously measures system state against declared goals and autonomously acts to close deviations.
+
+Four plugins compose the pipeline:
+
+1. **WorldStateCollector** — six independent tickers collect domain state: `services` (30s), `board` (60s), `CI` (5min), `portfolio` (15min), `security` (30s), `agent_health` (60s). Results are merged into a single `WorldState` snapshot.
+2. **GoalEvaluatorPlugin** — evaluates every goal in `goals.yaml` against the current snapshot. When a goal is violated, publishes `world.goal.violated`.
+3. **PlannerPluginL0** — on `world.goal.violated`, scans `actions.yaml` for applicable tier_0 actions (matching goal + preconditions), selects the highest-priority set, and publishes `world.action.plan`.
+4. **ActionDispatcherPlugin** — executes the plan. For `fireAndForget: true` actions (alerts, ceremonies), it publishes to the action's topic immediately and marks complete. WIP limit: 5 concurrent non-fire-and-forget actions.
+
+```mermaid
+flowchart LR
+    WSC["WorldStateCollector\n6 domains · independent ticks"]
+    GEP["GoalEvaluatorPlugin\ngoals.yaml"]
+    PL0["PlannerPluginL0\nactions.yaml"]
+    ADP["ActionDispatcherPlugin"]
+
+    subgraph Outcomes["Action outcomes"]
+        DISC["Discord alert"]
+        CER["ceremony.*.execute\n→ CeremonyPlugin → SkillBroker → A2A"]
+        SKILL["agent.skill.request\n→ SkillBroker → A2A"]
+    end
+
+    WSC --> GEP
+    GEP -- "world.goal.violated" --> PL0
+    PL0 -- "world.action.plan" --> ADP
+    ADP --> DISC & CER & SKILL
+```
+
+Goals and actions are **declarative YAML** — adding a new monitored condition requires only an entry in `goals.yaml` and a matching action in `actions.yaml`. No code change needed.
+
+---
+
+## The MCP server
+
+`mcp/server.ts` is a stdio MCP server that exposes the bus to Claude Code agents. It wraps the HTTP API and provides typed tools: `report_incident`, `report_bug`, `get_world_state`, `publish`, `run_ceremony`, and others. All tools accept a `projectSlug` parameter that flows through the event payload to route downstream work to the correct project's agents and board.
+
+This closes the loop: a Claude Code session can report an incident → the incident enters `incidents.yaml` → the security domain surfaces it in world state → GOAP fires the alert and triage ceremony → Quinn triages it and files a board issue.
 
 ---
 

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -1,0 +1,224 @@
+/**
+ * protoWorkstacean MCP Server
+ *
+ * Exposes the protoWorkstacean event bus and world state to Claude Code agents.
+ * Register in .claude/mcp.json (project-local) or ~/.claude.json (global):
+ *
+ *   "workstacean": {
+ *     "type": "stdio",
+ *     "command": "bun",
+ *     "args": ["run", "/path/to/protoWorkstacean/mcp/server.ts"],
+ *     "env": {
+ *       "WORKSTACEAN_URL": "http://localhost:3000",
+ *       "WORKSTACEAN_API_KEY": "<key>"
+ *     }
+ *   }
+ *
+ * Tools use projectSlug to route events to the correct project's agents,
+ * board, and Discord channels. Pass the slug from workspace/projects.yaml.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const BASE_URL = (process.env.WORKSTACEAN_URL ?? "http://localhost:3000").replace(/\/$/, "");
+const API_KEY  = process.env.WORKSTACEAN_API_KEY ?? "";
+
+// ── HTTP helper ────────────────────────────────────────────────────────────────
+
+async function api(method: string, path: string, body?: unknown): Promise<unknown> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (API_KEY) headers["X-API-Key"] = API_KEY;
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  return res.json();
+}
+
+function text(data: unknown): { content: Array<{ type: "text"; text: string }> } {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+// ── Server ─────────────────────────────────────────────────────────────────────
+
+const server = new McpServer({
+  name: "workstacean",
+  version: "0.1.0",
+});
+
+// ── health_check ───────────────────────────────────────────────────────────────
+
+server.tool(
+  "health_check",
+  "Verify the protoWorkstacean bus is reachable and return its status.",
+  {},
+  async () => text(await api("GET", "/health")),
+);
+
+// ── get_world_state ────────────────────────────────────────────────────────────
+
+server.tool(
+  "get_world_state",
+  "Read the current world state. Optionally scope to a single domain: services | board | ci | security | agent_health | portfolio.",
+  {
+    domain: z.enum(["services", "board", "ci", "security", "agent_health", "portfolio"])
+      .optional()
+      .describe("Domain to retrieve. Omit for the full world state."),
+  },
+  async ({ domain }) => {
+    const path = domain ? `/api/world-state/${domain}` : "/api/world-state";
+    return text(await api("GET", path));
+  },
+);
+
+// ── report_incident ────────────────────────────────────────────────────────────
+
+server.tool(
+  "report_incident",
+  "Report a security or operational incident to the bus. Triggers the GOAP security pipeline — world state updates immediately, goal evaluator fires, Discord alert and security-triage ceremony are dispatched.",
+  {
+    title: z.string().describe("Short description of the incident."),
+    severity: z.enum(["critical", "high", "medium", "low"])
+      .describe("Incident severity. Use 'critical' for active breaches or leaked secrets."),
+    description: z.string().optional().describe("Full details: what happened, what was exposed, what mitigation is in place."),
+    projectSlug: z.string().optional().describe("Slug from projects.yaml (e.g. protolabsai-protomaker). Routes the incident to the correct project's agents and board."),
+    assignee: z.string().optional().describe("Agent name to assign triage to. Defaults to 'quinn'."),
+  },
+  async ({ title, severity, description, projectSlug, assignee }) => {
+    return text(await api("POST", "/api/incidents", {
+      title,
+      severity,
+      description,
+      affectedProjects: projectSlug ? [projectSlug] : [],
+      assignee: assignee ?? "quinn",
+    }));
+  },
+);
+
+// ── get_incidents ──────────────────────────────────────────────────────────────
+
+server.tool(
+  "get_incidents",
+  "List all security/operational incidents. Optionally filter to a specific project.",
+  {
+    projectSlug: z.string().optional().describe("Filter to incidents affecting this project slug."),
+    status: z.enum(["open", "investigating", "resolved", "all"]).optional()
+      .describe("Filter by status. Defaults to all."),
+  },
+  async ({ projectSlug, status }) => {
+    const result = await api("GET", "/api/incidents") as { success: boolean; data: Array<{
+      id: string; status: string; affectedProjects?: string[];
+    }> };
+    let incidents = result.data ?? [];
+    if (projectSlug) {
+      incidents = incidents.filter(i => i.affectedProjects?.includes(projectSlug));
+    }
+    if (status && status !== "all") {
+      incidents = incidents.filter(i => i.status === status);
+    }
+    return text({ ...result, data: incidents });
+  },
+);
+
+// ── resolve_incident ───────────────────────────────────────────────────────────
+
+server.tool(
+  "resolve_incident",
+  "Mark a security/operational incident as resolved. Publishes to the bus — world state security domain recollects immediately.",
+  {
+    id: z.string().describe("Incident ID (e.g. INC-001)."),
+  },
+  async ({ id }) => text(await api("POST", `/api/incidents/${id}/resolve`)),
+);
+
+// ── report_bug ─────────────────────────────────────────────────────────────────
+
+server.tool(
+  "report_bug",
+  "Report a bug against a project. Routes to quinn's bug_triage skill via the skill broker. Quinn will triage, create a board issue, and escalate to ava if actionable.",
+  {
+    title: z.string().describe("Bug title."),
+    description: z.string().describe("Steps to reproduce, expected vs actual behaviour, any relevant logs or stack traces."),
+    projectSlug: z.string().describe("Slug from projects.yaml — determines which project board the issue is filed against and which agents are notified."),
+    priority: z.enum(["urgent", "high", "medium", "low"]).optional()
+      .describe("Priority hint passed to quinn. Defaults to 'medium'."),
+  },
+  async ({ title, description, projectSlug, priority }) => {
+    return text(await api("POST", "/publish", {
+      topic: "agent.skill.request",
+      payload: {
+        skill: "bug_triage",
+        agentId: "quinn",
+        projectSlug,
+        context: {
+          title,
+          description,
+          priority: priority ?? "medium",
+          source: "mcp",
+        },
+      },
+    }));
+  },
+);
+
+// ── run_ceremony ───────────────────────────────────────────────────────────────
+
+server.tool(
+  "run_ceremony",
+  "Manually trigger a named ceremony. The ceremony YAML must exist in workspace/ceremonies/.",
+  {
+    ceremonyId: z.string().describe("Ceremony ID (matches the YAML filename without extension, e.g. 'security-triage', 'board-health')."),
+    projectSlug: z.string().optional().describe("Project context to include in the ceremony payload."),
+  },
+  async ({ ceremonyId, projectSlug }) => {
+    // POST /api/ceremonies/:id/run expects an auth header — pass it via the helper
+    const result = await api("POST", `/api/ceremonies/${ceremonyId}/run`, {
+      projectSlug,
+    });
+    return text(result);
+  },
+);
+
+// ── publish ────────────────────────────────────────────────────────────────────
+
+server.tool(
+  "publish",
+  "Publish a raw event to the protoWorkstacean bus. Use this for advanced routing when no higher-level tool fits.",
+  {
+    topic: z.string().describe("Bus topic (e.g. 'agent.skill.request', 'message.inbound.discord.alert')."),
+    payload: z.record(z.unknown()).describe("Event payload. Include 'projectSlug' to enable downstream project-scoped routing."),
+    projectSlug: z.string().optional().describe("Convenience — merged into payload.projectSlug if provided."),
+  },
+  async ({ topic, payload, projectSlug }) => {
+    return text(await api("POST", "/publish", {
+      topic,
+      payload: projectSlug ? { ...payload, projectSlug } : payload,
+    }));
+  },
+);
+
+// ── list_ceremonies ────────────────────────────────────────────────────────────
+
+server.tool(
+  "list_ceremonies",
+  "List all available ceremonies defined in workspace/ceremonies/.",
+  {},
+  async () => text(await api("GET", "/api/ceremonies")),
+);
+
+// ── get_goals ─────────────────────────────────────────────────────────────────
+
+server.tool(
+  "get_goals",
+  "List all GOAP goals and their current definitions. Use get_world_state to see which goals are currently violated.",
+  {},
+  async () => text(await api("GET", "/api/goals")),
+);
+
+// ── Start ──────────────────────────────────────────────────────────────────────
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "start": "bun run src/index.ts"
+    "start": "bun run src/index.ts",
+    "mcp": "bun run mcp/server.ts"
   },
   "dependencies": {
     "@makeplane/plane-node-sdk": "^0.2.9",
     "@mariozechner/pi-coding-agent": "^0.64.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "cron-parser": "^5.5.0",
     "discord.js": "^14.0.0",
     "openai": "^4.77.0",


### PR DESCRIPTION
## Summary
- Adds \`mcp/server.ts\` — a stdio MCP server wrapping the protoWorkstacean HTTP API
- Exposes 10 tools: \`report_incident\`, \`report_bug\`, \`publish\`, \`get_world_state\`, \`get_incidents\`, \`resolve_incident\`, \`run_ceremony\`, \`list_ceremonies\`, \`get_goals\`, \`health_check\`
- All tools accept \`projectSlug\` to route events to the correct project's agents, board, and Discord channels
- \`report_bug\` publishes \`agent.skill.request\` → quinn's \`bug_triage\` skill; \`report_incident\` triggers the full GOAP security pipeline

## Registration
Add to \`.claude/mcp.json\`:
\`\`\`json
"workstacean": {
  "type": "stdio",
  "command": "bun",
  "args": ["run", "/path/to/protoWorkstacean/mcp/server.ts"],
  "env": { "WORKSTACEAN_URL": "http://localhost:3000", "WORKSTACEAN_API_KEY": "<key>" }
}
\`\`\`

## Test plan
- [ ] CI passes
- [ ] \`bun run mcp\` starts without error
- [ ] \`health_check\` returns \`{ status: "ok" }\` against a running bus

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MCP server exposing tools for health checks, world-state queries, incident lifecycle (create/list/resolve), bug reporting, ceremony execution, event publishing, and goal retrieval via an HTTP-backed integration.
* **Documentation**
  * Reworked architecture docs to a "homeostatic agent orchestration" view with flow diagrams, updated topics/routing, and expanded World Engine and ceremony pipeline descriptions.
* **Chores**
  * Added an npm script to run the MCP server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->