### PR TITLE
fix: post-merge CI fixes — CodeRabbit review + type check

### DIFF
--- a/src/agent-runtime/__tests__/tool-registry.test.ts
+++ b/src/agent-runtime/__tests__/tool-registry.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeEach } from "bun:test";
 import { ToolRegistry } from "../tool-registry.ts";
 import { tool } from "@protolabsai/sdk";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/src/agent-runtime/__tests__/tool-registry.test.ts
+++ b/src/agent-runtime/__tests__/tool-registry.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeEach } from "bun:test";
 import { ToolRegistry } from "../tool-registry.ts";
 import { tool } from "@protolabsai/sdk";
-import { z } from "zod/v3";
+import { z } from "zod";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/src/agent-runtime/tools/bus-tools.ts
+++ b/src/agent-runtime/tools/bus-tools.ts
@@ -14,7 +14,7 @@
  */
 
 import { tool } from "@protolabsai/sdk";
-import { z } from "zod";
+import { z } from "zod/v3";
 import type { SdkMcpToolDefinition } from "@protolabsai/sdk";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/agent-runtime/tools/bus-tools.ts
+++ b/src/agent-runtime/tools/bus-tools.ts
@@ -15,10 +15,6 @@
 
 import { tool } from "@protolabsai/sdk";
 import { z } from "zod";
-import type { SdkMcpToolDefinition } from "@protolabsai/sdk";
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyToolDef = SdkMcpToolDefinition<any>;
 
 function ok(data: unknown) {
   return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
@@ -64,7 +60,7 @@ export interface BusToolsOptions {
  * Create all built-in bus tool definitions.
  * Call once at startup and register the returned array with ToolRegistry.
  */
-export function createBusTools(opts: BusToolsOptions = {}): AnyToolDef[] {
+export function createBusTools(opts: BusToolsOptions = {}) {
   const baseUrl = opts.baseUrl ?? "http://localhost:3000";
   const apiKey = opts.apiKey;
 
@@ -199,10 +195,7 @@ export function createBusTools(opts: BusToolsOptions = {}): AnyToolDef[] {
     },
   );
 
-  // Each tool is SdkMcpToolDefinition<SpecificSchema>. TypeScript's strict function
-  // parameter contravariance prevents direct assignment to AnyToolDef[], so cast here.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return [publishEvent, getWorldState, getIncidents, reportIncident, getCeremonies, runCeremony] as unknown as AnyToolDef[];
+  return [publishEvent, getWorldState, getIncidents, reportIncident, getCeremonies, runCeremony];
 }
 
 /**

--- a/src/agent-runtime/tools/bus-tools.ts
+++ b/src/agent-runtime/tools/bus-tools.ts
@@ -14,7 +14,7 @@
  */
 
 import { tool } from "@protolabsai/sdk";
-import { z } from "zod/v3";
+import { z } from "zod";
 import type { SdkMcpToolDefinition } from "@protolabsai/sdk";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

Follow-up fixes that landed after #56 was merged:

- **CodeRabbit review fixes** — tick serialization, maxAgeMs null return, trace chain in dispatch-queue, debounce cleanup, source field placement, prototype restore in tests
- **Zod version alignment** — downgrade `zod ^4.3.6 → ^3.25.0` to match `@protolabsai/sdk@0.2.0`'s Zod 3 dependency; eliminates `ZodString`/`ZodObject` type incompatibility that was breaking `tsc --noEmit`
- **`agent-executor.ts`** — cast to `SDKResultMessageSuccess` after `"result" in message` narrowing; access `stop_reason` safely via index signature
- **`bus-tools.ts`** — drop explicit `SdkMcpToolDefinition<any>[]` return type; TypeScript infers the concrete union which assigns cleanly to `ToolRegistry.registerAll(SdkMcpToolDefinition<any>[])` without any cast

## Test plan

- [ ] `bun run tsc --noEmit` passes cleanly
- [ ] `bun test` — 577 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code quality through type system refinements, enhancing code maintainability without any user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->