### PR TITLE
fix: event-viewer serves Astro directory-based routes

### DIFF
--- a/lib/plugins/event-viewer.ts
+++ b/lib/plugins/event-viewer.ts
@@ -160,31 +160,52 @@ export class EventViewerPlugin implements Plugin {
   }
 
   private async serveStatic(pathname: string): Promise<Response> {
-    if (pathname === "/" || pathname === "/index.html")
+    if (pathname === "/" || pathname === "/index.html") {
       return this.serveFile("index.html", "text/html");
+    }
 
-    const safePath = pathname.replace(/\.\./g, "");
-    const ext = safePath.split(".").pop()?.toLowerCase() || "";
+    // Strip leading slash and any path-traversal attempts
+    const safePath = pathname.replace(/^\/+/, "").replace(/\.\./g, "");
+
+    // MIME map for recognised extensions
     const mimes: Record<string, string> = {
+      html: "text/html",
       css: "text/css",
       js: "application/javascript",
       svg: "image/svg+xml",
       png: "image/png",
       ico: "image/x-icon",
+      json: "application/json",
+      woff: "font/woff",
+      woff2: "font/woff2",
     };
+
+    // If the path has an extension, try it directly
+    const ext = safePath.split(".").pop()?.toLowerCase() || "";
+    if (ext && mimes[ext]) {
+      return this.serveFile(safePath, mimes[ext]);
+    }
+
+    // Astro builds directory-based routes: /world-state → dist/world-state/index.html
+    const directResp = await this.serveFile(`${safePath}/index.html`, "text/html");
+    if (directResp.status !== 404) return directResp;
+
+    // Fallback: try the raw path (for extensionless assets)
     return this.serveFile(safePath, mimes[ext] || "application/octet-stream");
   }
 
   private async serveFile(path: string, contentType: string): Promise<Response> {
     try {
       const resolved = resolve(this.viewerDir, path);
+      const viewerRoot = resolve(this.viewerDir);
       // Path traversal guard: resolved path must stay within viewerDir
-      if (!resolved.startsWith(resolve(this.viewerDir))) {
+      if (!resolved.startsWith(viewerRoot)) {
         return new Response("Forbidden", { status: 403 });
       }
       const file = Bun.file(resolved);
-      if (await file.exists())
+      if (await file.exists()) {
         return new Response(file, { headers: { "Content-Type": contentType } });
+      }
     } catch {}
     return new Response("Not found", { status: 404 });
   }


### PR DESCRIPTION
## Summary

Fixes a regression from v0.6.0 where all dashboard pages except `/` returned 403/404.

### Root cause
The `event-viewer` plugin's `serveStatic()` had two bugs for Astro's directory-based static output:

1. **Leading slash in pathname** was passed through to `resolve()`, producing a resolved path that failed the path-traversal guard → **403 Forbidden**
2. **Extensionless paths** weren't checked for `<path>/index.html` (Astro's default dir layout) → couldn't find `dist/world-state/index.html` when requested as `/world-state`

### Verified live
All 5 dashboard pages now return HTTP 200:
- `/` → 200
- `/world-state` → 200 (was 403)
- `/events` → 200 (was 403)
- `/goals` → 200 (was 403)
- `/projects` → 200 (was 403)

## Test plan
- [x] `bun test` — 626 pass, 0 fail
- [x] Live verification on deployed container

🤖 Generated with [Claude Code](https://claude.com/claude-code)