### PR TITLE
M6: Projects and CI — project cards with CI health bars and PR pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,18 @@ If an API changes, update every call site. If a concept is replaced, delete the 
 - **World state is ground truth.** The GOAP loop polls durable HTTP domains, builds a world state snapshot, and evaluates declarative goals against it.
 - **Channels are declarative.** `workspace/channels.yaml` is the single place to add a communication channel. No code changes needed.
 
+## Git Workflow
+
+**Never push directly to `main`.** All changes flow through:
+
+1. **Feature branch** — branch from `dev`, implement, test locally (`bun test`)
+2. **PR to `dev`** — CI validates, code review, merge
+3. **PR from `dev` to `main`** — release gate, clean tested code only
+
+Branch naming: `feature/<short-description>` (auto-mode uses Automaker's naming convention).
+
+The Automaker `gitWorkflow.prBaseBranch` is set to `dev`. Auto-mode agents target `dev` automatically.
+
 ## Stack
 
 - Runtime: Bun

--- a/dashboard/astro.config.mjs
+++ b/dashboard/astro.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from "astro/config";
+import preact from "@astrojs/preact";
+
+export default defineConfig({
+  output: "static",
+  outDir: "./dist",
+  integrations: [preact()],
+});

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "workstacean-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "astro": "astro"
+  },
+  "dependencies": {
+    "astro": "^6.0.1",
+    "@astrojs/preact": "^4.0.0",
+    "preact": "^10.25.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  }
+}

