### PR TITLE
fix: CodeRabbit reviews dev→main promotion PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,5 +14,8 @@ reviews:
     enabled: true
     drafts: false
     # Review PRs targeting dev (feature PRs) and main (dev→main promotion).
+    # main is in the list so promotion PRs get the required CodeRabbit
+    # status check without needing a manual "@coderabbitai review" comment.
     base_branches:
       - '^dev$'
+      - '^main$'


### PR DESCRIPTION
## Summary

The CodeRabbit \`auto_review.base_branches\` config only matched \`^dev$\`, so dev→main promotion PRs never got a CodeRabbit status check. Since CodeRabbit is a required check on \`main\`, promotion PRs were permanently blocked unless someone manually ran \`@coderabbitai review\`.

The comment already said \"Review PRs targeting dev (feature PRs) and main (dev→main promotion)\" — the regex just never matched that intent. Added \`^main$\` to the list.

Discovered while shepherding PR #85 (the current dev→main promotion): CI passed, \`test\` was green, but the required \`CodeRabbit\` check never fired, leaving the PR in \`BLOCKED\` state despite \`MERGEABLE\`. Worked around that PR with a manual trigger comment; this fix prevents the next promotion from hitting the same wall.

## Test plan

- [ ] CI passes
- [ ] CodeRabbit posts a review on *this* PR (which targets dev — already covered)
- [ ] Next dev→main promotion PR auto-receives CodeRabbit review without manual trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal review configuration to apply auto-review settings to additional branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->