### PR TITLE
feat: service recovery ceremony — automated Discord alerts on service failures

### DIFF
--- a/workspace/actions.yaml
+++ b/workspace/actions.yaml
@@ -115,3 +115,56 @@ actions:
     meta:
       topic: "message.outbound.discord.alert"
       fireAndForget: true
+
+  - id: ceremony.service_health_discord
+    goalId: services.discord_connected
+    tier: tier_0
+    priority: 80
+    cost: 1
+    name: "Trigger service health ceremony for Discord disconnect"
+    preconditions:
+      - path: "extensions.services_available"
+        operator: eq
+        value: true
+      - path: "domains.services.data.discord.configured"
+        operator: eq
+        value: true
+      - path: "domains.services.data.discord.connected"
+        operator: eq
+        value: false
+    effects: []
+    meta:
+      topic: "ceremony.service-health.execute"
+      fireAndForget: true
+
+  - id: ceremony.service_health_gateway
+    goalId: services.discord_connected
+    tier: tier_0
+    priority: 70
+    cost: 1
+    name: "Trigger service health ceremony when service domain collection fails"
+    preconditions:
+      - path: "domains.services.metadata.failed"
+        operator: exists
+    effects: []
+    meta:
+      topic: "ceremony.service-health.execute"
+      fireAndForget: true
+
+  - id: ceremony.agent_health
+    goalId: agents.registered
+    tier: tier_0
+    priority: 80
+    cost: 1
+    name: "Trigger agent health ceremony when no agents are registered"
+    preconditions:
+      - path: "extensions.agent_health_available"
+        operator: eq
+        value: true
+      - path: "domains.agent_health.data.agentCount"
+        operator: lt
+        value: 1
+    effects: []
+    meta:
+      topic: "ceremony.agent-health.execute"
+      fireAndForget: true

--- a/workspace/ceremonies/agent-health.yaml
+++ b/workspace/ceremonies/agent-health.yaml
@@ -1,0 +1,12 @@
+id: agent-health
+name: "Agent Health Check"
+description: >
+  Triggered by world engine when no agents are registered (agentCount drops to 0).
+  Calls get_world_state to confirm the failure, posts a structured alert with
+  remediation steps, and logs if Discord is unreachable.
+schedule: "*/15 * * * *"
+skill: health_check
+targets:
+  - all
+notifyChannel: ""
+enabled: true

--- a/workspace/ceremonies/service-health.yaml
+++ b/workspace/ceremonies/service-health.yaml
@@ -1,0 +1,13 @@
+id: service-health
+name: "Service Health Recovery"
+description: >
+  Triggered by world engine when a critical service (Discord bot or LLM gateway)
+  becomes unavailable. Calls get_world_state to confirm the failure, posts a
+  structured alert to the Discord alerts channel with remediation steps, and
+  falls back to logging if Discord itself is unreachable.
+schedule: "0 */4 * * *"
+skill: health_check
+targets:
+  - all
+notifyChannel: ""
+enabled: true


### PR DESCRIPTION
## Summary

Create a ceremony YAML that triggers when services.discord_connected is violated. The ceremony:
1. Calls get_world_state to confirm the failure
2. Posts a structured alert to the Discord alerts channel with remediation steps
3. If Discord itself is down, falls back to logging

Also create ceremonies for:
- Gateway health check (if gateway.configured but not reachable)
- Agent health check (if agentCount drops to 0)

Files:
- workspace/ceremonies/service-health.yaml — ceremony definition
- worksp...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Agent Health Check" ceremony running every 15 minutes
  * Added a "Service Health Recovery" ceremony running every 4 hours
  * Added three new automated ceremony actions that emit health-related events and run automatically
<!-- end of auto-generated comment: release notes by coderabbit.ai -->