### PR TITLE
fix: dashboard envelope unwrap, caching, Overview shape bugs, Events sticky header

### DIFF
--- a/dashboard/src/components/EventStream.tsx
+++ b/dashboard/src/components/EventStream.tsx
@@ -129,15 +129,60 @@ export default function EventStream() {
   return (
     <>
       <style>{`
+        .es-root {
+          display: flex;
+          flex-direction: column;
+          /* Fill the main-content area (which has its own overflow) */
+          min-height: calc(100vh - var(--header-height) - 48px);
+          margin: -24px;
+        }
+        .es-sticky {
+          position: sticky;
+          top: -24px;
+          z-index: 10;
+          background: linear-gradient(180deg, #161b22 0%, #12161d 100%);
+          border-bottom: 1px solid #30363d;
+          box-shadow: 0 4px 12px -8px rgba(0, 0, 0, 0.5);
+          backdrop-filter: blur(8px);
+        }
         .es-header {
           display: flex;
           align-items: center;
           gap: 12px;
-          background: #161b22;
-          border-bottom: 1px solid #30363d;
-          padding: 10px 16px;
-          flex-shrink: 0;
+          padding: 12px 20px 10px 20px;
           flex-wrap: wrap;
+          position: relative;
+        }
+        .es-header::before {
+          content: "";
+          position: absolute;
+          left: 20px;
+          top: 0;
+          width: 3px;
+          height: 100%;
+          background: linear-gradient(180deg, #58a6ff 0%, #1f6feb 100%);
+          border-radius: 0 0 2px 2px;
+          opacity: 0.8;
+        }
+        .es-header-title {
+          font-size: 13px;
+          font-weight: 600;
+          color: #c9d1d9;
+          letter-spacing: 0.3px;
+          text-transform: uppercase;
+          display: flex;
+          align-items: center;
+          gap: 8px;
+        }
+        .es-header-title::before {
+          content: "◉";
+          color: #58a6ff;
+          font-size: 14px;
+          animation: es-pulse-dot 2s ease-in-out infinite;
+        }
+        @keyframes es-pulse-dot {
+          0%, 100% { opacity: 0.4; transform: scale(1); }
+          50% { opacity: 1; transform: scale(1.1); }
         }
         .es-tabs {
           display: flex;
@@ -145,9 +190,10 @@ export default function EventStream() {
           background: #0d1117;
           border-radius: 6px;
           padding: 2px;
+          border: 1px solid #21262d;
         }
         .es-tab {
-          padding: 4px 14px;
+          padding: 5px 16px;
           font-size: 12px;
           border-radius: 4px;
           cursor: pointer;
@@ -155,10 +201,15 @@ export default function EventStream() {
           border: none;
           background: transparent;
           font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
+          font-weight: 500;
           transition: all 0.15s;
         }
         .es-tab:hover { color: #c9d1d9; }
-        .es-tab.active { background: #21262d; color: #c9d1d9; }
+        .es-tab.active {
+          background: #21262d;
+          color: #c9d1d9;
+          box-shadow: 0 0 0 1px rgba(88, 166, 255, 0.2);
+        }
 
         .status-dot {
           width: 8px;
@@ -168,7 +219,10 @@ export default function EventStream() {
           transition: background 0.2s;
           flex-shrink: 0;
         }
-        .status-dot.connected { background: #3fb950; }
+        .status-dot.connected {
+          background: #3fb950;
+          box-shadow: 0 0 6px rgba(63, 185, 80, 0.6);
+        }
         .status-dot.connecting { background: #d29922; animation: es-pulse 1s infinite; }
         @keyframes es-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
 
@@ -182,23 +236,23 @@ export default function EventStream() {
           background: #21262d;
           color: #c9d1d9;
           font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
+          border: 1px solid #30363d;
         }
         .es-badge {
           font-size: 11px;
           background: #30363d;
-          padding: 2px 8px;
+          padding: 3px 10px;
           border-radius: 10px;
-          color: #8b949e;
+          color: #c9d1d9;
           font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
+          font-weight: 500;
+          margin-left: auto;
         }
         .es-toolbar {
-          background: #161b22;
-          border-bottom: 1px solid #30363d;
-          padding: 8px 16px;
+          padding: 8px 20px 12px 20px;
           display: flex;
           gap: 8px;
           align-items: center;
-          flex-shrink: 0;
           flex-wrap: wrap;
         }
         .es-filter {
@@ -383,78 +437,83 @@ export default function EventStream() {
         }
       `}</style>
 
-      <div class="es-header">
-        <div class="es-tabs">
-          <button
-            class={`es-tab${activeTab === "events" ? " active" : ""}`}
-            onClick={() => { setActiveTab("events"); setExpandedId(null); }}
-          >
-            Events
-          </button>
-          <button
-            class={`es-tab${activeTab === "logs" ? " active" : ""}`}
-            onClick={() => { setActiveTab("logs"); setExpandedId(null); }}
-          >
-            Logs
-          </button>
-        </div>
-        <div class="es-status">
-          <span class={dotClass} />
-          {statusLabel}
-        </div>
-        <div class="es-badge">
-          {filtered.length} {activeTab === "events" ? "events" : "logs"}
-        </div>
-      </div>
-
-      <div class="es-toolbar">
-        <input
-          class="es-filter"
-          type="text"
-          placeholder={activeTab === "events" ? "Filter by topic (e.g. agent.*)" : "Filter by topic (e.g. debug.*)"}
-          value={filter}
-          onInput={(e) => setFilter((e.target as HTMLInputElement).value)}
-        />
-        <button class="es-btn" onClick={clearActive}>Clear</button>
-        <button
-          class={`es-btn${isPaused ? " paused" : ""}`}
-          onClick={() => setIsPaused((p) => !p)}
-        >
-          {isPaused ? "Resume" : "Pause"}
-        </button>
-        <button
-          class={`es-btn${autoScroll ? " active" : ""}`}
-          onClick={() => setAutoScroll((a) => !a)}
-          title="Toggle auto-scroll"
-        >
-          Auto-scroll
-        </button>
-      </div>
-
-      <div class="es-list" ref={listRef} onScroll={handleScroll}>
-        {filtered.length === 0 ? (
-          <div class="es-empty">
-            <p>{items.length === 0 ? "Waiting for events…" : "No matches for current filter"}</p>
+      <div class="es-root">
+        <div class="es-sticky">
+          <div class="es-header">
+            <div class="es-header-title">Event Stream</div>
+            <div class="es-tabs">
+              <button
+                class={`es-tab${activeTab === "events" ? " active" : ""}`}
+                onClick={() => { setActiveTab("events"); setExpandedId(null); }}
+              >
+                Events
+              </button>
+              <button
+                class={`es-tab${activeTab === "logs" ? " active" : ""}`}
+                onClick={() => { setActiveTab("logs"); setExpandedId(null); }}
+              >
+                Logs
+              </button>
+            </div>
+            <div class="es-status">
+              <span class={dotClass} />
+              {statusLabel}
+            </div>
+            <div class="es-badge">
+              {filtered.length} {activeTab === "events" ? "events" : "logs"}
+            </div>
           </div>
-        ) : (
-          filtered.map((msg) =>
-            activeTab === "events" ? (
-              <EventRow
-                key={msg.id ?? msg.timestamp}
-                msg={msg}
-                isExpanded={expandedId === (msg.id ?? msg.timestamp)}
-                onClick={() => toggleExpanded(msg.id ?? msg.timestamp)}
-              />
-            ) : (
-              <LogRow
-                key={msg.id ?? msg.timestamp}
-                msg={msg}
-                isExpanded={expandedId === (msg.id ?? msg.timestamp)}
-                onClick={() => toggleExpanded(msg.id ?? msg.timestamp)}
-              />
+
+          <div class="es-toolbar">
+            <input
+              class="es-filter"
+              type="text"
+              placeholder={activeTab === "events" ? "Filter by topic (e.g. agent.*)" : "Filter by topic (e.g. debug.*)"}
+              value={filter}
+              onInput={(e) => setFilter((e.target as HTMLInputElement).value)}
+            />
+            <button class="es-btn" onClick={clearActive}>Clear</button>
+            <button
+              class={`es-btn${isPaused ? " paused" : ""}`}
+              onClick={() => setIsPaused((p) => !p)}
+            >
+              {isPaused ? "Resume" : "Pause"}
+            </button>
+            <button
+              class={`es-btn${autoScroll ? " active" : ""}`}
+              onClick={() => setAutoScroll((a) => !a)}
+              title="Toggle auto-scroll"
+            >
+              Auto-scroll
+            </button>
+          </div>
+        </div>
+
+        <div class="es-list" ref={listRef} onScroll={handleScroll}>
+          {filtered.length === 0 ? (
+            <div class="es-empty">
+              <p>{items.length === 0 ? "Waiting for events…" : "No matches for current filter"}</p>
+            </div>
+          ) : (
+            filtered.map((msg) =>
+              activeTab === "events" ? (
+                <EventRow
+                  key={msg.id ?? msg.timestamp}
+                  msg={msg}
+                  isExpanded={expandedId === (msg.id ?? msg.timestamp)}
+                  onClick={() => toggleExpanded(msg.id ?? msg.timestamp)}
+                />
+              ) : (
+                <LogRow
+                  key={msg.id ?? msg.timestamp}
+                  msg={msg}
+                  isExpanded={expandedId === (msg.id ?? msg.timestamp)}
+                  onClick={() => toggleExpanded(msg.id ?? msg.timestamp)}
+                />
+              )
             )
-          )
-        )}
+          )}
+        </div>
       </div>
     </>
   );

--- a/dashboard/src/components/GoalStatus.tsx
+++ b/dashboard/src/components/GoalStatus.tsx
@@ -2,18 +2,9 @@ import { useState, useEffect } from "preact/hooks";
 import GoalCard from "./GoalCard.tsx";
 import { evaluateGoal } from "../lib/goal-evaluator.ts";
 import type { Goal, EvalResult } from "../lib/goal-evaluator.ts";
+import { getGoals, getWorldState, peek, type WorldStateResponse } from "../lib/api";
 
 const POLL_INTERVAL_MS = 30_000;
-
-interface GoalsApiResponse {
-  success: boolean;
-  data: Goal[];
-}
-
-interface WorldStateApiResponse {
-  success: boolean;
-  data: unknown;
-}
 
 interface GoalWithResult {
   goal: Goal;
@@ -21,26 +12,29 @@ interface GoalWithResult {
 }
 
 export default function GoalStatus() {
-  const [items, setItems] = useState<GoalWithResult[]>([]);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  // Seed from cache for instant render on revisit
+  const cachedGoals = peek<Goal[]>("/api/goals");
+  const cachedWs = peek<WorldStateResponse>("/api/world-state");
+  const seeded: GoalWithResult[] =
+    cachedGoals && cachedWs
+      ? (cachedGoals as Goal[]).map((g) => ({ goal: g, result: evaluateGoal(g, cachedWs) }))
+      : [];
 
-  async function fetchAndEvaluate() {
+  const [items, setItems] = useState<GoalWithResult[]>(seeded);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(seeded.length === 0);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(
+    seeded.length > 0 ? new Date() : null,
+  );
+
+  async function fetchAndEvaluate(force = false) {
     try {
-      const [goalsRes, wsRes] = await Promise.all([
-        fetch("/api/goals"),
-        fetch("/api/world-state"),
+      const [goalsData, worldState] = await Promise.all([
+        getGoals(),
+        getWorldState(force),
       ]);
 
-      if (!goalsRes.ok) throw new Error(`/api/goals: ${goalsRes.status}`);
-      if (!wsRes.ok) throw new Error(`/api/world-state: ${wsRes.status}`);
-
-      const goalsJson = (await goalsRes.json()) as GoalsApiResponse;
-      const wsJson = (await wsRes.json()) as WorldStateApiResponse;
-
-      const goals: Goal[] = Array.isArray(goalsJson.data) ? goalsJson.data : [];
-      const worldState = wsJson.data ?? null;
+      const goals: Goal[] = Array.isArray(goalsData) ? (goalsData as Goal[]) : [];
 
       const evaluated: GoalWithResult[] = goals.map((goal) => ({
         goal,
@@ -64,8 +58,8 @@ export default function GoalStatus() {
   }
 
   useEffect(() => {
-    fetchAndEvaluate();
-    const timer = setInterval(fetchAndEvaluate, POLL_INTERVAL_MS);
+    fetchAndEvaluate(true);
+    const timer = setInterval(() => fetchAndEvaluate(true), POLL_INTERVAL_MS);
     return () => clearInterval(timer);
   }, []);
 

--- a/dashboard/src/components/OutcomesTable.tsx
+++ b/dashboard/src/components/OutcomesTable.tsx
@@ -1,29 +1,10 @@
 import { useState, useEffect } from "preact/hooks";
+import { getOutcomes, peek, type OutcomesResponse } from "../lib/api";
 
 const POLL_INTERVAL_MS = 30_000;
 
-interface OutcomeSummary {
-  success: number;
-  failure: number;
-  timeout: number;
-  total: number;
-}
-
-interface OutcomeRecord {
-  correlationId: string;
-  actionId: string;
-  goalId: string;
-  status: "success" | "failure" | "timeout";
-  startedAt: number;
-  completedAt: number;
-  durationMs: number;
-  error?: string;
-}
-
-interface OutcomesApiResponse {
-  summary: OutcomeSummary;
-  recent: OutcomeRecord[];
-}
+type OutcomeSummary = OutcomesResponse["summary"];
+type OutcomeRecord = OutcomesResponse["recent"][number];
 
 function formatTimestamp(ms: number): string {
   return new Date(ms).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
@@ -42,17 +23,18 @@ const statusBadgeClass: Record<string, string> = {
 };
 
 export default function OutcomesTable() {
-  const [summary, setSummary] = useState<OutcomeSummary | null>(null);
-  const [recent, setRecent] = useState<OutcomeRecord[]>([]);
+  const cached = peek<OutcomesResponse>("/api/outcomes");
+  const [summary, setSummary] = useState<OutcomeSummary | null>(cached?.summary ?? null);
+  const [recent, setRecent] = useState<OutcomeRecord[]>(
+    cached?.recent ? cached.recent.slice().reverse() : [],
+  );
   const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [loading, setLoading] = useState(!cached);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(cached ? new Date() : null);
 
-  async function fetchOutcomes() {
+  async function fetchOutcomes(force = false) {
     try {
-      const res = await fetch("/api/outcomes");
-      if (!res.ok) throw new Error(`/api/outcomes: ${res.status}`);
-      const json = (await res.json()) as OutcomesApiResponse;
+      const json = await getOutcomes(force);
       setSummary(json.summary ?? { success: 0, failure: 0, timeout: 0, total: 0 });
       setRecent(Array.isArray(json.recent) ? json.recent.slice().reverse() : []);
       setError(null);
@@ -65,8 +47,8 @@ export default function OutcomesTable() {
   }
 
   useEffect(() => {
-    fetchOutcomes();
-    const timer = setInterval(fetchOutcomes, POLL_INTERVAL_MS);
+    fetchOutcomes(true);
+    const timer = setInterval(() => fetchOutcomes(true), POLL_INTERVAL_MS);
     return () => clearInterval(timer);
   }, []);
 

--- a/dashboard/src/components/OverviewGrid.tsx
+++ b/dashboard/src/components/OverviewGrid.tsx
@@ -1,4 +1,20 @@
 import { useState, useEffect } from "preact/hooks";
+import {
+  getServices,
+  getAgentHealth,
+  getCiHealth,
+  getPrPipeline,
+  getFlowMetrics,
+  getSecuritySummary,
+  getHitlPending,
+  peek,
+  type ServicesResponse,
+  type AgentHealthResponse,
+  type CiHealthResponse,
+  type PrPipelineResponse,
+  type FlowMetricsResponse,
+  type SecuritySummaryResponse,
+} from "../lib/api";
 
 type Status = "green" | "yellow" | "red" | "loading";
 
@@ -10,102 +26,157 @@ interface CardState {
 
 const POLL_INTERVAL = 30_000;
 
-function deriveServicesStatus(data: unknown): Pick<CardState, "metric" | "status"> {
-  if (!data || typeof data !== "object") return { metric: "Unknown", status: "loading" };
-  const entries = Object.values(data as Record<string, { status?: string }>);
-  if (entries.length === 0) return { metric: "No services", status: "yellow" };
-  const down = entries.filter((s) => s?.status === "down").length;
-  const degraded = entries.filter((s) => s?.status === "degraded").length;
-  if (down > 0) return { metric: `${down} down`, status: "red" };
-  if (degraded > 0) return { metric: `${degraded} degraded`, status: "yellow" };
-  return { metric: `${entries.length} healthy`, status: "green" };
+function deriveServicesStatus(data: ServicesResponse): Pick<CardState, "metric" | "status"> {
+  // Services response: { discord: { configured, connected }, github: { configured, ... }, ... }
+  const services = Object.entries(data).filter(([, v]) => v && typeof v === "object");
+  if (services.length === 0) return { metric: "No services", status: "yellow" };
+
+  const configured = services.filter(([, v]) => (v as { configured?: boolean }).configured);
+  const unhealthy = configured.filter(([name, v]) => {
+    // "connected" for Discord, "configured" is enough for the rest
+    if (name === "discord") return !(v as { connected?: boolean }).connected;
+    return false;
+  });
+
+  if (unhealthy.length > 0) {
+    return { metric: `${unhealthy.length} unhealthy`, status: "red" };
+  }
+  return { metric: `${configured.length} healthy`, status: "green" };
 }
 
-function deriveAgentHealthStatus(data: unknown): Pick<CardState, "metric" | "status"> {
-  if (!data || typeof data !== "object") return { metric: "Unknown", status: "loading" };
-  const agents = (data as { agents?: Array<{ status?: string }> }).agents ?? [];
-  if (agents.length === 0) return { metric: "None registered", status: "red" };
-  const active = agents.filter((a) => a?.status === "active" || a?.status === "idle" || a?.status === "registered").length;
-  const errored = agents.filter((a) => a?.status === "error").length;
-  if (errored === agents.length) return { metric: `${errored} errors`, status: "red" };
-  return { metric: `${active} / ${agents.length} online`, status: errored > 0 ? "yellow" : "green" };
+function deriveAgentHealthStatus(data: AgentHealthResponse): Pick<CardState, "metric" | "status"> {
+  const count = data.agentCount ?? 0;
+  if (count === 0) return { metric: "None registered", status: "red" };
+  return { metric: `${count} registered`, status: "green" };
 }
 
-function deriveCiHealthStatus(data: unknown): Pick<CardState, "metric" | "status"> {
-  if (!data || typeof data !== "object") return { metric: "Unknown", status: "loading" };
-  const projects = (data as { projects?: Array<{ successRate?: number }> }).projects ?? [];
-  if (projects.length === 0) return { metric: "No data", status: "yellow" };
-  const avg = projects.reduce((sum, p) => sum + (p?.successRate ?? 0), 0) / projects.length;
-  const pct = Math.round(avg * 100);
-  if (avg >= 0.8) return { metric: `${pct}% pass rate`, status: "green" };
-  if (avg >= 0.5) return { metric: `${pct}% pass rate`, status: "yellow" };
+function deriveCiHealthStatus(data: CiHealthResponse): Pick<CardState, "metric" | "status"> {
+  const { successRate = 1, totalRuns = 0, projects = [] } = data;
+  if (totalRuns === 0 || projects.length === 0) return { metric: "No data", status: "yellow" };
+  const pct = Math.round(successRate * 100);
+  if (successRate >= 0.8) return { metric: `${pct}% pass rate`, status: "green" };
+  if (successRate >= 0.5) return { metric: `${pct}% pass rate`, status: "yellow" };
   return { metric: `${pct}% pass rate`, status: "red" };
 }
 
-function derivePrPipelineStatus(data: unknown): Pick<CardState, "metric" | "status"> {
-  if (!data || typeof data !== "object") return { metric: "Unknown", status: "loading" };
-  const { open = 0, failed = 0 } = data as { open?: number; failed?: number };
-  if (failed > 0) return { metric: `${failed} failed`, status: "red" };
-  if (open > 5) return { metric: `${open} open`, status: "yellow" };
-  return { metric: `${open} open`, status: "green" };
+function derivePrPipelineStatus(data: PrPipelineResponse): Pick<CardState, "metric" | "status"> {
+  const { totalOpen = 0, conflicting = 0, stale = 0, failing = 0 } = data;
+  if (conflicting > 0 || failing > 0) {
+    return { metric: `${conflicting + failing} needs attention`, status: "red" };
+  }
+  if (stale > 0) return { metric: `${stale} stale`, status: "yellow" };
+  return { metric: `${totalOpen} open`, status: "green" };
 }
 
-function deriveFlowMetricsStatus(data: unknown): Pick<CardState, "metric" | "status"> {
-  if (!data || typeof data !== "object") return { metric: "Unknown", status: "loading" };
-  const { eventsPerMinute = 0, totalEvents = 0 } = data as {
-    eventsPerMinute?: number;
-    totalEvents?: number;
-  };
-  const epm = typeof eventsPerMinute === "number" ? eventsPerMinute : 0;
+function deriveFlowMetricsStatus(data: FlowMetricsResponse): Pick<CardState, "metric" | "status"> {
+  const efficiency = data.efficiency;
+  if (!efficiency) return { metric: "No data", status: "yellow" };
+  const pct = Math.round((efficiency.ratio ?? 0) * 100);
   return {
-    metric: `${epm.toFixed(1)} ev/min (${totalEvents} total)`,
-    status: epm > 0 ? "green" : "yellow",
+    metric: `${pct}% efficiency`,
+    status: efficiency.healthy ? "green" : "yellow",
   };
 }
 
-function deriveSecurityStatus(data: unknown): Pick<CardState, "metric" | "status"> {
-  if (!data || typeof data !== "object") return { metric: "Unknown", status: "loading" };
-  const d = data as { openIncidents?: number; incidents?: unknown[] };
-  const count = d.openIncidents ?? d.incidents?.length ?? 0;
-  if (count === 0) return { metric: "No incidents", status: "green" };
-  return { metric: `${count} open`, status: "red" };
+function deriveSecurityStatus(data: SecuritySummaryResponse): Pick<CardState, "metric" | "status"> {
+  const { openCount = 0, criticalCount = 0 } = data;
+  if (criticalCount > 0) return { metric: `${criticalCount} critical`, status: "red" };
+  if (openCount > 0) return { metric: `${openCount} open`, status: "yellow" };
+  return { metric: "No incidents", status: "green" };
 }
 
-function deriveHitlStatus(data: unknown): Pick<CardState, "metric" | "status"> {
-  if (!data || typeof data !== "object") return { metric: "Unknown", status: "loading" };
-  const pending = (data as { pending?: unknown[] }).pending ?? [];
+function deriveHitlStatus(data: { data?: unknown[] }): Pick<CardState, "metric" | "status"> {
+  const pending = Array.isArray(data?.data) ? data.data : [];
   const count = pending.length;
   if (count === 0) return { metric: "None pending", status: "green" };
   if (count <= 3) return { metric: `${count} pending`, status: "yellow" };
   return { metric: `${count} pending`, status: "red" };
 }
 
-async function fetchCard(
-  endpoint: string,
-  derive: (data: unknown) => Pick<CardState, "metric" | "status">
+interface CardFetcher {
+  label: string;
+  endpoint: string;
+  fetch: (force?: boolean) => Promise<Pick<CardState, "metric" | "status">>;
+  seedFromCache: () => Pick<CardState, "metric" | "status"> | null;
+}
+
+async function safeFetch<T>(
+  loader: (force?: boolean) => Promise<T>,
+  derive: (data: T) => Pick<CardState, "metric" | "status">,
+  force: boolean,
 ): Promise<Pick<CardState, "metric" | "status">> {
   try {
-    const res = await fetch(endpoint);
-    if (!res.ok) throw new Error(`${res.status}`);
-    const data = await res.json();
+    const data = await loader(force);
     return derive(data);
   } catch {
     return { metric: "Error", status: "red" };
   }
 }
 
-const CARD_CONFIGS: Array<{
-  label: string;
-  endpoint: string;
-  derive: (data: unknown) => Pick<CardState, "metric" | "status">;
-}> = [
-  { label: "Service Connectivity", endpoint: "/api/services", derive: deriveServicesStatus },
-  { label: "Agent Health", endpoint: "/api/agent-health", derive: deriveAgentHealthStatus },
-  { label: "CI Success Rate", endpoint: "/api/ci-health", derive: deriveCiHealthStatus },
-  { label: "PR Pipeline", endpoint: "/api/pr-pipeline", derive: derivePrPipelineStatus },
-  { label: "Flow Metrics", endpoint: "/api/flow-metrics", derive: deriveFlowMetricsStatus },
-  { label: "Security Summary", endpoint: "/api/security-summary", derive: deriveSecurityStatus },
-  { label: "Pending HITL", endpoint: "/api/hitl/pending", derive: deriveHitlStatus },
+const CARD_CONFIGS: CardFetcher[] = [
+  {
+    label: "Service Connectivity",
+    endpoint: "/api/services",
+    fetch: (force) => safeFetch(getServices, deriveServicesStatus, force ?? false),
+    seedFromCache: () => {
+      const cached = peek<ServicesResponse>("/api/services");
+      return cached ? deriveServicesStatus(cached) : null;
+    },
+  },
+  {
+    label: "Agent Health",
+    endpoint: "/api/agent-health",
+    fetch: (force) => safeFetch(getAgentHealth, deriveAgentHealthStatus, force ?? false),
+    seedFromCache: () => {
+      const cached = peek<AgentHealthResponse>("/api/agent-health");
+      return cached ? deriveAgentHealthStatus(cached) : null;
+    },
+  },
+  {
+    label: "CI Success Rate",
+    endpoint: "/api/ci-health",
+    fetch: (force) => safeFetch(getCiHealth, deriveCiHealthStatus, force ?? false),
+    seedFromCache: () => {
+      const cached = peek<CiHealthResponse>("/api/ci-health");
+      return cached ? deriveCiHealthStatus(cached) : null;
+    },
+  },
+  {
+    label: "PR Pipeline",
+    endpoint: "/api/pr-pipeline",
+    fetch: (force) => safeFetch(getPrPipeline, derivePrPipelineStatus, force ?? false),
+    seedFromCache: () => {
+      const cached = peek<PrPipelineResponse>("/api/pr-pipeline");
+      return cached ? derivePrPipelineStatus(cached) : null;
+    },
+  },
+  {
+    label: "Flow Efficiency",
+    endpoint: "/api/flow-metrics",
+    fetch: (force) => safeFetch(getFlowMetrics, deriveFlowMetricsStatus, force ?? false),
+    seedFromCache: () => {
+      const cached = peek<FlowMetricsResponse>("/api/flow-metrics");
+      return cached ? deriveFlowMetricsStatus(cached) : null;
+    },
+  },
+  {
+    label: "Security",
+    endpoint: "/api/security-summary",
+    fetch: (force) => safeFetch(getSecuritySummary, deriveSecurityStatus, force ?? false),
+    seedFromCache: () => {
+      const cached = peek<SecuritySummaryResponse>("/api/security-summary");
+      return cached ? deriveSecurityStatus(cached) : null;
+    },
+  },
+  {
+    label: "Pending HITL",
+    endpoint: "/api/hitl/pending",
+    fetch: (force) => safeFetch(getHitlPending, deriveHitlStatus, force ?? false),
+    seedFromCache: () => {
+      const cached = peek<{ data?: unknown[] }>("/api/hitl/pending");
+      return cached ? deriveHitlStatus(cached) : null;
+    },
+  },
 ];
 
 function HealthCardView({ label, metric, status }: CardState) {
@@ -161,22 +232,26 @@ function HealthCardView({ label, metric, status }: CardState) {
 }
 
 export default function OverviewGrid() {
-  const [cards, setCards] = useState<CardState[]>(
-    CARD_CONFIGS.map((c) => ({ label: c.label, metric: "Loading…", status: "loading" as Status }))
+  // Seed from cache instantly so page revisits render immediately
+  const [cards, setCards] = useState<CardState[]>(() =>
+    CARD_CONFIGS.map((c) => {
+      const cached = c.seedFromCache();
+      return {
+        label: c.label,
+        metric: cached?.metric ?? "Loading…",
+        status: cached?.status ?? ("loading" as Status),
+      };
+    }),
   );
 
-  async function refresh() {
-    const results = await Promise.all(
-      CARD_CONFIGS.map((c) => fetchCard(c.endpoint, c.derive))
-    );
-    setCards(
-      CARD_CONFIGS.map((c, i) => ({ label: c.label, ...results[i] }))
-    );
+  async function refresh(force = false) {
+    const results = await Promise.all(CARD_CONFIGS.map((c) => c.fetch(force)));
+    setCards(CARD_CONFIGS.map((c, i) => ({ label: c.label, ...results[i] })));
   }
 
   useEffect(() => {
-    refresh();
-    const id = setInterval(refresh, POLL_INTERVAL);
+    refresh(true); // force on mount to get fresh data
+    const id = setInterval(() => refresh(true), POLL_INTERVAL);
     return () => clearInterval(id);
   }, []);
 

--- a/dashboard/src/components/ProjectsView.tsx
+++ b/dashboard/src/components/ProjectsView.tsx
@@ -1,54 +1,41 @@
 import { useState, useEffect } from "preact/hooks";
 import ProjectCard from "./ProjectCard.tsx";
 import type { ProjectEntry, CiProjectData, PrData } from "./ProjectCard.tsx";
+import {
+  getProjects,
+  getCiHealth,
+  getPrPipeline,
+  peek,
+  type CiHealthResponse,
+  type PrPipelineResponse,
+} from "../lib/api";
 
 const POLL_INTERVAL_MS = 60_000;
 
-interface ProjectsApiResponse {
-  success: boolean;
-  data: ProjectEntry[];
-}
-
-interface CiHealthResponse {
-  successRate: number;
-  totalRuns: number;
-  failedRuns: number;
-  projects: CiProjectData[];
-}
-
-interface PrPipelineResponse {
-  totalOpen: number;
-  conflicting: number;
-  stale: number;
-  failing: number;
-  prs: PrData[];
-}
-
 export default function ProjectsView() {
-  const [projects, setProjects] = useState<ProjectEntry[]>([]);
-  const [ciHealth, setCiHealth] = useState<CiHealthResponse | null>(null);
-  const [prPipeline, setPrPipeline] = useState<PrPipelineResponse | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  // Seed from cache
+  const cachedProjects = peek<ProjectEntry[]>("/api/projects");
+  const cachedCi = peek<CiHealthResponse>("/api/ci-health");
+  const cachedPr = peek<PrPipelineResponse>("/api/pr-pipeline");
 
-  async function fetchAll() {
+  const [projects, setProjects] = useState<ProjectEntry[]>(cachedProjects ?? []);
+  const [ciHealth, setCiHealth] = useState<CiHealthResponse | null>(cachedCi ?? null);
+  const [prPipeline, setPrPipeline] = useState<PrPipelineResponse | null>(cachedPr ?? null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(!(cachedProjects && cachedCi && cachedPr));
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(
+    cachedProjects && cachedCi && cachedPr ? new Date() : null,
+  );
+
+  async function fetchAll(force = false) {
     try {
-      const [projRes, ciRes, prRes] = await Promise.all([
-        fetch("/api/projects"),
-        fetch("/api/ci-health"),
-        fetch("/api/pr-pipeline"),
+      const [projData, ciJson, prJson] = await Promise.all([
+        getProjects(),
+        getCiHealth(force),
+        getPrPipeline(force),
       ]);
 
-      if (!projRes.ok) throw new Error(`/api/projects: ${projRes.status}`);
-      if (!ciRes.ok) throw new Error(`/api/ci-health: ${ciRes.status}`);
-      if (!prRes.ok) throw new Error(`/api/pr-pipeline: ${prRes.status}`);
-
-      const projJson = (await projRes.json()) as ProjectsApiResponse;
-      const ciJson = (await ciRes.json()) as CiHealthResponse;
-      const prJson = (await prRes.json()) as PrPipelineResponse;
-
-      setProjects(Array.isArray(projJson.data) ? projJson.data : []);
+      setProjects(Array.isArray(projData) ? (projData as ProjectEntry[]) : []);
       setCiHealth(ciJson);
       setPrPipeline(prJson);
       setError(null);
@@ -61,8 +48,8 @@ export default function ProjectsView() {
   }
 
   useEffect(() => {
-    fetchAll();
-    const timer = setInterval(fetchAll, POLL_INTERVAL_MS);
+    fetchAll(true);
+    const timer = setInterval(() => fetchAll(true), POLL_INTERVAL_MS);
     return () => clearInterval(timer);
   }, []);
 

--- a/dashboard/src/components/WorldStateViewer.tsx
+++ b/dashboard/src/components/WorldStateViewer.tsx
@@ -1,40 +1,24 @@
 import { useState, useEffect, useMemo } from "preact/hooks";
 import DomainCard from "./DomainCard.tsx";
-
-interface DomainMetadata {
-  collectedAt: number;
-  domain: string;
-  tickNumber: number;
-  failed?: boolean;
-  errorMessage?: string;
-}
-
-interface DomainEntry {
-  data: unknown;
-  metadata: DomainMetadata;
-}
-
-interface WorldStateResponse {
-  timestamp: number;
-  domains: Record<string, DomainEntry>;
-  extensions: Record<string, unknown>;
-  snapshotVersion: number;
-}
+import { getWorldState, peek, type WorldStateResponse } from "../lib/api";
 
 const POLL_INTERVAL = 15_000;
 
 export default function WorldStateViewer() {
-  const [worldState, setWorldState] = useState<WorldStateResponse | null>(null);
+  // Seed from cache if present — instant render on page revisit
+  const [worldState, setWorldState] = useState<WorldStateResponse | null>(
+    () => peek<WorldStateResponse>("/api/world-state") ?? null,
+  );
   const [error, setError] = useState<string | null>(null);
-  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(
+    worldState ? new Date() : null,
+  );
   const [filter, setFilter] = useState<string>("");
   const [selectedDomain, setSelectedDomain] = useState<string>("all");
 
-  async function fetchWorldState() {
+  async function fetchWorldState(force = false) {
     try {
-      const res = await fetch("/api/world-state");
-      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-      const data = (await res.json()) as WorldStateResponse;
+      const data = await getWorldState(force);
       setWorldState(data);
       setLastUpdated(new Date());
       setError(null);
@@ -44,8 +28,8 @@ export default function WorldStateViewer() {
   }
 
   useEffect(() => {
-    fetchWorldState();
-    const id = setInterval(fetchWorldState, POLL_INTERVAL);
+    fetchWorldState(true); // force on mount to refresh
+    const id = setInterval(() => fetchWorldState(true), POLL_INTERVAL);
     return () => clearInterval(id);
   }, []);
 

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1,44 +1,229 @@
-// Typed fetch wrapper for all /api/* endpoints
-// All requests go through the event-viewer proxy at the same origin (:8080)
+// Typed fetch wrapper for all /api/* endpoints.
+// All requests go through the event-viewer proxy at the same origin (:8080).
+//
+// Features:
+//  - Automatic unwrap of { success, data } envelopes
+//  - In-memory session cache with TTL per endpoint
+//  - Stale-while-revalidate: components get cached data instantly, fresh in background
+//  - invalidate() to force refresh
 
 const API_BASE = "";
+const DEFAULT_TTL = 30_000;
 
-async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+interface CacheEntry {
+  data: unknown;
+  expiry: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+function hasEnvelope(obj: unknown): obj is { success: boolean; data: unknown } {
+  return (
+    !!obj &&
+    typeof obj === "object" &&
+    "success" in obj &&
+    "data" in (obj as Record<string, unknown>)
+  );
+}
+
+async function apiFetch<T>(
+  path: string,
+  opts: { ttl?: number; force?: boolean } = {},
+): Promise<T> {
+  const { ttl = DEFAULT_TTL, force = false } = opts;
+  const cacheKey = `GET:${path}`;
+
+  if (!force) {
+    const cached = cache.get(cacheKey);
+    if (cached && cached.expiry > Date.now()) {
+      return cached.data as T;
+    }
+  }
+
   const res = await fetch(`${API_BASE}${path}`, {
-    headers: { "Content-Type": "application/json", ...init?.headers },
-    ...init,
+    headers: { Accept: "application/json" },
   });
+
   if (!res.ok) {
     throw new Error(`API ${path} failed: ${res.status} ${res.statusText}`);
   }
-  return res.json() as Promise<T>;
+
+  const raw = await res.json();
+  const unwrapped = hasEnvelope(raw) ? raw.data : raw;
+
+  cache.set(cacheKey, { data: unwrapped, expiry: Date.now() + ttl });
+  return unwrapped as T;
 }
 
-// Event-viewer local APIs (served by event-viewer plugin itself)
-export const getEvents = (topic?: string, limit = 100) => {
+/** Invalidate one or all cached endpoints. */
+export function invalidate(path?: string): void {
+  if (!path) {
+    cache.clear();
+    return;
+  }
+  cache.delete(`GET:${path}`);
+}
+
+/** Read cache without network. Returns undefined if not cached. */
+export function peek<T>(path: string): T | undefined {
+  const entry = cache.get(`GET:${path}`);
+  if (!entry || entry.expiry <= Date.now()) return undefined;
+  return entry.data as T;
+}
+
+// ── Event-viewer local APIs ────────────────────────────────────────
+export const getEvents = (topic?: string, limit = 500) => {
   const params = new URLSearchParams({ limit: String(limit) });
   if (topic) params.set("topic", topic);
-  return apiFetch<unknown[]>(`/api/events?${params}`);
+  return apiFetch<unknown[]>(`/api/events?${params}`, { ttl: 5_000 });
 };
 
 export const getTopics = () => apiFetch<string[]>("/api/topics");
 export const getConsumers = () => apiFetch<string[]>("/api/consumers");
-export const getProjects = () =>
-  apiFetch<{ success: boolean; data: unknown[] }>("/api/projects");
-export const getAgents = () =>
-  apiFetch<{ success: boolean; data: unknown[] }>("/api/agents");
 
-// Proxied APIs from main server (:3000)
-export const getWorldState = () => apiFetch<unknown>("/api/world-state");
-export const getServices = () => apiFetch<unknown>("/api/services");
-export const getAgentHealth = () => apiFetch<unknown>("/api/agent-health");
-export const getFlowMetrics = () => apiFetch<unknown>("/api/flow-metrics");
-export const getOutcomes = () => apiFetch<unknown>("/api/outcomes");
-export const getCiHealth = () => apiFetch<unknown>("/api/ci-health");
-export const getPrPipeline = () => apiFetch<unknown>("/api/pr-pipeline");
-export const getCeremonies = () => apiFetch<unknown>("/api/ceremonies");
-export const getIncidents = () => apiFetch<unknown>("/api/incidents");
-export const getSecuritySummary = () =>
-  apiFetch<unknown>("/api/security-summary");
-export const getChannels = () => apiFetch<unknown>("/api/channels");
-export const getHitlPending = () => apiFetch<unknown>("/api/hitl/pending");
+// ── Proxied APIs from main server (:3000) ─────────────────────────
+// TTL tuned to each endpoint's refresh cadence.
+export const getWorldState = (force = false) =>
+  apiFetch<WorldStateResponse>("/api/world-state", { ttl: 15_000, force });
+
+export const getServices = (force = false) =>
+  apiFetch<ServicesResponse>("/api/services", { ttl: 30_000, force });
+
+export const getAgentHealth = (force = false) =>
+  apiFetch<AgentHealthResponse>("/api/agent-health", { ttl: 30_000, force });
+
+export const getFlowMetrics = (force = false) =>
+  apiFetch<FlowMetricsResponse>("/api/flow-metrics", { ttl: 30_000, force });
+
+export const getOutcomes = (force = false) =>
+  apiFetch<OutcomesResponse>("/api/outcomes", { ttl: 15_000, force });
+
+export const getCiHealth = (force = false) =>
+  apiFetch<CiHealthResponse>("/api/ci-health", { ttl: 300_000, force });
+
+export const getPrPipeline = (force = false) =>
+  apiFetch<PrPipelineResponse>("/api/pr-pipeline", { ttl: 120_000, force });
+
+export const getBranchDrift = (force = false) =>
+  apiFetch<BranchDriftResponse>("/api/branch-drift", { ttl: 600_000, force });
+
+export const getSecuritySummary = (force = false) =>
+  apiFetch<SecuritySummaryResponse>("/api/security-summary", { ttl: 60_000, force });
+
+export const getProjects = () =>
+  apiFetch<unknown[]>("/api/projects", { ttl: 60_000 });
+
+export const getAgents = () =>
+  apiFetch<unknown[]>("/api/agents", { ttl: 60_000 });
+
+export const getGoals = () =>
+  apiFetch<unknown[]>("/api/goals", { ttl: 60_000 });
+
+export const getIncidents = () =>
+  apiFetch<{ data: unknown[] }>("/api/incidents", { ttl: 60_000 });
+
+export const getCeremonies = () =>
+  apiFetch<{ data: unknown[] }>("/api/ceremonies", { ttl: 60_000 });
+
+export const getHitlPending = () =>
+  apiFetch<{ data: unknown[] }>("/api/hitl/pending", { ttl: 30_000 });
+
+// ── Response types (match actual API shapes after envelope unwrap) ─
+export interface WorldStateResponse {
+  timestamp: number;
+  domains: Record<string, {
+    data: unknown;
+    metadata: {
+      collectedAt: number;
+      domain: string;
+      tickNumber: number;
+      failed?: boolean;
+      errorMessage?: string;
+    };
+  }>;
+  extensions: Record<string, unknown>;
+  snapshotVersion: number;
+}
+
+export interface ServicesResponse {
+  discord: { configured: boolean; connected: boolean; bot: string | null };
+  github: { configured: boolean; authType: string | null };
+  plane: { configured: boolean; baseUrl: string | null };
+  gateway: { configured: boolean; url: string | null };
+  langfuse: { configured: boolean };
+  graphiti: { configured: boolean; url: string | null };
+}
+
+export interface AgentHealthResponse {
+  agentCount: number;
+  agents: Record<string, { skills: string[]; executorType: string }>;
+  registrationCount: number;
+}
+
+export interface FlowMetricsResponse {
+  velocity?: { currentPeriodCount: number; rollingAverage: number; trend: number };
+  leadTime?: { p50Ms: number; p95Ms: number };
+  efficiency?: { ratio: number; target: number; healthy: boolean };
+  load?: { totalWIP: number };
+  distribution?: { ratios: Record<string, number>; balanced: boolean };
+  bottleneck?: { primaryBottleneck: string | null; hasBottleneck: boolean };
+}
+
+export interface OutcomesResponse {
+  summary: { success: number; failure: number; timeout: number; total: number };
+  recent: Array<{
+    correlationId: string;
+    actionId: string;
+    goalId: string;
+    status: string;
+    startedAt: number;
+    completedAt: number;
+    durationMs: number;
+  }>;
+}
+
+export interface CiHealthResponse {
+  successRate: number;
+  totalRuns: number;
+  failedRuns: number;
+  projects: Array<{
+    repo: string;
+    successRate: number;
+    totalRuns: number;
+    failedRuns: number;
+    latestConclusion: string | null;
+  }>;
+}
+
+export interface PrPipelineResponse {
+  totalOpen: number;
+  conflicting: number;
+  stale: number;
+  failing: number;
+  prs: Array<{
+    repo: string;
+    number: number;
+    title: string;
+    mergeable: string;
+    checksPass: boolean;
+    updatedAt: string;
+    stale: boolean;
+  }>;
+}
+
+export interface BranchDriftResponse {
+  maxDrift: number;
+  projects: Array<{
+    repo: string;
+    devToStaging: number | null;
+    stagingToMain: number | null;
+    devToMain: number;
+    defaultBranch: string;
+  }>;
+}
+
+export interface SecuritySummaryResponse {
+  openCount: number;
+  criticalCount: number;
+  incidents: Array<{ id: string; title: string; severity: string; status: string }>;
+}


### PR DESCRIPTION
## Summary

Fixes multiple dashboard issues in one pass.

### Bugs
- **World State page never loaded** — component unwrapped `{ success, data }` envelope incorrectly, `data.domains` was undefined, stuck on "Loading…" forever
- **Overview cards showed wrong data** — 6 of 7 derive functions expected fields that don't match the actual API response shapes
- **No caching between navigations** — every page visit re-fetched everything from scratch
- **Events header was static** — scrolled away with content, no sticky tabs/filter

### Fixes

**`api.ts` rewrite**
- Auto-unwrap `{ success, data }` envelopes (hasEnvelope check)
- In-memory session cache with per-endpoint TTLs (15s to 10min)
- `peek<T>()` lets components seed state from cache instantly on mount
- Typed response interfaces (`WorldStateResponse`, `ServicesResponse`, etc.) matching actual API shapes
- `invalidate()` + `force` flag for refresh control

**Overview derive functions rewritten**
All now match real API shapes:
| Card | Before | After |
|------|--------|-------|
| Services | looked for `status:"down"` | checks `discord.connected` + `configured` count |
| Agent Health | looked for `agents[].status` | uses `agentCount` field |
| CI | looked in `projects[].successRate` (wrong math) | uses top-level `successRate` |
| PR Pipeline | looked for `open`/`failed` | uses `totalOpen`/`conflicting`/`stale`/`failing` |
| Flow | looked for `eventsPerMinute` | uses `efficiency.ratio` + `efficiency.healthy` |
| Security | looked for `openIncidents` | uses `openCount`/`criticalCount` |

**Events page sticky header + glow-up**
- Wrapped header + toolbar in `.es-sticky` (position: sticky, backdrop-blur)
- Added "◉ Event Stream" title with pulsing accent dot
- Accent bar on left edge of header
- Connected status dot glows green when live
- Active tab has subtle blue ring
- Event count badge aligned right

### Component updates
- `WorldStateViewer` — uses `getWorldState()` + `peek()` seed
- `OverviewGrid` — 7 cards seed from cache, force refresh on mount + interval
- `OutcomesTable` — uses `getOutcomes()` + cache seed
- `GoalStatus` — uses `getGoals()` + `getWorldState()` + cache seed
- `ProjectsView` — uses 3 cached endpoints in parallel

## Test plan
- [x] `cd dashboard && bun run build` — 5 pages built
- [x] `bun test` — 626 pass, 0 fail
- [ ] Deploy, verify world-state page loads
- [ ] Verify Overview shows correct metrics
- [ ] Verify page navigation is instant (cache hits)
- [ ] Verify Events page tabs + filter stay pinned on scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)