### PR TITLE
fix(pr-remediator): use Quinn GitHub App auth for merges

### DIFF
--- a/lib/plugins/pr-remediator.ts
+++ b/lib/plugins/pr-remediator.ts
@@ -28,15 +28,20 @@
  * layer — this plugin does not loop on its own.
  *
  * Env:
- *   GITHUB_TOKEN  — required for merge API calls
- *   PR_REMEDIATOR_AUTO_MERGE  — "1" enables auto-merge (default off; dry-run mode)
+ *   QUINN_APP_ID / QUINN_APP_PRIVATE_KEY — GitHub App creds (preferred — has
+ *     pull_requests:write scoped per-installation)
+ *   GITHUB_TOKEN                         — PAT fallback when App creds absent
+ *   PR_REMEDIATOR_AUTO_MERGE             — "1" enables auto-merge (default
+ *     off; dry-run mode just logs)
  */
 
 import type { Plugin, EventBus, BusMessage, HITLRequest } from "../types.ts";
 import type { WorldState } from "../types/world-state.ts";
+import { makeGitHubAuth } from "../github-auth.ts";
 
-const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const AUTO_MERGE_ENABLED = process.env.PR_REMEDIATOR_AUTO_MERGE === "1";
+// Resolved at install() time — null when no GitHub credentials are present.
+const getGithubToken = makeGitHubAuth();
 
 // ── Allowlist: titles / authors that may auto-merge without HITL ─────────────
 
@@ -77,12 +82,15 @@ function isAutoMergeEligible(pr: PrDomainEntry): boolean {
 }
 
 async function ghMerge(repo: string, num: number): Promise<{ ok: boolean; status: number; error?: string }> {
-  if (!GITHUB_TOKEN) return { ok: false, status: 0, error: "GITHUB_TOKEN not set" };
+  if (!getGithubToken) return { ok: false, status: 0, error: "no GitHub credentials (QUINN_APP_* or GITHUB_TOKEN)" };
+  const [owner, repoName] = repo.split("/");
+  if (!owner || !repoName) return { ok: false, status: 0, error: `malformed repo slug "${repo}"` };
   try {
+    const token = await getGithubToken(owner, repoName);
     const resp = await fetch(`https://api.github.com/repos/${repo}/pulls/${num}/merge`, {
       method: "PUT",
       headers: {
-        Authorization: `Bearer ${GITHUB_TOKEN}`,
+        Authorization: `Bearer ${token}`,
         Accept: "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
         "Content-Type": "application/json",
@@ -146,7 +154,7 @@ export class PrRemediatorPlugin implements Plugin {
     }));
 
     console.log(
-      `[pr-remediator] installed — auto-merge ${AUTO_MERGE_ENABLED ? "ENABLED" : "DRY-RUN"}, token ${GITHUB_TOKEN ? "set" : "MISSING"}`,
+      `[pr-remediator] installed — auto-merge ${AUTO_MERGE_ENABLED ? "ENABLED" : "DRY-RUN"}, auth ${getGithubToken ? "configured" : "MISSING"}`,
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -258,7 +258,7 @@ const pluginRegistry: PluginRegistryEntry[] = [
   },
   {
     name: "pr-remediator",
-    condition: () => !!process.env.GITHUB_TOKEN,
+    condition: () => !!(process.env.QUINN_APP_PRIVATE_KEY || process.env.GITHUB_TOKEN),
     factory: async () => {
       const { PrRemediatorPlugin } = await import("../lib/plugins/pr-remediator.js");
       return new PrRemediatorPlugin();


### PR DESCRIPTION
## The problem

The remediator was calling \`ghMerge()\` with the generic \`GITHUB_TOKEN\` PAT from Infisical. That PAT doesn't have \`pull_requests:write\`, so every attempted auto-merge 403'd:

\`\`\`
[pr-remediator] auto-merge failed protoLabsAI/protoMaker#3331:
  {\"message\":\"Resource not accessible by personal access token\",\"status\":\"403\"}
[pr-remediator] HITL approval requested for protoLabsAI/protoMaker#3331
\`\`\`

The HITL fallback fires as designed — but for allowlisted titles (dependabot, \`promote:\`, etc.) the whole point is to skip HITL and merge autonomously. The allowlist was effectively dead code.

## The fix

Use the existing \`lib/github-auth.ts:makeGitHubAuth()\` helper, which already handles the Quinn GitHub App → PAT fallback cleanly:

\`\`\`ts
const getGithubToken = makeGitHubAuth();   // GitHubApp | PAT | null
// ...
const token = await getGithubToken(owner, repoName);
\`\`\`

The Quinn App has \`pull_requests:write\` scoped per-installation, so merges land. The \`GitHubAppAuth\` class in \`lib/github-auth.ts\` caches installation tokens for 1 hour per repo, so the hot-path is just a hashmap lookup.

## Changes

- \`lib/plugins/pr-remediator.ts\` — swap \`GITHUB_TOKEN\` const for \`makeGitHubAuth()\` resolver, update \`ghMerge()\` to await per-repo tokens, update the install log line and module docstring
- \`src/index.ts\` — plugin registration condition now accepts either \`QUINN_APP_PRIVATE_KEY\` or \`GITHUB_TOKEN\`, not just the PAT

## Verification

- \`bun test\` → **639 pass / 0 fail**
- \`bunx tsc --noEmit\` → clean
- After deploy, the \`[pr-remediator] installed\` log should say \`auth configured\`, and allowlisted PRs should auto-merge directly instead of dropping through to HITL

## Test plan

- [ ] CI green on this PR
- [ ] Deploy the container
- [ ] Verify install log: \`[pr-remediator] installed — auto-merge ENABLED, auth configured\`
- [ ] Observe a \`promote:\` or dependabot PR auto-merge without HITL escalation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication flexibility: The PR remediator plugin now supports GitHub App credentials as the preferred authentication method, with GitHub tokens available as a fallback for connecting to GitHub repositories.
  * Enhanced configuration handling: Improved error reporting and validation when GitHub credentials are missing or invalid, including better detection of malformed repository references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->