### PR TITLE
fix: align Ava goal/action selectors with actual API response

### DIFF
--- a/workspace/actions.yaml
+++ b/workspace/actions.yaml
@@ -207,7 +207,7 @@ actions:
       - path: "extensions.ava_board_available"
         operator: eq
         value: true
-      - path: "domains.ava_board.data.blocked_count"
+      - path: "domains.ava_board.data.blocked"
         operator: gt
         value: 3
     effects: []
@@ -225,7 +225,7 @@ actions:
       - path: "extensions.ava_board_available"
         operator: eq
         value: true
-      - path: "domains.ava_board.data.blocked_count"
+      - path: "domains.ava_board.data.blocked"
         operator: gt
         value: 3
     effects: []
@@ -235,20 +235,46 @@ actions:
       agentId: ava
       fireAndForget: true
 
-  - id: alert.ava_auto_mode_off
-    goalId: ava.auto_mode_active
+  - id: alert.ava_backlog_piling
+    goalId: ava.backlog_not_piling
     tier: tier_0
-    priority: 10
+    priority: 15
     cost: 0
-    name: "Alert when auto-mode is disabled"
+    name: "Alert when backlog exceeds 10 features"
     preconditions:
-      - path: "extensions.ava_pipeline_available"
+      - path: "extensions.ava_board_available"
         operator: eq
         value: true
-      - path: "domains.ava_pipeline.data.auto_mode"
-        operator: eq
-        value: false
+      - path: "domains.ava_board.data.backlog"
+        operator: gt
+        value: 10
     effects: []
     meta:
       topic: "message.outbound.discord.alert"
+      fireAndForget: true
+
+  - id: action.ava_start_auto_mode
+    goalId: ava.backlog_not_piling
+    tier: tier_0
+    priority: 30
+    cost: 1
+    name: "Dispatch Ava to start auto-mode when backlog has work"
+    preconditions:
+      - path: "extensions.ava_board_available"
+        operator: eq
+        value: true
+      - path: "extensions.ava_pipeline_available"
+        operator: eq
+        value: true
+      - path: "domains.ava_pipeline.data.runningCount"
+        operator: eq
+        value: 0
+      - path: "domains.ava_board.data.backlog"
+        operator: gt
+        value: 0
+    effects: []
+    meta:
+      topic: "agent.skill.request"
+      skillHint: auto_mode
+      agentId: ava
       fireAndForget: true

--- a/workspace/goals.yaml
+++ b/workspace/goals.yaml
@@ -70,13 +70,13 @@ goals:
   - id: ava.board_healthy
     type: Threshold
     severity: high
-    selector: "domains.ava_board.data.blocked_count"
+    selector: "domains.ava_board.data.blocked"
     max: 3
     description: "No more than 3 features blocked simultaneously"
 
-  - id: ava.auto_mode_active
-    type: Invariant
+  - id: ava.backlog_not_piling
+    type: Threshold
     severity: medium
-    selector: "domains.ava_pipeline.data.auto_mode"
-    operator: truthy
-    description: "Auto-mode should be running when backlog has work"
+    selector: "domains.ava_board.data.backlog"
+    max: 10
+    description: "Backlog should not exceed 10 features — work is piling up"


### PR DESCRIPTION
## Summary
- Fix selector paths: `blocked_count` → `blocked`, `backlog_count` → `backlog` (Ava uses camelCase)
- Remove `ava.auto_mode_active` goal — agent-health endpoint doesn't expose `auto_mode`
- Add `ava.backlog_not_piling` goal (max 10 backlog features)
- Add `action.ava_start_auto_mode` — dispatches Ava when backlog > 0 and no agents running

## Test plan
- [ ] Deploy with Ava world endpoints live, verify selectors resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added backlog overflow monitoring that alerts when items exceed 10.
  * Implemented automatic work processing that triggers when backlog has pending items and system capacity permits.

* **Improvements**
  * Enhanced board health tracking by refining blocked item detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->