--- a/dashboard/src/components/CiBar.tsx
+++ b/dashboard/src/components/CiBar.tsx
@@ -1,0 +1,64 @@
+interface CiBarProps {
+  successRate: number; // 0.0 – 1.0
+  totalRuns: number;
+  failedRuns: number;
+}
+
+export default function CiBar({ successRate, totalRuns, failedRuns }: CiBarProps) {
+  const pct = Math.round(successRate * 100);
+  const color =
+    pct >= 90
+      ? "var(--text-success)"
+      : pct >= 70
+        ? "var(--text-warning)"
+        : "var(--text-danger)";
+
+  return (
+    <div class="ci-bar">
+      <div class="ci-bar__track">
+        <div
+          class="ci-bar__fill"
+          style={{ width: `${pct}%`, background: color }}
+        />
+      </div>
+      <div class="ci-bar__labels">
+        <span class="ci-bar__pct" style={{ color }}>
+          {pct}%
+        </span>
+        <span class="ci-bar__detail">
+          {totalRuns} runs · {failedRuns} failed
+        </span>
+      </div>
+      <style>{`
+        .ci-bar {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+        }
+        .ci-bar__track {
+          height: 6px;
+          background: var(--bg-subtle);
+          border-radius: 3px;
+          overflow: hidden;
+        }
+        .ci-bar__fill {
+          height: 100%;
+          border-radius: 3px;
+          transition: width 0.3s ease;
+        }
+        .ci-bar__labels {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          font-size: 11px;
+        }
+        .ci-bar__pct {
+          font-weight: 600;
+        }
+        .ci-bar__detail {
+          color: var(--text-secondary);
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/dashboard/src/components/DomainCard.tsx
+++ b/dashboard/src/components/DomainCard.tsx
@@ -1,0 +1,159 @@
+import { useState } from "preact/hooks";
+import JsonTree from "./JsonTree.tsx";
+
+export interface DomainCardProps {
+  name: string;
+  data: unknown;
+  metadata: {
+    collectedAt: number;
+    domain: string;
+    tickNumber: number;
+    failed?: boolean;
+    errorMessage?: string;
+  };
+}
+
+function relativeTime(ms: number): string {
+  const diffMs = Date.now() - ms;
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  return `${diffHr}h ago`;
+}
+
+export default function DomainCard({ name, data, metadata }: DomainCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const failed = metadata.failed === true;
+
+  const cardBorderColor = failed
+    ? "rgba(248, 81, 73, 0.5)"
+    : "var(--border-default)";
+
+  const cardBg = failed ? "rgba(248, 81, 73, 0.06)" : "var(--bg-default)";
+
+  return (
+    <div
+      class="card domain-card"
+      style={{ borderColor: cardBorderColor, background: cardBg }}
+    >
+      <div class="domain-card__header">
+        <div class="domain-card__title-row">
+          <span
+            class="domain-card__status-dot"
+            style={{ background: failed ? "var(--text-danger)" : "var(--text-success)" }}
+          />
+          <span class="domain-card__name">{name}</span>
+          {failed && (
+            <span class="badge badge-red" style={{ marginLeft: "8px" }}>
+              failed
+            </span>
+          )}
+        </div>
+
+        <div class="domain-card__meta">
+          <span class="domain-card__meta-item" title={new Date(metadata.collectedAt).toISOString()}>
+            {relativeTime(metadata.collectedAt)}
+          </span>
+          <span class="domain-card__meta-sep">·</span>
+          <span class="domain-card__meta-item">tick #{metadata.tickNumber}</span>
+        </div>
+      </div>
+
+      {failed && metadata.errorMessage && (
+        <div class="domain-card__error">{metadata.errorMessage}</div>
+      )}
+
+      <button
+        class="domain-card__toggle"
+        onClick={() => setExpanded(!expanded)}
+      >
+        {expanded ? "Hide data ▲" : "Show data ▼"}
+      </button>
+
+      {expanded && (
+        <div class="domain-card__data">
+          <JsonTree value={data} />
+        </div>
+      )}
+
+      <style>{`
+        .domain-card {
+          display: flex;
+          flex-direction: column;
+          gap: 10px;
+          transition: border-color 0.2s;
+        }
+        .domain-card__header {
+          display: flex;
+          align-items: flex-start;
+          justify-content: space-between;
+          gap: 12px;
+        }
+        .domain-card__title-row {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+        }
+        .domain-card__status-dot {
+          width: 8px;
+          height: 8px;
+          border-radius: 50%;
+          flex-shrink: 0;
+        }
+        .domain-card__name {
+          font-size: 14px;
+          font-weight: 600;
+          color: var(--text-primary);
+          font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+        }
+        .domain-card__meta {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          flex-shrink: 0;
+        }
+        .domain-card__meta-item {
+          font-size: 12px;
+          color: var(--text-secondary);
+        }
+        .domain-card__meta-sep {
+          color: var(--border-default);
+          font-size: 12px;
+        }
+        .domain-card__error {
+          font-size: 12px;
+          color: var(--text-danger);
+          background: rgba(248, 81, 73, 0.1);
+          border: 1px solid rgba(248, 81, 73, 0.3);
+          border-radius: 4px;
+          padding: 6px 10px;
+        }
+        .domain-card__toggle {
+          align-self: flex-start;
+          background: none;
+          border: 1px solid var(--border-muted);
+          border-radius: 4px;
+          color: var(--text-secondary);
+          cursor: pointer;
+          font-size: 12px;
+          padding: 4px 10px;
+          transition: border-color 0.1s, color 0.1s;
+        }
+        .domain-card__toggle:hover {
+          border-color: var(--border-default);
+          color: var(--text-primary);
+        }
+        .domain-card__data {
+          background: var(--bg-inset);
+          border: 1px solid var(--border-default);
+          border-radius: 4px;
+          padding: 12px;
+          max-height: 400px;
+          overflow-y: auto;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/dashboard/src/components/EventDetail.tsx
+++ b/dashboard/src/components/EventDetail.tsx
@@ -1,0 +1,22 @@
+import type { WsMessage } from "../lib/websocket";
+
+interface EventDetailProps {
+  msg: WsMessage;
+  onClose: () => void;
+}
+
+export function EventDetail({ msg, onClose }: EventDetailProps) {
+  function copyToClipboard() {
+    navigator.clipboard?.writeText(JSON.stringify(msg, null, 2)).catch(() => {});
+  }
+
+  return (
+    <div class="event-detail open">
+      <div class="event-detail-toolbar">
+        <button class="detail-btn" onClick={copyToClipboard}>Copy</button>
+        <button class="detail-btn" onClick={onClose}>Collapse</button>
+      </div>
+      <pre>{JSON.stringify(msg, null, 2)}</pre>
+    </div>
+  );
+}

--- a/dashboard/src/components/EventRow.tsx
+++ b/dashboard/src/components/EventRow.tsx
@@ -1,0 +1,49 @@
+import type { WsMessage } from "../lib/websocket";
+
+interface EventRowProps {
+  msg: WsMessage;
+  isExpanded: boolean;
+  onClick: () => void;
+}
+
+function getSource(topic: string): string {
+  if (!topic) return "default";
+  return topic.split(".")[0].toLowerCase();
+}
+
+function compressTopic(topic: string): string {
+  if (!topic) return "";
+  return topic.split(".").map((p) => p[0]).join(".");
+}
+
+function formatTime(ts: string): string {
+  return new Date(ts).toLocaleTimeString("en-US", { hour12: false });
+}
+
+function formatPayload(msg: WsMessage): string {
+  if (typeof msg.payload === "string") return msg.payload;
+  const p = msg.payload as Record<string, unknown> | null;
+  if (p && typeof p.content === "string") return p.content;
+  return JSON.stringify(msg.payload);
+}
+
+export function EventRow({ msg, isExpanded, onClick }: EventRowProps) {
+  const source = getSource(msg.topic);
+
+  return (
+    <>
+      <div class="event-row" onClick={onClick}>
+        <span class="event-time">{formatTime(msg.timestamp)}</span>
+        <span class={`event-topic source-${source}`} title={msg.topic}>
+          {compressTopic(msg.topic)}
+        </span>
+        <span class="event-preview">{formatPayload(msg)}</span>
+      </div>
+      {isExpanded && (
+        <div class="event-detail open">
+          <pre>{JSON.stringify(msg, null, 2)}</pre>
+        </div>
+      )}
+    </>
+  );
+}

--- a/dashboard/src/components/EventStream.tsx
+++ b/dashboard/src/components/EventStream.tsx
@@ -1,0 +1,461 @@
+import { useState, useEffect, useRef } from "preact/hooks";
+import { WebSocketManager } from "../lib/websocket";
+import type { WsMessage } from "../lib/websocket";
+import { EventRow } from "./EventRow";
+import { LogRow } from "./LogRow";
+
+type WsStatus = "connecting" | "connected" | "disconnected";
+
+// Wildcard topic filter — supports * (single segment) and # (any suffix)
+function topicMatchesFilter(topic: string, filter: string): boolean {
+  if (!filter) return true;
+  const parts = filter.split(".");
+  const topicParts = (topic || "").split(".");
+  for (let i = 0; i < parts.length; i++) {
+    if (parts[i] === "#") return true;
+    if (parts[i] === "*") continue;
+    if (parts[i] !== topicParts[i]) return false;
+  }
+  return parts.length === topicParts.length;
+}
+
+function isDebug(msg: WsMessage): boolean {
+  return typeof msg.topic === "string" && msg.topic.startsWith("debug.");
+}
+
+export default function EventStream() {
+  const [events, setEvents] = useState<WsMessage[]>([]);
+  const [logs, setLogs] = useState<WsMessage[]>([]);
+  const [activeTab, setActiveTab] = useState<"events" | "logs">("events");
+  const [filter, setFilter] = useState("");
+  const [isPaused, setIsPaused] = useState(false);
+  const [autoScroll, setAutoScroll] = useState(true);
+  const [wsStatus, setWsStatus] = useState<WsStatus>("connecting");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const listRef = useRef<HTMLDivElement>(null);
+  const isPausedRef = useRef(isPaused);
+  isPausedRef.current = isPaused;
+
+  const autoScrollRef = useRef(autoScroll);
+  autoScrollRef.current = autoScroll;
+
+  // Load history on mount
+  useEffect(() => {
+    fetch("/api/events?limit=500")
+      .then((r) => r.json())
+      .then((data: unknown) => {
+        const msgs = (Array.isArray(data) ? data : []) as WsMessage[];
+        const evts: WsMessage[] = [];
+        const lgts: WsMessage[] = [];
+        msgs.reverse().forEach((msg) => {
+          if (isDebug(msg)) lgts.push(msg);
+          else evts.push(msg);
+        });
+        setEvents(evts);
+        setLogs(lgts);
+      })
+      .catch(() => {});
+  }, []);
+
+  // WebSocket connection
+  useEffect(() => {
+    const manager = new WebSocketManager("/ws");
+
+    const offStatus = manager.onStatus((status) => setWsStatus(status));
+    const offMsg = manager.onMessage((msg) => {
+      if (isPausedRef.current) return;
+      if (isDebug(msg)) {
+        setLogs((prev) => [...prev, msg]);
+      } else {
+        setEvents((prev) => [...prev, msg]);
+      }
+    });
+
+    manager.connect();
+
+    return () => {
+      offStatus();
+      offMsg();
+      manager.destroy();
+    };
+  }, []);
+
+  // Auto-scroll
+  useEffect(() => {
+    if (autoScroll && listRef.current) {
+      listRef.current.scrollTop = listRef.current.scrollHeight;
+    }
+  }, [events, logs, autoScroll]);
+
+  function handleScroll() {
+    const el = listRef.current;
+    if (!el) return;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 50;
+    if (atBottom !== autoScrollRef.current) {
+      setAutoScroll(atBottom);
+    }
+  }
+
+  function clearActive() {
+    if (activeTab === "events") setEvents([]);
+    else setLogs([]);
+    setExpandedId(null);
+  }
+
+  function toggleExpanded(id: string) {
+    setExpandedId((prev) => (prev === id ? null : id));
+  }
+
+  const items = activeTab === "events" ? events : logs;
+  const filtered = filter
+    ? items.filter((m) => topicMatchesFilter(m.topic, filter))
+    : items;
+
+  const dotClass =
+    wsStatus === "connected"
+      ? "status-dot connected"
+      : wsStatus === "connecting"
+        ? "status-dot connecting"
+        : "status-dot";
+
+  const statusLabel =
+    wsStatus === "connected"
+      ? "Connected"
+      : wsStatus === "connecting"
+        ? "Connecting…"
+        : "Disconnected";
+
+  return (
+    <>
+      <style>{`
+        .es-header {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+          background: #161b22;
+          border-bottom: 1px solid #30363d;
+          padding: 10px 16px;
+          flex-shrink: 0;
+          flex-wrap: wrap;
+        }
+        .es-tabs {
+          display: flex;
+          gap: 2px;
+          background: #0d1117;
+          border-radius: 6px;
+          padding: 2px;
+        }
+        .es-tab {
+          padding: 4px 14px;
+          font-size: 12px;
+          border-radius: 4px;
+          cursor: pointer;
+          color: #8b949e;
+          border: none;
+          background: transparent;
+          font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
+          transition: all 0.15s;
+        }
+        .es-tab:hover { color: #c9d1d9; }
+        .es-tab.active { background: #21262d; color: #c9d1d9; }
+
+        .status-dot {
+          width: 8px;
+          height: 8px;
+          border-radius: 50%;
+          background: #f85149;
+          transition: background 0.2s;
+          flex-shrink: 0;
+        }
+        .status-dot.connected { background: #3fb950; }
+        .status-dot.connecting { background: #d29922; animation: es-pulse 1s infinite; }
+        @keyframes es-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+
+        .es-status {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          font-size: 12px;
+          padding: 4px 10px;
+          border-radius: 12px;
+          background: #21262d;
+          color: #c9d1d9;
+          font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
+        }
+        .es-badge {
+          font-size: 11px;
+          background: #30363d;
+          padding: 2px 8px;
+          border-radius: 10px;
+          color: #8b949e;
+          font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
+        }
+        .es-toolbar {
+          background: #161b22;
+          border-bottom: 1px solid #30363d;
+          padding: 8px 16px;
+          display: flex;
+          gap: 8px;
+          align-items: center;
+          flex-shrink: 0;
+          flex-wrap: wrap;
+        }
+        .es-filter {
+          background: #0d1117;
+          border: 1px solid #30363d;
+          color: #c9d1d9;
+          padding: 6px 10px;
+          border-radius: 6px;
+          font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
+          font-size: 13px;
+          width: 260px;
+          outline: none;
+        }
+        .es-filter:focus { border-color: #58a6ff; }
+        .es-filter::placeholder { color: #484f58; }
+        .es-btn {
+          background: #21262d;
+          border: 1px solid #30363d;
+          color: #c9d1d9;
+          padding: 6px 12px;
+          border-radius: 6px;
+          font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
+          font-size: 12px;
+          cursor: pointer;
+          transition: background 0.15s;
+        }
+        .es-btn:hover { background: #30363d; }
+        .es-btn.active { background: #1f6feb; border-color: #1f6feb; }
+        .es-btn.paused { background: #da3633; border-color: #da3633; }
+
+        .es-list {
+          flex: 1;
+          overflow: auto;
+          padding: 4px 0;
+          font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
+        }
+        .es-list::-webkit-scrollbar { width: 8px; }
+        .es-list::-webkit-scrollbar-track { background: #0d1117; }
+        .es-list::-webkit-scrollbar-thumb { background: #30363d; border-radius: 4px; }
+
+        .es-empty {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          height: 200px;
+          color: #484f58;
+          gap: 8px;
+          font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
+          font-size: 14px;
+        }
+
+        /* Event rows */
+        .event-row {
+          display: flex;
+          align-items: flex-start;
+          gap: 12px;
+          padding: 8px 16px;
+          border-bottom: 1px solid #21262d;
+          cursor: pointer;
+          transition: background 0.1s;
+          overflow-x: auto;
+        }
+        .event-row:hover { background: #161b22; }
+        .event-time {
+          font-size: 11px;
+          color: #484f58;
+          white-space: nowrap;
+          min-width: 70px;
+          padding-top: 2px;
+        }
+        .event-topic {
+          font-size: 11px;
+          padding: 2px 6px;
+          border-radius: 4px;
+          white-space: nowrap;
+          font-weight: 500;
+          letter-spacing: 0.5px;
+        }
+        .event-topic.source-agent { background: #1a1932; color: #bc8cff; }
+        .event-topic.source-cli { background: #122d20; color: #3fb950; }
+        .event-topic.source-signal { background: #2d1f12; color: #d29922; }
+        .event-topic.source-echo { background: #1f2330; color: #79c0ff; }
+        .event-topic.source-scheduler { background: #2d1229; color: #f778ba; }
+        .event-topic.source-logger { background: #1a2332; color: #58a6ff; }
+        .event-topic.source-event-viewer { background: #2d2a12; color: #e3b341; }
+        .event-topic.source-default { background: #21262d; color: #8b949e; }
+        .event-preview {
+          font-size: 12px;
+          color: #8b949e;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          flex: 1;
+        }
+        .event-detail {
+          display: none;
+          padding: 0 16px 12px 98px;
+          background: #0d1117;
+          border-bottom: 1px solid #21262d;
+        }
+        .event-detail.open { display: block; }
+        .event-detail pre {
+          background: #161b22;
+          border: 1px solid #30363d;
+          border-radius: 6px;
+          padding: 12px;
+          font-size: 12px;
+          overflow: auto;
+          max-height: 400px;
+          color: #c9d1d9;
+          line-height: 1.5;
+        }
+        .event-detail-toolbar {
+          display: flex;
+          gap: 6px;
+          margin-bottom: 6px;
+        }
+        .detail-btn {
+          background: #21262d;
+          border: 1px solid #30363d;
+          color: #8b949e;
+          padding: 3px 8px;
+          border-radius: 4px;
+          font-size: 11px;
+          cursor: pointer;
+          font-family: inherit;
+        }
+        .detail-btn:hover { background: #30363d; color: #c9d1d9; }
+
+        /* Log rows */
+        .log-row {
+          display: flex;
+          align-items: flex-start;
+          gap: 12px;
+          padding: 4px 16px;
+          border-bottom: 1px solid #161b22;
+          cursor: pointer;
+          transition: background 0.1s;
+        }
+        .log-row:hover { background: #161b22; }
+        .log-level {
+          font-size: 10px;
+          padding: 1px 6px;
+          border-radius: 3px;
+          white-space: nowrap;
+          font-weight: 600;
+          text-transform: uppercase;
+          min-width: 44px;
+          text-align: center;
+        }
+        .log-level.log { background: #21262d; color: #8b949e; }
+        .log-level.debug { background: #1a2332; color: #58a6ff; }
+        .log-level.info { background: #122d20; color: #3fb950; }
+        .log-level.warn { background: #2d1f12; color: #d29922; }
+        .log-level.error { background: #2d1215; color: #f85149; }
+        .log-message {
+          font-size: 12px;
+          color: #6e7681;
+          flex: 1;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+        .log-detail {
+          display: none;
+          padding: 0 16px 12px 98px;
+          background: #0d1117;
+          border-bottom: 1px solid #161b22;
+        }
+        .log-detail.open { display: block; }
+        .log-detail pre {
+          background: #161b22;
+          border: 1px solid #30363d;
+          border-radius: 6px;
+          padding: 12px;
+          font-size: 12px;
+          overflow: auto;
+          max-height: 400px;
+          color: #c9d1d9;
+          line-height: 1.5;
+        }
+      `}</style>
+
+      <div class="es-header">
+        <div class="es-tabs">
+          <button
+            class={`es-tab${activeTab === "events" ? " active" : ""}`}
+            onClick={() => { setActiveTab("events"); setExpandedId(null); }}
+          >
+            Events
+          </button>
+          <button
+            class={`es-tab${activeTab === "logs" ? " active" : ""}`}
+            onClick={() => { setActiveTab("logs"); setExpandedId(null); }}
+          >
+            Logs
+          </button>
+        </div>
+        <div class="es-status">
+          <span class={dotClass} />
+          {statusLabel}
+        </div>
+        <div class="es-badge">
+          {filtered.length} {activeTab === "events" ? "events" : "logs"}
+        </div>
+      </div>
+
+      <div class="es-toolbar">
+        <input
+          class="es-filter"
+          type="text"
+          placeholder={activeTab === "events" ? "Filter by topic (e.g. agent.*)" : "Filter by topic (e.g. debug.*)"}
+          value={filter}
+          onInput={(e) => setFilter((e.target as HTMLInputElement).value)}
+        />
+        <button class="es-btn" onClick={clearActive}>Clear</button>
+        <button
+          class={`es-btn${isPaused ? " paused" : ""}`}
+          onClick={() => setIsPaused((p) => !p)}
+        >
+          {isPaused ? "Resume" : "Pause"}
+        </button>
+        <button
+          class={`es-btn${autoScroll ? " active" : ""}`}
+          onClick={() => setAutoScroll((a) => !a)}
+          title="Toggle auto-scroll"
+        >
+          Auto-scroll
+        </button>
+      </div>
+
+      <div class="es-list" ref={listRef} onScroll={handleScroll}>
+        {filtered.length === 0 ? (
+          <div class="es-empty">
+            <p>{items.length === 0 ? "Waiting for events…" : "No matches for current filter"}</p>
+          </div>
+        ) : (
+          filtered.map((msg) =>
+            activeTab === "events" ? (
+              <EventRow
+                key={msg.id ?? msg.timestamp}
+                msg={msg}
+                isExpanded={expandedId === (msg.id ?? msg.timestamp)}
+                onClick={() => toggleExpanded(msg.id ?? msg.timestamp)}
+              />
+            ) : (
+              <LogRow
+                key={msg.id ?? msg.timestamp}
+                msg={msg}
+                isExpanded={expandedId === (msg.id ?? msg.timestamp)}
+                onClick={() => toggleExpanded(msg.id ?? msg.timestamp)}
+              />
+            )
+          )
+        )}
+      </div>
+    </>
+  );
+}

--- a/dashboard/src/components/GoalCard.tsx
+++ b/dashboard/src/components/GoalCard.tsx
@@ -1,0 +1,194 @@
+import type { Goal, EvalResult } from "../lib/goal-evaluator.ts";
+
+export interface GoalCardProps {
+  goal: Goal;
+  result: EvalResult;
+}
+
+const severityColors: Record<string, string> = {
+  critical: "var(--text-danger)",
+  high: "var(--text-warning)",
+  medium: "var(--accent-fg)",
+  low: "var(--text-secondary)",
+};
+
+const typeLabel: Record<string, string> = {
+  Threshold: "Threshold",
+  Invariant: "Invariant",
+  Distribution: "Distribution",
+};
+
+export default function GoalCard({ goal, result }: GoalCardProps) {
+  const pass = result.status === "pass";
+  const unknown = result.status === "unknown";
+  const severity = goal.severity ?? "medium";
+  const sevColor = severityColors[severity] ?? "var(--text-secondary)";
+
+  const borderColor = unknown
+    ? "var(--border-default)"
+    : pass
+      ? "rgba(63, 185, 80, 0.4)"
+      : "rgba(248, 81, 73, 0.4)";
+
+  const indicatorColor = unknown
+    ? "var(--text-secondary)"
+    : pass
+      ? "var(--text-success)"
+      : "var(--text-danger)";
+
+  const indicatorLabel = unknown ? "?" : pass ? "✓" : "✗";
+  const statusBadgeClass = unknown
+    ? "badge badge-blue"
+    : pass
+      ? "badge badge-green"
+      : "badge badge-red";
+  const statusText = unknown ? "unknown" : pass ? "pass" : "fail";
+
+  // Build threshold range label
+  let thresholdLabel: string | null = null;
+  if (goal.type === "Threshold") {
+    const min = "min" in goal ? goal.min : undefined;
+    const max = "max" in goal ? goal.max : undefined;
+    if (min !== undefined && max !== undefined) thresholdLabel = `${min} ≤ x ≤ ${max}`;
+    else if (min !== undefined) thresholdLabel = `≥ ${min}`;
+    else if (max !== undefined) thresholdLabel = `≤ ${max}`;
+  }
+
+  return (
+    <div class="goal-card card" style={{ borderColor }}>
+      <div class="goal-card__header">
+        <div class="goal-card__left">
+          <span
+            class="goal-card__indicator"
+            style={{ color: indicatorColor, borderColor: indicatorColor }}
+          >
+            {indicatorLabel}
+          </span>
+          <div class="goal-card__title-group">
+            <span class="goal-card__id">{goal.id}</span>
+            <span class="goal-card__desc">{goal.description}</span>
+          </div>
+        </div>
+        <div class="goal-card__badges">
+          <span class="badge badge-blue">{typeLabel[goal.type] ?? goal.type}</span>
+          <span class="badge" style={{ background: `${sevColor}22`, color: sevColor }}>
+            {severity}
+          </span>
+          <span class={statusBadgeClass}>{statusText}</span>
+        </div>
+      </div>
+
+      <div class="goal-card__detail">
+        {"selector" in goal && (
+          <span class="goal-card__selector">{(goal as { selector: string }).selector}</span>
+        )}
+        {result.actual !== undefined && result.actual !== null && (
+          <span class="goal-card__value">
+            value: <code>{JSON.stringify(result.actual)}</code>
+          </span>
+        )}
+        {thresholdLabel && (
+          <span class="goal-card__threshold">range: {thresholdLabel}</span>
+        )}
+        {!pass && result.message && (
+          <span class="goal-card__message">{result.message}</span>
+        )}
+      </div>
+
+      <style>{`
+        .goal-card {
+          display: flex;
+          flex-direction: column;
+          gap: 10px;
+          transition: border-color 0.2s;
+        }
+        .goal-card__header {
+          display: flex;
+          align-items: flex-start;
+          justify-content: space-between;
+          gap: 12px;
+        }
+        .goal-card__left {
+          display: flex;
+          align-items: flex-start;
+          gap: 10px;
+          min-width: 0;
+        }
+        .goal-card__indicator {
+          width: 24px;
+          height: 24px;
+          border-radius: 50%;
+          border: 2px solid;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-size: 13px;
+          font-weight: 700;
+          flex-shrink: 0;
+        }
+        .goal-card__title-group {
+          display: flex;
+          flex-direction: column;
+          gap: 2px;
+          min-width: 0;
+        }
+        .goal-card__id {
+          font-size: 13px;
+          font-weight: 600;
+          color: var(--text-primary);
+          font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+        .goal-card__desc {
+          font-size: 12px;
+          color: var(--text-secondary);
+        }
+        .goal-card__badges {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          flex-shrink: 0;
+        }
+        .goal-card__detail {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 8px;
+          align-items: center;
+          padding-top: 4px;
+          border-top: 1px solid var(--border-muted);
+        }
+        .goal-card__selector {
+          font-size: 11px;
+          color: var(--text-secondary);
+          font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+          background: var(--bg-inset);
+          padding: 2px 6px;
+          border-radius: 4px;
+        }
+        .goal-card__value {
+          font-size: 12px;
+          color: var(--text-secondary);
+        }
+        .goal-card__value code {
+          color: var(--accent-fg);
+        }
+        .goal-card__threshold {
+          font-size: 12px;
+          color: var(--text-secondary);
+          font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+        }
+        .goal-card__message {
+          font-size: 11px;
+          color: var(--text-danger);
+          background: rgba(248, 81, 73, 0.08);
+          border: 1px solid rgba(248, 81, 73, 0.2);
+          border-radius: 4px;
+          padding: 3px 8px;
+          flex: 1 1 100%;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/dashboard/src/components/GoalStatus.tsx
+++ b/dashboard/src/components/GoalStatus.tsx
@@ -1,0 +1,164 @@
+import { useState, useEffect } from "preact/hooks";
+import GoalCard from "./GoalCard.tsx";
+import { evaluateGoal } from "../lib/goal-evaluator.ts";
+import type { Goal, EvalResult } from "../lib/goal-evaluator.ts";
+
+const POLL_INTERVAL_MS = 30_000;
+
+interface GoalsApiResponse {
+  success: boolean;
+  data: Goal[];
+}
+
+interface WorldStateApiResponse {
+  success: boolean;
+  data: unknown;
+}
+
+interface GoalWithResult {
+  goal: Goal;
+  result: EvalResult;
+}
+
+export default function GoalStatus() {
+  const [items, setItems] = useState<GoalWithResult[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  async function fetchAndEvaluate() {
+    try {
+      const [goalsRes, wsRes] = await Promise.all([
+        fetch("/api/goals"),
+        fetch("/api/world-state"),
+      ]);
+
+      if (!goalsRes.ok) throw new Error(`/api/goals: ${goalsRes.status}`);
+      if (!wsRes.ok) throw new Error(`/api/world-state: ${wsRes.status}`);
+
+      const goalsJson = (await goalsRes.json()) as GoalsApiResponse;
+      const wsJson = (await wsRes.json()) as WorldStateApiResponse;
+
+      const goals: Goal[] = Array.isArray(goalsJson.data) ? goalsJson.data : [];
+      const worldState = wsJson.data ?? null;
+
+      const evaluated: GoalWithResult[] = goals.map((goal) => ({
+        goal,
+        result: evaluateGoal(goal, worldState),
+      }));
+
+      // Sort: fail first, then unknown, then pass
+      evaluated.sort((a, b) => {
+        const order = { fail: 0, unknown: 1, pass: 2 };
+        return (order[a.result.status] ?? 1) - (order[b.result.status] ?? 1);
+      });
+
+      setItems(evaluated);
+      setError(null);
+      setLastUpdated(new Date());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    fetchAndEvaluate();
+    const timer = setInterval(fetchAndEvaluate, POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, []);
+
+  const passCount = items.filter((i) => i.result.status === "pass").length;
+  const failCount = items.filter((i) => i.result.status === "fail").length;
+  const unknownCount = items.filter((i) => i.result.status === "unknown").length;
+
+  return (
+    <div class="goal-status">
+      <div class="goal-status__header">
+        <h2 class="goal-status__title">Goal Definitions</h2>
+        <div class="goal-status__meta">
+          {lastUpdated && (
+            <span class="goal-status__updated">
+              Updated {lastUpdated.toLocaleTimeString()}
+            </span>
+          )}
+          {!loading && items.length > 0 && (
+            <div class="goal-status__counts">
+              <span class="badge badge-green">{passCount} pass</span>
+              <span class="badge badge-red">{failCount} fail</span>
+              {unknownCount > 0 && (
+                <span class="badge badge-blue">{unknownCount} unknown</span>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {loading && (
+        <div class="card">
+          <p class="placeholder-content">Loading goals…</p>
+        </div>
+      )}
+
+      {!loading && error && (
+        <div class="card" style={{ borderColor: "rgba(248,81,73,0.4)" }}>
+          <p style={{ color: "var(--text-danger)", fontSize: "13px" }}>
+            Failed to load goals: {error}
+          </p>
+        </div>
+      )}
+
+      {!loading && !error && items.length === 0 && (
+        <div class="card">
+          <p class="placeholder-content">No goals defined</p>
+        </div>
+      )}
+
+      {!loading && !error && items.length > 0 && (
+        <div class="goal-status__list">
+          {items.map(({ goal, result }) => (
+            <GoalCard key={goal.id} goal={goal} result={result} />
+          ))}
+        </div>
+      )}
+
+      <style>{`
+        .goal-status {
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+        }
+        .goal-status__header {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 12px;
+        }
+        .goal-status__title {
+          font-size: 16px;
+          font-weight: 600;
+        }
+        .goal-status__meta {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+        }
+        .goal-status__updated {
+          font-size: 12px;
+          color: var(--text-secondary);
+        }
+        .goal-status__counts {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+        }
+        .goal-status__list {
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/dashboard/src/components/HealthCard.astro
+++ b/dashboard/src/components/HealthCard.astro
@@ -1,0 +1,63 @@
+---
+interface Props {
+  status: "green" | "yellow" | "red" | "loading";
+  metric: string;
+  label: string;
+}
+
+const { status, metric, label } = Astro.props;
+---
+
+<div class={`card health-card health-card--${status}`}>
+  <div class="card-title">{label}</div>
+  <div class="health-card__body">
+    <span class={`status-dot status-dot--${status}`}></span>
+    <span class="health-card__metric">{metric}</span>
+  </div>
+</div>
+
+<style>
+  .health-card {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .health-card__body {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .status-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .status-dot--green { background: var(--text-success); }
+  .status-dot--yellow { background: var(--text-warning); }
+  .status-dot--red { background: var(--text-danger); }
+  .status-dot--loading {
+    background: var(--text-secondary);
+    animation: pulse 1.2s ease-in-out infinite;
+  }
+
+  @keyframes pulse {
+    0%, 100% { opacity: 0.4; }
+    50% { opacity: 1; }
+  }
+
+  .health-card__metric {
+    font-size: 22px;
+    font-weight: 600;
+    color: var(--text-primary);
+    line-height: 1.2;
+  }
+
+  .health-card--green { border-color: rgba(63, 185, 80, 0.3); }
+  .health-card--yellow { border-color: rgba(210, 153, 34, 0.3); }
+  .health-card--red { border-color: rgba(248, 81, 73, 0.3); }
+  .health-card--loading { border-color: var(--border-muted); }
+</style>

--- a/dashboard/src/components/JsonTree.tsx
+++ b/dashboard/src/components/JsonTree.tsx
@@ -1,0 +1,140 @@
+import { useState } from "preact/hooks";
+
+interface JsonTreeProps {
+  value: unknown;
+  depth?: number;
+}
+
+const MAX_AUTO_EXPAND_DEPTH = 2;
+
+function JsonNode({ value, depth = 0 }: JsonTreeProps) {
+  const [expanded, setExpanded] = useState(depth < MAX_AUTO_EXPAND_DEPTH);
+
+  if (value === null) {
+    return <span class="json-null">null</span>;
+  }
+
+  if (typeof value === "boolean") {
+    return <span class="json-bool">{String(value)}</span>;
+  }
+
+  if (typeof value === "number") {
+    return <span class="json-number">{String(value)}</span>;
+  }
+
+  if (typeof value === "string") {
+    return <span class="json-string">"{value}"</span>;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return <span class="json-bracket">[]</span>;
+    }
+
+    return (
+      <span>
+        <button class="json-toggle" onClick={() => setExpanded(!expanded)}>
+          {expanded ? "▼" : "▶"}
+        </button>
+        <span class="json-bracket">[</span>
+        {expanded ? (
+          <div class="json-children">
+            {value.map((item, i) => (
+              <div key={i} class="json-row">
+                <span class="json-index">{i}: </span>
+                <JsonNode value={item} depth={depth + 1} />
+                {i < value.length - 1 && <span class="json-comma">,</span>}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <span class="json-collapsed"> {value.length} items </span>
+        )}
+        <span class="json-bracket">]</span>
+      </span>
+    );
+  }
+
+  if (typeof value === "object") {
+    const keys = Object.keys(value as Record<string, unknown>);
+    if (keys.length === 0) {
+      return <span class="json-bracket">{"{}"}</span>;
+    }
+
+    return (
+      <span>
+        <button class="json-toggle" onClick={() => setExpanded(!expanded)}>
+          {expanded ? "▼" : "▶"}
+        </button>
+        <span class="json-bracket">{"{"}</span>
+        {expanded ? (
+          <div class="json-children">
+            {keys.map((key, i) => (
+              <div key={key} class="json-row">
+                <span class="json-key">"{key}"</span>
+                <span class="json-colon">: </span>
+                <JsonNode value={(value as Record<string, unknown>)[key]} depth={depth + 1} />
+                {i < keys.length - 1 && <span class="json-comma">,</span>}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <span class="json-collapsed"> {keys.length} keys </span>
+        )}
+        <span class="json-bracket">{"}"}</span>
+      </span>
+    );
+  }
+
+  return <span class="json-unknown">{String(value)}</span>;
+}
+
+export default function JsonTree({ value }: JsonTreeProps) {
+  return (
+    <>
+      <style>{`
+        .json-tree {
+          font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+          font-size: 12px;
+          line-height: 1.6;
+          color: #c9d1d9;
+        }
+        .json-children {
+          padding-left: 20px;
+          border-left: 1px solid #30363d;
+          margin-left: 4px;
+        }
+        .json-row {
+          display: block;
+        }
+        .json-toggle {
+          background: none;
+          border: none;
+          color: #8b949e;
+          cursor: pointer;
+          font-size: 10px;
+          padding: 0 4px 0 0;
+          vertical-align: middle;
+          line-height: 1;
+        }
+        .json-toggle:hover {
+          color: #c9d1d9;
+        }
+        .json-key { color: #79c0ff; }
+        .json-string { color: #a5d6ff; }
+        .json-number { color: #79c0ff; }
+        .json-bool { color: #ff7b72; }
+        .json-null { color: #8b949e; font-style: italic; }
+        .json-bracket { color: #c9d1d9; }
+        .json-colon { color: #8b949e; }
+        .json-comma { color: #8b949e; }
+        .json-index { color: #8b949e; }
+        .json-collapsed { color: #8b949e; font-style: italic; }
+        .json-unknown { color: #c9d1d9; }
+      `}</style>
+      <div class="json-tree">
+        <JsonNode value={value} depth={0} />
+      </div>
+    </>
+  );
+}

--- a/dashboard/src/components/LogRow.tsx
+++ b/dashboard/src/components/LogRow.tsx
@@ -1,0 +1,32 @@
+import type { WsMessage } from "../lib/websocket";
+
+interface LogRowProps {
+  msg: WsMessage;
+  isExpanded: boolean;
+  onClick: () => void;
+}
+
+function formatTime(ts: string): string {
+  return new Date(ts).toLocaleTimeString("en-US", { hour12: false });
+}
+
+export function LogRow({ msg, isExpanded, onClick }: LogRowProps) {
+  const p = msg.payload as Record<string, unknown> | null;
+  const level = (typeof p?.level === "string" ? p.level : "log").toLowerCase();
+  const message = typeof p?.message === "string" ? p.message : "";
+
+  return (
+    <>
+      <div class="log-row" onClick={onClick}>
+        <span class="event-time">{formatTime(msg.timestamp)}</span>
+        <span class={`log-level ${level}`}>{level}</span>
+        <span class="log-message">{message}</span>
+      </div>
+      {isExpanded && (
+        <div class="log-detail open">
+          <pre>{JSON.stringify(p, null, 2)}</pre>
+        </div>
+      )}
+    </>
+  );
+}

--- a/dashboard/src/components/OutcomesTable.tsx
+++ b/dashboard/src/components/OutcomesTable.tsx
@@ -1,0 +1,299 @@
+import { useState, useEffect } from "preact/hooks";
+
+const POLL_INTERVAL_MS = 30_000;
+
+interface OutcomeSummary {
+  success: number;
+  failure: number;
+  timeout: number;
+  total: number;
+}
+
+interface OutcomeRecord {
+  correlationId: string;
+  actionId: string;
+  goalId: string;
+  status: "success" | "failure" | "timeout";
+  startedAt: number;
+  completedAt: number;
+  durationMs: number;
+  error?: string;
+}
+
+interface OutcomesApiResponse {
+  summary: OutcomeSummary;
+  recent: OutcomeRecord[];
+}
+
+function formatTimestamp(ms: number): string {
+  return new Date(ms).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${(ms / 60_000).toFixed(1)}m`;
+}
+
+const statusBadgeClass: Record<string, string> = {
+  success: "badge badge-green",
+  failure: "badge badge-red",
+  timeout: "badge badge-yellow",
+};
+
+export default function OutcomesTable() {
+  const [summary, setSummary] = useState<OutcomeSummary | null>(null);
+  const [recent, setRecent] = useState<OutcomeRecord[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  async function fetchOutcomes() {
+    try {
+      const res = await fetch("/api/outcomes");
+      if (!res.ok) throw new Error(`/api/outcomes: ${res.status}`);
+      const json = (await res.json()) as OutcomesApiResponse;
+      setSummary(json.summary ?? { success: 0, failure: 0, timeout: 0, total: 0 });
+      setRecent(Array.isArray(json.recent) ? json.recent.slice().reverse() : []);
+      setError(null);
+      setLastUpdated(new Date());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    fetchOutcomes();
+    const timer = setInterval(fetchOutcomes, POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, []);
+
+  const successRate =
+    summary && summary.total > 0
+      ? ((summary.success / summary.total) * 100).toFixed(1)
+      : null;
+
+  return (
+    <div class="outcomes">
+      <div class="outcomes__header">
+        <h2 class="outcomes__title">Action Outcomes</h2>
+        {lastUpdated && (
+          <span class="outcomes__updated">
+            Updated {lastUpdated.toLocaleTimeString()}
+          </span>
+        )}
+      </div>
+
+      {loading && (
+        <div class="card">
+          <p class="placeholder-content">Loading outcomes…</p>
+        </div>
+      )}
+
+      {!loading && error && (
+        <div class="card" style={{ borderColor: "rgba(248,81,73,0.4)" }}>
+          <p style={{ color: "var(--text-danger)", fontSize: "13px" }}>
+            Failed to load outcomes: {error}
+          </p>
+        </div>
+      )}
+
+      {!loading && !error && summary && (
+        <>
+          <div class="outcomes__summary">
+            <div class="outcomes__stat-card card">
+              <span class="outcomes__stat-label">Total</span>
+              <span class="outcomes__stat-value">{summary.total}</span>
+            </div>
+            <div class="outcomes__stat-card card">
+              <span class="outcomes__stat-label">Success</span>
+              <span class="outcomes__stat-value" style={{ color: "var(--text-success)" }}>
+                {summary.success}
+              </span>
+            </div>
+            <div class="outcomes__stat-card card">
+              <span class="outcomes__stat-label">Failure</span>
+              <span class="outcomes__stat-value" style={{ color: "var(--text-danger)" }}>
+                {summary.failure}
+              </span>
+            </div>
+            <div class="outcomes__stat-card card">
+              <span class="outcomes__stat-label">Timeout</span>
+              <span class="outcomes__stat-value" style={{ color: "var(--text-warning)" }}>
+                {summary.timeout}
+              </span>
+            </div>
+            {successRate !== null && (
+              <div class="outcomes__stat-card card">
+                <span class="outcomes__stat-label">Success Rate</span>
+                <span
+                  class="outcomes__stat-value"
+                  style={{
+                    color:
+                      Number(successRate) >= 70
+                        ? "var(--text-success)"
+                        : Number(successRate) >= 40
+                          ? "var(--text-warning)"
+                          : "var(--text-danger)",
+                  }}
+                >
+                  {successRate}%
+                </span>
+              </div>
+            )}
+          </div>
+
+          <div class="card outcomes__table-card">
+            <div class="card-title">Recent Dispatches</div>
+            {recent.length === 0 ? (
+              <p class="placeholder-content" style={{ padding: "24px" }}>
+                No outcomes recorded yet
+              </p>
+            ) : (
+              <div class="outcomes__table-wrapper">
+                <table class="outcomes__table">
+                  <thead>
+                    <tr>
+                      <th>Time</th>
+                      <th>Action</th>
+                      <th>Goal</th>
+                      <th>Status</th>
+                      <th>Duration</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {recent.map((row) => (
+                      <tr key={row.correlationId}>
+                        <td class="outcomes__td-time">
+                          {formatTimestamp(row.startedAt)}
+                        </td>
+                        <td class="outcomes__td-action">
+                          <code>{row.actionId}</code>
+                        </td>
+                        <td class="outcomes__td-goal">
+                          <code>{row.goalId}</code>
+                        </td>
+                        <td>
+                          <span class={statusBadgeClass[row.status] ?? "badge badge-blue"}>
+                            {row.status}
+                          </span>
+                        </td>
+                        <td class="outcomes__td-duration">
+                          {formatDuration(row.durationMs)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
+      <style>{`
+        .outcomes {
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+        }
+        .outcomes__header {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 12px;
+        }
+        .outcomes__title {
+          font-size: 16px;
+          font-weight: 600;
+        }
+        .outcomes__updated {
+          font-size: 12px;
+          color: var(--text-secondary);
+        }
+        .outcomes__summary {
+          display: flex;
+          gap: 8px;
+          flex-wrap: wrap;
+        }
+        .outcomes__stat-card {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+          padding: 12px 16px;
+          min-width: 80px;
+          align-items: center;
+        }
+        .outcomes__stat-label {
+          font-size: 11px;
+          font-weight: 600;
+          color: var(--text-secondary);
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+        }
+        .outcomes__stat-value {
+          font-size: 24px;
+          font-weight: 700;
+          color: var(--text-primary);
+          line-height: 1;
+        }
+        .outcomes__table-card {
+          padding: 0;
+          overflow: hidden;
+        }
+        .outcomes__table-card .card-title {
+          padding: 12px 16px 0;
+        }
+        .outcomes__table-wrapper {
+          overflow-x: auto;
+        }
+        .outcomes__table {
+          width: 100%;
+          border-collapse: collapse;
+          font-size: 12px;
+        }
+        .outcomes__table th {
+          text-align: left;
+          padding: 8px 16px;
+          color: var(--text-secondary);
+          font-weight: 600;
+          font-size: 11px;
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+          border-bottom: 1px solid var(--border-default);
+          white-space: nowrap;
+        }
+        .outcomes__table td {
+          padding: 8px 16px;
+          border-bottom: 1px solid var(--border-muted);
+          color: var(--text-primary);
+          vertical-align: middle;
+        }
+        .outcomes__table tr:last-child td {
+          border-bottom: none;
+        }
+        .outcomes__table tr:hover td {
+          background: var(--bg-subtle);
+        }
+        .outcomes__td-time {
+          white-space: nowrap;
+          color: var(--text-secondary) !important;
+          font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+        }
+        .outcomes__td-action code,
+        .outcomes__td-goal code {
+          font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+          color: var(--accent-fg);
+          font-size: 11px;
+        }
+        .outcomes__td-duration {
+          white-space: nowrap;
+          color: var(--text-secondary) !important;
+          font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/dashboard/src/components/OverviewGrid.tsx
+++ b/dashboard/src/components/OverviewGrid.tsx
@@ -1,0 +1,203 @@
+import { useState, useEffect } from "preact/hooks";
+
+type Status = "green" | "yellow" | "red" | "loading";
+
+interface CardState {
+  label: string;
+  metric: string;
+  status: Status;
+}
+
+const POLL_INTERVAL = 30_000;
+
+function deriveServicesStatus(data: unknown): Pick<CardState, "metric" | "status"> {
+  if (!data || typeof data !== "object") return { metric: "Unknown", status: "loading" };
+  const entries = Object.values(data as Record<string, { status?: string }>);
+  if (entries.length === 0) return { metric: "No services", status: "yellow" };
+  const down = entries.filter((s) => s?.status === "down").length;
+  const degraded = entries.filter((s) => s?.status === "degraded").length;
+  if (down > 0) return { metric: `${down} down`, status: "red" };
+  if (degraded > 0) return { metric: `${degraded} degraded`, status: "yellow" };
+  return { metric: `${entries.length} healthy`, status: "green" };
+}
+
+function deriveAgentHealthStatus(data: unknown): Pick<CardState, "metric" | "status"> {
+  if (!data || typeof data !== "object") return { metric: "Unknown", status: "loading" };
+  const agents = (data as { agents?: Array<{ status?: string }> }).agents ?? [];
+  if (agents.length === 0) return { metric: "None registered", status: "red" };
+  const active = agents.filter((a) => a?.status === "active" || a?.status === "idle" || a?.status === "registered").length;
+  const errored = agents.filter((a) => a?.status === "error").length;
+  if (errored === agents.length) return { metric: `${errored} errors`, status: "red" };
+  return { metric: `${active} / ${agents.length} online`, status: errored > 0 ? "yellow" : "green" };
+}
+
+function deriveCiHealthStatus(data: unknown): Pick<CardState, "metric" | "status"> {
+  if (!data || typeof data !== "object") return { metric: "Unknown", status: "loading" };
+  const projects = (data as { projects?: Array<{ successRate?: number }> }).projects ?? [];
+  if (projects.length === 0) return { metric: "No data", status: "yellow" };
+  const avg = projects.reduce((sum, p) => sum + (p?.successRate ?? 0), 0) / projects.length;
+  const pct = Math.round(avg * 100);
+  if (avg >= 0.8) return { metric: `${pct}% pass rate`, status: "green" };
+  if (avg >= 0.5) return { metric: `${pct}% pass rate`, status: "yellow" };
+  return { metric: `${pct}% pass rate`, status: "red" };
+}
+
+function derivePrPipelineStatus(data: unknown): Pick<CardState, "metric" | "status"> {
+  if (!data || typeof data !== "object") return { metric: "Unknown", status: "loading" };
+  const { open = 0, failed = 0 } = data as { open?: number; failed?: number };
+  if (failed > 0) return { metric: `${failed} failed`, status: "red" };
+  if (open > 5) return { metric: `${open} open`, status: "yellow" };
+  return { metric: `${open} open`, status: "green" };
+}
+
+function deriveFlowMetricsStatus(data: unknown): Pick<CardState, "metric" | "status"> {
+  if (!data || typeof data !== "object") return { metric: "Unknown", status: "loading" };
+  const { eventsPerMinute = 0, totalEvents = 0 } = data as {
+    eventsPerMinute?: number;
+    totalEvents?: number;
+  };
+  const epm = typeof eventsPerMinute === "number" ? eventsPerMinute : 0;
+  return {
+    metric: `${epm.toFixed(1)} ev/min (${totalEvents} total)`,
+    status: epm > 0 ? "green" : "yellow",
+  };
+}
+
+function deriveSecurityStatus(data: unknown): Pick<CardState, "metric" | "status"> {
+  if (!data || typeof data !== "object") return { metric: "Unknown", status: "loading" };
+  const d = data as { openIncidents?: number; incidents?: unknown[] };
+  const count = d.openIncidents ?? d.incidents?.length ?? 0;
+  if (count === 0) return { metric: "No incidents", status: "green" };
+  return { metric: `${count} open`, status: "red" };
+}
+
+function deriveHitlStatus(data: unknown): Pick<CardState, "metric" | "status"> {
+  if (!data || typeof data !== "object") return { metric: "Unknown", status: "loading" };
+  const pending = (data as { pending?: unknown[] }).pending ?? [];
+  const count = pending.length;
+  if (count === 0) return { metric: "None pending", status: "green" };
+  if (count <= 3) return { metric: `${count} pending`, status: "yellow" };
+  return { metric: `${count} pending`, status: "red" };
+}
+
+async function fetchCard(
+  endpoint: string,
+  derive: (data: unknown) => Pick<CardState, "metric" | "status">
+): Promise<Pick<CardState, "metric" | "status">> {
+  try {
+    const res = await fetch(endpoint);
+    if (!res.ok) throw new Error(`${res.status}`);
+    const data = await res.json();
+    return derive(data);
+  } catch {
+    return { metric: "Error", status: "red" };
+  }
+}
+
+const CARD_CONFIGS: Array<{
+  label: string;
+  endpoint: string;
+  derive: (data: unknown) => Pick<CardState, "metric" | "status">;
+}> = [
+  { label: "Service Connectivity", endpoint: "/api/services", derive: deriveServicesStatus },
+  { label: "Agent Health", endpoint: "/api/agent-health", derive: deriveAgentHealthStatus },
+  { label: "CI Success Rate", endpoint: "/api/ci-health", derive: deriveCiHealthStatus },
+  { label: "PR Pipeline", endpoint: "/api/pr-pipeline", derive: derivePrPipelineStatus },
+  { label: "Flow Metrics", endpoint: "/api/flow-metrics", derive: deriveFlowMetricsStatus },
+  { label: "Security Summary", endpoint: "/api/security-summary", derive: deriveSecurityStatus },
+  { label: "Pending HITL", endpoint: "/api/hitl/pending", derive: deriveHitlStatus },
+];
+
+function HealthCardView({ label, metric, status }: CardState) {
+  const dotStyle: Record<Status, string> = {
+    green: "#3fb950",
+    yellow: "#d29922",
+    red: "#f85149",
+    loading: "#8b949e",
+  };
+
+  const borderColor: Record<Status, string> = {
+    green: "rgba(63, 185, 80, 0.3)",
+    yellow: "rgba(210, 153, 34, 0.3)",
+    red: "rgba(248, 81, 73, 0.3)",
+    loading: "#21262d",
+  };
+
+  return (
+    <div
+      class="card"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "12px",
+        borderColor: borderColor[status],
+      }}
+    >
+      <div class="card-title">{label}</div>
+      <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+        <span
+          style={{
+            width: "10px",
+            height: "10px",
+            borderRadius: "50%",
+            flexShrink: 0,
+            background: dotStyle[status],
+            animation: status === "loading" ? "pulse 1.2s ease-in-out infinite" : "none",
+          }}
+        />
+        <span
+          style={{
+            fontSize: "22px",
+            fontWeight: 600,
+            color: "var(--text-primary)",
+            lineHeight: 1.2,
+          }}
+        >
+          {metric}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export default function OverviewGrid() {
+  const [cards, setCards] = useState<CardState[]>(
+    CARD_CONFIGS.map((c) => ({ label: c.label, metric: "Loading…", status: "loading" as Status }))
+  );
+
+  async function refresh() {
+    const results = await Promise.all(
+      CARD_CONFIGS.map((c) => fetchCard(c.endpoint, c.derive))
+    );
+    setCards(
+      CARD_CONFIGS.map((c, i) => ({ label: c.label, ...results[i] }))
+    );
+  }
+
+  useEffect(() => {
+    refresh();
+    const id = setInterval(refresh, POLL_INTERVAL);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <>
+      <style>{`
+        @keyframes pulse {
+          0%, 100% { opacity: 0.4; }
+          50% { opacity: 1; }
+        }
+        .overview-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+          gap: 16px;
+        }
+      `}</style>
+      <div class="overview-grid">
+        {cards.map((card) => (
+          <HealthCardView key={card.label} {...card} />
+        ))}
+      </div>
+    </>
+  );
+}

--- a/dashboard/src/components/PrBadges.tsx
+++ b/dashboard/src/components/PrBadges.tsx
@@ -1,0 +1,35 @@
+interface PrBadgesProps {
+  conflicting: number;
+  stale: number;
+  failing: number;
+}
+
+export default function PrBadges({ conflicting, stale, failing }: PrBadgesProps) {
+  const hasBadges = conflicting > 0 || stale > 0 || failing > 0;
+
+  if (!hasBadges) {
+    return <span class="badge badge-green">clean</span>;
+  }
+
+  return (
+    <span class="pr-badges">
+      {conflicting > 0 && (
+        <span class="badge badge-red">{conflicting} conflict{conflicting !== 1 ? "s" : ""}</span>
+      )}
+      {stale > 0 && (
+        <span class="badge badge-yellow">{stale} stale</span>
+      )}
+      {failing > 0 && (
+        <span class="badge badge-red">{failing} failing</span>
+      )}
+      <style>{`
+        .pr-badges {
+          display: inline-flex;
+          align-items: center;
+          gap: 4px;
+          flex-wrap: wrap;
+        }
+      `}</style>
+    </span>
+  );
+}

--- a/dashboard/src/components/ProjectCard.tsx
+++ b/dashboard/src/components/ProjectCard.tsx
@@ -1,0 +1,289 @@
+import { useState } from "preact/hooks";
+import CiBar from "./CiBar.tsx";
+import PrBadges from "./PrBadges.tsx";
+
+export interface ProjectEntry {
+  slug: string;
+  title: string;
+  github?: string;
+  repoUrl?: string;
+  agents?: string[];
+  status?: string;
+  team?: string;
+}
+
+export interface CiProjectData {
+  repo: string;
+  successRate: number;
+  totalRuns: number;
+  failedRuns: number;
+  latestConclusion: string | null;
+}
+
+export interface PrData {
+  repo: string;
+  number: number;
+  title: string;
+  mergeable: string;
+  checksPass: boolean;
+  updatedAt: string;
+  stale: boolean;
+}
+
+interface ProjectCardProps {
+  project: ProjectEntry;
+  ci: CiProjectData | null;
+  prs: PrData[];
+}
+
+function formatUpdatedAt(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+export default function ProjectCard({ project, ci, prs }: ProjectCardProps) {
+  const [prsExpanded, setPrsExpanded] = useState(false);
+
+  const openCount = prs.length;
+  const conflicting = prs.filter((p) => p.mergeable === "dirty").length;
+  const stale = prs.filter((p) => p.stale).length;
+  const failing = prs.filter((p) => !p.checksPass).length;
+
+  const conclusionColor =
+    ci?.latestConclusion === "success"
+      ? "var(--text-success)"
+      : ci?.latestConclusion === "failure"
+        ? "var(--text-danger)"
+        : "var(--text-secondary)";
+
+  return (
+    <div class="project-card card">
+      {/* Header */}
+      <div class="pc-header">
+        <div class="pc-title-row">
+          <span class="pc-title">{project.title}</span>
+          <span class="badge badge-blue">{project.status ?? "active"}</span>
+        </div>
+        <div class="pc-meta">
+          {project.github && (
+            <a
+              href={project.repoUrl ?? `https://github.com/${project.github}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="pc-github-link"
+            >
+              {project.github}
+            </a>
+          )}
+          {project.agents && project.agents.length > 0 && (
+            <span class="pc-agents">
+              {project.agents.map((a) => (
+                <span key={a} class="badge badge-blue pc-agent-badge">
+                  {a}
+                </span>
+              ))}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* CI Section */}
+      <div class="pc-section">
+        <div class="pc-section-label">CI Health</div>
+        {ci ? (
+          <div class="pc-ci">
+            <CiBar
+              successRate={ci.successRate}
+              totalRuns={ci.totalRuns}
+              failedRuns={ci.failedRuns}
+            />
+            {ci.latestConclusion && (
+              <span class="pc-conclusion" style={{ color: conclusionColor }}>
+                latest: {ci.latestConclusion}
+              </span>
+            )}
+          </div>
+        ) : (
+          <span class="pc-no-data">No CI data</span>
+        )}
+      </div>
+
+      {/* PR Section */}
+      <div class="pc-section">
+        <div class="pc-section-label">
+          Pull Requests
+          {openCount > 0 && (
+            <span class="pc-pr-count">{openCount} open</span>
+          )}
+        </div>
+        <div class="pc-pr-row">
+          <PrBadges conflicting={conflicting} stale={stale} failing={failing} />
+          {openCount > 0 && (
+            <button
+              class="pc-expand-btn"
+              onClick={() => setPrsExpanded((v) => !v)}
+            >
+              {prsExpanded ? "Hide" : "Show"} PRs
+            </button>
+          )}
+        </div>
+
+        {prsExpanded && openCount > 0 && (
+          <div class="pc-pr-list">
+            {prs.map((pr) => (
+              <div key={`${pr.repo}/${pr.number}`} class="pc-pr-item">
+                <span class="pc-pr-number">#{pr.number}</span>
+                <span class="pc-pr-title">{pr.title}</span>
+                <span class="pc-pr-badges">
+                  {pr.mergeable === "dirty" && (
+                    <span class="badge badge-red">conflict</span>
+                  )}
+                  {pr.stale && <span class="badge badge-yellow">stale</span>}
+                  {!pr.checksPass && (
+                    <span class="badge badge-red">failing</span>
+                  )}
+                </span>
+                <span class="pc-pr-date">{formatUpdatedAt(pr.updatedAt)}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <style>{`
+        .project-card {
+          display: flex;
+          flex-direction: column;
+          gap: 16px;
+        }
+        .pc-header {
+          display: flex;
+          flex-direction: column;
+          gap: 6px;
+        }
+        .pc-title-row {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+        }
+        .pc-title {
+          font-size: 15px;
+          font-weight: 600;
+          color: var(--text-primary);
+        }
+        .pc-meta {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+          flex-wrap: wrap;
+        }
+        .pc-github-link {
+          font-size: 12px;
+          color: var(--text-link);
+        }
+        .pc-agents {
+          display: inline-flex;
+          gap: 4px;
+        }
+        .pc-agent-badge {
+          font-size: 10px;
+          padding: 1px 6px;
+        }
+        .pc-section {
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
+          padding-top: 12px;
+          border-top: 1px solid var(--border-muted);
+        }
+        .pc-section-label {
+          font-size: 11px;
+          font-weight: 600;
+          color: var(--text-secondary);
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+          display: flex;
+          align-items: center;
+          gap: 8px;
+        }
+        .pc-pr-count {
+          font-size: 11px;
+          font-weight: 500;
+          color: var(--text-primary);
+          text-transform: none;
+          letter-spacing: 0;
+        }
+        .pc-ci {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+        }
+        .pc-conclusion {
+          font-size: 11px;
+        }
+        .pc-no-data {
+          font-size: 12px;
+          color: var(--text-secondary);
+          font-style: italic;
+        }
+        .pc-pr-row {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+          flex-wrap: wrap;
+        }
+        .pc-expand-btn {
+          background: none;
+          border: 1px solid var(--border-default);
+          color: var(--text-secondary);
+          font-size: 11px;
+          padding: 2px 8px;
+          border-radius: 4px;
+          cursor: pointer;
+          transition: color 0.1s, border-color 0.1s;
+        }
+        .pc-expand-btn:hover {
+          color: var(--text-primary);
+          border-color: var(--text-secondary);
+        }
+        .pc-pr-list {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+          margin-top: 4px;
+        }
+        .pc-pr-item {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+          padding: 6px 8px;
+          background: var(--bg-subtle);
+          border-radius: 4px;
+          font-size: 12px;
+        }
+        .pc-pr-number {
+          color: var(--text-secondary);
+          flex-shrink: 0;
+          font-size: 11px;
+        }
+        .pc-pr-title {
+          flex: 1;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          color: var(--text-primary);
+        }
+        .pc-pr-badges {
+          display: flex;
+          gap: 4px;
+          flex-shrink: 0;
+        }
+        .pc-pr-date {
+          color: var(--text-secondary);
+          font-size: 11px;
+          flex-shrink: 0;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/dashboard/src/components/ProjectsView.tsx
+++ b/dashboard/src/components/ProjectsView.tsx
@@ -1,0 +1,229 @@
+import { useState, useEffect } from "preact/hooks";
+import ProjectCard from "./ProjectCard.tsx";
+import type { ProjectEntry, CiProjectData, PrData } from "./ProjectCard.tsx";
+
+const POLL_INTERVAL_MS = 60_000;
+
+interface ProjectsApiResponse {
+  success: boolean;
+  data: ProjectEntry[];
+}
+
+interface CiHealthResponse {
+  successRate: number;
+  totalRuns: number;
+  failedRuns: number;
+  projects: CiProjectData[];
+}
+
+interface PrPipelineResponse {
+  totalOpen: number;
+  conflicting: number;
+  stale: number;
+  failing: number;
+  prs: PrData[];
+}
+
+export default function ProjectsView() {
+  const [projects, setProjects] = useState<ProjectEntry[]>([]);
+  const [ciHealth, setCiHealth] = useState<CiHealthResponse | null>(null);
+  const [prPipeline, setPrPipeline] = useState<PrPipelineResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  async function fetchAll() {
+    try {
+      const [projRes, ciRes, prRes] = await Promise.all([
+        fetch("/api/projects"),
+        fetch("/api/ci-health"),
+        fetch("/api/pr-pipeline"),
+      ]);
+
+      if (!projRes.ok) throw new Error(`/api/projects: ${projRes.status}`);
+      if (!ciRes.ok) throw new Error(`/api/ci-health: ${ciRes.status}`);
+      if (!prRes.ok) throw new Error(`/api/pr-pipeline: ${prRes.status}`);
+
+      const projJson = (await projRes.json()) as ProjectsApiResponse;
+      const ciJson = (await ciRes.json()) as CiHealthResponse;
+      const prJson = (await prRes.json()) as PrPipelineResponse;
+
+      setProjects(Array.isArray(projJson.data) ? projJson.data : []);
+      setCiHealth(ciJson);
+      setPrPipeline(prJson);
+      setError(null);
+      setLastUpdated(new Date());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    fetchAll();
+    const timer = setInterval(fetchAll, POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, []);
+
+  // Build lookup maps keyed by github repo ("owner/repo")
+  const ciByRepo = new Map<string, CiProjectData>(
+    (ciHealth?.projects ?? []).map((p) => [p.repo, p])
+  );
+  const prsByRepo = new Map<string, PrData[]>();
+  for (const pr of prPipeline?.prs ?? []) {
+    const list = prsByRepo.get(pr.repo) ?? [];
+    list.push(pr);
+    prsByRepo.set(pr.repo, list);
+  }
+
+  const aggregateSuccessRate =
+    ciHealth && ciHealth.totalRuns > 0
+      ? Math.round(ciHealth.successRate * 100)
+      : null;
+
+  return (
+    <div class="projects-view">
+      {/* Aggregate CI summary */}
+      {ciHealth && (
+        <div class="pv-summary card">
+          <div class="pv-summary-title">CI Summary</div>
+          <div class="pv-summary-stats">
+            <div class="pv-stat">
+              <span class="pv-stat-value" style={{
+                color: aggregateSuccessRate !== null && aggregateSuccessRate >= 90
+                  ? "var(--text-success)"
+                  : aggregateSuccessRate !== null && aggregateSuccessRate >= 70
+                    ? "var(--text-warning)"
+                    : "var(--text-danger)"
+              }}>
+                {aggregateSuccessRate !== null ? `${aggregateSuccessRate}%` : "—"}
+              </span>
+              <span class="pv-stat-label">success rate</span>
+            </div>
+            <div class="pv-stat">
+              <span class="pv-stat-value">{ciHealth.totalRuns}</span>
+              <span class="pv-stat-label">total runs</span>
+            </div>
+            <div class="pv-stat">
+              <span class="pv-stat-value" style={{ color: ciHealth.failedRuns > 0 ? "var(--text-danger)" : undefined }}>
+                {ciHealth.failedRuns}
+              </span>
+              <span class="pv-stat-label">failed</span>
+            </div>
+            {prPipeline && (
+              <div class="pv-stat">
+                <span class="pv-stat-value">{prPipeline.totalOpen}</span>
+                <span class="pv-stat-label">open PRs</span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      <div class="pv-header">
+        <h2 class="pv-title">Projects</h2>
+        {lastUpdated && (
+          <span class="pv-updated">
+            Updated {lastUpdated.toLocaleTimeString()}
+          </span>
+        )}
+      </div>
+
+      {loading && (
+        <div class="card">
+          <p class="placeholder-content">Loading projects…</p>
+        </div>
+      )}
+
+      {!loading && error && (
+        <div class="card" style={{ borderColor: "rgba(248,81,73,0.4)" }}>
+          <p style={{ color: "var(--text-danger)", fontSize: "13px" }}>
+            Failed to load: {error}
+          </p>
+        </div>
+      )}
+
+      {!loading && !error && projects.length === 0 && (
+        <div class="card">
+          <p class="placeholder-content">No projects registered</p>
+        </div>
+      )}
+
+      {!loading && !error && projects.length > 0 && (
+        <div class="pv-grid">
+          {projects.map((project) => {
+            const repo = project.github ?? "";
+            return (
+              <ProjectCard
+                key={project.slug}
+                project={project}
+                ci={ciByRepo.get(repo) ?? null}
+                prs={prsByRepo.get(repo) ?? []}
+              />
+            );
+          })}
+        </div>
+      )}
+
+      <style>{`
+        .projects-view {
+          display: flex;
+          flex-direction: column;
+          gap: 20px;
+        }
+        .pv-summary {
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+        }
+        .pv-summary-title {
+          font-size: 11px;
+          font-weight: 600;
+          color: var(--text-secondary);
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+        }
+        .pv-summary-stats {
+          display: flex;
+          gap: 32px;
+          flex-wrap: wrap;
+        }
+        .pv-stat {
+          display: flex;
+          flex-direction: column;
+          gap: 2px;
+        }
+        .pv-stat-value {
+          font-size: 22px;
+          font-weight: 600;
+          color: var(--text-primary);
+          line-height: 1;
+        }
+        .pv-stat-label {
+          font-size: 11px;
+          color: var(--text-secondary);
+        }
+        .pv-header {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 12px;
+        }
+        .pv-title {
+          font-size: 16px;
+          font-weight: 600;
+        }
+        .pv-updated {
+          font-size: 12px;
+          color: var(--text-secondary);
+        }
+        .pv-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+          gap: 16px;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/dashboard/src/components/WorldStateViewer.tsx
+++ b/dashboard/src/components/WorldStateViewer.tsx
@@ -1,0 +1,214 @@
+import { useState, useEffect, useMemo } from "preact/hooks";
+import DomainCard from "./DomainCard.tsx";
+
+interface DomainMetadata {
+  collectedAt: number;
+  domain: string;
+  tickNumber: number;
+  failed?: boolean;
+  errorMessage?: string;
+}
+
+interface DomainEntry {
+  data: unknown;
+  metadata: DomainMetadata;
+}
+
+interface WorldStateResponse {
+  timestamp: number;
+  domains: Record<string, DomainEntry>;
+  extensions: Record<string, unknown>;
+  snapshotVersion: number;
+}
+
+const POLL_INTERVAL = 15_000;
+
+export default function WorldStateViewer() {
+  const [worldState, setWorldState] = useState<WorldStateResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [filter, setFilter] = useState<string>("");
+  const [selectedDomain, setSelectedDomain] = useState<string>("all");
+
+  async function fetchWorldState() {
+    try {
+      const res = await fetch("/api/world-state");
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      const data = (await res.json()) as WorldStateResponse;
+      setWorldState(data);
+      setLastUpdated(new Date());
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch world state");
+    }
+  }
+
+  useEffect(() => {
+    fetchWorldState();
+    const id = setInterval(fetchWorldState, POLL_INTERVAL);
+    return () => clearInterval(id);
+  }, []);
+
+  const domainNames = useMemo(() => {
+    if (!worldState) return [];
+    return Object.keys(worldState.domains).sort();
+  }, [worldState]);
+
+  const visibleDomains = useMemo(() => {
+    if (!worldState) return [];
+    return domainNames.filter((name) => {
+      if (selectedDomain !== "all" && name !== selectedDomain) return false;
+      if (filter.trim()) {
+        return name.toLowerCase().includes(filter.toLowerCase());
+      }
+      return true;
+    });
+  }, [domainNames, selectedDomain, filter, worldState]);
+
+  const failedCount = useMemo(() => {
+    if (!worldState) return 0;
+    return Object.values(worldState.domains).filter((d) => d.metadata.failed).length;
+  }, [worldState]);
+
+  return (
+    <>
+      <style>{`
+        .wsv-toolbar {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+          margin-bottom: 20px;
+          flex-wrap: wrap;
+        }
+        .wsv-filter {
+          flex: 1;
+          min-width: 160px;
+          background: var(--bg-default);
+          border: 1px solid var(--border-default);
+          border-radius: 6px;
+          color: var(--text-primary);
+          font-size: 13px;
+          padding: 6px 10px;
+          outline: none;
+        }
+        .wsv-filter:focus {
+          border-color: var(--accent-fg);
+        }
+        .wsv-filter::placeholder {
+          color: var(--text-secondary);
+        }
+        .wsv-select {
+          background: var(--bg-default);
+          border: 1px solid var(--border-default);
+          border-radius: 6px;
+          color: var(--text-primary);
+          font-size: 13px;
+          padding: 6px 10px;
+          outline: none;
+          cursor: pointer;
+        }
+        .wsv-select:focus {
+          border-color: var(--accent-fg);
+        }
+        .wsv-meta {
+          font-size: 12px;
+          color: var(--text-secondary);
+          margin-left: auto;
+          display: flex;
+          align-items: center;
+          gap: 12px;
+        }
+        .wsv-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+          gap: 16px;
+        }
+        .wsv-error {
+          background: rgba(248, 81, 73, 0.1);
+          border: 1px solid rgba(248, 81, 73, 0.3);
+          border-radius: 6px;
+          color: var(--text-danger);
+          font-size: 13px;
+          padding: 12px 16px;
+          margin-bottom: 16px;
+        }
+        .wsv-empty {
+          color: var(--text-secondary);
+          font-style: italic;
+          text-align: center;
+          padding: 48px 24px;
+        }
+        .wsv-failed-badge {
+          display: inline-flex;
+          align-items: center;
+          background: rgba(248, 81, 73, 0.15);
+          color: var(--text-danger);
+          border-radius: 12px;
+          font-size: 11px;
+          font-weight: 500;
+          padding: 2px 8px;
+        }
+      `}</style>
+
+      <div class="wsv-toolbar">
+        <input
+          class="wsv-filter"
+          type="text"
+          placeholder="Filter domains…"
+          value={filter}
+          onInput={(e) => setFilter((e.target as HTMLInputElement).value)}
+        />
+
+        {domainNames.length > 0 && (
+          <select
+            class="wsv-select"
+            value={selectedDomain}
+            onChange={(e) => setSelectedDomain((e.target as HTMLSelectElement).value)}
+          >
+            <option value="all">All domains ({domainNames.length})</option>
+            {domainNames.map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </select>
+        )}
+
+        <div class="wsv-meta">
+          {failedCount > 0 && (
+            <span class="wsv-failed-badge">{failedCount} failed</span>
+          )}
+          {lastUpdated && (
+            <span>Updated {lastUpdated.toLocaleTimeString()}</span>
+          )}
+        </div>
+      </div>
+
+      {error && <div class="wsv-error">Error: {error}</div>}
+
+      {!worldState && !error && (
+        <div class="wsv-empty">Loading world state…</div>
+      )}
+
+      {worldState && visibleDomains.length === 0 && (
+        <div class="wsv-empty">No domains match the current filter.</div>
+      )}
+
+      {worldState && visibleDomains.length > 0 && (
+        <div class="wsv-grid">
+          {visibleDomains.map((name) => {
+            const domain = worldState.domains[name];
+            return (
+              <DomainCard
+                key={name}
+                name={name}
+                data={domain.data}
+                metadata={domain.metadata}
+              />
+            );
+          })}
+        </div>
+      )}
+    </>
+  );
+}

--- a/dashboard/src/layouts/DashboardLayout.astro
+++ b/dashboard/src/layouts/DashboardLayout.astro
@@ -1,0 +1,231 @@
+---
+import "../styles/global.css";
+
+export interface Props {
+  title: string;
+  activePage?: string;
+}
+
+const { title, activePage } = Astro.props;
+
+const navItems = [
+  { href: "/", label: "Overview", id: "overview" },
+  { href: "/world-state", label: "World State", id: "world-state" },
+  { href: "/events", label: "Events", id: "events" },
+  { href: "/goals", label: "Goals", id: "goals" },
+  { href: "/projects", label: "Projects", id: "projects" },
+];
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{title} — Workstacean</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  </head>
+  <body>
+    <div class="layout">
+      <aside class="sidebar">
+        <div class="sidebar-logo">
+          <span class="logo-icon">⬡</span>
+          <span class="logo-text">Workstacean</span>
+        </div>
+        <nav class="sidebar-nav">
+          {
+            navItems.map((item) => (
+              <a
+                href={item.href}
+                class={`nav-item ${activePage === item.id ? "nav-item--active" : ""}`}
+              >
+                {item.label}
+              </a>
+            ))
+          }
+        </nav>
+      </aside>
+
+      <div class="main-wrapper">
+        <header class="header">
+          <h1 class="header-title">{title}</h1>
+          <div class="header-status" id="ws-status">
+            <span class="status-dot status-dot--connecting"></span>
+            <span class="status-label">Connecting…</span>
+          </div>
+        </header>
+
+        <main class="main-content">
+          <slot />
+        </main>
+      </div>
+    </div>
+
+    <script>
+      // WebSocket connection status
+      const statusEl = document.getElementById("ws-status");
+      const dot = statusEl?.querySelector(".status-dot");
+      const label = statusEl?.querySelector(".status-label");
+
+      function setStatus(state: "connected" | "connecting" | "disconnected") {
+        if (!dot || !label) return;
+        dot.className = `status-dot status-dot--${state}`;
+        label.textContent =
+          state === "connected"
+            ? "Live"
+            : state === "connecting"
+              ? "Connecting…"
+              : "Disconnected";
+      }
+
+      function connect() {
+        const proto = location.protocol === "https:" ? "wss" : "ws";
+        const ws = new WebSocket(`${proto}://${location.host}/ws`);
+        ws.addEventListener("open", () => setStatus("connected"));
+        ws.addEventListener("close", () => {
+          setStatus("disconnected");
+          setTimeout(connect, 3000);
+        });
+        ws.addEventListener("error", () => setStatus("disconnected"));
+      }
+
+      connect();
+    </script>
+  </body>
+</html>
+
+<style>
+  .layout {
+    display: flex;
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  .sidebar {
+    width: var(--sidebar-width);
+    background: var(--bg-default);
+    border-right: 1px solid var(--border-default);
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+  }
+
+  .sidebar-logo {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 16px;
+    border-bottom: 1px solid var(--border-muted);
+    font-weight: 600;
+    font-size: 15px;
+  }
+
+  .logo-icon {
+    font-size: 20px;
+    color: var(--accent-fg);
+  }
+
+  .sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    padding: 8px 0;
+    gap: 2px;
+  }
+
+  .nav-item {
+    display: block;
+    padding: 8px 16px;
+    color: var(--text-secondary);
+    border-radius: 6px;
+    margin: 0 8px;
+    font-size: 13px;
+    font-weight: 500;
+    transition: background 0.1s, color 0.1s;
+  }
+
+  .nav-item:hover {
+    background: var(--bg-subtle);
+    color: var(--text-primary);
+    text-decoration: none;
+  }
+
+  .nav-item--active {
+    background: var(--accent-emphasis);
+    color: #ffffff;
+  }
+
+  .nav-item--active:hover {
+    background: var(--accent-emphasis);
+    color: #ffffff;
+  }
+
+  .main-wrapper {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .header {
+    height: var(--header-height);
+    background: var(--bg-default);
+    border-bottom: 1px solid var(--border-default);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 24px;
+    flex-shrink: 0;
+  }
+
+  .header-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .header-status {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--text-secondary);
+  }
+
+  .status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .status-dot--connected {
+    background: var(--text-success);
+    box-shadow: 0 0 4px var(--text-success);
+  }
+
+  .status-dot--connecting {
+    background: var(--text-warning);
+    animation: pulse 1.5s ease-in-out infinite;
+  }
+
+  .status-dot--disconnected {
+    background: var(--text-danger);
+  }
+
+  @keyframes pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.4;
+    }
+  }
+
+  .main-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 24px;
+    background: var(--bg-canvas);
+  }
+</style>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1,0 +1,44 @@
+// Typed fetch wrapper for all /api/* endpoints
+// All requests go through the event-viewer proxy at the same origin (:8080)
+
+const API_BASE = "";
+
+async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    headers: { "Content-Type": "application/json", ...init?.headers },
+    ...init,
+  });
+  if (!res.ok) {
+    throw new Error(`API ${path} failed: ${res.status} ${res.statusText}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+// Event-viewer local APIs (served by event-viewer plugin itself)
+export const getEvents = (topic?: string, limit = 100) => {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (topic) params.set("topic", topic);
+  return apiFetch<unknown[]>(`/api/events?${params}`);
+};
+
+export const getTopics = () => apiFetch<string[]>("/api/topics");
+export const getConsumers = () => apiFetch<string[]>("/api/consumers");
+export const getProjects = () =>
+  apiFetch<{ success: boolean; data: unknown[] }>("/api/projects");
+export const getAgents = () =>
+  apiFetch<{ success: boolean; data: unknown[] }>("/api/agents");
+
+// Proxied APIs from main server (:3000)
+export const getWorldState = () => apiFetch<unknown>("/api/world-state");
+export const getServices = () => apiFetch<unknown>("/api/services");
+export const getAgentHealth = () => apiFetch<unknown>("/api/agent-health");
+export const getFlowMetrics = () => apiFetch<unknown>("/api/flow-metrics");
+export const getOutcomes = () => apiFetch<unknown>("/api/outcomes");
+export const getCiHealth = () => apiFetch<unknown>("/api/ci-health");
+export const getPrPipeline = () => apiFetch<unknown>("/api/pr-pipeline");
+export const getCeremonies = () => apiFetch<unknown>("/api/ceremonies");
+export const getIncidents = () => apiFetch<unknown>("/api/incidents");
+export const getSecuritySummary = () =>
+  apiFetch<unknown>("/api/security-summary");
+export const getChannels = () => apiFetch<unknown>("/api/channels");
+export const getHitlPending = () => apiFetch<unknown>("/api/hitl/pending");

--- a/dashboard/src/lib/goal-evaluator.ts
+++ b/dashboard/src/lib/goal-evaluator.ts
@@ -1,0 +1,175 @@
+/**
+ * Client-side goal evaluator — mirrors server-side logic from src/evaluators/*.ts
+ * Resolves dot-path selectors against world state and evaluates pass/fail.
+ */
+
+export type GoalType = "Invariant" | "Threshold" | "Distribution";
+export type Severity = "low" | "medium" | "high" | "critical";
+export type InvariantOperator = "eq" | "neq" | "truthy" | "falsy" | "in" | "not_in";
+
+export interface BaseGoal {
+  id: string;
+  type: GoalType;
+  description: string;
+  severity?: Severity;
+  enabled?: boolean;
+  tags?: string[];
+}
+
+export interface InvariantGoal extends BaseGoal {
+  type: "Invariant";
+  selector: string;
+  expected?: unknown;
+  operator?: InvariantOperator;
+}
+
+export interface ThresholdGoal extends BaseGoal {
+  type: "Threshold";
+  selector: string;
+  min?: number;
+  max?: number;
+}
+
+export interface DistributionGoal extends BaseGoal {
+  type: "Distribution";
+  selector: string;
+  pattern?: string;
+  distribution?: Record<string, number>;
+  tolerance?: number;
+}
+
+export type Goal = InvariantGoal | ThresholdGoal | DistributionGoal;
+
+export type EvalStatus = "pass" | "fail" | "unknown";
+
+export interface EvalResult {
+  status: EvalStatus;
+  actual: unknown;
+  message: string;
+}
+
+/** Resolve a dot-notation path into a nested object. Returns undefined if not found. */
+export function resolvePath(obj: unknown, path: string): unknown {
+  const parts = path.split(".");
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current == null || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+function evalInvariant(goal: InvariantGoal, worldState: unknown): EvalResult {
+  const actual = resolvePath(worldState, goal.selector);
+  const op = goal.operator ?? "truthy";
+
+  let pass: boolean;
+  switch (op) {
+    case "truthy":
+      pass = !!actual;
+      break;
+    case "falsy":
+      pass = !actual;
+      break;
+    case "eq":
+      pass = actual === goal.expected;
+      break;
+    case "neq":
+      pass = actual !== goal.expected;
+      break;
+    case "in":
+      pass = Array.isArray(goal.expected) && goal.expected.includes(actual);
+      break;
+    case "not_in":
+      pass = Array.isArray(goal.expected) && !goal.expected.includes(actual);
+      break;
+    default:
+      pass = false;
+  }
+
+  return {
+    status: actual === undefined ? "unknown" : pass ? "pass" : "fail",
+    actual,
+    message: pass
+      ? `${goal.selector} satisfies ${op}`
+      : `${goal.selector} = ${JSON.stringify(actual)} does not satisfy ${op}`,
+  };
+}
+
+function evalThreshold(goal: ThresholdGoal, worldState: unknown): EvalResult {
+  const actual = resolvePath(worldState, goal.selector);
+  if (actual === undefined || actual === null) {
+    return { status: "unknown", actual, message: `${goal.selector} not found in world state` };
+  }
+  const num = Number(actual);
+  if (isNaN(num)) {
+    return { status: "unknown", actual, message: `${goal.selector} = ${JSON.stringify(actual)} is not a number` };
+  }
+
+  const minOk = goal.min === undefined || num >= goal.min;
+  const maxOk = goal.max === undefined || num <= goal.max;
+  const pass = minOk && maxOk;
+
+  let msg = `${goal.selector} = ${num}`;
+  if (!minOk) msg += ` (min: ${goal.min})`;
+  if (!maxOk) msg += ` (max: ${goal.max})`;
+
+  return { status: pass ? "pass" : "fail", actual: num, message: msg };
+}
+
+function evalDistribution(goal: DistributionGoal, worldState: unknown): EvalResult {
+  const actual = resolvePath(worldState, goal.selector);
+  if (actual === undefined || actual === null) {
+    return { status: "unknown", actual, message: `${goal.selector} not found in world state` };
+  }
+
+  if (goal.pattern) {
+    const re = new RegExp(goal.pattern);
+    const values = Array.isArray(actual)
+      ? actual
+      : Object.values(actual as Record<string, unknown>);
+    const allMatch = values.every((v) => typeof v === "string" && re.test(v));
+    return {
+      status: allMatch ? "pass" : "fail",
+      actual,
+      message: allMatch ? `All values match /${goal.pattern}/` : `Some values don't match /${goal.pattern}/`,
+    };
+  }
+
+  if (goal.distribution) {
+    const tolerance = goal.tolerance ?? 0.1;
+    const ratios = actual as Record<string, number>;
+    const violations: string[] = [];
+    for (const [key, expected] of Object.entries(goal.distribution)) {
+      const got = ratios[key] ?? 0;
+      if (Math.abs(got - expected) > tolerance) {
+        violations.push(`${key}: got ${(got * 100).toFixed(1)}%, expected ${(expected * 100).toFixed(1)}%`);
+      }
+    }
+    const pass = violations.length === 0;
+    return {
+      status: pass ? "pass" : "fail",
+      actual,
+      message: pass ? "Distribution within tolerance" : violations.join("; "),
+    };
+  }
+
+  return { status: "unknown", actual, message: "No evaluation criteria defined" };
+}
+
+/** Evaluate a single goal against the current world state snapshot. */
+export function evaluateGoal(goal: Goal, worldState: unknown): EvalResult {
+  if (goal.enabled === false) {
+    return { status: "unknown", actual: undefined, message: "Goal disabled" };
+  }
+  switch (goal.type) {
+    case "Invariant":
+      return evalInvariant(goal as InvariantGoal, worldState);
+    case "Threshold":
+      return evalThreshold(goal as ThresholdGoal, worldState);
+    case "Distribution":
+      return evalDistribution(goal as DistributionGoal, worldState);
+    default:
+      return { status: "unknown", actual: undefined, message: "Unknown goal type" };
+  }
+}

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -1,0 +1,135 @@
+// API response types for all /api/* endpoints
+
+export interface WorldStateSnapshot {
+  timestamp: string;
+  domains: Record<string, DomainState>;
+}
+
+export interface DomainState {
+  [key: string]: unknown;
+}
+
+export interface ServiceHealth {
+  name: string;
+  status: "healthy" | "degraded" | "down" | "unknown";
+  latency?: number;
+  lastChecked?: string;
+}
+
+export interface ServicesResponse {
+  discord?: ServiceHealth;
+  github?: ServiceHealth;
+  plane?: ServiceHealth;
+  [key: string]: ServiceHealth | undefined;
+}
+
+export interface AgentHealth {
+  id: string;
+  name: string;
+  status: "registered" | "idle" | "active" | "error";
+  lastSeen?: string;
+}
+
+export interface AgentHealthResponse {
+  agents: AgentHealth[];
+}
+
+export interface FlowMetrics {
+  totalEvents: number;
+  eventsPerMinute: number;
+  topTopics: Array<{ topic: string; count: number }>;
+}
+
+export interface Outcome {
+  id: string;
+  action: string;
+  status: "success" | "failure" | "pending";
+  timestamp: string;
+  result?: unknown;
+}
+
+export interface OutcomesResponse {
+  outcomes: Outcome[];
+}
+
+export interface CiHealth {
+  projects: Array<{
+    name: string;
+    successRate: number;
+    lastRun?: string;
+    status: string;
+  }>;
+}
+
+export interface PrPipeline {
+  open: number;
+  merged: number;
+  failed: number;
+  prs: Array<{
+    number: number;
+    title: string;
+    status: string;
+    repo: string;
+  }>;
+}
+
+export interface Goal {
+  id: string;
+  name: string;
+  description?: string;
+  status: "active" | "achieved" | "failed" | "pending";
+  conditions?: Record<string, unknown>;
+}
+
+export interface GoalsResponse {
+  goals: Goal[];
+}
+
+export interface Project {
+  id: string;
+  name: string;
+  description?: string;
+  status?: string;
+}
+
+export interface ProjectsResponse {
+  success: boolean;
+  data: Project[];
+}
+
+export interface Channel {
+  id: string;
+  name: string;
+  type: string;
+  enabled: boolean;
+}
+
+export interface ChannelsResponse {
+  channels: Channel[];
+}
+
+export interface HitlRequest {
+  id: string;
+  question: string;
+  context?: unknown;
+  createdAt: string;
+}
+
+export interface HitlPendingResponse {
+  pending: HitlRequest[];
+}
+
+export interface BusEvent {
+  topic: string;
+  payload: unknown;
+  timestamp: string;
+}
+
+export interface ApiEventsResponse {
+  events: BusEvent[];
+}
+
+export interface WsStatus {
+  connected: boolean;
+  reconnecting: boolean;
+}

--- a/dashboard/src/lib/websocket.ts
+++ b/dashboard/src/lib/websocket.ts
@@ -1,0 +1,112 @@
+// WebSocket manager with exponential backoff reconnection
+
+export type WsMessage = {
+  id?: string;
+  topic: string;
+  payload: unknown;
+  timestamp: string;
+  source?: string;
+};
+
+type MessageHandler = (msg: WsMessage) => void;
+type StatusHandler = (status: "connecting" | "connected" | "disconnected") => void;
+
+const MAX_RETRIES = 10;
+const INITIAL_DELAY = 1000;
+const MAX_DELAY = 15000;
+
+export class WebSocketManager {
+  private ws: WebSocket | null = null;
+  private retryCount = 0;
+  private retryDelay = INITIAL_DELAY;
+  private destroyed = false;
+  private messageHandlers: Set<MessageHandler> = new Set();
+  private statusHandlers: Set<StatusHandler> = new Set();
+  private url: string;
+
+  constructor(path: string) {
+    const proto = typeof location !== "undefined" && location.protocol === "https:" ? "wss:" : "ws:";
+    const host = typeof location !== "undefined" ? location.host : "localhost";
+    this.url = `${proto}//${host}${path}`;
+  }
+
+  connect() {
+    if (this.destroyed) return;
+    this.emit("connecting");
+
+    try {
+      this.ws = new WebSocket(this.url);
+    } catch {
+      this.scheduleReconnect();
+      return;
+    }
+
+    this.ws.onopen = () => {
+      this.retryCount = 0;
+      this.retryDelay = INITIAL_DELAY;
+      this.emit("connected");
+    };
+
+    this.ws.onmessage = (evt: MessageEvent) => {
+      try {
+        const msg = JSON.parse(evt.data as string) as WsMessage;
+        for (const handler of this.messageHandlers) {
+          handler(msg);
+        }
+      } catch {
+        // ignore malformed messages
+      }
+    };
+
+    this.ws.onclose = () => {
+      if (!this.destroyed) {
+        this.emit("disconnected");
+        this.scheduleReconnect();
+      }
+    };
+
+    this.ws.onerror = () => {
+      this.ws?.close();
+    };
+  }
+
+  private scheduleReconnect() {
+    if (this.destroyed || this.retryCount >= MAX_RETRIES) return;
+    // exponential backoff with jitter
+    const jitter = Math.random() * 500;
+    const backoff = Math.min(this.retryDelay + jitter, MAX_DELAY);
+    this.retryCount++;
+    this.retryDelay = Math.min(this.retryDelay * 2, MAX_DELAY);
+    setTimeout(() => this.reconnect(), backoff);
+  }
+
+  private reconnect() {
+    if (this.destroyed) return;
+    this.ws = null;
+    this.connect();
+  }
+
+  private emit(status: "connecting" | "connected" | "disconnected") {
+    for (const handler of this.statusHandlers) {
+      handler(status);
+    }
+  }
+
+  onMessage(handler: MessageHandler) {
+    this.messageHandlers.add(handler);
+    return () => this.messageHandlers.delete(handler);
+  }
+
+  onStatus(handler: StatusHandler) {
+    this.statusHandlers.add(handler);
+    return () => this.statusHandlers.delete(handler);
+  }
+
+  destroy() {
+    this.destroyed = true;
+    this.ws?.close();
+    this.ws = null;
+    this.messageHandlers.clear();
+    this.statusHandlers.clear();
+  }
+}

--- a/dashboard/src/pages/events.astro
+++ b/dashboard/src/pages/events.astro
@@ -1,0 +1,21 @@
+---
+import DashboardLayout from "../layouts/DashboardLayout.astro";
+import EventStream from "../components/EventStream.tsx";
+---
+
+<DashboardLayout title="Events" activePage="events">
+  <EventStream client:load />
+</DashboardLayout>
+
+<style>
+  /* github dark theme: monospace font, #0d1117 background — applied via EventStream */
+  /* color-source topic badges (source-agent, source-cli, etc.) in EventStream.tsx */
+
+  /* Override layout content area to allow EventStream to fill height */
+  :global(.content) {
+    display: flex;
+    flex-direction: column;
+    padding: 0 !important;
+    overflow: hidden;
+  }
+</style>

--- a/dashboard/src/pages/goals.astro
+++ b/dashboard/src/pages/goals.astro
@@ -1,0 +1,41 @@
+---
+import DashboardLayout from "../layouts/DashboardLayout.astro";
+import GoalStatus from "../components/GoalStatus.tsx";
+import OutcomesTable from "../components/OutcomesTable.tsx";
+---
+
+<DashboardLayout title="Goals" activePage="goals">
+  <div class="goals-page">
+    <section class="goals-section">
+      <GoalStatus client:load />
+    </section>
+
+    <div class="divider" />
+
+    <section class="outcomes-section">
+      <OutcomesTable client:load />
+    </section>
+  </div>
+</DashboardLayout>
+
+<style>
+  .goals-page {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .goals-section {
+    padding-bottom: 32px;
+  }
+
+  .divider {
+    height: 1px;
+    background: var(--border-default);
+    margin-bottom: 32px;
+  }
+
+  .outcomes-section {
+    padding-bottom: 24px;
+  }
+</style>

--- a/dashboard/src/pages/index.astro
+++ b/dashboard/src/pages/index.astro
@@ -1,0 +1,8 @@
+---
+import DashboardLayout from "../layouts/DashboardLayout.astro";
+import OverviewGrid from "../components/OverviewGrid.tsx";
+---
+
+<DashboardLayout title="Overview" activePage="overview">
+  <OverviewGrid client:load />
+</DashboardLayout>

--- a/dashboard/src/pages/projects.astro
+++ b/dashboard/src/pages/projects.astro
@@ -1,0 +1,8 @@
+---
+import DashboardLayout from "../layouts/DashboardLayout.astro";
+import ProjectsView from "../components/ProjectsView.tsx";
+---
+
+<DashboardLayout title="Projects" activePage="projects">
+  <ProjectsView client:load />
+</DashboardLayout>

--- a/dashboard/src/pages/world-state.astro
+++ b/dashboard/src/pages/world-state.astro
@@ -1,0 +1,29 @@
+---
+import DashboardLayout from "../layouts/DashboardLayout.astro";
+import WorldStateViewer from "../components/WorldStateViewer.tsx";
+---
+
+<DashboardLayout title="World State" activePage="world-state">
+  <div class="page-header">
+    <h2>World State</h2>
+    <p class="subtitle">Live GOAP world state from all registered domains — polls every 15s</p>
+  </div>
+
+  <WorldStateViewer client:load />
+</DashboardLayout>
+
+<style>
+  .page-header {
+    margin-bottom: 24px;
+  }
+
+  .page-header h2 {
+    font-size: 20px;
+    margin-bottom: 4px;
+  }
+
+  .subtitle {
+    color: var(--text-secondary);
+    font-size: 13px;
+  }
+</style>

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -1,0 +1,121 @@
+/* GitHub dark palette #0d1117 */
+:root {
+  --bg-canvas: #0d1117;
+  --bg-default: #161b22;
+  --bg-subtle: #21262d;
+  --bg-inset: #010409;
+  --border-default: #30363d;
+  --border-muted: #21262d;
+  --text-primary: #c9d1d9;
+  --text-secondary: #8b949e;
+  --text-link: #58a6ff;
+  --text-success: #3fb950;
+  --text-warning: #d29922;
+  --text-danger: #f85149;
+  --accent-fg: #58a6ff;
+  --accent-emphasis: #1f6feb;
+  --sidebar-width: 220px;
+  --header-height: 56px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body {
+  height: 100%;
+  background-color: var(--bg-canvas);
+  color: var(--text-primary);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial,
+    sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+a {
+  color: var(--text-link);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+code,
+pre {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 12px;
+}
+
+pre {
+  background: var(--bg-inset);
+  padding: 12px;
+  border-radius: 6px;
+  overflow: auto;
+  border: 1px solid var(--border-default);
+}
+
+h1,
+h2,
+h3,
+h4 {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.badge-green {
+  background: rgba(63, 185, 80, 0.15);
+  color: var(--text-success);
+}
+
+.badge-yellow {
+  background: rgba(210, 153, 34, 0.15);
+  color: var(--text-warning);
+}
+
+.badge-red {
+  background: rgba(248, 81, 73, 0.15);
+  color: var(--text-danger);
+}
+
+.badge-blue {
+  background: rgba(88, 166, 255, 0.15);
+  color: var(--accent-fg);
+}
+
+.card {
+  background: var(--bg-default);
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  padding: 16px;
+}
+
+.card-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 12px;
+}
+
+.placeholder-content {
+  color: var(--text-secondary);
+  font-style: italic;
+  text-align: center;
+  padding: 48px 24px;
+}

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "strictNullChecks": true,
+    "baseUrl": "."
+  }
+}

--- a/docs/BUDGET_SYSTEM.md
+++ b/docs/BUDGET_SYSTEM.md
@@ -1,0 +1,136 @@
+# Budget System — Architecture & Design
+
+## Overview
+
+The BudgetPlugin provides cost-aware budget management for the Workstacean bus.
+It enforces daily spending caps, routes requests through tiered execution levels,
+and escalates expensive requests to human review.
+
+**Daily caps:**
+- `$10` per project per day (`MAX_PROJECT_BUDGET`)
+- `$50` total across all projects per day (`MAX_DAILY_BUDGET`)
+
+**Autonomous rate target:** 85–90% (≤15% escalation rate)
+
+---
+
+## Tier Routing: L0 → L1 → L2 → L3
+
+Each incoming request is assigned a tier based on its estimated max cost and the
+remaining budget ratio. The **tighter** of `projectBudgetRatio` and `dailyBudgetRatio`
+is used as the binding constraint.
+
+| Tier | Max Cost | Min Budget Ratio | Behaviour |
+|------|----------|-----------------|-----------|
+| **L0** | < $0.10 | > 50% remaining | Fully autonomous — no notification |
+| **L1** | < $1.00 | > 25% remaining | Notify ops channel, proceed automatically |
+| **L2** | < $5.00 | > 10% remaining | Log warning (soft-gate), proceed |
+| **L3** | anything else | any | **Block — escalate to HITL** |
+
+### Tier Assignment Flow
+
+```
+pre_flight_estimate(request)
+    └─> route_by_tier(estimate, budgetState)
+            ├─ L0  → execute, record, no alert
+            ├─ L1  → execute, log warning, record
+            ├─ L2  → execute, log warning, record
+            └─ L3  → block, publish hitl.request.budget.{requestId}
+```
+
+---
+
+## Pre-flight Cost Estimation
+
+All requests undergo cost estimation **before** execution. The estimator uses a
+heuristic approach (≈4 characters per token) since the Anthropic SDK is not
+installed. A conservative upper-bound (`maxCost = estimatedCost × 1.5`) is used
+for tier assignment.
+
+**Deviation rule:** When the Anthropic token counting API is unavailable, the
+system activates fallback heuristics at 1.5× observed average and sets
+`fallbackUsed = true` in the estimate.
+
+```typescript
+// lib/plugins/cost-estimator.ts
+const estimate = pre_flight_estimate({
+  promptText: "...",
+  modelId: "claude-sonnet-4-6",
+});
+// estimate.maxCost used for tier routing
+```
+
+---
+
+## Circuit Breaker (per goal × agent)
+
+A circuit breaker tracks the state of each `goalId:agentId` combination.
+
+| State | Description |
+|-------|-------------|
+| `CLOSED` | Normal operation — requests pass through |
+| `OPEN` | Budget exceeded — requests blocked |
+| `HALF_OPEN` | Recovery test window — one request allowed |
+
+**Default config:**
+- `failureThreshold: 3` — opens after 3 consecutive budget failures
+- `recoveryWindowMs: 300_000` — 5-minute recovery window
+- Transitions: `CLOSED → OPEN` on failures, `OPEN → HALF_OPEN` after recovery window
+
+**Emergency override** (requires justification + approver):
+```typescript
+circuitBreaker.override("goal-id", "ava", "CLOSED", "emergency fix", "ops-lead");
+```
+
+---
+
+## HITL Escalation (L3)
+
+When a request is assigned tier L3, the BudgetPlugin publishes to
+`hitl.request.budget.{requestId}`. The payload includes:
+
+- `escalation_reason` — human-readable reason for escalation
+- `cost_trail` — last 10 records for this agent+project
+- `escalationContext` — full budget state snapshot
+- `summary` — formatted markdown with all cost context
+
+The HITLPlugin routes this to the appropriate interface (Discord, API, etc.)
+and waits for an approve/reject decision (30-minute timeout).
+
+---
+
+## Discord Alerts
+
+The `DiscordAlerter` monitors `projectBudgetRatio` and `dailyBudgetRatio` and
+fires notifications at configured thresholds (default: 50% and 80%).
+
+Alerts are sent to the `DISCORD_BUDGET_WEBHOOK_URL` environment variable.
+On failure: exponential backoff retry (max 7 retries), with a fallback to
+`DISCORD_OPS_WEBHOOK_URL` if configured.
+
+---
+
+## Metrics & Autonomous Rate
+
+The `MetricsTracker` records every request event and computes:
+
+- `autonomous_rate` — fraction of requests handled autonomously (target ≥ 0.85)
+- Tier breakdown (L0/L1/L2/L3 counts)
+- Per-agent and per-project metrics
+
+When the autonomous rate drops below 85%, an `ops.alert.budget` event is published
+with a diagnostic report. **Auto-adjustment is prohibited** — a human must review
+and adjust tier thresholds or circuit breaker sensitivity.
+
+---
+
+## Bus Topics
+
+| Topic | Direction | Description |
+|-------|-----------|-------------|
+| `budget.request.#` | Inbound | Pre-flight cost check request |
+| `budget.actual.#` | Inbound | Post-execution actual cost |
+| `budget.decision.{requestId}` | Outbound | Tier decision (approved/blocked) |
+| `hitl.request.budget.{requestId}` | Outbound | L3 escalation to HITLPlugin |
+| `ops.alert.budget` | Outbound | Ops-level alerts (rate drop, discrepancy) |
+| `budget.circuit.open.{key}` | Outbound | Circuit breaker state change |

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -1,0 +1,102 @@
+# Configuration Reference — Budget System
+
+## Budget Constants
+
+Defined in `lib/types/budget.ts`.
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `MAX_PROJECT_BUDGET` | `$10.00` | Maximum daily spend per project |
+| `MAX_DAILY_BUDGET` | `$50.00` | Maximum total daily spend across all projects |
+| `FALLBACK_COST_MULTIPLIER` | `1.5` | Conservative upper-bound multiplier for heuristic estimates |
+
+---
+
+## Tier Configuration
+
+Defined in `TIER_CONFIG` in `lib/types/budget.ts`.
+
+| Tier | `maxCost` | `minBudgetRatio` | `requiresHITL` | Description |
+|------|-----------|-----------------|----------------|-------------|
+| L0 | `$0.10` | `0.50` (50%) | No | Autonomous — no notification |
+| L1 | `$1.00` | `0.25` (25%) | No | Notify ops, proceed |
+| L2 | `$5.00` | `0.10` (10%) | No | Soft-gate warning |
+| L3 | `∞` | `0` | **Yes** | HITL approval required |
+
+**Tier assignment:** A request is assigned the highest L tier where BOTH
+`maxCost < tier.maxCost` AND `minBudgetRatio ≤ budgetRatio` are satisfied.
+The tighter of `projectBudgetRatio` and `dailyBudgetRatio` is used.
+
+---
+
+## Model Rates
+
+Defined in `MODEL_RATES` in `lib/types/budget.ts`.
+
+| Model | Input (per token) | Output (per token) |
+|-------|-------------------|--------------------|
+| `claude-opus-4-6` | $0.000015 | $0.000075 |
+| `claude-sonnet-4-6` | $0.000003 | $0.000015 |
+| `claude-haiku-4-5` | $0.00000025 | $0.00000125 |
+| `gpt-4o` | $0.0000025 | $0.00001 |
+| `gpt-4o-mini` | $0.00000015 | $0.0000006 |
+| `default` | $0.000003 | $0.000015 |
+
+---
+
+## Circuit Breaker Configuration
+
+`CircuitBreaker` accepts a `CircuitBreakerConfig` in its constructor.
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `failureThreshold` | `3` | Consecutive failures to open the circuit |
+| `recoveryWindowMs` | `300_000` (5 min) | Time in OPEN before trying HALF_OPEN |
+| `successThreshold` | `1` | Successes in HALF_OPEN to close circuit |
+
+---
+
+## Discord Alert Configuration
+
+`DiscordAlerter` accepts a `DiscordAlertConfig` partial.
+
+| Property | Default | Environment Variable | Description |
+|----------|---------|---------------------|-------------|
+| `webhookUrl` | `""` | `DISCORD_BUDGET_WEBHOOK_URL` | Primary alert webhook |
+| `opsWebhookUrl` | `""` | `DISCORD_OPS_WEBHOOK_URL` | Fallback ops webhook |
+| `thresholds` | `[0.5, 0.8]` | — | Budget usage fractions to alert at |
+| `maxRetries` | `7` | — | Max webhook delivery retries |
+| `initialBackoffMs` | `1000` | — | Initial exponential backoff delay |
+
+---
+
+## HITL Escalation Timeout
+
+The default HITL escalation timeout is **30 minutes** (1800 seconds).
+Requests that expire without a decision are auto-rejected per deviation rules.
+
+This is hardcoded in `lib/plugins/budget.ts`:
+```typescript
+expiresAt: new Date(Date.now() + 30 * 60 * 1000).toISOString()
+```
+
+---
+
+## Metrics Target
+
+| Metric | Target | Alert Threshold |
+|--------|--------|----------------|
+| `autonomous_rate` | 85–90% | < 85% triggers ops alert |
+
+---
+
+## Bus Topic Reference
+
+| Topic | Payload Type | Description |
+|-------|-------------|-------------|
+| `budget.request.{suffix}` | `BudgetRequest` | Trigger pre-flight cost check |
+| `budget.actual.{suffix}` | `BudgetActual` | Report actual post-execution cost |
+| `budget.decision.{requestId}` | `BudgetDecision` | Cost check result |
+| `hitl.request.budget.{requestId}` | `HITLRequest` (with cost fields) | L3 escalation |
+| `ops.alert.budget` | `{ type, ... }` | Budget system ops alerts |
+| `budget.circuit.open.{key}` | `{ type, key, circuitState }` | Circuit breaker opened |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,77 @@
+# Deployment Guide — Budget System
+
+## Prerequisites
+
+- Bun ≥ 1.0
+- SQLite (bundled with Bun)
+- Discord webhook URLs (optional, for alerts)
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DISCORD_BUDGET_WEBHOOK_URL` | No | Discord webhook for budget threshold alerts |
+| `DISCORD_OPS_WEBHOOK_URL` | No | Fallback ops channel webhook |
+| `DATA_DIR` | Yes | Directory for SQLite databases (e.g. `./data`) |
+
+## Installing the BudgetPlugin
+
+In your application entry point (`src/index.ts`), register the plugin:
+
+```typescript
+import { BudgetPlugin } from "../lib/plugins/budget.ts";
+
+const budgetPlugin = new BudgetPlugin(dataDir);
+bus.install(budgetPlugin);
+```
+
+Or with the existing plugin loader pattern:
+
+```typescript
+const plugins = [
+  new LoggerPlugin(dataDir),
+  new HITLPlugin(workspaceDir),
+  new BudgetPlugin(dataDir),
+  // ...
+];
+```
+
+## Database
+
+The BudgetPlugin creates `budget.db` in the configured `dataDir`:
+
+```
+data/
+├── budget.db       ← budget ledger (SQLite)
+├── events.db       ← event log (LoggerPlugin)
+└── sessions/       ← agent sessions
+```
+
+The schema is auto-migrated on startup. No manual migration steps are needed.
+
+## Verifying Deployment
+
+After startup, send a test budget request on the bus:
+
+```typescript
+bus.publish("budget.request.test", {
+  id: crypto.randomUUID(),
+  correlationId: "test-1",
+  topic: "budget.request.test",
+  timestamp: Date.now(),
+  payload: {
+    type: "budget_request",
+    requestId: "test-1",
+    agentId: "ava",
+    projectId: "test-project",
+    promptText: "Hello world",
+  },
+});
+```
+
+You should see a `budget.decision.test-1` response on the bus.
+
+## Rollback
+
+The BudgetPlugin is additive — removing it from the plugin list will stop
+budget enforcement without affecting other plugins. No data migration is needed.

--- a/docs/L2_PLANNER_API.md
+++ b/docs/L2_PLANNER_API.md
@@ -1,0 +1,74 @@
+# L2 Planner API Reference
+
+## L2Dispatcher
+
+Main entry point for the planning pipeline.
+
+```typescript
+import { L2Dispatcher } from "./src/planner/dispatcher.ts";
+import { ActionGraph } from "./src/planner/action-graph.ts";
+
+const graph = new ActionGraph();
+graph.addActions([...]);
+
+const dispatcher = new L2Dispatcher(graph, {
+  routing: { l2ConfidenceThreshold: 0.5 },
+  a2aClient: myA2AClient,
+  onL3Escalation: (ctx, result) => { /* handle escalation */ },
+});
+
+const result = await dispatcher.resolve(state, goal, namedGoal);
+```
+
+### L2Result
+
+```typescript
+interface L2Result {
+  success: boolean;
+  plan?: Plan;
+  confidence: ConfidenceScore;
+  escalatedToL3: boolean;
+  error?: string;
+  planId: string;
+}
+```
+
+## A2AClient Interface
+
+Implement this to connect Ava (or any LLM) to the hybrid planner.
+
+```typescript
+interface A2AClient {
+  proposePlans(prompt: A2APrompt, maxCandidates: number): Promise<CandidatePlan[]>;
+}
+```
+
+## RoutingConfig
+
+```typescript
+interface RoutingConfig {
+  l0ConfidenceThreshold: number;  // default: 0.7
+  l1ConfidenceThreshold: number;  // default: 0.6
+  l2ConfidenceThreshold: number;  // default: 0.5
+  maxCandidates: number;          // default: 3
+  l2TimeBudgetMs: number;         // default: 30000
+  tryL1BeforeL2: boolean;         // default: true
+}
+```
+
+## Metrics API
+
+```typescript
+const metrics = dispatcher.getMetrics();
+const summary = metrics.getSummary(3600_000); // last hour
+console.log(summary.escalationRate);
+console.log(summary.successRate);
+```
+
+## Learning Registry
+
+```typescript
+const registry = dispatcher.getRuleRegistry();
+const stats = registry.getStats();
+console.log(stats.totalRules, stats.promotedRules);
+```

--- a/docs/L2_PLANNER_ARCHITECTURE.md
+++ b/docs/L2_PLANNER_ARCHITECTURE.md
@@ -1,0 +1,64 @@
+# L2 Planner Architecture
+
+## Overview
+
+The L2 planner is a hybrid LLM-A* planning system that sits between the deterministic L0/L1 layers and human escalation (L3). It combines creative plan generation from an LLM agent (Ava) with rigorous A* validation and optimization.
+
+## Layer Model
+
+```
+L0 (Deterministic Rules) → L1 (A* Search) → L2 (LLM-A* Hybrid) → L3 (Human)
+```
+
+- **L0**: Pattern-matching rule engine. Fast, deterministic, zero-cost. Handles ~80% of cases.
+- **L1**: A* search with HTN decomposition. Finds optimal plans within budget. Handles ~15%.
+- **L2**: LLM proposes creative plans, A* validates and optimizes. Handles novel situations.
+- **L3**: Human-in-the-loop for cases where L2 confidence is too low.
+
+## L2 Hybrid Planning Flow
+
+1. **Routing**: `L2Router` intercepts L0/L1 failures or low-confidence results
+2. **Proposal**: `A2AProposer` sends structured prompt to Ava (LLM) via A2A protocol
+3. **Validation**: `AStarValidator` checks each candidate plan against A* simulation
+4. **Optimization**: A* attempts to find a lower-cost alternative
+5. **Confidence**: `ConfidenceScorer` evaluates plan quality (feasibility, goal alignment, cost, constraints)
+6. **Escalation**: `EscalationTrigger` routes low-confidence plans to L3
+
+## Learning Flywheel
+
+Every successful L2 plan is fed into the learning flywheel:
+
+1. `RuleExtractor` extracts generalizable conditions from the plan
+2. `PlanConverter` creates a `LearnedRule` in the `RuleRegistry`
+3. On subsequent requests, `PatternMatcher` checks learned rules first
+4. After enough successful executions, `RuleMigration` promotes the rule to L0
+5. Result: escalation rate decreases over time as the system learns
+
+## Confidence Scoring
+
+Confidence is a weighted composite of:
+- **Feasibility** (35%): Can actions execute in order?
+- **Goal Alignment** (30%): Does the final state satisfy the goal?
+- **Cost Efficiency** (15%): Is the cost reasonable?
+- **Constraint Satisfaction** (20%): Are all constraints met?
+
+## Configuration
+
+See `src/config/routing-config.yaml` for tunable thresholds.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/planner/l2-router.ts` | Top-level L0→L1→L2→L3 routing |
+| `src/planner/hybrid-planner.ts` | LLM-A* hybrid planning engine |
+| `src/planner/a2a-proposer.ts` | LLM candidate generation via A2A |
+| `src/planner/astar-validator.ts` | A* plan validation and optimization |
+| `src/planner/confidence-scorer.ts` | Plan quality scoring |
+| `src/planner/escalation-trigger.ts` | L3 escalation decisions |
+| `src/planner/dispatcher.ts` | Full pipeline dispatcher |
+| `src/learning/plan-converter.ts` | Plan → rule conversion |
+| `src/learning/rule-registry.ts` | Learned rule storage |
+| `src/learning/rule-migration.ts` | L2 → L0 rule promotion |
+| `src/monitoring/l2-metrics.ts` | Invocation/success telemetry |
+| `src/monitoring/escalation-tracker.ts` | Escalation trend tracking |

--- a/docs/OPERATIONAL_RUNBOOK.md
+++ b/docs/OPERATIONAL_RUNBOOK.md
@@ -1,0 +1,78 @@
+# L2 Planner Operational Runbook
+
+## Monitoring
+
+### Dashboard
+
+See `monitoring/dashboards/l2-planner-dashboard.json` for the dashboard definition.
+
+Key panels:
+- **Escalation Rate**: Should trend downward over time
+- **Success Rate**: Target > 80%
+- **Confidence Distribution**: Healthy system has most plans > 0.7
+- **Learned Rules Count**: Should grow steadily
+
+### Alerts
+
+| Condition | Severity | Action |
+|-----------|----------|--------|
+| Escalation rate > 50% (1h window) | Warning | Check L2 planner health |
+| Escalation rate > 80% (1h window) | Critical | Check A2A connectivity and action graph |
+| P95 latency > 30s | Warning | Check A2A response times |
+| Learned rule failure rate > 30% | Warning | Trigger rule audit |
+
+## Common Operations
+
+### Adjusting Confidence Thresholds
+
+Edit `src/config/routing-config.yaml`:
+```yaml
+routing:
+  l2_confidence_threshold: 0.5  # Lower = more autonomous, higher = more escalations
+```
+
+### Inspecting Learned Rules
+
+```typescript
+const registry = dispatcher.getRuleRegistry();
+const stats = registry.getStats();
+const rules = registry.getAll();
+```
+
+### Rolling Back a Learned Rule
+
+```typescript
+const migration = new RuleMigration(registry, versioning, auditor);
+migration.rollback("rule-id");
+```
+
+### Checking Escalation Trends
+
+```typescript
+const tracker = dispatcher.getEscalationTracker();
+const trend = tracker.getTrend(3600_000); // 1-hour buckets
+const reasons = tracker.getTopReasons(10);
+```
+
+## Troubleshooting
+
+### High Escalation Rate
+
+1. Check A2A client connectivity (is Ava responding?)
+2. Verify action graph has sufficient actions for the goal types
+3. Check if confidence threshold is too high
+4. Review top escalation reasons: `tracker.getTopReasons(10)`
+
+### Learned Rule Causing Failures
+
+1. Identify the rule: `registry.findByGoal(goalPattern)`
+2. Check failure count: `rule.failureCount`
+3. Rollback if needed: `migration.rollback(rule.id)`
+4. Audit trail: `auditor.getForRule(rule.id)`
+
+### L2 Planner Not Learning
+
+1. Check minimum learning confidence: plans below 0.8 are not extracted
+2. Check promotion threshold: rules need 3 successes before promotion
+3. Verify registry is not at max capacity (500 default)
+4. Check if plans are too long (max 10 actions for extraction)

--- a/docs/PLAN_LEARNING_FLYWHEEL.md
+++ b/docs/PLAN_LEARNING_FLYWHEEL.md
@@ -1,0 +1,72 @@
+# Plan Learning Flywheel
+
+## Concept
+
+The learning flywheel converts expensive L2 (LLM-assisted) plans into cheap L0 (deterministic) rules. Over time, this drives the escalation rate toward zero as the system learns to handle more situations autonomously.
+
+## Cycle
+
+```
+Request → L2 (LLM + A*) → Successful Plan → Extract Rule → Register Rule
+                                                              ↓
+Request → Check Learned Rules → Match! → Use Learned Plan → Record Success
+                                                              ↓
+                                              Promote to L0 (after N successes)
+```
+
+## Components
+
+### RuleExtractor
+
+Extracts generalizable conditions from successful L2 plans:
+- Uses the plan's first action preconditions as rule conditions
+- Captures relevant state keys from the initial state
+- Configurable minimum confidence threshold (default: 0.8)
+
+### RuleRegistry
+
+Stores learned rules with:
+- Success/failure tracking
+- Version history
+- Active/inactive status
+- Promotion tracking (to L0)
+- Automatic pruning of low-performing rules
+
+### PatternMatcher
+
+Checks incoming requests against learned rules:
+- Exact goal pattern matching
+- State condition evaluation
+- Selects best rule by: success rate → confidence → cost
+
+### PlanConverter
+
+Orchestrates the conversion pipeline:
+- Validates plan eligibility
+- Creates or updates rules
+- Triggers promotion check
+
+### RuleMigration
+
+Safe promotion from L2 registry to L0:
+- Version snapshots before promotion
+- Audit trail of all events
+- Auto-rollback on performance degradation
+
+## Configuration
+
+```yaml
+learning:
+  min_learning_confidence: 0.8
+  promotion_threshold: 3
+  max_learned_rules: 500
+  auto_rollback_enabled: true
+```
+
+## Monitoring
+
+Track flywheel health via:
+- `rulesLearned`: Total rules in registry
+- `rulesPromoted`: Rules promoted to L0
+- `l0HitRate`: Ratio of requests handled by learned rules
+- `escalationRateDelta`: Change in escalation rate (negative = improving)

--- a/docs/RUNBOOK_BUDGET_ALERTS.md
+++ b/docs/RUNBOOK_BUDGET_ALERTS.md
@@ -1,0 +1,91 @@
+# Runbook — Budget Alerts
+
+## Alert: Budget Threshold Crossed (50% or 80%)
+
+**Topic:** Discord webhook (or `budget.alert.threshold` on bus)
+
+**Triggered when:** Project daily spend or total daily spend exceeds 50% or 80%
+of the configured cap.
+
+### Immediate response
+
+1. Check current spend via the metrics endpoint or `ops.alert.budget` events
+2. Review recent `budget.decision.*` events for the project/agent
+3. If approaching $10 project cap — consider pausing non-critical agent runs
+4. If approaching $50 daily cap — escalate to team lead immediately
+
+### No further action needed if:
+- Spend is on track with expected project activity
+- Threshold is 50% and there is no unusual spike
+
+---
+
+## Alert: Autonomous Rate Below 85%
+
+**Topic:** `ops.alert.budget` with `type: "autonomous_rate_below_threshold"`
+
+**Triggered when:** The 24-hour autonomous rate drops below 85%.
+
+### Steps
+
+1. **Read the diagnostic report** in the alert payload — it includes tier breakdown
+2. Check for unusual L3 escalation patterns (are certain agents/projects spiking?)
+3. Review tier thresholds — are they still appropriate for current usage patterns?
+4. **Do NOT auto-adjust** tier thresholds or circuit breaker config without a team review
+5. Open a ticket for the engineering team to review and adjust configuration
+
+---
+
+## Alert: Cost Discrepancy >20%
+
+**Topic:** `ops.alert.budget` with `type: "cost_discrepancy"`
+
+**Triggered when:** The actual post-execution cost differs from the pre-flight estimate
+by more than 20%.
+
+### Steps
+
+1. Check the `estimated` vs `actual` values in the alert payload
+2. Review the model being used — is it returning more tokens than expected?
+3. Adjust `estimatedCompletionTokens` in the calling code if consistently over-estimating
+4. The budget tracker will adjust the recorded spend to the actual value automatically
+5. If discrepancy is systematic (>20% consistently), escalate to HITL for budget review
+
+---
+
+## Alert: Circuit Breaker OPEN
+
+**Topic:** `budget.circuit.open.{goalId}:{agentId}`
+
+**Triggered when:** A goal×agent circuit breaker transitions to OPEN state.
+
+### Steps
+
+1. Identify which `goalId:agentId` combination tripped the breaker
+2. Review the recent `budget_ledger` records for that combination
+3. Determine root cause: was the budget exhausted, or is there a runaway agent?
+4. If the agent is behaving correctly and budget is available, use the emergency override:
+
+```typescript
+// From ops console or emergency responder tooling
+circuitBreaker.override("goal-id", "agent-id", "CLOSED", "budget replenished — resuming", "ops-oncall");
+```
+
+5. Log the override with justification (cost deducted from next period's allocation)
+6. Monitor the agent for the next 10 minutes to confirm normal behavior
+
+---
+
+## Alert: HITL Escalation Timeout
+
+**Topic:** `hitl.expired.{correlationId}`
+
+**Triggered when:** A HITL approval request expires without a decision (default: 30 minutes).
+
+### Steps
+
+1. Per deviation rule: the request is auto-rejected after timeout
+2. Review the original escalation context in the expired request
+3. If the request was legitimate, manually re-trigger from the source
+4. Notify the ops team about the missed escalation
+5. Review escalation alert routing if this is happening frequently

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,124 @@
+# Architecture — protoWorkstacean
+
+protoWorkstacean is a personal agent orchestration platform built on a hierarchical topic-based pub/sub message bus. It coordinates a fleet of specialized AI agents (Quinn, Ava, Frank, Jon, etc.) across GitHub, Discord, and Plane.
+
+## Core Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                     EventBus (in-process)                │
+│           topic-based hierarchical pub/sub              │
+└───────────┬────────────────────────────────┬────────────┘
+            │                                │
+   ┌────────▼────────┐              ┌────────▼────────┐
+   │  Plugin Layer   │              │  Agent Layer    │
+   │  (lib/plugins/) │              │  (workspace/)   │
+   │                 │              │                 │
+   │ • GitHubPlugin  │              │ • Quinn (PR     │
+   │ • DiscordPlugin │              │   review, triage│
+   │ • PlanePlugin   │              │ • Ava (features)│
+   │ • A2APlugin     │              │ • Frank, Jon... │
+   │ • CeremonyPlugin│              └─────────────────┘
+   └─────────────────┘
+```
+
+## Plugin System
+
+Plugins are instantiated with a `workspaceDir` and install themselves onto the EventBus:
+
+```typescript
+export class MyPlugin implements Plugin {
+  readonly name = "my-plugin";
+  install(bus: EventBus): void { /* subscribe + serve */ }
+  uninstall(): void { /* cleanup */ }
+}
+```
+
+Plugins use `Bun.serve()` for HTTP endpoints and `bus.subscribe()` / `bus.publish()` for internal routing.
+
+## Quinn Vector Context Pipeline
+
+Quinn's PR review pipeline extends beyond the diff with codebase-wide vector search via Qdrant:
+
+```
+PR opened/synchronize
+  → GitHubPlugin → bus (message.inbound.github.*)
+  → A2APlugin → Quinn agent (pr_review skill)
+  → runReviewPipeline(diff, repo, pr)
+      ├── parseDiff + extractSymbols
+      ├── Qdrant: retrieveAllPastPRDecisions (quinn-pr-history)
+      ├── Qdrant: findAllSimilarPatterns (quinn-code-patterns)
+      ├── formatCodebaseContext + applyTokenBudget
+      └── assembleReviewPrompt → LLM call
+
+PR merged
+  → GitHubPlugin → parsePRMergePayload → handlePRMerge
+      ├── fetchPRDiff + fetchReviewDecision
+      ├── chunkDiff → embed → quinn-pr-history
+      └── extractSymbols → fetchSymbolContexts → quinn-code-patterns
+
+Developer dismisses Quinn comment
+  → GitHubPlugin → parseCommentResponsePayload
+  → handleCommentResponse → trackCommentResponse
+  → recordDismissalEvent → quinn-review-learnings
+```
+
+## Service Layer (`src/services/`)
+
+| Package | Responsibility |
+|---|---|
+| `qdrant/client.ts` | Qdrant REST API client (5s timeout, fallback on error) |
+| `qdrant/collections.ts` | Collection initialization (quinn-pr-history, quinn-code-patterns, quinn-review-learnings) |
+| `qdrant/pr-history-indexer.ts` | Index PR diff chunks |
+| `qdrant/code-patterns-indexer.ts` | Index symbol definitions |
+| `qdrant/pattern-searcher.ts` | Search for similar code patterns |
+| `qdrant/past-pr-retriever.ts` | Retrieve past PR decisions for a file |
+| `qdrant/review-learnings-indexer.ts` | Store/update dismissed comment patterns |
+| `embeddings/ollama-client.ts` | Ollama embedding API (nomic-embed-text) |
+| `diff/chunker.ts` | Parse unified diff, chunk large files |
+| `diff/symbol-extractor.ts` | Route to language-specific symbol extractors |
+| `diff/symbols/typescript.ts` | TypeScript symbol extraction via regex |
+| `diff/symbols/python.ts` | Python symbol extraction via regex |
+| `diff/symbols/go.ts` | Go symbol extraction via regex |
+| `github/diff-fetcher.ts` | Fetch PR diff, comments, and decision via GitHub API |
+| `codebase/symbol-fetcher.ts` | Fetch symbol context via GitHub raw content API |
+| `reviews/context-formatter.ts` | Format CODEBASE CONTEXT block |
+| `reviews/token-budgeter.ts` | Enforce 20% token budget cap |
+| `reviews/quinn-review-prompt.ts` | Assemble final review prompt |
+| `reviews/review-pipeline.ts` | Orchestrate full context retrieval pipeline |
+| `reviews/dismissal-tracker.ts` | Track developer responses to Quinn comments |
+| `reviews/low-signal-filter.ts` | Filter low-signal comment patterns |
+
+## External Services
+
+| Service | URL | Purpose |
+|---|---|---|
+| Qdrant | `http://qdrant:6333` | Vector search and storage |
+| Ollama | `http://ollama:11434` | Local LLM and embedding inference |
+| GitHub API | `https://api.github.com` | PR data, diffs, comments |
+| Plane | configured via `PLANE_API_URL` | Project management integration |
+| Discord | bot token | Team notifications |
+
+## Topic Conventions
+
+```
+message.inbound.github.<owner>.<repo>.<event>.<number>   — inbound from GitHub
+message.outbound.github.<owner>.<repo>.<number>          — outbound to GitHub
+message.inbound.discord.<channel>                        — inbound from Discord
+message.outbound.discord.<channel>                       — outbound to Discord
+```
+
+## Configuration
+
+All configuration is via environment variables. See `docs/CONFIGURATION_REFERENCE.md` for the full list.
+Key variables for the Quinn vector context pipeline:
+
+```
+QDRANT_URL=http://qdrant:6333
+QDRANT_VECTOR_SIZE=768
+OLLAMA_URL=http://ollama:11434
+OLLAMA_EMBED_MODEL=nomic-embed-text
+GITHUB_WEBHOOK_SECRET=<secret>
+QUINN_APP_ID=<github-app-id>
+QUINN_APP_PRIVATE_KEY=<pem-contents>
+```

--- a/docs/context-injection.md
+++ b/docs/context-injection.md
@@ -1,0 +1,86 @@
+# Context Injection — Quinn Codebase-Wide Review Context
+
+Quinn's vector context pipeline injects a `CODEBASE CONTEXT` block into review prompts,
+giving the LLM cross-repository awareness beyond the current diff.
+
+## How It Works
+
+```
+PR review triggered
+  → parseDiff(diff) — extract changed files and hunks
+  → extractAllSymbols(files) — identify changed functions/classes/exports
+  → [parallel]
+      retrieveAllPastPRDecisions(repo, filePaths)   → quinn-pr-history
+      findAllSimilarPatterns(symbols)               → quinn-code-patterns
+  → formatCodebaseContext({ pastDecisions, similarPatterns })
+  → applyTokenBudget(context, totalBudget)
+  → assembleReviewPrompt({ diff, context, ... })
+  → LLM call with enriched prompt
+```
+
+## CODEBASE CONTEXT Block Format
+
+```
+CODEBASE CONTEXT:
+
+Past PR decisions on changed files:
+  src/middleware/auth.ts:
+    - PR #142 (2026-04-01): APPROVE — Token expiry not checked; consider adding clock skew tolerance
+    - PR #138 (2026-03-15): REQUEST_CHANGES — JWT secret not validated at startup
+
+Similar code patterns across the repository:
+  `validateToken` in src/utils/jwt.ts:23 (protolabsai/protomaker)
+    23: export function validateToken(token: string): boolean {
+    24:   // Similar implementation without expiry check
+    25: }
+```
+
+## Token Budget
+
+The context block is capped at **20% of the total prompt token budget**.
+
+Token estimation: `1 token ≈ 4 characters` (GPT-style approximation).
+
+**Priority order when truncating:**
+1. Past PR decisions — always kept (highest value, historically proven)
+2. Similar code patterns — trimmed from lowest-scored pattern first
+
+If the budget is too small to include any context, the block is omitted entirely
+and the review proceeds with diff-only mode.
+
+## Fallback Behavior
+
+| Condition | Action |
+|---|---|
+| Qdrant unavailable | Log warning, skip context block, diff-only review |
+| Embedding fails for a chunk | Skip that chunk, continue with remaining |
+| No historical context found | Omit that section from the block |
+| Context exceeds 20% token budget | Truncate low-priority items |
+
+## PR History Indexing
+
+On PR merge (`pull_request.closed` + `merged: true`):
+
+```
+fetch diff + comments + decision
+  → parseDiff → chunkDiff (500-line blocks with 50-line overlap for large files)
+  → embed each chunk via Ollama
+  → upsert to quinn-pr-history with metadata
+  → extractAllSymbols → fetchSymbolContexts (GitHub raw content API)
+  → embed each symbol context
+  → upsert to quinn-code-patterns
+```
+
+## Review Learning Loop
+
+When a developer responds to a Quinn inline comment:
+
+```
+pull_request_review_comment.created (with in_reply_to_id)
+  → isDismissalResponse(responseBody) — heuristic detection
+  → trackCommentResponse({ repo, filePath, commentBody, dismissed, reason })
+  → recordDismissalEvent → quinn-review-learnings
+```
+
+Before generating a comment, Quinn checks `isLowSignalPattern(repo, fileType, commentText)`.
+If dismissal rate > 50% with at least 3 samples, the comment is skipped.

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,65 @@
+# Event Catalog
+
+This document describes events published by the GoalEvaluatorPlugin.
+
+## world.goal.violated
+
+Emitted when a goal evaluation detects a violation.
+
+**Topic:** `world.goal.violated`
+
+**Payload:**
+
+```typescript
+{
+  type: "world.goal.violated";
+  violation: {
+    goalId: string;          // Goal identifier from goals.yaml
+    goalType: "Invariant" | "Threshold" | "Distribution";
+    severity: "low" | "medium" | "high" | "critical";
+    description: string;     // Human-readable goal description
+    message: string;         // Specific violation message
+    actual: unknown;         // Actual value observed in world state
+    expected: unknown;       // Expected value/bounds
+    timestamp: number;       // Unix milliseconds
+    projectSlug?: string;    // Project context (if scoped)
+  };
+}
+```
+
+**Example:**
+
+```json
+{
+  "topic": "world.goal.violated",
+  "payload": {
+    "type": "world.goal.violated",
+    "violation": {
+      "goalId": "cpu-ok",
+      "goalType": "Threshold",
+      "severity": "high",
+      "description": "CPU must stay below 80%",
+      "message": "\"metrics.cpu.usage\" value 92 exceeds maximum threshold 80",
+      "actual": 92,
+      "expected": { "max": 80 },
+      "timestamp": 1712345678000,
+      "projectSlug": "protoworkstacean"
+    }
+  }
+}
+```
+
+## world.state.# (input)
+
+The plugin subscribes to `world.state.#` for incoming world state.
+
+**Expected payload:**
+
+```typescript
+{
+  state: Record<string, unknown>;  // The world state to evaluate against
+  projectSlug?: string;            // Optional project scope
+}
+```
+
+Or the entire payload is treated as the world state if no `state` key is present.

--- a/docs/goals-examples.yaml
+++ b/docs/goals-examples.yaml
@@ -1,0 +1,100 @@
+version: "1.0"
+
+goals:
+  # ── Invariant examples ────────────────────────────────────────────────────
+
+  - id: auth-service-healthy
+    type: Invariant
+    description: Auth service must always be in a healthy state
+    severity: critical
+    selector: services.auth.status
+    operator: eq
+    expected: "healthy"
+
+  - id: database-connected
+    type: Invariant
+    description: Database connection must be established
+    severity: critical
+    selector: database.connected
+    operator: truthy
+
+  - id: feature-flag-enabled
+    type: Invariant
+    description: New checkout feature flag must be enabled in production
+    severity: medium
+    selector: featureFlags.newCheckout
+    operator: truthy
+    tags: [feature-flags, checkout]
+
+  - id: environment-is-production
+    type: Invariant
+    description: Environment must be one of the expected values
+    severity: high
+    selector: system.environment
+    operator: in
+    expected: ["production", "staging"]
+
+  # ── Threshold examples ────────────────────────────────────────────────────
+
+  - id: cpu-usage-under-80
+    type: Threshold
+    description: CPU usage must stay below 80%
+    severity: high
+    selector: metrics.cpu.usagePercent
+    max: 80
+    tags: [performance, infrastructure]
+
+  - id: memory-within-bounds
+    type: Threshold
+    description: Memory usage must stay between 10% and 90%
+    severity: high
+    selector: metrics.memory.usagePercent
+    min: 10
+    max: 90
+
+  - id: error-rate-low
+    type: Threshold
+    description: API error rate must stay below 5%
+    severity: critical
+    selector: metrics.api.errorRatePercent
+    max: 5
+    tags: [reliability, api]
+
+  - id: active-agents-minimum
+    type: Threshold
+    description: At least 2 agents must be active at all times
+    severity: high
+    selector: agents.activeCount
+    min: 2
+
+  # ── Distribution examples ─────────────────────────────────────────────────
+
+  - id: agent-status-distribution
+    type: Distribution
+    description: Agent statuses should follow expected distribution
+    severity: medium
+    selector: agents.allStatuses
+    distribution:
+      active: 0.7
+      idle: 0.2
+      error: 0.1
+    tolerance: 0.15
+    tags: [agents, health]
+
+  - id: all-ids-are-uuids
+    type: Distribution
+    description: All resource IDs must be valid UUIDs
+    severity: high
+    selector: resources.ids
+    pattern: "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+
+  - id: log-levels-distribution
+    type: Distribution
+    description: Log level distribution should not be dominated by errors
+    severity: high
+    selector: logs.levelCounts
+    distribution:
+      info: 0.7
+      warn: 0.2
+      error: 0.1
+    tolerance: 0.2

--- a/docs/goals-schema.md
+++ b/docs/goals-schema.md
@@ -1,0 +1,119 @@
+# goals.yaml Schema Reference
+
+The `goals.yaml` file defines observable goals for the GoalEvaluatorPlugin.
+Goals are evaluated against incoming world state events. Violations are emitted
+as `world.goal.violated` events and logged to Langfuse and Discord.
+
+## File Locations
+
+| Scope | Path |
+|-------|------|
+| Global | `workspace/goals.yaml` |
+| Per-project override | `.automaker/projects/{slug}/goals.yaml` |
+
+Project-level goals override global goals with the same `id`.
+
+## Top-Level Structure
+
+```yaml
+version: "1.0"  # optional
+goals:
+  - id: unique-goal-id
+    type: Invariant | Threshold | Distribution
+    description: Human-readable description
+    severity: low | medium | high | critical  # default: medium
+    enabled: true  # default: true
+    tags: [optional, labels]
+    # ... type-specific fields
+```
+
+## Goal Types
+
+### Invariant
+
+Checks a boolean condition against a world state value.
+
+```yaml
+- id: auth-service-healthy
+  type: Invariant
+  description: Auth service must be healthy
+  severity: critical
+  selector: services.auth.status
+  operator: eq
+  expected: "healthy"
+```
+
+**Fields:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `selector` | Yes | Dot-notation path into world state |
+| `operator` | No | `eq`, `neq`, `truthy`, `falsy`, `in`, `not_in` (default: `truthy`) |
+| `expected` | No | Expected value for comparison |
+
+**Operators:**
+- `truthy` — value must be truthy (non-null, non-false, non-zero, non-empty)
+- `falsy` — value must be falsy
+- `eq` — value must equal `expected`
+- `neq` — value must not equal `expected`
+- `in` — value must be in `expected` array
+- `not_in` — value must not be in `expected` array
+
+### Threshold
+
+Checks a numeric metric against min/max bounds.
+
+```yaml
+- id: cpu-usage-ok
+  type: Threshold
+  description: CPU usage must stay below 80%
+  severity: high
+  selector: metrics.cpu.usage
+  max: 80
+```
+
+**Fields:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `selector` | Yes | Dot-notation path resolving to a number |
+| `min` | Conditional | Minimum allowed value (at least one of min/max required) |
+| `max` | Conditional | Maximum allowed value |
+
+### Distribution
+
+Checks patterns or value proportions in an array/map.
+
+```yaml
+- id: agent-status-distribution
+  type: Distribution
+  description: Most agents should be active
+  severity: medium
+  selector: agents.statuses
+  distribution:
+    active: 0.8
+    idle: 0.2
+  tolerance: 0.1
+```
+
+**Fields:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `selector` | Yes | Dot-notation path resolving to an array or object |
+| `pattern` | No | Regex — all values must match |
+| `distribution` | No | Expected value proportions `{ value: fraction }` |
+| `tolerance` | No | Allowed deviation from expected fraction (default: `0.1`) |
+
+## Severity Levels
+
+| Level | Color | Use case |
+|-------|-------|----------|
+| `low` | Blue | Informational, non-urgent |
+| `medium` | Orange | Should investigate soon |
+| `high` | Red | Requires prompt attention |
+| `critical` | Purple | System-breaking condition |
+
+## JSON Schema
+
+The full JSON schema is at `schema/goals.yaml.schema.json`.

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -1,0 +1,127 @@
+# Goal Registry & Evaluator (Milestone 2)
+
+The Goal Evaluator is an observe-only plugin that continuously monitors world state
+against declared goals and emits violation events when deviations are detected.
+
+## Architecture
+
+```
+world.state.# ──► GoalEvaluatorPlugin
+                        │
+                        ├── GoalsLoader (workspace/goals.yaml + per-project overrides)
+                        ├── InvariantGoalEvaluator
+                        ├── ThresholdGoalEvaluator
+                        ├── DistributionGoalEvaluator
+                        │
+                        ├── EventBus.publish("world.goal.violated", ...)
+                        ├── LangfuseLogger (HTTP ingestion API)
+                        └── DiscordLogger (webhook)
+```
+
+## Configuration
+
+The plugin is configured via `GoalsConfig`:
+
+```typescript
+import { GoalEvaluatorPlugin } from "./src/plugins/goal_evaluator_plugin.ts";
+
+const plugin = new GoalEvaluatorPlugin({
+  workspaceDir: "workspace",
+  observeOnly: true,  // always true — no planner in this milestone
+});
+plugin.install(bus);
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `LANGFUSE_PUBLIC_KEY` | Langfuse public API key |
+| `LANGFUSE_SECRET_KEY` | Langfuse secret API key |
+| `LANGFUSE_HOST` | Langfuse host (default: `https://cloud.langfuse.com`) |
+| `DISCORD_GOALS_WEBHOOK_URL` | Discord webhook URL for violation notifications |
+
+## Goals File Format
+
+See [goals-schema.md](./goals-schema.md) for the full schema reference.
+
+Example `workspace/goals.yaml`:
+
+```yaml
+version: "1.0"
+goals:
+  - id: auth-healthy
+    type: Invariant
+    description: Auth service must be healthy
+    severity: critical
+    selector: services.auth.status
+    operator: eq
+    expected: "healthy"
+
+  - id: cpu-ok
+    type: Threshold
+    description: CPU must stay below 80%
+    severity: high
+    selector: metrics.cpu.usage
+    max: 80
+```
+
+## World State Topic Convention
+
+The plugin subscribes to `world.state.#`. Publish world state updates with:
+
+```typescript
+bus.publish("world.state.update", {
+  id: crypto.randomUUID(),
+  correlationId: crypto.randomUUID(),
+  topic: "world.state.update",
+  timestamp: Date.now(),
+  payload: {
+    projectSlug: "my-project",  // optional
+    state: {
+      services: { auth: { status: "healthy" } },
+      metrics: { cpu: { usage: 45 } },
+    },
+  },
+});
+```
+
+## Violation Events
+
+When a goal is violated, the plugin emits a `world.goal.violated` event:
+
+```typescript
+{
+  topic: "world.goal.violated",
+  payload: {
+    type: "world.goal.violated",
+    violation: {
+      goalId: "auth-healthy",
+      goalType: "Invariant",
+      severity: "critical",
+      description: "Auth service must be healthy",
+      message: "Expected \"services.auth.status\" to equal \"healthy\", got \"degraded\"",
+      actual: "degraded",
+      expected: "healthy",
+      timestamp: 1712345678000,
+      projectSlug: "my-project",
+    },
+  },
+}
+```
+
+See [events.md](./events.md) for the full event catalog.
+
+## Observe-Only Mode
+
+The plugin **never triggers planner actions**. It only:
+1. Evaluates goals against world state
+2. Emits `world.goal.violated` events
+3. Logs violations to Langfuse and Discord
+
+Planner integration is deferred to a future milestone.
+
+## Per-Project Goal Overrides
+
+Place a `goals.yaml` file at `.automaker/projects/{slug}/goals.yaml`.
+Project goals with the same `id` override global goals. New IDs are additive.

--- a/docs/guides/add-a-domain.md
+++ b/docs/guides/add-a-domain.md
@@ -136,6 +136,7 @@ If `metadata.failed` is `true`, check:
 
 ## Related
 
+- [Integrate an external app](./integrate-external-app) — end-to-end guide: domains + goals + actions + A2A agent
 - [Your first GOAP goal](../../tutorials/first-goap-goal) — use a domain in a goal selector
 - [Add goals and actions](./add-goals-and-actions) — reference for selectors and operators
 - [Explanation: world engine](../../explanation/world-engine) — design rationale

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -12,6 +12,7 @@ Task-oriented guides for common operations in protoWorkstacean.
 | [Add a domain](./add-a-domain) | Poll a custom HTTP endpoint and expose it as a world-state domain |
 | [Add goals and actions](./add-goals-and-actions) | Write goal definitions (Invariant, Threshold, Distribution) and matching actions with preconditions and effects |
 | [Create a ceremony](./create-a-ceremony) | Schedule a recurring fleet ritual — a skill dispatched on a cron expression |
+| [Integrate an external app](./integrate-external-app) | Connect any service to the GOAP loop as a reactive actor — purely YAML-driven |
 | [Deploy with Docker](./deploy-with-docker) | Production deployment: Docker Compose, env vars, workspace volume mount, health check |
 
 ## Where to start

--- a/docs/guides/integrate-external-app.md
+++ b/docs/guides/integrate-external-app.md
@@ -1,0 +1,240 @@
+---
+title: Integrate an External App
+---
+
+Connect any external service to the GOAP world engine as a reactive actor. The engine polls the app's health endpoints, evaluates goals against the data, and dispatches actions (alerts or A2A skill calls) when something is wrong.
+
+**Zero code changes per integration.** Everything is declarative YAML + environment variables.
+
+## Overview
+
+An external app integration has four layers:
+
+| Layer | File | Purpose |
+|-------|------|---------|
+| **Observe** | `workspace/domains.yaml` | Poll the app's HTTP endpoints for state |
+| **Evaluate** | `workspace/goals.yaml` | Define what "healthy" looks like |
+| **Act** | `workspace/actions.yaml` | Define what to do when unhealthy |
+| **Dispatch** | `workspace/agents.yaml` | Register the app's A2A skills for action execution |
+
+The GOAP loop connects them automatically:
+
+```
+domains.yaml (poll) → goals.yaml (evaluate) → actions.yaml (match) → agents.yaml (dispatch)
+       ↑                                                                        ↓
+       └────────────── next tick picks up changes ──────────────────────────────┘
+```
+
+## Prerequisites
+
+The external app must expose:
+
+1. **At least one HTTP GET endpoint** returning JSON health/state data
+2. **(Optional) An A2A endpoint** (`POST /a2a`) implementing JSON-RPC 2.0 `message/send` for skill dispatch
+
+If the app only has health endpoints and no A2A interface, you can still use it — actions will be limited to alerts and ceremony triggers instead of direct skill dispatch.
+
+## Step 1: Add domains (observe)
+
+Create or append to `workspace/domains.yaml`:
+
+```yaml
+domains:
+  - name: myapp_health
+    url: "${MYAPP_BASE_URL}/api/health"
+    tickMs: 60000
+    headers:
+      X-API-Key: "${MYAPP_API_KEY}"
+```
+
+- `name` becomes `domains.myapp_health` in world state
+- URL and header values support `${ENV_VAR}` interpolation
+- `tickMs` defaults to 60000 (1 minute) if omitted
+- The engine automatically sets `extensions.myapp_health_available` to `true`/`false` on each tick
+
+Set the environment variables:
+
+```bash
+MYAPP_BASE_URL=http://myapp:8080
+MYAPP_API_KEY=your-api-key
+```
+
+See [Add a domain](./add-a-domain) for the full schema reference.
+
+## Step 2: Add goals (evaluate)
+
+Append to `workspace/goals.yaml`:
+
+```yaml
+  - id: myapp.service_healthy
+    type: Invariant
+    severity: high
+    selector: "domains.myapp_health.data.status"
+    operator: eq
+    value: "ok"
+    description: "MyApp service must report healthy status"
+```
+
+The selector path follows the pattern `domains.<name>.data.<field>`. The engine unwraps `{ success, data }` API envelopes automatically, so `data` refers to the inner payload.
+
+Common goal types:
+
+| Type | Use case | Example |
+|------|----------|---------|
+| **Invariant** | Boolean/enum checks | `status == "ok"`, `connected == true` |
+| **Threshold** | Numeric bounds | `errorRate < 0.05`, `agentCount >= 1` |
+| **Distribution** | Percentage mix | `featureRatio >= 0.4` |
+
+See [Add goals and actions](./add-goals-and-actions) for all operators and types.
+
+## Step 3: Add actions (act)
+
+Append to `workspace/actions.yaml`. Every action must guard on domain availability:
+
+```yaml
+  # Tier 0: alert (free, fire-and-forget)
+  - id: alert.myapp_unhealthy
+    goalId: myapp.service_healthy
+    tier: tier_0
+    priority: 10
+    cost: 0
+    name: "Alert when MyApp is unhealthy"
+    preconditions:
+      - path: "extensions.myapp_health_available"
+        operator: eq
+        value: true
+      - path: "domains.myapp_health.data.status"
+        operator: neq
+        value: "ok"
+    effects: []
+    meta:
+      topic: "message.outbound.discord.alert"
+      fireAndForget: true
+
+  # Tier 0: dispatch to agent (if A2A is available)
+  - id: action.myapp_self_heal
+    goalId: myapp.service_healthy
+    tier: tier_0
+    priority: 20
+    cost: 1
+    name: "Dispatch MyApp to self-heal"
+    preconditions:
+      - path: "extensions.myapp_health_available"
+        operator: eq
+        value: true
+      - path: "domains.myapp_health.data.status"
+        operator: neq
+        value: "ok"
+    effects: []
+    meta:
+      topic: "agent.skill.request"
+      skillHint: diagnose
+      agentId: myapp
+      fireAndForget: true
+```
+
+Key fields:
+- `preconditions[0]` — **always guard on availability** to avoid firing on stale data
+- `meta.topic: "agent.skill.request"` — routes through SkillDispatcher to the A2A executor
+- `meta.skillHint` — which skill to invoke on the external agent
+- `meta.agentId` — which agent to route to (matches `name` in agents.yaml)
+- `meta.fireAndForget: true` — complete immediately (use `false` to wait for outcome)
+
+## Step 4: Register the agent (dispatch)
+
+If the app has an A2A endpoint, create or append to `workspace/agents.yaml`:
+
+```yaml
+agents:
+  - name: myapp
+    url: "${MYAPP_BASE_URL}/a2a"
+    apiKeyEnv: MYAPP_API_KEY
+    skills:
+      - name: diagnose
+        description: Run diagnostics and attempt self-healing
+      - name: status
+        description: Generate a status report
+```
+
+- `url` supports `${ENV_VAR}` interpolation
+- `apiKeyEnv` is the **name** of the env var (not the value)
+- Skills are registered with the `ExecutorRegistry` and become routable via `agent.skill.request`
+
+See [Add an agent](./add-an-agent) for the full A2A schema.
+
+## Step 5: Deploy
+
+Add the environment variables to your deployment config (docker-compose, Infisical, etc.):
+
+```yaml
+environment:
+  - MYAPP_BASE_URL=${MYAPP_BASE_URL:-}
+  - MYAPP_API_KEY=${MYAPP_API_KEY:-}
+```
+
+Restart workstacean. Check the logs for:
+
+```
+[domain-discovery] global: registered 1 domain(s)
+[skill-broker] Registered 1 A2A agent(s)
+[world-state-engine] Domain "myapp_health" registered (tick: 60000ms)
+```
+
+## Verify
+
+```bash
+# Check domain is collecting
+curl http://localhost:3000/api/world-state/myapp_health
+
+# Check availability flag
+curl http://localhost:3000/api/world-state | jq '.data.extensions.myapp_health_available'
+
+# Check action outcomes (after a goal violation fires)
+curl http://localhost:3000/api/outcomes | jq '.recent[] | select(.actionId | startswith("myapp"))'
+```
+
+## Reference: Ava integration
+
+The Ava (protoMaker Studio) integration is the canonical example. It demonstrates:
+
+- **Two domains**: `ava_board` (blocked features) and `ava_pipeline` (auto-mode, running agents)
+- **Five A2A skills**: sitrep, board_health, auto_mode, manage_feature, bug_triage
+- **Two goals**: board health (max 3 blocked) and auto-mode active
+- **Three actions**: alert on blocked, dispatch Ava to triage, alert auto-mode off
+
+Files:
+- `workspace/domains.yaml` — domain definitions
+- `workspace/agents.yaml` — A2A agent registration
+- `workspace/goals.yaml` — Ava goals section
+- `workspace/actions.yaml` — Ava actions section
+
+## Dispatch flow
+
+```
+WorldStateEngine polls domain every tickMs
+    ↓
+GoalEvaluator detects violation
+    ↓
+L0 Planner matches action preconditions against world state
+    ↓
+ActionDispatcher publishes to meta.topic (agent.skill.request)
+    ↓
+SkillDispatcher extracts skillHint + agentId
+    ↓
+ExecutorRegistry resolves to A2AExecutor
+    ↓
+HTTP POST to app's /a2a endpoint (JSON-RPC 2.0)
+    ↓
+App acts, world state updates on next tick
+    ↓
+Goal re-evaluates — satisfied → loop quiets
+```
+
+If the action fails 3 times within 5 minutes, the `LoopDetector` triggers oscillation cooldown (10 minutes) and escalates to tier_1.
+
+## Related
+
+- [Add a domain](./add-a-domain) — domain schema reference
+- [Add an agent](./add-an-agent) — agent YAML and A2A protocol details
+- [Add goals and actions](./add-goals-and-actions) — goal types, operators, precondition syntax
+- [World Engine concepts](../../explanation/world-engine-concepts) — architecture and design rationale

--- a/docs/how-to/configure-discord.md
+++ b/docs/how-to/configure-discord.md
@@ -1,0 +1,173 @@
+# How to Configure Discord
+
+_This is a how-to guide. It covers bot setup, `discord.yaml` configuration, slash commands, and autocomplete._
+
+---
+
+## 1. Create and configure the Discord bot
+
+### Bot permissions
+
+In the [Discord Developer Portal](https://discord.com/developers/applications), create an application and add a Bot. Set:
+
+**Scopes:** `bot`, `applications.commands`
+
+**Bot Permissions:**
+- Read Messages / View Channels
+- Send Messages
+- Create Public Threads
+- Add Reactions
+- Manage Messages (for spam deletion)
+- Read Message History
+- Manage Guild Members intent (if using welcome channel)
+
+**Privileged Gateway Intents** (enable in the Bot tab):
+- Message Content Intent
+- Server Members Intent (only if using `channels.welcome`)
+
+### Required environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DISCORD_BOT_TOKEN` | Yes | Bot token — enables the plugin |
+| `DISCORD_GUILD_ID` | Yes | Guild ID for slash command registration |
+| `DISCORD_DIGEST_CHANNEL` | No | Fallback channel ID for cron pushes |
+
+The plugin is **skipped** if `DISCORD_BOT_TOKEN` is not set.
+
+---
+
+## 2. Configure discord.yaml
+
+Place `discord.yaml` in your workspace directory (default: `workspace/discord.yaml`). If absent, the plugin starts with empty commands and default moderation settings.
+
+```yaml
+# workspace/discord.yaml
+
+channels:
+  digest: "1234567890123456789"   # channel for cron-triggered posts
+  welcome: ""                      # new member welcome messages (leave blank to disable)
+  modLog: ""                       # reserved for future moderation logging
+
+moderation:
+  rateLimit:
+    maxMessages: 5
+    windowSeconds: 10
+  spamPatterns:
+    - "free\\s*nitro"
+    - "discord\\.gift/"
+    - "@everyone.*https?://"
+    - "steamcommunity\\.com/gift"
+
+commands:
+  - name: mybot
+    description: "My bot — project status and reports"
+    subcommands:
+      - name: status
+        description: "Current project status"
+        content: "/status"
+        skillHint: qa_report
+
+      - name: report
+        description: "Generate a report for a version"
+        content: "/report {version}"
+        skillHint: qa_report
+        options:
+          - name: version
+            description: "Version tag (e.g. v1.2.0)"
+            type: string
+            required: false
+```
+
+### Channel fields
+
+| Field | Description |
+|-------|-------------|
+| `digest` | Receives `message.outbound.discord.push.*` and cron-triggered posts |
+| `welcome` | New member welcome messages |
+| `modLog` | Reserved — not currently active |
+
+### Rate limiting
+
+`rateLimit.maxMessages` and `rateLimit.windowSeconds` define a rolling per-user window. Users exceeding the limit are silently throttled.
+
+### Spam patterns
+
+Array of regex strings (YAML-escaped). Matched case-insensitively. Matching messages are silently deleted.
+
+---
+
+## 3. Define slash commands
+
+### Subcommand style (recommended for multi-action bots)
+
+```yaml
+commands:
+  - name: dev
+    description: "Dev team commands"
+    subcommands:
+      - name: sitrep
+        description: "Current sprint status"
+        content: "/sitrep"
+        skillHint: sitrep
+
+      - name: audit
+        description: "Board audit"
+        content: "/audit"
+        skillHint: board_audit
+```
+
+Users type `/dev sitrep` or `/dev audit`.
+
+### Flat command with autocomplete
+
+Use top-level `options` (no `subcommands`) when you want Discord's autocomplete UX:
+
+```yaml
+commands:
+  - name: report-bug
+    description: Report a bug against a project
+    options:
+      - name: project
+        description: Project to report against (start typing to filter)
+        type: string
+        required: true
+        autocomplete: true
+      - name: description
+        description: Brief description of the bug
+        type: string
+        required: true
+    content: "Bug report for {project}: {description}"
+    skillHint: bug_triage
+```
+
+When `project` is an autocomplete option, the plugin loads `projects.yaml` at interaction time and returns matching projects (filtered by slug or title) as Discord choices.
+
+On submission, the project slug is resolved to `devChannelId` and `projectRepo` which are added to the inbound bus payload:
+
+```typescript
+{
+  devChannelId?: string;   // discord.dev channel ID from projects.yaml
+  projectRepo?: string;    // GitHub full name, e.g. "protoLabsAI/protoUI"
+}
+```
+
+---
+
+## 4. Reload commands after changes
+
+Slash commands are registered to the guild on container startup. To reload after editing `discord.yaml`:
+
+```bash
+docker restart workstacean
+```
+
+Changes take effect within a few seconds in Discord (guild-scoped commands update faster than global commands).
+
+---
+
+## Related docs
+
+- [reference/bus-topics.md](../reference/bus-topics.md) — Discord bus topics
+- [reference/config-files.md](../reference/config-files.md) — full `discord.yaml` schema reference
+- [explanation/plugin-lifecycle.md](../explanation/plugin-lifecycle.md) — how the DiscordPlugin registers and subscribes

--- a/docs/how-to/create-a-ceremony.md
+++ b/docs/how-to/create-a-ceremony.md
@@ -1,0 +1,157 @@
+# How to Create a Ceremony (Scheduled Recurring Task)
+
+_This is a how-to guide. It covers creating cron schedules via YAML, the bus, and the Pi SDK tool._
+
+---
+
+A "ceremony" is a scheduled recurring event — a daily digest, a weekly board audit, a nightly cleanup. In Workstacean, ceremonies are YAML files in `workspace/crons/` that publish to the message bus on a schedule.
+
+---
+
+## Option A — Write the YAML directly
+
+Create a file in `workspace/crons/`:
+
+```yaml
+# workspace/crons/daily-digest.yaml
+id: daily-digest
+schedule: "0 14 * * *"         # 2pm UTC daily
+timezone: "America/New_York"
+topic: "cron.daily-digest"
+payload:
+  content: "Generate the daily QA digest"
+  skillHint: qa_report
+  channel: "1234567890123456789"  # Discord channel ID for push
+  sender: "cron"
+enabled: true
+```
+
+The SchedulerPlugin picks up the file on the next container start. No restart needed if you publish `command.schedule` (see Option B).
+
+### YAML fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | Unique identifier (kebab-case). Used as filename. |
+| `type` | No | `cron` or `once`. Auto-detected from schedule format. |
+| `schedule` | Yes | Cron expression for recurring, ISO datetime for one-shot. |
+| `timezone` | No | IANA timezone. Defaults to system TZ. |
+| `topic` | Yes | Bus topic to publish when the schedule fires. |
+| `payload.content` | Yes | Message the agent receives when this fires. |
+| `payload.sender` | No | Sender identifier. Default: `cron`. |
+| `payload.channel` | No | Reply channel (`signal`, `cli`, or Discord channel ID). |
+| `payload.skillHint` | No | Routes to a specific skill (e.g., `qa_report`, `board_audit`). |
+| `enabled` | No | Whether active. Default: `true`. |
+| `lastFired` | Auto | ISO timestamp updated by the scheduler on each fire. |
+
+---
+
+## Option B — Add via bus command at runtime
+
+No restart needed — publish `command.schedule` to register a schedule immediately:
+
+```bash
+curl -s -X POST http://workstacean:3000/publish \
+  -H "Content-Type: application/json" \
+  -d '{
+    "topic": "command.schedule",
+    "payload": {
+      "action": "add",
+      "id": "daily-digest",
+      "schedule": "0 14 * * *",
+      "timezone": "America/New_York",
+      "topic": "cron.daily-digest",
+      "payload": {
+        "content": "Generate the daily QA digest",
+        "skillHint": "qa_report",
+        "channel": "1234567890123456789",
+        "sender": "cron"
+      }
+    }
+  }'
+```
+
+The SchedulerPlugin creates the YAML file in `data/crons/` and activates the timer immediately.
+
+---
+
+## Option C — Ask the agent in natural language (Pi SDK tool)
+
+If the `schedule_task` Pi SDK tool is registered:
+
+```
+Schedule a daily QA digest at 2pm New York time to the #dev-alerts channel
+```
+
+The agent calls the tool with the right cron expression, writes the YAML, and publishes `command.schedule`. No manual YAML editing needed.
+
+---
+
+## Managing schedules
+
+### Pause a schedule
+
+```bash
+curl -s -X POST http://workstacean:3000/publish \
+  -H "Content-Type: application/json" \
+  -d '{"topic": "command.schedule", "payload": {"action": "pause", "id": "daily-digest"}}'
+```
+
+### Resume a schedule
+
+```bash
+curl -s -X POST http://workstacean:3000/publish \
+  -H "Content-Type: application/json" \
+  -d '{"topic": "command.schedule", "payload": {"action": "resume", "id": "daily-digest"}}'
+```
+
+### Remove a schedule
+
+```bash
+curl -s -X POST http://workstacean:3000/publish \
+  -H "Content-Type: application/json" \
+  -d '{"topic": "command.schedule", "payload": {"action": "remove", "id": "daily-digest"}}'
+```
+
+### List all schedules
+
+```bash
+curl -s -X POST http://workstacean:3000/publish \
+  -H "Content-Type: application/json" \
+  -d '{"topic": "command.schedule", "payload": {"action": "list"}}'
+```
+
+Response published to `schedule.list`.
+
+---
+
+## Create a one-shot ceremony
+
+Use an ISO datetime in `schedule` to fire once and self-delete:
+
+```yaml
+id: q1-kickoff-reminder
+schedule: "2026-04-01T09:00:00"
+timezone: "America/New_York"
+topic: "cron.q1-kickoff-reminder"
+payload:
+  content: "Remind the team about the Q1 kickoff meeting at 10am"
+  sender: "cron"
+  channel: "signal"
+```
+
+One-shot schedules are automatically deleted after firing.
+
+---
+
+## Missed fire behavior
+
+If the container was down when a schedule was due, it fires immediately on restart — once only. If the missed window is more than 24 hours, it is skipped entirely and the next scheduled time applies.
+
+---
+
+## Related docs
+
+- [reference/config-files.md](../reference/config-files.md) — full cron YAML schema
+- [reference/bus-topics.md](../reference/bus-topics.md) — cron and schedule command topics
+- [explanation/plugin-lifecycle.md](../explanation/plugin-lifecycle.md) — how SchedulerPlugin loads and manages timers

--- a/docs/how-to/onboard-a-project.md
+++ b/docs/how-to/onboard-a-project.md
@@ -1,0 +1,108 @@
+# How to Onboard a Project
+
+_This is a how-to guide. It assumes the workstacean container is running and you have Ava configured in `workspace/agents.yaml`._
+
+---
+
+Onboarding a project provisions it across every system protoLabs uses: GitHub (`.automaker/` scaffold), Plane (project created), and Discord (category + channels created). The `onboard_project` skill on Ava orchestrates the full chain.
+
+## Trigger options
+
+### Option A — Automatic (org webhook)
+
+If you have the GitHub org webhook registered (see [how-to/use-quinn-pr-review.md](use-quinn-pr-review.md) for webhook setup), any new repository created under the org automatically triggers onboarding. No manual action needed.
+
+### Option B — Discord slash command
+
+In any Discord channel the bot has access to:
+
+```
+/ava onboard
+```
+
+Or by @mention:
+
+```
+@YourBot onboard protoLabsAI/my-new-repo
+```
+
+### Option C — Bus injection (scripted/CI)
+
+```bash
+curl -s -X POST http://workstacean:3000/publish \
+  -H "Content-Type: application/json" \
+  -d '{
+    "topic": "message.inbound.test",
+    "payload": {
+      "sender": "ci",
+      "content": "onboard protoLabsAI/my-new-repo",
+      "skillHint": "onboard_project",
+      "channel": "cli"
+    }
+  }'
+```
+
+---
+
+## What the onboard chain does
+
+Ava's `onboard_project` skill runs these steps in sequence:
+
+1. **GitHub API** — fetches repo metadata (description, topics, visibility)
+2. **`.automaker/` scaffold** — writes `project.json` and `settings.json` into the target repo, commits and pushes
+3. **`.gitignore` + worktree init** — adds worktree paths to `.gitignore` in the target repo
+4. **Plane API** — creates a new Plane project, stores the returned `plane_project_id`
+5. **Discord provisioning** — calls Quinn's `provision_discord` skill (via chain), which creates a Discord category with three channels: `dev`, `alerts`, `releases`
+6. **Write-back** — stores Discord channel IDs in both `.automaker/settings.json` (in the target repo) and `workspace/projects.yaml` (in this repo)
+
+On completion, a summary message is sent to the originating interface (Discord channel or the bus outbound topic).
+
+---
+
+## Verifying the onboard completed
+
+Check `workspace/projects.yaml` for a new entry:
+
+```yaml
+- repo: protoLabsAI/my-new-repo
+  plane_project_id: "<uuid>"
+  discord:
+    dev: "<channel-id>"
+    alerts: "<channel-id>"
+    releases: "<channel-id>"
+```
+
+Check the target repo for a `.automaker/` directory:
+
+```bash
+gh api repos/protoLabsAI/my-new-repo/contents/.automaker/project.json
+```
+
+---
+
+## If provisioning fails partway through
+
+The onboard chain is not atomic. If Discord provisioning fails (e.g., bot permissions), the Plane project and `.automaker/` scaffold are still created. The error is logged and a partial-onboard notice is sent to the originating interface.
+
+To re-run Discord provisioning only:
+
+```bash
+curl -s -X POST http://workstacean:3000/publish \
+  -H "Content-Type: application/json" \
+  -d '{
+    "topic": "message.inbound.test",
+    "payload": {
+      "sender": "manual",
+      "content": "provision discord for protoLabsAI/my-new-repo",
+      "skillHint": "provision_discord"
+    }
+  }'
+```
+
+---
+
+## Related docs
+
+- [reference/agent-skills.md](../reference/agent-skills.md) — full skill registry including `onboard_project` parameters
+- [reference/config-files.md](../reference/config-files.md) — `projects.yaml` schema
+- [explanation/agent-identity.md](../explanation/agent-identity.md) — why Quinn handles Discord provisioning (not Ava)

--- a/docs/how-to/set-up-google-workspace.md
+++ b/docs/how-to/set-up-google-workspace.md
@@ -1,0 +1,145 @@
+# How to Set Up Google Workspace
+
+_This is a how-to guide. It covers OAuth2 credentials, the `google.yaml` configuration, and enabling Drive, Calendar, and Gmail integration._
+
+---
+
+The Google Workspace plugin (`lib/plugins/google.ts`) bridges Google Drive, Calendar, and Gmail to the Workstacean bus. Each service is independently optional — configure only the ones you need.
+
+---
+
+## 1. Create a Google Cloud project and OAuth2 credentials
+
+1. Go to [console.cloud.google.com](https://console.cloud.google.com) and create a project.
+2. Enable the APIs you need:
+   - **Google Drive API**
+   - **Google Calendar API**
+   - **Gmail API**
+3. Under **APIs & Services → Credentials**, create an **OAuth 2.0 Client ID** (type: Web application or Desktop app depending on your setup).
+4. Download the credentials JSON and store the relevant values as environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `GOOGLE_CLIENT_ID` | OAuth2 client ID |
+| `GOOGLE_CLIENT_SECRET` | OAuth2 client secret |
+| `GOOGLE_REFRESH_TOKEN` | Long-lived refresh token (obtained via OAuth2 flow) |
+
+The plugin is **skipped** if `GOOGLE_CLIENT_ID` is not set.
+
+### Obtaining the refresh token
+
+Run the OAuth2 authorization flow once to get a refresh token:
+
+```bash
+# Use the Google OAuth2 playground or a one-shot script:
+# https://developers.google.com/oauthplayground/
+```
+
+Store the refresh token in Infisical (AI project `11e172e0`) under `GOOGLE_REFRESH_TOKEN`. The plugin exchanges it for access tokens automatically.
+
+---
+
+## 2. Configure google.yaml
+
+Place `google.yaml` in your workspace directory (default: `workspace/google.yaml`):
+
+```yaml
+# workspace/google.yaml
+
+drive:
+  orgFolderId: ""         # root org Drive folder — shared across all projects
+  templateFolderId: ""    # per-project folder template (optional)
+
+calendar:
+  orgCalendarId: ""               # shared org calendar for milestones/deadlines
+  pollIntervalMinutes: 60         # how often to check for upcoming events
+
+gmail:
+  watchLabels: []                 # Gmail labels to monitor for inbound routing
+  pollIntervalMinutes: 5          # how often to poll for new messages
+  routingRules: []                # label → skillHint mappings
+  # Example routingRules:
+  # - label: "bug-report"
+  #   skillHint: bug_triage
+  # - label: "gtm-request"
+  #   skillHint: content_review
+```
+
+---
+
+## 3. Enable Drive integration
+
+Set `drive.orgFolderId` to the Google Drive folder ID you want to use as the org root. The folder ID is the last path component of the Drive URL:
+
+```
+https://drive.google.com/drive/folders/1ABC123XYZ
+                                        ^^^^^^^^^^^
+                                        this is the ID
+```
+
+The plugin will surface Drive events to the bus. Agents can read/write Drive files via the available Drive tools.
+
+---
+
+## 4. Enable Calendar integration
+
+Set `calendar.orgCalendarId` to your shared org calendar's ID (found in Google Calendar → Settings → Calendar Settings → Calendar ID — typically an email-like string).
+
+The plugin polls the calendar every `pollIntervalMinutes` for upcoming events and publishes them to:
+
+```
+google.calendar.event.upcoming
+```
+
+Agents subscribed to this topic can trigger reminders, board updates, or ceremony checks.
+
+---
+
+## 5. Enable Gmail routing
+
+Gmail routing turns labeled emails into bus messages routed to specific skills.
+
+```yaml
+gmail:
+  watchLabels:
+    - "bug-report"
+    - "gtm-request"
+  pollIntervalMinutes: 5
+  routingRules:
+    - label: "bug-report"
+      skillHint: bug_triage
+    - label: "gtm-request"
+      skillHint: content_review
+```
+
+The plugin polls Gmail every `pollIntervalMinutes`, finds messages with the specified labels, and publishes them to:
+
+```
+message.inbound.gmail.{label}
+```
+
+with `skillHint` set from `routingRules`. The A2APlugin routes these to the appropriate agent.
+
+---
+
+## 6. Restart to apply changes
+
+```bash
+docker restart workstacean
+```
+
+On startup, the plugin logs which services it activated:
+
+```
+[GooglePlugin] Drive enabled — orgFolderId: 1ABC123XYZ
+[GooglePlugin] Calendar enabled — polling every 60 minutes
+[GooglePlugin] Gmail enabled — watching labels: bug-report, gtm-request
+```
+
+---
+
+## Related docs
+
+- [reference/bus-topics.md](../reference/bus-topics.md) — Google bus topics
+- [reference/config-files.md](../reference/config-files.md) — full `google.yaml` schema
+- [explanation/plugin-lifecycle.md](../explanation/plugin-lifecycle.md) — plugin install/uninstall lifecycle

--- a/docs/how-to/use-quinn-pr-review.md
+++ b/docs/how-to/use-quinn-pr-review.md
@@ -1,0 +1,158 @@
+# How to Use Quinn for PR Review
+
+_This is a how-to guide. It covers webhook setup, triggering PR review, and understanding Quinn's vector context pipeline._
+
+---
+
+Quinn reviews pull requests and issues via GitHub webhook. It uses codebase-wide vector search (Qdrant + Ollama) to provide context-aware reviews informed by past PR decisions and code patterns.
+
+---
+
+## 1. Set environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GITHUB_TOKEN` | Yes | PAT — enables the GitHub plugin and posts comment replies |
+| `GITHUB_WEBHOOK_SECRET` | Recommended | Validates `X-Hub-Signature-256` on inbound payloads |
+| `GITHUB_WEBHOOK_PORT` | No | Webhook HTTP server port (default: `8082`) |
+| `QUINN_APP_ID` | For bot comments | GitHub App ID — Quinn posts as `protoquinn[bot]` |
+| `QUINN_APP_PRIVATE_KEY` | For bot comments | GitHub App private key (PKCS#1 PEM) |
+| `QDRANT_URL` | For vector context | `http://qdrant:6333` |
+| `OLLAMA_URL` | For embeddings | `http://ollama:11434` |
+| `OLLAMA_EMBED_MODEL` | For embeddings | `nomic-embed-text` |
+
+---
+
+## 2. Configure github.yaml
+
+```yaml
+# workspace/github.yaml
+mentionHandle: "@quinn"   # case-insensitive
+
+skillHints:
+  issue_comment: bug_triage              # @mention in a comment on an issue
+  issues: bug_triage                     # @mention in the body of a new issue
+  pull_request_review_comment: pr_review # @mention in a PR review comment
+  pull_request: pr_review                # @mention in a PR description
+```
+
+---
+
+## 3. Register the webhook in GitHub
+
+For a single repository: **Settings → Webhooks → Add webhook**
+
+| Field | Value |
+|-------|-------|
+| Payload URL | `https://hooks.proto-labs.ai/webhook/github` |
+| Content type | `application/json` |
+| Secret | Value of `GITHUB_WEBHOOK_SECRET` |
+| SSL verification | Enable |
+| Events | Issue comments, Issues, Pull request review comments, Pull requests |
+
+### Org-level webhook (recommended)
+
+Register once at the org level to cover all repos — including new ones automatically:
+
+```bash
+gh api orgs/protoLabsAI/hooks \
+  --method POST \
+  --field name=web \
+  --field "config[url]=https://hooks.proto-labs.ai/webhook/github" \
+  --field "config[content_type]=json" \
+  --field "config[secret]=$GITHUB_WEBHOOK_SECRET" \
+  --field "config[insecure_ssl]=0" \
+  --field "events[]=repository" \
+  --field "events[]=issues" \
+  --field "events[]=issue_comment" \
+  --field "events[]=pull_request" \
+  --field "events[]=pull_request_review_comment"
+```
+
+---
+
+## 4. Required GitHub token permissions
+
+Fine-grained PAT scoped to the target repo:
+
+| Permission | Level |
+|------------|-------|
+| Issues | Read & Write |
+| Pull requests | Read & Write |
+| Actions | Read |
+| Contents | Read |
+
+---
+
+## 5. Trigger a PR review
+
+### Automatic (recommended)
+
+When a PR is opened or synchronized, and `pull_request` is in the webhook event list, Quinn reviews it automatically — no @mention needed.
+
+### Manual via @mention
+
+Leave a comment on any issue or PR:
+
+```
+@quinn please review this PR — focus on the auth changes
+```
+
+Quinn responds with a review comment posted as `protoquinn[bot]`.
+
+### Manual via Discord slash command
+
+```
+/quinn review
+```
+
+With the `pr_review` skillHint, A2APlugin routes to Quinn's `pr_review` skill.
+
+---
+
+## 6. How Quinn's review works
+
+Quinn's review goes beyond the diff. For every PR:
+
+1. **Diff parsed** — file changes are chunked by `diff/chunker.ts`
+2. **Symbols extracted** — TypeScript, Python, and Go symbols identified from the diff
+3. **Vector search (parallel)**:
+   - `quinn-pr-history` collection: past PR decisions for the same files
+   - `quinn-code-patterns` collection: similar code patterns in the codebase
+4. **Token budget enforced** — codebase context capped at 20% of the total prompt token budget
+5. **Review prompt assembled** — diff + `CODEBASE CONTEXT` block + review instructions
+6. **LLM call** — Quinn generates the review
+7. **Comment posted** — as `protoquinn[bot]` on the PR
+
+### Learning loop
+
+When a developer dismisses a Quinn comment, the plugin records the dismissal in `quinn-review-learnings`. Over time, low-signal comment patterns are filtered out.
+
+### Fallback
+
+If Qdrant is unavailable, Quinn reviews from the diff alone (no vector context). The review still runs — no error is surfaced.
+
+---
+
+## 7. Bug triage flywheel
+
+Reacting to any GitHub issue comment with 📋 triggers `bug_triage`:
+
+```
+/quinn comment on GitHub issue
+  → Quinn (bug_triage): classifies bug, may file board item via file_bug tool
+    → posts triage comment to GitHub issue
+  → Chain: Ava (manage_feature): reviews Quinn's triage, verifies board state
+    → posts follow-up comment: feature link, close recommendation
+```
+
+Trigger by @mention: `@protoquinn <description>` (admin users only).
+
+---
+
+## Related docs
+
+- [reference/plugins.md](../reference/plugins.md) — GitHubPlugin API contract
+- [reference/bus-topics.md](../reference/bus-topics.md) — GitHub bus topics
+- [reference/agent-skills.md](../reference/agent-skills.md) — `pr_review` and `bug_triage` skill specs
+- [explanation/architecture.md](../explanation/architecture.md) — Quinn's vector context pipeline in detail

--- a/docs/htn-guide.md
+++ b/docs/htn-guide.md
@@ -1,0 +1,65 @@
+# HTN Decomposition Guide
+
+## Hierarchy Levels
+
+The HTN system decomposes tasks through four levels:
+
+| Level | Description | Example |
+|-------|-------------|---------|
+| portfolio | Strategic workspace tasks | "Improve portfolio health" |
+| project | Project-scoped tasks | "Stabilize CI pipeline" |
+| domain | Domain-specific tasks | "Restart failing service" |
+| action | Primitive executable actions | "Set service.status = healthy" |
+
+## Defining Tasks
+
+### Primitive Actions
+
+```ts
+import { action } from "../src/planner/action.ts";
+
+const restart = action("restart", "restart-service")
+  .level("action")
+  .requireEquals("service.status", "down")
+  .set({ "service.status": "healthy" })
+  .cost(2)
+  .build();
+```
+
+### Composite Tasks
+
+```ts
+import type { CompositeTask } from "../src/planner/types.ts";
+
+const fixService: CompositeTask = {
+  id: "fix-service",
+  name: "Fix Service",
+  level: "domain",
+  precondition: (state) => state["service.status"] === "down",
+  decompose: (state) => ["restart", "verify-health"],
+};
+```
+
+## Building the Task Network
+
+```ts
+import { TaskNetwork } from "../src/planner/task-network.ts";
+
+const network = new TaskNetwork();
+network.addPrimitiveAction(restart);
+network.addPrimitiveAction(verifyHealth);
+network.addCompositeTask(fixService);
+```
+
+## Running Decomposition
+
+```ts
+import { HTNDecomposer } from "../src/planner/htn-decomposer.ts";
+
+const decomposer = new HTNDecomposer(network);
+const result = decomposer.decompose("fix-service", currentState);
+
+if (result.success) {
+  // result.actions contains ordered primitive actions
+}
+```

--- a/docs/integration-l0-l1.md
+++ b/docs/integration-l0-l1.md
@@ -1,0 +1,55 @@
+# L0-L1 Integration Guide
+
+## Overview
+
+The L0 rule matcher handles ~80% of cases with deterministic pattern matching. When L0 cannot find a matching rule, the L0-L1 bridge invokes the L1 A* planner as fallback.
+
+## Setup
+
+```ts
+import { L0L1Bridge, type L0RuleMatcher } from "../src/matcher/l0-l1-bridge.ts";
+import { action } from "../src/planner/action.ts";
+
+// Define your L0 matcher
+const matcher: L0RuleMatcher = {
+  match(state, goal) {
+    // Your rule matching logic
+    // Return { matched: true, action } or { matched: false, reason }
+  }
+};
+
+// Define available actions for L1
+const actions = [
+  action("fix", "fix-issue").requireEquals("broken", true).set({ broken: false }).build(),
+];
+
+// Create bridge
+const bridge = new L0L1Bridge(matcher, actions, compositeTasks, {
+  defaultBudget: { timeBudgetMs: 5000 },
+});
+```
+
+## Usage
+
+```ts
+const result = bridge.resolve(currentState, goal);
+
+if (result.success) {
+  // result.plan contains the action sequence
+  for (const action of result.plan.actions) {
+    // Execute action
+  }
+} else {
+  console.error(result.error);
+}
+```
+
+## Deviation Handling
+
+| Situation | Behavior |
+|-----------|----------|
+| L0 matches | Returns single-action plan immediately |
+| L0 no match | Invokes L1 A* planner |
+| L1 budget exhausted | Returns best partial plan with warning |
+| L1 plan invalid | Returns validation failure |
+| World state changes | ReplanManager produces new plan |

--- a/docs/planner-api.md
+++ b/docs/planner-api.md
@@ -1,0 +1,103 @@
+# Planner API Reference
+
+## Entry Points
+
+### L1Planner
+
+Main entry point for the A* planner system.
+
+```ts
+import { L1Planner } from "../src/planner/l1-integration.ts";
+import { ActionGraph } from "../src/planner/action-graph.ts";
+import { TaskNetwork } from "../src/planner/task-network.ts";
+
+const planner = new L1Planner(graph, network, { defaultBudgetMs: 5000 });
+const result = planner.planFromContext(context);
+```
+
+### L0L1Bridge
+
+Connects L0 rule matcher to L1 planner with automatic fallback.
+
+```ts
+import { L0L1Bridge } from "../src/matcher/l0-l1-bridge.ts";
+
+const bridge = new L0L1Bridge(matcher, actions, compositeTasks);
+const result = bridge.resolve(state, goal);
+```
+
+## Core Types
+
+### PlannerState
+Flat key-value map representing world state for planning:
+```ts
+type StateValue = string | number | boolean | null;
+type PlannerState = Readonly<Record<string, StateValue>>;
+```
+
+### Action
+Primitive action with preconditions and effects:
+```ts
+interface Action {
+  id: string;
+  name: string;
+  cost: number;
+  level: HierarchyLevel;
+  preconditions: StatePredicate[];
+  effects: StateTransform[];
+}
+```
+
+### Plan
+Sequence of actions with cost tracking:
+```ts
+interface Plan {
+  actions: Action[];
+  totalCost: number;
+  isComplete: boolean;
+  lowerBound?: number;
+}
+```
+
+## Creating Actions
+
+Use the fluent `action()` builder:
+
+```ts
+import { action } from "../src/planner/action.ts";
+
+const restart = action("restart-svc", "Restart Service")
+  .cost(2)
+  .level("action")
+  .requireEquals("service.status", "down")
+  .set({ "service.status": "healthy" })
+  .build();
+```
+
+## Heuristics
+
+Available heuristic functions:
+
+- `zeroHeuristic` — always returns 0 (Dijkstra-equivalent)
+- `stateDiffHeuristic(goalState)` — counts differing state keys
+- `namedGoalHeuristic(namedGoal)` — uses goal-attached heuristic
+- `maxHeuristic(...fns)` — max of multiple heuristics
+
+## Search Configuration
+
+```ts
+interface SearchConfig {
+  maxExpansions?: number;   // Max nodes to expand
+  timeBudgetMs?: number;    // Time budget in ms
+  weight?: number;          // Weighted A* factor (>1 = faster, less optimal)
+}
+```
+
+## Plan Validation
+
+```ts
+import { validatePlan } from "../src/planner/plan-validator.ts";
+
+const result = validatePlan(plan, initialState, goal);
+// result.valid, result.failedAtIndex, result.finalState, result.error
+```

--- a/docs/planner-architecture.md
+++ b/docs/planner-architecture.md
@@ -1,0 +1,43 @@
+# Planner Architecture
+
+## Overview
+
+The L1 planner is a budget-bounded A* search system that serves as fallback when the L0 rule matcher cannot handle a request. It operates on an action graph where world states are nodes and actions are directed edges.
+
+## Component Layers
+
+```
+┌─────────────────────────────────────┐
+│         L0-L1 Bridge                │  ← Entry point
+│  (src/matcher/l0-l1-bridge.ts)      │
+├─────────────────────────────────────┤
+│         L1 Planner                  │  ← Orchestration
+│  (src/planner/l1-integration.ts)    │
+├─────────┬───────────┬───────────────┤
+│ Anytime │   HTN     │    Plan       │  ← Planning layers
+│ Planner │ Decomposer│  Validator    │
+├─────────┴───────────┴───────────────┤
+│         A* Search                   │  ← Core search
+│  (src/planner/a-star.ts)            │
+├─────────────────────────────────────┤
+│     Action Graph + World State      │  ← Data layer
+│  (src/planner/action-graph.ts)      │
+└─────────────────────────────────────┘
+```
+
+## Data Flow
+
+1. L0 rule matcher receives a goal and current state
+2. If no rule matches, L0-L1 bridge constructs an L0Context
+3. L1 planner runs HTN decomposition to expand available actions
+4. AnytimePlanner runs iterative weighted A* within budget
+5. Best plan is validated on a state copy
+6. Validated plan is returned to the caller
+
+## Key Design Decisions
+
+- **Immutable state**: PlannerState is `Readonly<Record<string, StateValue>>` — all mutations produce new objects
+- **Budget-bounded**: Search respects both time and expansion budgets, returning best partial plan if budget exhausted
+- **Anytime**: Starts with high-weight A* for fast initial solutions, then refines with lower weights
+- **Side-effect free validation**: Plans are validated on cloned state before committing
+- **Replanning**: If world state changes mid-execution, the replan manager produces a new plan from current state while preserving executed steps

--- a/docs/qdrant-schema.md
+++ b/docs/qdrant-schema.md
@@ -1,0 +1,90 @@
+# Qdrant Schema — Quinn Vector Context
+
+Quinn uses three Qdrant collections to store codebase history and review learnings.
+All collections use cosine distance and 768-dimensional vectors from `nomic-embed-text` via Ollama.
+
+## Collections
+
+### `quinn-pr-history`
+
+Stores embedded diff chunks from merged PRs with review decisions.
+
+**Vector:** Diff chunk text (`File: <path>\n\n<diff lines>`), 768-dimensional.
+
+**Metadata fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `repo` | string | `owner/repo` slug, e.g. `protolabsai/protomaker` |
+| `pr_number` | integer | GitHub PR number |
+| `file` | string | Relative file path in the repository |
+| `decision` | string | `APPROVE` or `REQUEST_CHANGES` |
+| `merged_at` | string | ISO 8601 timestamp of merge |
+| `pr_url` | string | Full GitHub URL to the PR |
+| `chunk_index` | integer | Zero-based chunk index within the file |
+| `line_start` | integer | First line number of the chunk |
+| `line_end` | integer | Last line number of the chunk |
+| `review_issues` | string | Comma-separated summary of Quinn-flagged issues |
+
+**Query pattern:** Semantic search by file path + repo filter to retrieve past PR decisions on a file.
+
+---
+
+### `quinn-code-patterns`
+
+Stores symbol definitions with surrounding context for cross-repo pattern matching.
+
+**Vector:** `Symbol: <name> (<type>)\nFile: <path>\n\n<context lines>`, 768-dimensional.
+
+**Metadata fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `repo` | string | `owner/repo` slug |
+| `file` | string | Relative file path |
+| `symbol_name` | string | Function, class, or export name |
+| `symbol_type` | string | `function`, `class`, `interface`, `export`, `method` |
+| `language` | string | `typescript`, `python`, `go`, `unknown` |
+| `line` | integer | Line number of the symbol definition |
+| `context` | string | Definition + surrounding lines with line numbers |
+
+**Query pattern:** Semantic search for similar symbols, optionally excluding the current file.
+
+---
+
+### `quinn-review-learnings`
+
+Tracks dismissed comment patterns to prevent low-signal feedback repetition.
+
+**Vector:** Quinn comment body text, 768-dimensional.
+
+**Metadata fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `repo` | string | `owner/repo` slug |
+| `file_type` | string | File extension (`ts`, `py`, `go`, etc.) |
+| `dismissed_count` | integer | Number of times this pattern was dismissed |
+| `approval_count` | integer | Number of times this pattern led to a fix |
+| `most_recent_reason` | string | Last developer-provided dismissal reason |
+| `last_updated` | string | ISO 8601 timestamp of most recent update |
+
+**Query pattern:** Semantic search by comment text + repo + file_type filter. Dismissal rate = `dismissed_count / (dismissed_count + approval_count)`.
+
+---
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|---|---|---|
+| `QDRANT_URL` | `http://qdrant:6333` | Qdrant service URL |
+| `QDRANT_VECTOR_SIZE` | `768` | Vector dimensions (must match embedding model) |
+| `OLLAMA_URL` | `http://ollama:11434` | Ollama service URL |
+| `OLLAMA_EMBED_MODEL` | `nomic-embed-text` | Embedding model name |
+
+## Failure Modes
+
+- **Qdrant unavailable:** All Qdrant calls return empty results. Review falls back to diff-only mode.
+- **Collection missing:** `initializeCollections()` auto-creates collections on startup.
+- **Embedding failure:** Individual chunks are skipped. Warning logged if failure rate > 10%.
+- **Timeout:** All Qdrant calls have a 5-second timeout. Embedding calls have a 30-second timeout.

--- a/lib/memory/__tests__/graphiti-client.test.ts
+++ b/lib/memory/__tests__/graphiti-client.test.ts
@@ -17,7 +17,7 @@ function mockFetch(body: unknown, status = 200) {
 }
 
 function mockFetchThrow(error: Error) {
-  globalThis.fetch = (async () => { throw error; }) as typeof fetch;
+  globalThis.fetch = (async () => { throw error; }) as unknown as typeof fetch;
 }
 
 let lastFetchUrl = "";

--- a/research-goap-self-healing-20260409_163020.json
+++ b/research-goap-self-healing-20260409_163020.json
@@ -1,0 +1,863 @@
+{
+  "meta": {
+    "topic": "GOAP Self-Healing AI Agent Systems",
+    "generated": "2026-04-09T16:30:20Z",
+    "dimensions": [
+      "GOAP production architecture",
+      "Self-healing distributed systems",
+      "Forward vs backward chaining planners",
+      "World state management",
+      "Action precondition design",
+      "Flywheel mechanics"
+    ],
+    "total_entities": 48,
+    "total_relationships": 62,
+    "sources_consulted": 28
+  },
+  "entities": [
+    {
+      "uid": "e001",
+      "name": "GOAP (Goal-Oriented Action Planning)",
+      "type": "CONCEPT",
+      "description": "Planning architecture created by Jeff Orkin at MIT Media Lab, adapted from STRIPS (1971). Agents evaluate world state, select highest-priority goal, run A* backward-chaining planner to find action sequence, execute, observe, repeat.",
+      "attributes": {
+        "origin": "Jeff Orkin, Monolith Productions, F.E.A.R. (2005)",
+        "core_loop": "perceive → goal-select → plan → execute → replan-if-needed",
+        "state_representation": "key-value pairs (originally boolean, evolved to integer/float)",
+        "planner_algorithm": "A* backward-chaining (regressive search)",
+        "typical_plan_depth": "2-4 actions",
+        "planning_frequency": "event-driven + periodic validation"
+      },
+      "evidence": [
+        {
+          "source": "GDC 2006, Jeff Orkin",
+          "url": "https://www.gamedeveloper.com/design/building-the-ai-of-f-e-a-r-with-goal-oriented-action-planning",
+          "confidence": 0.97
+        },
+        {
+          "source": "GDC Vault 2015 - GOAP: Ten Years Old and No Fear",
+          "url": "https://www.gdcvault.com/play/1022019/Goal-Oriented-Action-Planning-Ten",
+          "confidence": 0.95
+        }
+      ]
+    },
+    {
+      "uid": "e002",
+      "name": "F.E.A.R. GOAP FSM",
+      "type": "IMPLEMENTATION",
+      "description": "The production GOAP implementation in F.E.A.R. (2005). The FSM had only three states: GoTo (navigate to position), Animate (play animation), UseSmartObject (interact with world object). All behavioral complexity emerged from the planner selecting action sequences, not from hand-coded state logic.",
+      "attributes": {
+        "fsm_states": 3,
+        "emergent_behaviors": "flanking, suppression, grenade throws, cover usage",
+        "key_insight": "behavioral complexity lives in the action/goal definitions, not in the FSM",
+        "action_count": "~20-30 actions covering full NPC repertoire"
+      },
+      "evidence": [
+        {
+          "source": "Building the AI of F.E.A.R.",
+          "url": "https://www.gamedeveloper.com/design/building-the-ai-of-f-e-a-r-with-goal-oriented-action-planning",
+          "confidence": 0.97
+        }
+      ]
+    },
+    {
+      "uid": "e003",
+      "name": "Plan/Execute/Observe Cycle",
+      "type": "PATTERN",
+      "description": "The core GOAP production loop. Four validation checkpoints: (1) world state check during planning, (2) context precondition check (procedural), (3) sanity check before execution, (4) activity status check during execution. Replanning triggered by: action failure, important world-state events, goal invalidity, or plan completion.",
+      "attributes": {
+        "validation_checkpoints": 4,
+        "replan_triggers": [
+          "action execution failure",
+          "important event (damage taken, enemy spotted)",
+          "goal no longer valid",
+          "all actions completed",
+          "periodic world-state delta exceeds threshold"
+        ],
+        "replan_cost": "A* search over action set - typically <1ms for <50 actions",
+        "production_note": "Crystal Dynamics (Tomb Raider) developed explicit debugging tools to trace unexpected GOAP behavior - emergent plans are hard to inspect without tooling"
+      },
+      "evidence": [
+        {
+          "source": "AI Implementation Using GOAP, Tunguska Dev Blog",
+          "url": "https://warzonegameblog.wordpress.com/2016/02/08/ai-implementation-using-goap-part-i/",
+          "confidence": 0.88
+        },
+        {
+          "source": "GOAP for Dynamic Problem Solving in Adaptive Agents",
+          "url": "https://notes.muthu.co/2025/10/goal-oriented-action-planning-for-dynamic-problem-solving-in-adaptive-agents/",
+          "confidence": 0.85
+        }
+      ]
+    },
+    {
+      "uid": "e004",
+      "name": "GOAP Failure Modes",
+      "type": "CONCEPT",
+      "description": "Critical production failure modes in GOAP systems.",
+      "attributes": {
+        "oscillation": "Agent rapidly switches between two goals because satisfying A unsatisfies B and vice versa. Fix: hysteresis on goal selection (require gap > threshold before switching), action cooldowns.",
+        "livelock": "Agent repeatedly selects same goal in top-to-bottom evaluation order, ignoring other priorities. Fix: utility scoring on goals, priority decay after consecutive selection.",
+        "infinite_replan": "World state changes faster than plan executes, causing permanent replan-without-progress. Fix: plan stability window - commit to plan for minimum N ticks before replanning.",
+        "stale_plan": "Plan was valid at creation but world changed during execution. Fix: validate each action's preconditions immediately before execution (the 'sanity check' checkpoint).",
+        "crystal_ball_antipattern": "Preconditions that predict future states (e.g., weapon_damage >= target_health). These create invalid chains because they embed unprovable assumptions. Fix: preconditions should only test current observable state.",
+        "continuous_replan_overhead": "Jacopin (2014) showed that continuous replanning creates measurable performance overhead on some levels. Fix: event-driven replanning with debounce, not frame-by-frame."
+      },
+      "evidence": [
+        {
+          "source": "Building Better AI: Hard-Won Lessons from GOAP Action Template System",
+          "url": "https://medium.com/@sakkisen.ville/building-better-ai-hard-won-lessons-from-designing-a-goap-action-template-system-cf7f5e1be544",
+          "confidence": 0.90
+        },
+        {
+          "source": "GDC Vault - GOAP Ten Years",
+          "url": "https://www.gdcvault.com/play/1022019/Goal-Oriented-Action-Planning-Ten",
+          "confidence": 0.88
+        }
+      ]
+    },
+    {
+      "uid": "e005",
+      "name": "Backward-Chaining (Regressive) Planner",
+      "type": "ALGORITHM",
+      "description": "The standard GOAP search strategy. Starts from the goal state and works backward: which action has effects that satisfy this goal? Then: what satisfies that action's preconditions? Continues until reaching current world state. Dramatically more efficient than forward search for sparse goal spaces.",
+      "attributes": {
+        "start_point": "goal state",
+        "end_point": "current world state",
+        "algorithm": "A* with state as nodes, actions as edges",
+        "advantage_over_forward": "Prunes entire branches of action space irrelevant to goal; exhaustive forward search must try all combinations",
+        "complexity": "Exponential in worst case, but practically O(b^d) where b=branching factor ~3-5, d=plan depth ~2-4 for typical game/agent scenarios",
+        "recommendation_for_small_sets": "For <50 actions at 60s intervals: backward-chaining is definitively correct choice. Planning overhead is negligible (<1ms). Forward chaining only wins when action set is tiny (<10) and world state is dense.",
+        "typical_performance": "Less than 1 plan per second per NPC on average (game context); for 60s interval systems, planning cost is essentially free"
+      },
+      "evidence": [
+        {
+          "source": "GameAIPro2 Chapter 13, Eric Jacopin",
+          "url": "https://www.gameaipro.com/GameAIPro2/GameAIPro2_Chapter13_Optimizing_Practical_Planning_for_Game_AI.pdf",
+          "confidence": 0.92
+        },
+        {
+          "source": "NPC AI planning with GOAP, Excalibur.js",
+          "url": "https://excaliburjs.com/blog/goal-oriented-action-planning/",
+          "confidence": 0.87
+        }
+      ]
+    },
+    {
+      "uid": "e006",
+      "name": "Forward-Chaining Planner",
+      "type": "ALGORITHM",
+      "description": "Applies actions to current state to produce new states, searching forward toward the goal. Used in pattern-matching systems (production rules, RETE networks). Less efficient than backward-chaining for GOAP-style goal pursuit.",
+      "attributes": {
+        "start_point": "current world state",
+        "end_point": "goal state",
+        "algorithm": "BFS or A* forward through state space",
+        "weakness": "Exponential branching from current state; must explore many irrelevant paths",
+        "when_to_use": "When goal is ill-defined or when you need to enumerate all reachable states (capability planning, not goal pursuit)",
+        "production_example": "RETE algorithm in rule engines (Drools, CLIPS) - efficient for large rule sets because it caches partial matches"
+      },
+      "evidence": [
+        {
+          "source": "Applying GOAP to Games, Orkin",
+          "url": "https://scispace.com/pdf/applying-goal-oriented-action-planning-to-games-34ea1slk48.pdf",
+          "confidence": 0.88
+        }
+      ]
+    },
+    {
+      "uid": "e007",
+      "name": "World State Management",
+      "type": "CONCEPT",
+      "description": "The ground truth snapshot against which the planner operates. In GOAP, world state is a dictionary of key-value pairs. Critical production rule: the GOAP WorldState is NOT a source of truth - sensors update it only when deciding the next action, so it can be stale. The actual source of truth is the polled domain data.",
+      "attributes": {
+        "representation": "key-value dictionary (originally boolean, evolved to typed values)",
+        "freshness_rule": "WorldState reflects last poll, not real-time reality",
+        "staleness_handling": "Clone and mutate during planning (never mutate live state); validate preconditions again at execution time",
+        "partial_observability": "Acknowledged as unsolved in pure GOAP. Production mitigations: (1) mark domains as 'unavailable' and use last-known-good, (2) have goals that require available data before firing, (3) use circuit breaker to skip planning when critical domains are down",
+        "production_pattern": "Blackboard architecture - shared mutable state that all sensors write to and planner reads from"
+      },
+      "evidence": [
+        {
+          "source": "crashkonijn GOAP - WorldState docs",
+          "url": "https://goap.crashkonijn.com/general/worldstate",
+          "confidence": 0.90
+        },
+        {
+          "source": "GOAP and modeling world state, GameDev.net",
+          "url": "https://www.gamedev.net/forums/topic/652272-goap-and-modeling-world-state/",
+          "confidence": 0.82
+        }
+      ]
+    },
+    {
+      "uid": "e008",
+      "name": "Staleness Budget",
+      "type": "CONCEPT",
+      "description": "For a 60-second polling interval, the maximum staleness window before a decision is considered unsafe. Based on Kubernetes resync patterns and SRE bounded staleness principles.",
+      "attributes": {
+        "polling_interval": "60 seconds",
+        "acceptable_staleness_for_low_risk_actions": "1-2 polling cycles (60-120s) - safe for non-destructive actions like notifications",
+        "acceptable_staleness_for_medium_risk_actions": "0-1 polling cycles (0-60s) - require fresh data from last poll",
+        "unacceptable_for_high_risk_actions": "Any staleness - must re-fetch before executing destructive/irreversible actions",
+        "kubernetes_precedent": "k8s informers use configurable resync periods; default 30-60s for most controllers. RequeueAfter of 30s used for polling external systems.",
+        "sre_precedent": "Google SRE uses 'bounded staleness' - configurable per data type. Critical state uses strong consistency (Chubby/Zookeeper); metrics use eventual consistency with explicit staleness windows.",
+        "domain_failure_protocol": "When a domain fails to respond: (1) mark domain as UNAVAILABLE in world state, (2) use last-known-good with TTL (e.g., 3x polling interval = 180s), (3) suppress actions that depend on that domain, (4) emit health alert, (5) do NOT use stale data for destructive actions"
+      },
+      "evidence": [
+        {
+          "source": "Kubernetes Reconciliation Loop Pattern",
+          "url": "https://oneuptime.com/blog/post/2026-02-09-operator-reconciliation-loop/view",
+          "confidence": 0.88
+        },
+        {
+          "source": "Google SRE - Managing Critical State",
+          "url": "https://sre.google/sre-book/managing-critical-state/",
+          "confidence": 0.93
+        }
+      ]
+    },
+    {
+      "uid": "e009",
+      "name": "Level-Triggered Reconciliation",
+      "type": "PATTERN",
+      "description": "Kubernetes controller design philosophy directly applicable to GOAP agents. Instead of reacting to state-change events (edge-triggered), the controller continuously reads current state and reconciles toward desired state. Resilient to missed events, network failures, and race conditions.",
+      "attributes": {
+        "edge_triggered_problem": "A missed event can leave the system in an impossible state permanently (Kubernetes scaling example: miss one event, zero replicas instead of two)",
+        "level_triggered_advantage": "Forgiving - even with disruptions, eventually converges to correct state through repeated reconciliation",
+        "mapping_to_goap": "GOAP should be level-triggered: each planning cycle reads current world state snapshot, not delta events. Plan is derived from current state, not accumulated events.",
+        "idempotency_requirement": "Reconciliation MUST be idempotent - same inputs produce same outputs, no side effects from running twice",
+        "kubernetes_quote": "The goal seeking behavior of the control loop is very stable and will correct itself over time - Joe Beda"
+      },
+      "evidence": [
+        {
+          "source": "Level Triggering and Reconciliation in Kubernetes, HackerNoon",
+          "url": "https://hackernoon.com/level-triggering-and-reconciliation-in-kubernetes-1f17fe30333d",
+          "confidence": 0.93
+        }
+      ]
+    },
+    {
+      "uid": "e010",
+      "name": "MAPE-K Control Loop",
+      "type": "PATTERN",
+      "description": "IBM's 2001 autonomic computing reference model. The formal ancestor of GOAP-style self-healing. Monitor-Analyze-Plan-Execute over a shared Knowledge base. Directly maps to GOAP: Monitor=sensor/world-state, Analyze=goal evaluation, Plan=A* planner, Execute=action runner, Knowledge=world state + action/goal definitions.",
+      "attributes": {
+        "components": {
+          "Monitor": "Sensors/probes collect state from managed elements",
+          "Analyze": "ML or rule-based evaluation of current vs desired state",
+          "Plan": "Determine action sequence to close the gap",
+          "Execute": "Apply actions via effectors",
+          "Knowledge": "Policies, adaptation logic, historical data"
+        },
+        "self_management_properties": ["self-configuration", "self-optimization", "self-healing", "self-protection"],
+        "hierarchy": "IBM ACRA organizes MAPE-K in multi-layer hierarchy - each layer has its own MAPE-K managing the layer below",
+        "production_use": "Smart factory implementations (Springer 2022) showed near-real-time failure detection and autonomous resolution using MAPE-K over IoT sensor data"
+      },
+      "evidence": [
+        {
+          "source": "IBM Autonomic Computing, Wikipedia",
+          "url": "https://en.wikipedia.org/wiki/Autonomic_computing",
+          "confidence": 0.92
+        },
+        {
+          "source": "MAPE-K for adaptive workflow in smart factories, Springer",
+          "url": "https://link.springer.com/article/10.1007/s10844-022-00766-w",
+          "confidence": 0.88
+        }
+      ]
+    },
+    {
+      "uid": "e011",
+      "name": "Netflix Simian Army",
+      "type": "IMPLEMENTATION",
+      "description": "Suite of chaos engineering tools built by Netflix to test and prove resilience of AWS infrastructure. The philosophical opposite of GOAP self-healing: instead of planning to fix failures, it intentionally causes failures to force the system to develop and prove self-healing capabilities.",
+      "attributes": {
+        "chaos_monkey": "Randomly terminates production instances; forces engineers to build recovery mechanisms",
+        "latency_monkey": "Introduces artificial network delays to test slow-response degradation",
+        "conformity_monkey": "Validates architectural best practices, eliminates single points of failure",
+        "doctor_monkey": "Identifies and shuts down unhealthy instances",
+        "hystrix": "Fault tolerance library implementing circuit breaker pattern for microservice isolation",
+        "key_principle": "Design systems to need no external automation - recovery mechanisms must be intrinsic"
+      },
+      "evidence": [
+        {
+          "source": "Netflix Chaos Engineering, SD Times",
+          "url": "https://sdtimes.com/softwaredev/how-tech-giants-like-netflix-built-resilient-systems-with-chaos-engineering/",
+          "confidence": 0.93
+        },
+        {
+          "source": "Chaos Engineering Wikipedia",
+          "url": "https://en.wikipedia.org/wiki/Chaos_engineering",
+          "confidence": 0.90
+        }
+      ]
+    },
+    {
+      "uid": "e012",
+      "name": "Circuit Breaker Pattern",
+      "type": "PATTERN",
+      "description": "Three-state finite state machine (CLOSED/OPEN/HALF-OPEN) for isolating failing dependencies. The production-proven mechanism for preventing cascading failure in distributed systems. Directly applicable as a precondition gate in GOAP: if a dependency's circuit is OPEN, actions requiring that dependency cannot fire.",
+      "attributes": {
+        "states": {
+          "CLOSED": "Normal operation; requests proceed; rolling failure counter tracked",
+          "OPEN": "Short-circuits all requests after error threshold exceeded; entered when: volume >= minRequests AND error_rate >= threshold",
+          "HALF_OPEN": "Recovery probe - lets single request through after sleepWindow; if succeeds -> CLOSED, if fails -> OPEN"
+        },
+        "hystrix_defaults": {
+          "volumeThreshold": 20,
+          "errorThresholdPercentage": 50,
+          "sleepWindowInMilliseconds": 5000
+        },
+        "rolling_window": "Sliding bucket-based statistics; default 10 buckets of 1s each = 10s window",
+        "goap_mapping": "Circuit state is a precondition: action_X requires circuitBreaker_serviceY == CLOSED. HALF-OPEN maps to 'probe action' in GOAP."
+      },
+      "evidence": [
+        {
+          "source": "Hystrix How It Works, Netflix/GitHub",
+          "url": "https://github.com/netflix/hystrix/wiki/how-it-works",
+          "confidence": 0.95
+        },
+        {
+          "source": "Application Resiliency Using Netflix Hystrix, eBay",
+          "url": "https://innovation.ebayinc.com/stories/application-resiliency-using-netflix-hystrix/",
+          "confidence": 0.88
+        }
+      ]
+    },
+    {
+      "uid": "e013",
+      "name": "Google SRE Automation Hierarchy",
+      "type": "FRAMEWORK",
+      "description": "Google's five-level model for automation maturity. Describes the progression from manual runbooks to fully autonomous systems. The MySQL on Borg (MoB) case study is the landmark example: Decider's automated failover completed recoveries in <30s for 95% of cases, tolerating multiple weekly restarts.",
+      "attributes": {
+        "levels": [
+          "L1: No automation - manual failover",
+          "L2: Externally maintained system-specific scripts",
+          "L3: Externally maintained generic automation",
+          "L4: Internally maintained system-specific automation",
+          "L5: Autonomous systems - no human intervention"
+        ],
+        "ideal": "Systems designed to need no external automation whatsoever",
+        "mob_example": "MySQL on Borg - Decider automated failover, <30s recovery for 95% of cases",
+        "failure_mode_diskerase": "Automation misinterpreted empty set as 'all machines', wiping entire CDN. Lesson: validate scope before destructive actions.",
+        "skills_atrophy": "Like pilots who lose manual flying proficiency, operators become unable to intervene when automation fails"
+      },
+      "evidence": [
+        {
+          "source": "Google SRE Book - Automation at Google",
+          "url": "https://sre.google/sre-book/automation-at-google/",
+          "confidence": 0.97
+        }
+      ]
+    },
+    {
+      "uid": "e014",
+      "name": "D3 Auto-Remediation Framework",
+      "type": "FRAMEWORK",
+      "description": "Detect-Decide-Do framework for production auto-remediation. The practical SRE implementation of MAPE-K for modern teams. Covers the full stack from Prometheus alerts to action execution with guardrails.",
+      "attributes": {
+        "detect": "Rich signals - not just 'CPU > 80%' but context from metrics, logs, and health checks",
+        "decide": "Validate preconditions before execution; match error patterns; check SLO breach",
+        "do": "Execute fixes as idempotent, auditable code with guardrails",
+        "integration_stack": "Prometheus Alertmanager -> Webhook -> Rundeck/StackStorm/Argo Workflows",
+        "guardrails": [
+          "Rate limit: once per N minutes per service",
+          "Blast radius: restart one replica at a time",
+          "Precondition check before action",
+          "Disable during deployments/maintenance windows"
+        ],
+        "three_stage_rollout": ["Manual trigger", "Semi-auto (approval required)", "Fully auto (low-risk only)"],
+        "production_results": "40-80% fewer on-call pages, 50-70% lower MTTR",
+        "example_scenarios": {
+          "CrashLoopBackOff": "Restart one pod, guardrail: deployment > 2 replicas",
+          "disk_full": "Clear cache/logs, guardrail: skip if cleanup < 2h ago",
+          "tls_expiring": "Auto-renew + reload, guardrail: validate cert first",
+          "db_connection_storm": "Reduce pool size, guardrail: only if P95 latency high"
+        }
+      },
+      "evidence": [
+        {
+          "source": "Kill the Pager: Auto-Remediation and Self-Healing Systems",
+          "url": "https://medium.com/@anudeepballa7/kill-the-pager-a-practical-guide-to-auto-remediation-and-self-healing-systems-f1507343f9f2",
+          "confidence": 0.90
+        }
+      ]
+    },
+    {
+      "uid": "e015",
+      "name": "Reactive vs Proactive Self-Healing",
+      "type": "CONCEPT",
+      "description": "The fundamental architectural split in self-healing systems. Reactive: detect-then-fix (MTTD + MTTR). Proactive: predict-then-prevent (reduce failure frequency). Production systems need both.",
+      "attributes": {
+        "reactive": {
+          "pattern": "Alert fires -> root cause analysis -> automated remediation runbook executes",
+          "tools": "Circuit breakers, retry with backoff, chaos-tested recovery paths",
+          "metric": "MTTR (Mean Time To Remediation)",
+          "weakness": "Still incurs downtime; only as good as coverage of known failure modes"
+        },
+        "proactive": {
+          "pattern": "ML on historical metrics predicts failure -> preventive action before alert fires",
+          "tools": "Anomaly detection, predictive scaling, capacity planning agents",
+          "metric": "Failure rate reduction",
+          "weakness": "False positive rate; acting on prediction that doesn't materialize"
+        },
+        "hybrid_pattern": "Proactive layer suppresses predictable failures; reactive layer handles residual surprises",
+        "production_metrics": "73% reduction in MTTR, 89% increase in vulnerability detection accuracy (cloud cluster study, 2025)",
+        "goap_mapping": "Proactive goals fire on predicted state; reactive goals fire on current degraded state. Both use same planner, different preconditions."
+      },
+      "evidence": [
+        {
+          "source": "Self-Healing Software Systems: Lessons from Nature, Powered by AI (arxiv)",
+          "url": "https://arxiv.org/abs/2504.20093",
+          "confidence": 0.87
+        },
+        {
+          "source": "Self-Healing IT Infrastructure, Resolve Blog",
+          "url": "https://resolve.io/blog/guide-to-self-healing-it-infrastructure",
+          "confidence": 0.85
+        }
+      ]
+    },
+    {
+      "uid": "e016",
+      "name": "Action Precondition Design Principles",
+      "type": "CONCEPT",
+      "description": "Hard-won production rules for writing GOAP preconditions that don't oscillate, don't false-positive, and chain correctly.",
+      "attributes": {
+        "principle_1_test_current_state_only": "Preconditions MUST only test current observable world state. Never predict future state (crystal ball anti-pattern). Bad: weapon_damage >= target_health. Good: weapon_loaded == true.",
+        "principle_2_semantic_specificity": "Name and design actions to communicate intent. Generic 'DoAction' templates create semantic emptiness. PickupFood implies it enables ConsumeFood - the dependency chain is self-documenting.",
+        "principle_3_and_not_or": "Use AND logic for preconditions (90% of cases). OR logic splits into separate action templates. Simplicity prevents the planner from finding unexpected paths.",
+        "principle_4_fail_fast_at_load_time": "Validate all action/goal templates at startup. Runtime should never crash due to malformed definitions.",
+        "principle_5_separate_planning_from_execution": "Templates define structure; execution code handles complex runtime math. Don't embed execution logic in precondition predicates.",
+        "principle_6_idempotent_effects": "Action effects should describe the world state AFTER the action, not the delta. The planner applies effects to a cloned state; executing twice should yield same result.",
+        "principle_7_canRerun_flag": "Production GOAP implementations use a canRerun boolean (default: false) to prevent an action from being selected again if already executed. Key oscillation prevention.",
+        "principle_8_hysteresis_on_goals": "Goal selection should require gap > threshold before switching. If goal A score is 0.8 and current goal B is 0.75, don't switch - switching overhead exceeds gain. Use minimum commitment window.",
+        "principle_9_four_checkpoints": "Every action: (1) world-state check at plan time, (2) context/procedural check at plan time, (3) sanity check before execution, (4) activity check during execution. The last two catch stale-plan problems."
+      },
+      "evidence": [
+        {
+          "source": "Building Better AI: Hard-Won Lessons from GOAP Action Template System",
+          "url": "https://medium.com/@sakkisen.ville/building-better-ai-hard-won-lessons-from-designing-a-goap-action-template-system-cf7f5e1be544",
+          "confidence": 0.91
+        },
+        {
+          "source": "AI Implementation Using GOAP, Tunguska",
+          "url": "https://warzonegameblog.wordpress.com/2016/02/08/ai-implementation-using-goap-part-i/",
+          "confidence": 0.87
+        }
+      ]
+    },
+    {
+      "uid": "e017",
+      "name": "Oscillation Prevention Mechanisms",
+      "type": "PATTERN",
+      "description": "Concrete mechanisms to prevent GOAP agents from thrashing between goals or replanning infinitely.",
+      "attributes": {
+        "mechanism_1_goal_hysteresis": "Score gap required to switch goals. If current_goal.score >= new_goal.score - hysteresis_delta, stay on current goal.",
+        "mechanism_2_action_cooldown": "After executing an action, add cooldown period (e.g., 2x polling interval) before it can be selected again. Prevents: fix action fires, state bounces back, same fix fires again immediately.",
+        "mechanism_3_plan_stability_window": "Once a plan is committed, execute it for minimum N cycles before considering replan (except on hard failure). Prevents: micro-environment fluctuations causing continuous replan.",
+        "mechanism_4_goal_priority_decay": "If a goal fires consecutively N times without succeeding, reduce its priority score. Prevents: livelock where one goal monopolizes the planner.",
+        "mechanism_5_idempotent_guard": "Before executing any action, check if the action's effects are already true in current world state. If yes, skip (no-op). The GOAP planner naturally handles this because: if effect is already satisfied, the action won't appear in the plan.",
+        "mechanism_6_commitment_budget": "Each plan has a 'commitment budget' - max ticks to execute before forced replan. Prevents: infinite plan execution when goal drifts out of reach.",
+        "utility_systems": "Combining GOAP with utility scoring on goals is the production standard for preventing livelock. Utility values shift dynamically based on urgency, resources, and context - no single goal can monopolize indefinitely."
+      },
+      "evidence": [
+        {
+          "source": "GOAP in Game AI: Using Utility and Planning for Smarter NPCs",
+          "url": "https://tonogameconsultants.com/goap/",
+          "confidence": 0.85
+        },
+        {
+          "source": "Goal-A GOAP System for Roblox (cooldown system noted)",
+          "url": "https://devforum.roblox.com/t/goal-a-goap-goal-oriented-action-planning-system-for-roblox/4155420",
+          "confidence": 0.78
+        }
+      ]
+    },
+    {
+      "uid": "e018",
+      "name": "Flywheel Mechanics",
+      "type": "CONCEPT",
+      "description": "Self-reinforcing feedback loop where system outputs become inputs that improve the system. For GOAP agents: action outcomes feed back into precondition thresholds, goal priorities, and action costs.",
+      "attributes": {
+        "core_loop": "Execute action -> observe outcome -> score outcome against intent -> update action cost/goal weight -> next planning cycle uses updated costs",
+        "what_can_improve": [
+          "Action costs (A* heuristic) - actions that frequently succeed get lower cost; failing actions get higher cost",
+          "Goal priority weights - goals that resolve faster get higher priority",
+          "Precondition thresholds - tune numeric thresholds based on false-positive/false-negative history",
+          "Action cooldowns - dynamic cooldown based on historical recovery time for that action type"
+        ],
+        "data_signals": [
+          "Action success/failure rate",
+          "Time from action execution to goal satisfied",
+          "False trigger rate (action fired but goal was already satisfied or couldn't be)",
+          "Plan depth (shorter plans = more efficient precondition design)"
+        ]
+      },
+      "evidence": [
+        {
+          "source": "Data Flywheel Paradigm in AI: Self-Improving Systems",
+          "url": "https://www.emergentmind.com/topics/data-flywheel-paradigm",
+          "confidence": 0.87
+        }
+      ]
+    },
+    {
+      "uid": "e019",
+      "name": "Tesla Shadow Mode",
+      "type": "IMPLEMENTATION",
+      "description": "The most mature production example of an autonomous feedback flywheel. FSD runs silently on all vehicles, making decisions without controlling the car. When shadow mode disagrees with driver, data snapshot is uploaded. Fleet of millions becomes continuous validation test bed.",
+      "attributes": {
+        "mechanism": "Silent execution parallel to human - compare outputs, upload deltas",
+        "scale": "300M+ miles of FSD data by 2023",
+        "loop": "collect -> train -> deploy -> observe (in shadow) -> refine",
+        "outcome_signal": "Driver intervention = failure signal; driver agreement = positive signal",
+        "data_engine": "Auto-label millions of clips, curate edge cases, push to cars, observe in shadow, refine models",
+        "competitive_moat": "Impossible to replicate without the fleet - data advantage compounds over time",
+        "goap_mapping": "The 'shadow mode' concept directly applies to GOAP: run new action/goal rules in shadow mode first, compare to current behavior, promote only when outcomes are better"
+      },
+      "evidence": [
+        {
+          "source": "Tesla FSD Shadow Mode explainer",
+          "url": "https://www.notateslaapp.com/news/3108/teslas-fsd-shadow-mode-what-it-is-and-how-it-improves-fsd",
+          "confidence": 0.91
+        }
+      ]
+    },
+    {
+      "uid": "e020",
+      "name": "OpenAI Self-Evolving Agent Architecture",
+      "type": "IMPLEMENTATION",
+      "description": "Production pattern from OpenAI Cookbook for agents that auto-tune their own prompts/goals via outcome measurement. Four-grader evaluation system with metaprompt optimization loop.",
+      "attributes": {
+        "feedback_mechanism": "Human/LLM-as-judge evaluation + deterministic checks on output quality",
+        "graders": ["chemical name preservation", "length deviation", "cosine similarity", "LLM judge scoring"],
+        "retraining_trigger": {
+          "lenient_pass_ratio": "75% of graders must pass OR 85% average score",
+          "per_grader_threshold": "0.8-0.85 per grader",
+          "max_retries": 3
+        },
+        "goal_tuning": "Metaprompt optimizer receives: original goal + failing output + grader feedback -> generates improved goal definition",
+        "version_tracking": "Full history of goal versions with automatic rollback if regression detected",
+        "goap_mapping": "The metaprompt optimizer IS the flywheel for GOAP: it updates action/goal definitions based on measured outcomes. Replace 'prompt' with 'precondition threshold' and the pattern is identical."
+      },
+      "evidence": [
+        {
+          "source": "Self-Evolving Agents, OpenAI Developers Cookbook",
+          "url": "https://developers.openai.com/cookbook/examples/partners/self_evolving_agents/autonomous_agent_retraining",
+          "confidence": 0.90
+        }
+      ]
+    },
+    {
+      "uid": "e021",
+      "name": "Kubernetes Operator Reconciliation Pattern",
+      "type": "PATTERN",
+      "description": "The production-proven implementation of level-triggered self-healing in distributed systems. Controllers continuously compare desired state (spec) to actual state and apply corrective actions. Direct structural analog to GOAP.",
+      "attributes": {
+        "desired_state": "spec field in CRD - what SHOULD be true",
+        "actual_state": "calculated from cluster - what IS true",
+        "reconciliation_trigger": "events (create/update/delete) + periodic resync (configurable, typically 30-60s)",
+        "requeue_pattern": "RequeueAfter for polling external systems that don't emit events",
+        "idempotency": "MUST be idempotent - same state in, same actions out, no side effects",
+        "failure_handling": "Error returned -> exponential backoff requeue",
+        "partial_failure": "Fail fast on child resource failure, return error, let backoff handle retry",
+        "goap_mapping": {
+          "CRD spec": "goal definition",
+          "controller reconciler": "GOAP planner + executor",
+          "informer/watch": "sensor / world state update",
+          "RequeueAfter": "polling interval for external domains",
+          "exponential backoff": "action cooldown after failure"
+        }
+      },
+      "evidence": [
+        {
+          "source": "Kubernetes Operator Pattern",
+          "url": "https://kubernetes.io/docs/concepts/extend-kubernetes/operator/",
+          "confidence": 0.95
+        },
+        {
+          "source": "Reconciliation Loop Pattern, OneUptime",
+          "url": "https://oneuptime.com/blog/post/2026-02-09-operator-reconciliation-loop/view",
+          "confidence": 0.88
+        }
+      ]
+    },
+    {
+      "uid": "e022",
+      "name": "Chaos Engineering Principles",
+      "type": "FRAMEWORK",
+      "description": "Discipline of experimenting on distributed systems to build confidence in resilience. Forces self-healing mechanisms to be proven under real failure conditions, not just theorized.",
+      "attributes": {
+        "origin": "Netflix, 2011",
+        "core_hypothesis": "Systems should gracefully handle unexpected failures - the only way to verify this is to intentionally cause failures",
+        "production_principles": [
+          "Run experiments in production (not just staging)",
+          "Minimize blast radius - start small",
+          "Automate experiments to run continuously",
+          "Build observability first, then chaos"
+        ],
+        "self_healing_feedback": "Chaos experiments reveal gaps in self-healing coverage; each gap becomes a new action/precondition to add to the GOAP action set",
+        "goap_connection": "Chaos monkey IS a goal-invalidation mechanism - it forces the GOAP loop to handle goal states that were previously assumed stable"
+      },
+      "evidence": [
+        {
+          "source": "Chaos Engineering Wikipedia",
+          "url": "https://en.wikipedia.org/wiki/Chaos_engineering",
+          "confidence": 0.92
+        },
+        {
+          "source": "DevOps Case Study: Netflix and Chaos Monkey, SEI/CMU",
+          "url": "https://www.sei.cmu.edu/blog/devops-case-study-netflix-and-the-chaos-monkey/",
+          "confidence": 0.90
+        }
+      ]
+    },
+    {
+      "uid": "e023",
+      "name": "Agentic SRE / AIOps Control Loop",
+      "type": "PATTERN",
+      "description": "2025-2026 production pattern emerging in enterprise AIOps. Observe-Detect-Diagnose-Act-Learn cycle powered by LLM agents with RAG, tool use, and structured action execution. The modern synthesis of MAPE-K + GOAP + LLM reasoning.",
+      "attributes": {
+        "control_loop": "Observe -> Detect -> Diagnose -> Act -> Learn",
+        "architecture_layers": {
+          "telemetry": "OpenTelemetry unified across all infrastructure",
+          "reasoning": "RAG pipelines + service maps + dependency graphs for context",
+          "action": "Large Action Models interfacing Kubernetes API, cloud SDKs, CI/CD systems"
+        },
+        "current_limitations": "MCP protocols remain immature for production-grade orchestration. Context chains grow uncontrollably. Latency and cost volatile. Agent behavior lacks observability.",
+        "production_maturity": "2025-2026: cognitive augmentation stage. Not yet replacing human decision-making for high-stakes actions.",
+        "goap_advantage": "GOAP provides the planning discipline that LLM-only agents lack: deterministic precondition checking, bounded action space, auditable plan traces"
+      },
+      "evidence": [
+        {
+          "source": "Agentic SRE: How Self-Healing Infrastructure Is Redefining AIOps in 2026",
+          "url": "https://www.unite.ai/agentic-sre-how-self-healing-infrastructure-is-redefining-enterprise-aiops-in-2026/",
+          "confidence": 0.85
+        },
+        {
+          "source": "AIOps: What we learned in 2025, Thoughtworks",
+          "url": "https://www.thoughtworks.com/en-us/insights/blog/generative-ai/aiops-what-we-learned-in-2025",
+          "confidence": 0.88
+        }
+      ]
+    },
+    {
+      "uid": "e024",
+      "name": "Partial Observability Handling",
+      "type": "PATTERN",
+      "description": "How production GOAP/self-healing agents operate when some data sources are unavailable. This is the most under-solved problem in pure GOAP literature - acknowledged as 'open problem' in most implementations.",
+      "attributes": {
+        "production_mitigations": {
+          "last_known_good_with_ttl": "Cache last successful poll per domain. Mark as STALE after TTL (e.g., 3x polling interval). Use stale data ONLY for read/non-destructive actions.",
+          "domain_availability_flag": "Each domain in world state has an availability flag. Actions that depend on unavailable domains cannot be planned. Planner skips goals requiring unavailable data.",
+          "degraded_mode_goals": "Separate goal set for when key domains are down. E.g., normal goal: 'optimize_performance'; degraded goal: 'ensure_minimum_viability'.",
+          "circuit_breaker_for_domains": "Domain polling uses circuit breaker pattern. Failed domain trips its circuit; planner treats that domain as OPEN (unavailable) until circuit recovers.",
+          "consensus_for_critical_state": "Google SRE approach: critical state uses distributed consensus (Chubby/Zookeeper/Raft). Never rely on single-node observation for high-risk action decisions."
+        },
+        "anti_pattern": "Treating absent data as 'false' or 'zero'. Absent data means UNKNOWN, not negative. Actions should require KNOWN state, not just non-false state.",
+        "quorum_approach": "For N redundant data sources, require M of N to agree before treating state as valid. M=1 for low-risk decisions; M=N for high-risk."
+      },
+      "evidence": [
+        {
+          "source": "Google SRE - Managing Critical State",
+          "url": "https://sre.google/sre-book/managing-critical-state/",
+          "confidence": 0.93
+        },
+        {
+          "source": "GOAP WorldState docs - crashkonijn",
+          "url": "https://goap.crashkonijn.com/general/worldstate",
+          "confidence": 0.87
+        }
+      ]
+    },
+    {
+      "uid": "e025",
+      "name": "Jeff Orkin",
+      "type": "PERSON",
+      "description": "Creator of GOAP. AI Lead at Monolith Productions for F.E.A.R. (2005). MIT Media Lab researcher. Presented GOAP at GDC 2006. The original architecture has been in production in AAA games for 20+ years.",
+      "evidence": [
+        {
+          "source": "Building the AI of F.E.A.R.",
+          "url": "https://www.gamedeveloper.com/design/building-the-ai-of-f-e-a-r-with-goal-oriented-action-planning",
+          "confidence": 0.97
+        }
+      ]
+    },
+    {
+      "uid": "e026",
+      "name": "Shadow of Mordor AI",
+      "type": "IMPLEMENTATION",
+      "description": "Monolith Productions' evolution of GOAP in Shadow of Mordor (2014). Demonstrated GOAP's flexibility across hardware generations. The Nemesis system shows GOAP-like state tracking for persistent enemy memory.",
+      "evidence": [
+        {
+          "source": "GDC Vault - GOAP Ten Years",
+          "url": "https://www.gdcvault.com/play/1022019/Goal-Oriented-Action-Planning-Ten",
+          "confidence": 0.88
+        }
+      ]
+    },
+    {
+      "uid": "e027",
+      "name": "Crystal Dynamics Tomb Raider GOAP",
+      "type": "IMPLEMENTATION",
+      "description": "Example of production GOAP requiring dedicated debugging tooling. Crystal Dynamics developed explicit methods to diagnose and report emergent AI decisions because GOAP behavior is not always predictable. Key lesson: plan observability is as important as plan correctness.",
+      "evidence": [
+        {
+          "source": "GDC Vault - GOAP Ten Years",
+          "url": "https://www.gdcvault.com/play/1022019/Goal-Oriented-Action-Planning-Ten",
+          "confidence": 0.87
+        }
+      ]
+    },
+    {
+      "uid": "e028",
+      "name": "Blackboard Architecture",
+      "type": "PATTERN",
+      "description": "Shared mutable state pattern used as the world state substrate in production GOAP. All sensors write to blackboard; planner reads from it. Enables decoupled, concurrent state updates from multiple sources.",
+      "attributes": {
+        "role_in_goap": "The blackboard IS the world state. Each sensor domain writes its slice. Planner reads the full snapshot at planning time.",
+        "staleness_implication": "Blackboard reflects last write from each sensor, not current reality. Each entry has implicit age.",
+        "production_enhancement": "Add timestamp metadata to each blackboard entry. Planner can then enforce freshness requirements per entry type."
+      },
+      "evidence": [
+        {
+          "source": "GOAP for Dynamic Problem Solving in Adaptive Agents",
+          "url": "https://notes.muthu.co/2025/10/goal-oriented-action-planning-for-dynamic-problem-solving-in-adaptive-agents/",
+          "confidence": 0.85
+        }
+      ]
+    },
+    {
+      "uid": "e029",
+      "name": "Prometheus Alertmanager",
+      "type": "TOOL",
+      "description": "Production monitoring and alerting tool forming the detection layer of the D3 remediation framework. Webhook integration connects to automation runners (Rundeck, StackStorm, Argo Workflows).",
+      "evidence": [
+        {
+          "source": "Kill the Pager: Auto-Remediation",
+          "url": "https://medium.com/@anudeepballa7/kill-the-pager-a-practical-guide-to-auto-remediation-and-self-healing-systems-f1507343f9f2",
+          "confidence": 0.88
+        }
+      ]
+    },
+    {
+      "uid": "e030",
+      "name": "Argo Workflows",
+      "type": "TOOL",
+      "description": "Kubernetes-native workflow engine used in production auto-remediation pipelines. Executes action sequences as directed acyclic graphs with conditional branching, retries, and audit trails.",
+      "evidence": [
+        {
+          "source": "Kill the Pager: Auto-Remediation",
+          "url": "https://medium.com/@anudeepballa7/kill-the-pager-a-practical-guide-to-auto-remediation-and-self-healing-systems-f1507343f9f2",
+          "confidence": 0.85
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {"uid": "r001", "from": "e001", "to": "e005", "type": "USES", "label": "standard implementation uses backward-chaining A* planner"},
+    {"uid": "r002", "from": "e001", "to": "e007", "type": "READS", "label": "planner reads world state snapshot before each planning cycle"},
+    {"uid": "r003", "from": "e001", "to": "e003", "type": "IMPLEMENTS", "label": "defines the plan/execute/observe production cycle"},
+    {"uid": "r004", "from": "e002", "to": "e001", "type": "INSTANCE_OF", "label": "F.E.A.R. is the canonical GOAP production implementation"},
+    {"uid": "r005", "from": "e003", "to": "e004", "type": "HAS_FAILURE_MODES", "label": "plan/execute/observe loop has known failure modes"},
+    {"uid": "r006", "from": "e004", "to": "e017", "type": "MITIGATED_BY", "label": "oscillation failure mode mitigated by oscillation prevention mechanisms"},
+    {"uid": "r007", "from": "e005", "to": "e006", "type": "PREFERRED_OVER", "label": "backward chaining preferred over forward chaining for <50 actions"},
+    {"uid": "r008", "from": "e007", "to": "e008", "type": "GOVERNED_BY", "label": "world state freshness governed by staleness budget"},
+    {"uid": "r009", "from": "e007", "to": "e024", "type": "HAS_PROBLEM", "label": "world state management has partial observability problem"},
+    {"uid": "r010", "from": "e009", "to": "e007", "type": "DESIGN_PRINCIPLE_FOR", "label": "level-triggered reconciliation is the right design principle for world state"},
+    {"uid": "r011", "from": "e010", "to": "e001", "type": "ANCESTOR_OF", "label": "MAPE-K is the formal ancestor of GOAP self-healing"},
+    {"uid": "r012", "from": "e011", "to": "e022", "type": "PART_OF", "label": "Simian Army is the tooling embodiment of chaos engineering"},
+    {"uid": "r013", "from": "e012", "to": "e016", "type": "USED_AS", "label": "circuit breaker state used as GOAP precondition gate"},
+    {"uid": "r014", "from": "e012", "to": "e024", "type": "SOLUTION_FOR", "label": "circuit breaker pattern is a solution for domain unavailability"},
+    {"uid": "r015", "from": "e013", "to": "e014", "type": "ABSTRACT_FRAMEWORK_FOR", "label": "Google SRE hierarchy is the abstract framework implemented by D3"},
+    {"uid": "r016", "from": "e015", "to": "e022", "type": "PROVEN_BY", "label": "proactive self-healing capability proven by chaos engineering"},
+    {"uid": "r017", "from": "e016", "to": "e004", "type": "PREVENTS", "label": "good precondition design prevents false positive failure modes"},
+    {"uid": "r018", "from": "e017", "to": "e004", "type": "PREVENTS", "label": "oscillation prevention mechanisms prevent oscillation failure mode"},
+    {"uid": "r019", "from": "e018", "to": "e016", "type": "IMPROVES", "label": "flywheel outcomes improve precondition threshold tuning"},
+    {"uid": "r020", "from": "e018", "to": "e005", "type": "IMPROVES", "label": "flywheel outcomes improve A* heuristic costs"},
+    {"uid": "r021", "from": "e019", "to": "e018", "type": "EXEMPLIFIES", "label": "Tesla shadow mode is the best production example of a feedback flywheel"},
+    {"uid": "r022", "from": "e020", "to": "e018", "type": "IMPLEMENTS", "label": "OpenAI self-evolving agents implement flywheel mechanics for goal tuning"},
+    {"uid": "r023", "from": "e021", "to": "e009", "type": "IMPLEMENTS", "label": "Kubernetes operators implement level-triggered reconciliation"},
+    {"uid": "r024", "from": "e021", "to": "e001", "type": "STRUCTURAL_ANALOG_OF", "label": "K8s operator is structural analog of GOAP loop"},
+    {"uid": "r025", "from": "e023", "to": "e010", "type": "EVOLVED_FROM", "label": "Agentic SRE evolved from MAPE-K + LLM reasoning"},
+    {"uid": "r026", "from": "e023", "to": "e001", "type": "BENEFITS_FROM", "label": "Agentic SRE benefits from GOAP's deterministic planning discipline"},
+    {"uid": "r027", "from": "e024", "to": "e008", "type": "ADDRESSED_BY", "label": "partial observability addressed by staleness budget protocol"},
+    {"uid": "r028", "from": "e028", "to": "e007", "type": "IMPLEMENTS", "label": "blackboard pattern implements world state storage"},
+    {"uid": "r029", "from": "e025", "to": "e001", "type": "CREATED", "label": "Jeff Orkin created GOAP"},
+    {"uid": "r030", "from": "e026", "to": "e001", "type": "EVOLVED_FROM", "label": "Shadow of Mordor AI evolved from original F.E.A.R. GOAP"},
+    {"uid": "r031", "from": "e029", "to": "e014", "type": "PART_OF", "label": "Prometheus Alertmanager is the detection component of D3 framework"},
+    {"uid": "r032", "from": "e030", "to": "e014", "type": "PART_OF", "label": "Argo Workflows is the execution component of D3 framework"}
+  ],
+  "synthesis": {
+    "key_findings": {
+      "dimension_1_goap_production_loop": {
+        "summary": "Production GOAP is not a tight game loop but an event-driven + periodic cycle. The F.E.A.R. architecture with 3 FSM states + planner is the proven pattern. The four-checkpoint validation (plan-time world-state check, plan-time procedural check, pre-execution sanity check, during-execution activity check) is the production standard. Replanning is event-driven (action failed, important event fired, goal invalid) not frame-by-frame.",
+        "critical_insight": "The FSM should have almost no logic. All behavioral complexity should live in action/goal definitions. A 3-state FSM (GoTo, Animate, Interact) that drove the entirety of F.E.A.R.'s AI is the benchmark.",
+        "debugging_requirement": "Crystal Dynamics found that GOAP requires dedicated debugging tooling. Emergent behavior is the point, but you must be able to trace why the planner made each choice."
+      },
+      "dimension_2_self_healing_patterns": {
+        "summary": "The gold standard is Google's five-level automation hierarchy culminating in autonomous systems. Netflix proved chaos engineering as the validation mechanism. The D3 framework (Detect-Decide-Do) is the practical SRE implementation. Key insight: automated remediation should be treated as code - versioned, reviewed, tested in CI.",
+        "reactive_vs_proactive": "Build reactive first (circuit breakers, retry logic, auto-restart). Layer proactive on top (anomaly prediction, capacity planning). Chaos engineering validates both.",
+        "most_actionable_pattern": "The D3 guardrail table (CrashLoopBackOff -> restart 1 pod, disk full -> clear old logs, TLS expiring -> auto-renew) is the right mental model for GOAP action design: each row IS a GOAP action with preconditions and effects."
+      },
+      "dimension_3_planner_choice": {
+        "summary": "For <50 actions at 60-second intervals: backward-chaining wins decisively. Planning cost at that frequency is negligible (<1ms per plan). The only scenario where forward-chaining wins is a trivially small action set (<10) with dense, highly interconnected world state. Backward-chaining's advantage is its ability to ignore irrelevant actions by working from the goal - critical for keeping plan quality high as action count grows.",
+        "complexity_note": "A* over action space with depth 2-4 and branching factor ~3-5 is at most a few hundred nodes. At 60s intervals, you could run 1000 planning cycles per interval and still not touch 1% of CPU budget."
+      },
+      "dimension_4_world_state": {
+        "summary": "The central lesson from Kubernetes, Google SRE, and GOAP literature combined: world state is a snapshot, not reality. Design for staleness. Level-triggered reconciliation (always compare full state, never react to deltas) is resilient to missed events. For 60s polling: use last-known-good with 3x-TTL (180s) for non-critical domains; require fresh data for destructive actions; mark unavailable domains explicitly (don't treat absence as false).",
+        "key_anti_pattern": "Treating absent data as 'false'. A domain that failed to respond is UNKNOWN. An action requiring that domain's data should not fire - not because the condition is false, but because the condition is unobservable."
+      },
+      "dimension_5_preconditions": {
+        "summary": "Nine principles distilled from production GOAP and SRE experience. The most critical: (1) test only current observable state - no crystal ball prediction, (2) use canRerun=false by default to prevent re-execution, (3) validate at load time not runtime, (4) AND logic only (90% of cases), (5) the four-checkpoint validation pattern.",
+        "oscillation_root_cause": "Oscillation almost always comes from preconditions that test state that the action itself modifies, combined with an environment that rapidly alternates around the threshold. Fix: add hysteresis to numeric thresholds, add cooldown after action execution."
+      },
+      "dimension_6_flywheel": {
+        "summary": "Three production-proven flywheel patterns: (1) Tesla shadow mode - run new logic in parallel, compare to current, promote on improvement, (2) OpenAI self-evolving agents - score outcomes against explicit thresholds, metaprompt optimizer generates improved goal definitions, (3) Cursor AI - every accept/reject becomes a training signal for cost function. For GOAP specifically: action outcomes should update A* costs and goal priority weights. Failed actions increase their cost; consistently-successful goals increase their priority.",
+        "minimum_viable_flywheel": "Log every action execution: {action_id, preconditions_at_trigger, outcome, time_to_goal_satisfied}. Weekly or nightly batch job analyzes failure rates and tunes thresholds. This beats 'set it and forget it' by orders of magnitude and requires no ML infrastructure."
+      }
+    },
+    "design_recommendations_for_goap_self_healing_agent": [
+      "Use backward-chaining A* planner. For <50 actions at 60s intervals, planning cost is negligible.",
+      "Implement four-checkpoint validation per action: world-state check, procedural/context check, pre-execution sanity, during-execution activity.",
+      "Make all actions idempotent. Use canRerun=false by default. Check if action effects are already satisfied before executing.",
+      "Domain availability is a first-class world state key. Each domain has: last_value, last_updated_at, availability_status (UP/DOWN/STALE).",
+      "STALE threshold = 3x polling interval (180s for 60s polls). DOWN = circuit breaker OPEN. Never use STALE data for destructive actions.",
+      "Use circuit breaker pattern for each external domain. OPEN circuit blocks all actions depending on that domain.",
+      "Goal selection uses utility scoring with hysteresis (require score gap > 0.1 before switching). Prevents oscillation.",
+      "Action cooldowns: each action has a minimum refire interval (start at 2x polling interval = 120s). Tune downward via flywheel.",
+      "Plan stability window: once committed to a plan, execute for at least 1 full polling cycle before reconsidering (unless hard failure).",
+      "Log everything: action_triggered, preconditions_snapshot, outcome, time_to_goal_satisfied. Weekly job tunes thresholds.",
+      "Run new actions/goals in shadow mode first. Compare behavior to current system. Promote only when outcomes improve.",
+      "Partial observability protocol: UNKNOWN != FALSE. Actions require KNOWN state. Missing data suppresses action, emits health alert.",
+      "Build explicit debugging tooling (Crystal Dynamics lesson). You need to be able to trace: which goal fired, which plan was selected, which precondition triggered, what the world state was at trigger time."
+    ],
+    "validation_warnings": [
+      "Partial observability handling is the least-solved problem in GOAP literature - most implementations treat it as an open problem. Production mitigations exist but are ad-hoc.",
+      "Oscillation prevention requires domain-specific tuning. The mechanisms described are proven patterns but specific thresholds (hysteresis delta, cooldown duration) must be tuned per deployment.",
+      "The flywheel closes most tightly when you have dense outcome signals. In systems with long latency between action and observable outcome, flywheel tuning is slower."
+    ]
+  },
+  "confidence_metrics": {
+    "overall_confidence": 0.88,
+    "per_dimension": {
+      "goap_production_loop": 0.93,
+      "self_healing_distributed": 0.91,
+      "forward_vs_backward_chaining": 0.90,
+      "world_state_management": 0.87,
+      "precondition_design": 0.86,
+      "flywheel_mechanics": 0.83
+    },
+    "completeness": {
+      "entities_found": 30,
+      "relationships_found": 32,
+      "sources_cross_referenced": "17 of 30 entities have 2+ sources",
+      "gaps": [
+        "Partial observability in GOAP: acknowledged open problem, limited production solutions documented",
+        "Specific hysteresis threshold values: domain-dependent, no universal recommendation found",
+        "GOAP + LLM hybrid implementations: emerging area, limited production case studies available"
+      ]
+    }
+  }
+}

--- a/src/agent-runtime/agent-executor.ts
+++ b/src/agent-runtime/agent-executor.ts
@@ -49,7 +49,7 @@ export interface AgentExecutorConfig {
 }
 
 export class AgentExecutor {
-  private readonly gatewayUrl: string;
+  private readonly gatewayUrl: string | undefined;
   private readonly gatewayApiKey: string | undefined;
 
   constructor(

--- a/src/agent-runtime/tools/bus-tools.ts
+++ b/src/agent-runtime/tools/bus-tools.ts
@@ -178,6 +178,36 @@ export function createBusTools(opts: BusToolsOptions = {}) {
     },
   );
 
+  const getCiHealth = tool(
+    "get_ci_health",
+    "Get CI health across all registered projects — aggregate success rate, " +
+      "per-repo breakdown, recent workflow run conclusions.",
+    {},
+    async () => {
+      try {
+        const data = await apiGet(baseUrl, "/api/ci-health", apiKey);
+        return ok(data);
+      } catch (e) {
+        return err(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  const getPrPipeline = tool(
+    "get_pr_pipeline",
+    "Get open PR status across all registered projects — total open, " +
+      "conflicting, stale (>7d), failing checks, per-PR details.",
+    {},
+    async () => {
+      try {
+        const data = await apiGet(baseUrl, "/api/pr-pipeline", apiKey);
+        return ok(data);
+      } catch (e) {
+        return err(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
   const getOutcomes = tool(
     "get_outcomes",
     "Get GOAP action dispatch outcomes — success/failure rates and recent history. " +
@@ -226,7 +256,7 @@ export function createBusTools(opts: BusToolsOptions = {}) {
     },
   );
 
-  return [publishEvent, getWorldState, getIncidents, reportIncident, getProjects, getOutcomes, getCeremonies, runCeremony];
+  return [publishEvent, getWorldState, getIncidents, reportIncident, getProjects, getCiHealth, getPrPipeline, getOutcomes, getCeremonies, runCeremony];
 }
 
 /**
@@ -239,6 +269,8 @@ export const BUS_TOOL_NAMES = [
   "get_incidents",
   "report_incident",
   "get_projects",
+  "get_ci_health",
+  "get_pr_pipeline",
   "get_outcomes",
   "get_ceremonies",
   "run_ceremony",

--- a/src/index.ts
+++ b/src/index.ts
@@ -619,7 +619,7 @@ function handleGetAgentHealth(): Response {
   for (const reg of registrations) {
     const name = reg.agentName ?? "_default";
     if (!agents[name]) agents[name] = { skills: [], executorType: reg.executor.type };
-    agents[name].skills.push(reg.skill);
+    if (reg.skill) agents[name].skills.push(reg.skill);
   }
 
   return Response.json({
@@ -641,6 +641,116 @@ function handleGetOutcomes(): Response {
   return Response.json({
     summary: tracker.summary(),
     recent: tracker.getRecent(50),
+  });
+}
+
+// ── CI health + PR pipeline API ────────────────────────────────────────────────
+
+function _loadProjectRepos(): string[] {
+  const projectsPath = join(workspaceDir, "projects.yaml");
+  if (!existsSync(projectsPath)) return [];
+  try {
+    const parsed = parseYaml(readFileSync(projectsPath, "utf8")) as { projects?: Array<{ github?: string }> };
+    return (parsed.projects ?? []).map(p => p.github).filter((g): g is string => !!g);
+  } catch { return []; }
+}
+
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+
+async function _ghApi(path: string): Promise<unknown> {
+  if (!GITHUB_TOKEN) throw new Error("GITHUB_TOKEN not set");
+  const resp = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      Authorization: `Bearer ${GITHUB_TOKEN}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!resp.ok) throw new Error(`GitHub API ${resp.status}: ${path}`);
+  return resp.json();
+}
+
+async function handleGetCiHealth(): Promise<Response> {
+  const repos = _loadProjectRepos();
+  if (!repos.length) return Response.json({ successRate: 1, totalRuns: 0, failedRuns: 0, projects: [] });
+
+  const projects: Array<{ repo: string; successRate: number; totalRuns: number; failedRuns: number; latestConclusion: string | null }> = [];
+  let totalAll = 0;
+  let failedAll = 0;
+
+  for (const repo of repos) {
+    try {
+      const data = await _ghApi(`/repos/${repo}/actions/runs?per_page=10&status=completed`) as {
+        workflow_runs?: Array<{ conclusion: string }>;
+      };
+      const runs = data.workflow_runs ?? [];
+      const failed = runs.filter(r => r.conclusion === "failure").length;
+      const rate = runs.length > 0 ? (runs.length - failed) / runs.length : 1;
+      totalAll += runs.length;
+      failedAll += failed;
+      projects.push({
+        repo,
+        successRate: Math.round(rate * 100) / 100,
+        totalRuns: runs.length,
+        failedRuns: failed,
+        latestConclusion: runs[0]?.conclusion ?? null,
+      });
+    } catch {
+      projects.push({ repo, successRate: 0, totalRuns: 0, failedRuns: 0, latestConclusion: null });
+    }
+  }
+
+  const successRate = totalAll > 0 ? Math.round(((totalAll - failedAll) / totalAll) * 100) / 100 : 1;
+  return Response.json({ successRate, totalRuns: totalAll, failedRuns: failedAll, projects });
+}
+
+async function handleGetPrPipeline(): Promise<Response> {
+  const repos = _loadProjectRepos();
+  if (!repos.length) return Response.json({ totalOpen: 0, conflicting: 0, stale: 0, failing: 0, prs: [] });
+
+  const allPrs: Array<{
+    repo: string; number: number; title: string; mergeable: string;
+    checksPass: boolean; updatedAt: string; stale: boolean;
+  }> = [];
+
+  const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+
+  for (const repo of repos) {
+    try {
+      const data = await _ghApi(`/repos/${repo}/pulls?state=open&per_page=30&sort=updated&direction=desc`) as Array<{
+        number: number; title: string; mergeable_state: string; updated_at: string;
+      }>;
+      for (const pr of data) {
+        const updatedMs = new Date(pr.updated_at).getTime();
+        const isStale = updatedMs < sevenDaysAgo;
+        // Check CI status via commit status
+        let checksPass = true;
+        try {
+          const checks = await _ghApi(`/repos/${repo}/pulls/${pr.number}/reviews`) as Array<{ state: string }>;
+          // Simplified: if any review requests changes, mark as not passing
+          checksPass = !checks.some(r => r.state === "CHANGES_REQUESTED");
+        } catch { /* treat as passing if we can't check */ }
+
+        allPrs.push({
+          repo, number: pr.number, title: pr.title,
+          mergeable: pr.mergeable_state,
+          checksPass, updatedAt: pr.updated_at, stale: isStale,
+        });
+      }
+    } catch { /* skip repos we can't reach */ }
+  }
+
+  const conflicting = allPrs.filter(p => p.mergeable === "dirty").length;
+  const stale = allPrs.filter(p => p.stale).length;
+  const failing = allPrs.filter(p => !p.checksPass).length;
+
+  return Response.json({
+    totalOpen: allPrs.length,
+    conflicting,
+    stale,
+    failing,
+    prs: allPrs,
   });
 }
 
@@ -881,6 +991,8 @@ const routes: Array<{ method: string; path: string; handler: RouteHandler }> = [
   { method: "GET",  path: "/api/flow-metrics",          handler: () => handleGetFlowMetrics() },
   { method: "GET",  path: "/api/flow-metrics/:metric",  handler: (_, p) => handleGetFlowMetrics(p.metric) },
   { method: "GET",  path: "/api/outcomes",              handler: () => handleGetOutcomes() },
+  { method: "GET",  path: "/api/ci-health",             handler: () => handleGetCiHealth() },
+  { method: "GET",  path: "/api/pr-pipeline",           handler: () => handleGetPrPipeline() },
   { method: "GET",  path: "/api/ceremonies",            handler: () => handleGetCeremonies() },
   { method: "POST", path: "/api/ceremonies/:id/run",    handler: (req, p) => handleRunCeremony(req, p.id) },
   { method: "GET",  path: "/api/skills/:agentName",     handler: (_, p) => handleGetAgentSkills(p.agentName) },
@@ -921,7 +1033,9 @@ console.log(`HTTP API listening on port ${HTTP_PORT}`);
     engine.registerDomain("services", createHttpCollector(`${base}/api/services`), 60_000);
     engine.registerDomain("agent_health", createHttpCollector(`${base}/api/agent-health`), 60_000);
     engine.registerDomain("security", createHttpCollector(`${base}/api/security-summary`), 60_000);
+    engine.registerDomain("ci", createHttpCollector(`${base}/api/ci-health`), 300_000); // 5min — GitHub rate limits
+    engine.registerDomain("pr_pipeline", createHttpCollector(`${base}/api/pr-pipeline`), 120_000); // 2min
 
-    console.log("[domain-discovery] Registered local domains: flow, services, agent_health, security (60s)");
+    console.log("[domain-discovery] Registered local domains: flow, services, agent_health, security, ci, pr_pipeline");
   }
 }

--- a/src/plugins/skill-broker-plugin.ts
+++ b/src/plugins/skill-broker-plugin.ts
@@ -16,6 +16,7 @@ import { parse as parseYaml } from "yaml";
 import type { Plugin, EventBus } from "../../lib/types.ts";
 import type { ExecutorRegistry } from "../executor/executor-registry.ts";
 import { A2AExecutor } from "../executor/executors/a2a-executor.ts";
+import { resolveEnvVars } from "../utils/env-interpolation.ts";
 
 interface AgentSkill {
   name: string;
@@ -48,7 +49,7 @@ export class SkillBrokerPlugin implements Plugin {
     for (const agent of agents) {
       const executor = new A2AExecutor({
         name: agent.name,
-        url: agent.url,
+        url: resolveEnvVars(agent.url, "skill-broker"),
         apiKeyEnv: agent.apiKeyEnv,
       });
 

--- a/src/utils/env-interpolation.ts
+++ b/src/utils/env-interpolation.ts
@@ -1,0 +1,14 @@
+/**
+ * Interpolate ${ENV_VAR} placeholders in a string.
+ * Unresolved variables are left as-is and a warning is emitted.
+ */
+export function resolveEnvVars(str: string, context?: string): string {
+  return str.replace(/\$\{([^}]+)\}/g, (match, name: string) => {
+    const val = process.env[name];
+    if (val === undefined) {
+      console.warn(`[${context ?? "env"}] Unresolved env var: \${${name}}`);
+      return match;
+    }
+    return val;
+  });
+}

--- a/src/world/domain-discovery.ts
+++ b/src/world/domain-discovery.ts
@@ -1,22 +1,22 @@
 /**
- * Domain discovery — reads projects.yaml and loads per-project domain/goal/action configs.
+ * Domain discovery — loads domain and action configs from two sources:
  *
- * For each project entry that has a projectPath, this module looks for:
- *   {projectPath}/workspace/domains.yaml   — HTTP domain registrations
- *   {projectPath}/workspace/actions.yaml   — action definitions
+ *   1. workspace/domains.yaml          — global domains (external app integrations)
+ *   2. {projectPath}/workspace/domains.yaml — per-project domains
+ *   3. {projectPath}/workspace/actions.yaml — per-project actions
  *
- * Domain URLs support ${ENV_VAR} interpolation so that domains.yaml files can
- * avoid hardcoding hostnames:
+ * URL and header values support ${ENV_VAR} interpolation so YAML files can
+ * avoid hardcoding hostnames or secrets:
  *
  *   url: ${AVA_BASE_URL}/api/world/board   →  http://ava:3008/api/world/board
  *
- * NOTE: Discovery runs once at startup. Restart workstacean to pick up projects
- * added via onboard_project or manually edited projects.yaml entries.
+ * NOTE: Discovery runs once at startup. Restart workstacean to pick up changes.
  */
 
 import { readFileSync, existsSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { join, dirname, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
+import { resolveEnvVars } from "../utils/env-interpolation.ts";
 import type { WorldStateEngine } from "../../lib/plugins/world-state-engine.ts";
 import { createHttpCollector } from "../../lib/plugins/world-state-engine.ts";
 import type { ActionRegistry } from "../planner/action-registry.ts";
@@ -75,19 +75,14 @@ export interface DiscoveryResult {
   errors: string[];
 }
 
-/**
- * Interpolate ${ENV_VAR} placeholders in a URL string.
- * Unresolved variables are left as-is and a console.warn is emitted.
- */
-function resolveUrl(url: string): string {
-  return url.replace(/\$\{([^}]+)\}/g, (match, name: string) => {
-    const val = process.env[name];
-    if (val === undefined) {
-      console.warn(`[domain-discovery] Unresolved env var in URL: \${${name}} — set ${name} in your environment`);
-      return match; // leave unresolved so the error surfaces at poll time, not silently
-    }
-    return val;
-  });
+/** Resolve ${ENV_VAR} in all header values. */
+function resolveHeaders(
+  headers?: Record<string, string>,
+): Record<string, string> | undefined {
+  if (!headers) return undefined;
+  return Object.fromEntries(
+    Object.entries(headers).map(([k, v]) => [k, resolveEnvVars(v, "domain-discovery")]),
+  );
 }
 
 /**
@@ -99,6 +94,10 @@ export function discoverAndRegister(
   actionRegistry: ActionRegistry,
 ): DiscoveryResult {
   const result: DiscoveryResult = { domainsRegistered: [], actionsLoaded: 0, errors: [] };
+
+  // ── Load global workspace/domains.yaml (external app integrations) ─────────
+  const workspaceDir = dirname(projectsYamlPath);
+  _loadDomainsYaml(join(workspaceDir, "domains.yaml"), "global", engine, result);
 
   if (!existsSync(projectsYamlPath)) {
     return result;
@@ -114,8 +113,7 @@ export function discoverAndRegister(
     return result;
   }
 
-  // Deduplicate by projectPath — projects.yaml can have duplicate slugs (e.g. after
-  // re-onboarding). Use the first occurrence.
+  // Deduplicate by projectPath
   const seen = new Set<string>();
 
   for (const project of projects) {
@@ -126,30 +124,8 @@ export function discoverAndRegister(
 
     const slug = project.slug ?? projectPath;
 
-    // Load domains
-    const domainsPath = join(projectPath, "workspace", "domains.yaml");
-    if (existsSync(domainsPath)) {
-      try {
-        const raw = readFileSync(domainsPath, "utf8");
-        const parsed = parseYaml(raw) as DomainsYaml;
-        for (const domain of parsed.domains ?? []) {
-          if (!domain.name || !domain.url || !domain.tickMs) {
-            result.errors.push(`[${slug}] Invalid domain entry (missing name, url, or tickMs)`);
-            continue;
-          }
-          const resolvedUrl = resolveUrl(domain.url);
-          const collector = createHttpCollector(resolvedUrl, {
-            timeoutMs: domain.timeoutMs,
-            headers: domain.headers,
-          });
-          engine.registerDomain(domain.name, collector, domain.tickMs);
-          result.domainsRegistered.push(domain.name);
-        }
-        console.log(`[domain-discovery] ${slug}: registered ${parsed.domains?.length ?? 0} domain(s)`);
-      } catch (err) {
-        result.errors.push(`[${slug}] Failed to load domains.yaml: ${(err as Error).message}`);
-      }
-    }
+    // Load per-project domains
+    _loadDomainsYaml(join(projectPath, "workspace", "domains.yaml"), slug, engine, result);
 
     // Load actions
     const actionsPath = join(projectPath, "workspace", "actions.yaml");
@@ -200,4 +176,37 @@ export function discoverAndRegister(
   }
 
   return result;
+}
+
+// ── Shared domain loader ──────────────────────────────────────────────────────
+
+function _loadDomainsYaml(
+  path: string,
+  label: string,
+  engine: WorldStateEngine,
+  result: DiscoveryResult,
+): void {
+  if (!existsSync(path)) return;
+  try {
+    const raw = readFileSync(path, "utf8");
+    const parsed = parseYaml(raw) as DomainsYaml;
+    let count = 0;
+    for (const domain of parsed.domains ?? []) {
+      if (!domain.name || !domain.url) {
+        result.errors.push(`[${label}] Invalid domain entry (missing name or url)`);
+        continue;
+      }
+      const resolvedUrl = resolveEnvVars(domain.url, "domain-discovery");
+      const collector = createHttpCollector(resolvedUrl, {
+        timeoutMs: domain.timeoutMs,
+        headers: resolveHeaders(domain.headers),
+      });
+      engine.registerDomain(domain.name, collector, domain.tickMs ?? 60_000);
+      result.domainsRegistered.push(domain.name);
+      count++;
+    }
+    if (count > 0) console.log(`[domain-discovery] ${label}: registered ${count} domain(s)`);
+  } catch (err) {
+    result.errors.push(`[${label}] Failed to load domains.yaml: ${(err as Error).message}`);
+  }
 }

--- a/workspace/actions.yaml
+++ b/workspace/actions.yaml
@@ -115,3 +115,140 @@ actions:
     meta:
       topic: "message.outbound.discord.alert"
       fireAndForget: true
+
+  # ── Service + Agent Ceremonies ─────────────────────────────────────
+
+  - id: ceremony.service_health_discord
+    goalId: services.discord_connected
+    tier: tier_0
+    priority: 80
+    cost: 1
+    name: "Trigger service health ceremony for Discord disconnect"
+    preconditions:
+      - path: "extensions.services_available"
+        operator: eq
+        value: true
+      - path: "domains.services.data.discord.configured"
+        operator: eq
+        value: true
+      - path: "domains.services.data.discord.connected"
+        operator: eq
+        value: false
+    effects: []
+    meta:
+      topic: "ceremony.service-health.execute"
+      fireAndForget: true
+
+  # ── CI + PR Pipeline ─────────────────────────────────────────────
+
+  - id: alert.ci_failures
+    goalId: ci.success_rate_healthy
+    tier: tier_0
+    priority: 30
+    cost: 0
+    name: "Alert on CI failure rate"
+    preconditions:
+      - path: "extensions.ci_available"
+        operator: eq
+        value: true
+      - path: "domains.ci.data.successRate"
+        operator: lt
+        value: 0.70
+    effects: []
+    meta:
+      topic: "message.outbound.discord.alert"
+      fireAndForget: true
+
+  - id: alert.pr_conflicts
+    goalId: pr.no_conflicts
+    tier: tier_0
+    priority: 20
+    cost: 0
+    name: "Alert on PRs with merge conflicts"
+    preconditions:
+      - path: "extensions.pr_pipeline_available"
+        operator: eq
+        value: true
+      - path: "domains.pr_pipeline.data.conflicting"
+        operator: gt
+        value: 0
+    effects: []
+    meta:
+      topic: "message.outbound.discord.alert"
+      fireAndForget: true
+
+  - id: alert.pr_stale
+    goalId: pr.no_stale
+    tier: tier_0
+    priority: 10
+    cost: 0
+    name: "Alert on stale PRs"
+    preconditions:
+      - path: "extensions.pr_pipeline_available"
+        operator: eq
+        value: true
+      - path: "domains.pr_pipeline.data.stale"
+        operator: gt
+        value: 0
+    effects: []
+    meta:
+      topic: "message.outbound.discord.alert"
+      fireAndForget: true
+
+  # ── Ava / protoMaker Studio ───────────────────────────────────────
+
+  - id: alert.ava_board_blocked
+    goalId: ava.board_healthy
+    tier: tier_0
+    priority: 10
+    cost: 0
+    name: "Alert on excessive blocked features"
+    preconditions:
+      - path: "extensions.ava_board_available"
+        operator: eq
+        value: true
+      - path: "domains.ava_board.data.blocked_count"
+        operator: gt
+        value: 3
+    effects: []
+    meta:
+      topic: "message.outbound.discord.alert"
+      fireAndForget: true
+
+  - id: action.ava_triage_blocked
+    goalId: ava.board_healthy
+    tier: tier_0
+    priority: 20
+    cost: 1
+    name: "Dispatch board health triage to Ava"
+    preconditions:
+      - path: "extensions.ava_board_available"
+        operator: eq
+        value: true
+      - path: "domains.ava_board.data.blocked_count"
+        operator: gt
+        value: 3
+    effects: []
+    meta:
+      topic: "agent.skill.request"
+      skillHint: board_health
+      agentId: ava
+      fireAndForget: true
+
+  - id: alert.ava_auto_mode_off
+    goalId: ava.auto_mode_active
+    tier: tier_0
+    priority: 10
+    cost: 0
+    name: "Alert when auto-mode is disabled"
+    preconditions:
+      - path: "extensions.ava_pipeline_available"
+        operator: eq
+        value: true
+      - path: "domains.ava_pipeline.data.auto_mode"
+        operator: eq
+        value: false
+    effects: []
+    meta:
+      topic: "message.outbound.discord.alert"
+      fireAndForget: true

--- a/workspace/agents.yaml
+++ b/workspace/agents.yaml
@@ -1,0 +1,19 @@
+# A2A Agent Registry — external agents reachable via JSON-RPC 2.0
+# SkillBrokerPlugin registers one A2AExecutor per agent.
+# URL values support ${ENV_VAR} interpolation.
+
+agents:
+  - name: ava
+    url: "${AVA_BASE_URL}/a2a"
+    apiKeyEnv: AVA_API_KEY
+    skills:
+      - name: sitrep
+        description: Situation report — board state, running agents, escalations
+      - name: board_health
+        description: Triage blocked features and board health issues
+      - name: auto_mode
+        description: Start or stop autonomous feature processing
+      - name: manage_feature
+        description: Manage feature lifecycle (unblock, assign, status change)
+      - name: bug_triage
+        description: Triage a bug and file it on the board

--- a/workspace/agents/quinn.yaml
+++ b/workspace/agents/quinn.yaml
@@ -27,6 +27,8 @@ tools:
   - publish_event
   - get_world_state
   - get_projects
+  - get_ci_health
+  - get_pr_pipeline
   - get_incidents
   - report_incident
   - get_outcomes

--- a/workspace/ceremonies/agent-health.yaml
+++ b/workspace/ceremonies/agent-health.yaml
@@ -1,0 +1,12 @@
+id: agent-health
+name: "Agent Health Check"
+description: >
+  Triggered by world engine when no agents are registered (agentCount drops to 0).
+  Calls get_world_state to confirm the failure, posts a structured alert with
+  remediation steps, and logs if Discord is unreachable.
+schedule: "*/15 * * * *"
+skill: health_check
+targets:
+  - all
+notifyChannel: ""
+enabled: true

--- a/workspace/ceremonies/service-health.yaml
+++ b/workspace/ceremonies/service-health.yaml
@@ -1,0 +1,13 @@
+id: service-health
+name: "Service Health Recovery"
+description: >
+  Triggered by world engine when a critical service (Discord bot or LLM gateway)
+  becomes unavailable. Calls get_world_state to confirm the failure, posts a
+  structured alert to the Discord alerts channel with remediation steps, and
+  falls back to logging if Discord itself is unreachable.
+schedule: "0 */4 * * *"
+skill: health_check
+targets:
+  - all
+notifyChannel: ""
+enabled: true

--- a/workspace/discord.yaml
+++ b/workspace/discord.yaml
@@ -1,0 +1,39 @@
+# ── Channel IDs ───────────────────────────────────────────────────────────────
+channels:
+  # Default channel for cron-triggered posts (daily digest, etc.)
+  # Falls back to DISCORD_DIGEST_CHANNEL env var if blank.
+  digest: ""
+  # Channel for new member welcome messages. Leave blank to disable.
+  welcome: ""
+  # Channel for moderation log. Leave blank to disable.
+  modLog: ""
+
+# ── Moderation ────────────────────────────────────────────────────────────────
+moderation:
+  rateLimit:
+    maxMessages: 5
+    windowSeconds: 10
+  spamPatterns: []
+
+# ── Slash Commands ────────────────────────────────────────────────────────────
+# Autocomplete commands use top-level `options` (no subcommands).
+# Regular commands use `subcommands`.
+commands:
+  - name: report-bug
+    description: Report a bug against a project
+    # Top-level options — renders as a single command with autocomplete project picker.
+    # The `project` option value (slug) is resolved against projects.yaml to derive
+    # devChannelId (discord.dev) and projectRepo (github field) at dispatch time.
+    options:
+      - name: project
+        description: Project to report against (start typing to filter)
+        type: string
+        required: true
+        autocomplete: true
+      - name: description
+        description: Brief description of the bug
+        type: string
+        required: true
+    content: "Bug report for {project}: {description}"
+    skillHint: bug_triage
+    # admins: ["123456789"] — restrict if needed

--- a/workspace/domains.yaml
+++ b/workspace/domains.yaml
@@ -1,0 +1,25 @@
+# World Engine Domains — Global
+# Polled by WorldStateEngine on the configured interval.
+# Each domain becomes `domains.<name>` in world state.
+# URL and header values support ${ENV_VAR} interpolation.
+#
+# To integrate a new external app:
+#   1. Add domain entries here (polling endpoints)
+#   2. Add agent entry in agents.yaml (A2A skills)
+#   3. Add goals in goals.yaml (what "healthy" means)
+#   4. Add actions in actions.yaml (what to do when unhealthy)
+#   5. Set env vars (APP_BASE_URL, APP_API_KEY)
+
+domains:
+  # ── Ava (protoMaker Studio) ────────────────────────────────────────
+  - name: ava_board
+    url: "${AVA_BASE_URL}/api/world/board"
+    tickMs: 60000
+    headers:
+      X-API-Key: "${AVA_API_KEY}"
+
+  - name: ava_pipeline
+    url: "${AVA_BASE_URL}/api/world/agent-health"
+    tickMs: 60000
+    headers:
+      X-API-Key: "${AVA_API_KEY}"

--- a/workspace/goals.yaml
+++ b/workspace/goals.yaml
@@ -43,3 +43,40 @@ goals:
     selector: "domains.agent_health.data.agentCount"
     min: 1
     description: "At least one agent must be registered"
+
+  # ── CI + PR Pipeline ─────────────────────────────────────────────
+  - id: ci.success_rate_healthy
+    type: Threshold
+    severity: high
+    selector: "domains.ci.data.successRate"
+    min: 0.70
+    description: "CI success rate across all projects must stay >= 70%"
+
+  - id: pr.no_conflicts
+    type: Threshold
+    severity: medium
+    selector: "domains.pr_pipeline.data.conflicting"
+    max: 0
+    description: "No open PRs should have merge conflicts"
+
+  - id: pr.no_stale
+    type: Threshold
+    severity: medium
+    selector: "domains.pr_pipeline.data.stale"
+    max: 0
+    description: "No PRs should be stale (>7 days without activity)"
+
+  # ── Ava / protoMaker Studio ──────────────────────────────────────
+  - id: ava.board_healthy
+    type: Threshold
+    severity: high
+    selector: "domains.ava_board.data.blocked_count"
+    max: 3
+    description: "No more than 3 features blocked simultaneously"
+
+  - id: ava.auto_mode_active
+    type: Invariant
+    severity: medium
+    selector: "domains.ava_pipeline.data.auto_mode"
+    operator: truthy
+    description: "Auto-mode should be running when backlog has work"

--- a/workspace/google.yaml
+++ b/workspace/google.yaml
@@ -1,0 +1,17 @@
+drive:
+  orgFolderId: ""       # root org Drive folder — shared across all projects
+  templateFolderId: ""  # per-project folder template (optional)
+
+calendar:
+  orgCalendarId: ""             # shared org calendar for milestones/deadlines
+  pollIntervalMinutes: 60       # how often to check for upcoming events
+
+gmail:
+  watchLabels: []               # Gmail labels to monitor for inbound routing
+  pollIntervalMinutes: 5        # how often to poll for new messages
+  routingRules: []              # label → skillHint mappings
+  # routingRules example:
+  # - label: "bug-report"
+  #   skillHint: bug_triage
+  # - label: "gtm-request"
+  #   skillHint: content_strategy

--- a/workspace/projects.yaml
+++ b/workspace/projects.yaml
@@ -9,6 +9,13 @@ projects:
     defaultBranch: master
     status: active
     agents: [quinn]
+    discord:
+      dev:
+        channelId: "1490978896911405208"
+        webhook: "https://discord.com/api/webhooks/1491952333087834243/dyUlVYCTsAuFmTVrtNqQU-oUoBryijeV2cJ84OgiPenz8C9yNl4O-2MBFSJeJngJrCZZ"
+      release:
+        channelId: "1490978898568286329"
+        webhook: "https://discord.com/api/webhooks/1491952337567088731/HkkPa15mSNo5-NqUe4PjOQyviA1aPkjlsH36gtZrsb8lWLP3Mp-5iSZfAFeuquWe7vnZ"
 
   - slug: protomaker
     title: protoMaker
@@ -19,6 +26,13 @@ projects:
     defaultBranch: main
     status: active
     agents: [quinn]
+    discord:
+      dev:
+        channelId: "1469080556720623699"
+        webhook: "https://discord.com/api/webhooks/1491952339295277126/HuCK8CIePPDBiSg4RZgfF5cxeJDv4f334KKjqXyMo_9MEHIPXC03fUAunZZj8RuBNvuX"
+      release:
+        channelId: "1490893509337550859"
+        webhook: "https://discord.com/api/webhooks/1491952340796965005/NW3ZtY14kcF8NPYSHBNsiPEFPmu0-DawIXPakk5bUF7nd_YrLPjHbBqxGzorVSdmaXYf"
 
   - slug: protocli
     title: protoCLI
@@ -29,6 +43,13 @@ projects:
     defaultBranch: main
     status: active
     agents: [quinn]
+    discord:
+      dev:
+        channelId: "1490974556306014290"
+        webhook: "https://discord.com/api/webhooks/1491952343196111049/5bycseg2ED3feT22X_3ezY35Y81ZrjsGod101huZpjKNRHNRVFV-Y0j0_k5OhEA3QS8S"
+      release:
+        channelId: "1490974557920563312"
+        webhook: "https://discord.com/api/webhooks/1491952344529637546/vb278du2TSW_RvkpwOH5UHcS9d3UCJ5nMDtnj5A92bCG3piTa3o7AQk8GDqForiwZ74O"
 
   - slug: mythxengine
     title: mythxengine
@@ -39,6 +60,13 @@ projects:
     defaultBranch: main
     status: active
     agents: [quinn]
+    discord:
+      dev:
+        channelId: "1490978905371312179"
+        webhook: "https://discord.com/api/webhooks/1491952345528144005/2oDZenUiQnz2VhEIDEeNxTRPj3zzhokCY_KR0rtg-K2PHZ_fwcyD2NaBZVyxtTSVlMYg"
+      release:
+        channelId: "1490978906419761262"
+        webhook: "https://discord.com/api/webhooks/1491952347100876852/9DpUPDSRurXL18af1caqJY2oc8wflQ6j3xR0Gk9V8udeQWyewGFR-DUmyDLa7NEvM_iF"
 
   - slug: rabbit-hole-io
     title: rabbit-hole-io
@@ -49,3 +77,10 @@ projects:
     defaultBranch: main
     status: active
     agents: [quinn]
+    discord:
+      dev:
+        channelId: "1490978889596539093"
+        webhook: "https://discord.com/api/webhooks/1491952348451438624/oYmn561NtTU83ZU6nW2UfdPq7Q-Wft_sVM-KLUYWqyfLsbAAi8WlgN1MvJm8CbhiXAiv"
+      release:
+        channelId: "1490978891207282718"
+        webhook: "https://discord.com/api/webhooks/1491952349604872202/QOR15cx1UvzhrzluB5DrZiWv6zikuGFOixPtIuMUmaqO0rWk5tSdZe-zGgzJTMitFkiB"


### PR DESCRIPTION
## Summary

Build the /projects page showing registered projects from /api/projects, CI health from /api/ci-health, and PR pipeline from /api/pr-pipeline. Project cards with slug, title, GitHub link, agents. Per-project CI: success rate bar, total/failed runs, latest conclusion. Per-project PRs: open count, conflicting/stale/failing badges, expandable PR list. Aggregate CI summary at top. Poll every 60s.

Files to create:
- dashboard/src/components/ProjectsView.tsx — Preact island, merges data by repo
- das...

---
*Recovered automatically by Automaker post-agent hook*