### PR TITLE
docs: add refactor-on-write TODOs to growing files

### DIFF
--- a/lib/plugins/flow-monitor.ts
+++ b/lib/plugins/flow-monitor.ts
@@ -1,4 +1,16 @@
 /**
+ * TODO(refactor): This file is 933 lines with 6 distinct metric computations.
+ * When next touching this file, decompose into:
+ *   lib/plugins/flow/metrics/velocity.ts
+ *   lib/plugins/flow/metrics/lead-time.ts
+ *   lib/plugins/flow/metrics/efficiency.ts
+ *   lib/plugins/flow/metrics/load.ts
+ *   lib/plugins/flow/metrics/distribution.ts
+ *   lib/plugins/flow/metrics/bottleneck.ts
+ *   lib/plugins/flow-monitor.ts — plugin shell that calls them
+ * Pattern: src/api/ decomposition (PR #73). Each metric = pure function,
+ * plugin holds state + scheduling, delegates computation.
+ *
  * FlowMonitorPlugin — continuous collection of 5 Flow Framework metrics.
  *
  * Metrics collected:

--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -1,4 +1,11 @@
 /**
+ * TODO(refactor): This file is 664 lines mixing webhook handling + auto-triage
+ * + auth (GitHub App vs PAT). When next touching, consider splitting:
+ *   lib/plugins/github/webhook.ts — webhook signature verification + routing
+ *   lib/plugins/github/auto-triage.ts — issue auto-triage logic
+ *   lib/plugins/github/auth.ts — App vs PAT auth selection
+ *   lib/plugins/github.ts — plugin shell
+ *
  * GitHubPlugin — receives GitHub webhook events and routes @mentions to the bus.
  *
  * Inbound:

--- a/lib/plugins/onboarding.ts
+++ b/lib/plugins/onboarding.ts
@@ -1,4 +1,16 @@
 /**
+ * TODO(refactor): This file is 631 lines with 9 pipeline steps in one class.
+ * When next touching this file, decompose into:
+ *   lib/plugins/onboarding/steps/validate.ts
+ *   lib/plugins/onboarding/steps/plane-project.ts
+ *   lib/plugins/onboarding/steps/plane-webhook.ts
+ *   lib/plugins/onboarding/steps/github-webhook.ts
+ *   lib/plugins/onboarding/steps/discord-provision.ts
+ *   lib/plugins/onboarding/steps/projects-yaml.ts
+ *   lib/plugins/onboarding/steps/bus-notify.ts
+ *   lib/plugins/onboarding.ts — orchestrator (runs pipeline, handles rollback)
+ * Each step = { name, execute(ctx), rollback?(ctx) } interface.
+ *
  * OnboardingPlugin — deterministic 8-step project onboarding pipeline.
  *
  * Each step is idempotent: re-running for the same project slug is safe.

--- a/lib/plugins/world-state-engine.ts
+++ b/lib/plugins/world-state-engine.ts
@@ -1,4 +1,13 @@
 /**
+ * TODO(refactor): This file is 606 lines mixing engine + Redis + SQLite + HTTP
+ * collector factory + MCP tool factory. When next touching, consider splitting:
+ *   lib/plugins/world-state/engine.ts — core state machine, domain registry
+ *   lib/plugins/world-state/redis-cache.ts — Redis fast-path + fallback
+ *   lib/plugins/world-state/snapshot-store.ts — SQLite persistence
+ *   lib/plugins/world-state/http-collector.ts — createHttpCollector factory
+ *   lib/plugins/world-state/mcp-tool.ts — MCP tool factory
+ *   lib/plugins/world-state-engine.ts — plugin shell
+ *
  * WorldStateEngine — generic, application-agnostic world state machine.
  *
  * The engine makes no assumptions about what domains exist. Applications

--- a/src/plugins/CeremonyPlugin.ts
+++ b/src/plugins/CeremonyPlugin.ts
@@ -1,4 +1,13 @@
 /**
+ * TODO(refactor): This file is 514 lines mixing YAML loading + hot-reload +
+ * cron scheduling + skill dispatch + DB persistence. When next touching,
+ * consider splitting:
+ *   src/plugins/ceremony/loader.ts — YAML loading + hot-reload watcher
+ *   src/plugins/ceremony/scheduler.ts — cron scheduling + timer management
+ *   src/plugins/ceremony/dispatcher.ts — skill dispatch + outcome handling
+ *   src/plugins/ceremony/outcomes-db.ts — SQLite persistence
+ *   src/plugins/CeremonyPlugin.ts — plugin shell
+ *
  * CeremonyPlugin — fleet-wide ceremony scheduling and execution.
  *
  * Replaces hardcoded cron tasks with configurable, observable, and


### PR DESCRIPTION
## Summary

Add TODO(refactor) comments to 5 files approaching god-file status. Next agent touching any of these should decompose before adding more code.

| File | Lines | Decomposition target |
|------|-------|---------------------|
| `lib/plugins/flow-monitor.ts` | 933 | 6 metric computations → `flow/metrics/*` |
| `lib/plugins/github.ts` | 664 | webhook + triage + auth → `github/*` |
| `lib/plugins/onboarding.ts` | 631 | 9 pipeline steps → `onboarding/steps/*` |
| `lib/plugins/world-state-engine.ts` | 606 | engine + Redis + SQLite + factories → `world-state/*` |
| `src/plugins/CeremonyPlugin.ts` | 514 | loader + scheduler + dispatch + DB → `ceremony/*` |

Discord (1259 lines) and Google (822 lines) are tracked as dedicated refactor features on the board.

## Test plan
- [x] `bun test` — 626 pass, 0 fail
- [x] No code changes, docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)