### PR TITLE
fix(pr-remediator): route bug_triage to Ava via payload.meta.agentId

### DIFF
--- a/lib/plugins/pr-remediator.ts
+++ b/lib/plugins/pr-remediator.ts
@@ -511,6 +511,10 @@ Fetch the review comments via get_pr_feedback, address each point, and mark the 
   private _dispatchToAva(content: string, skillHint: string, parentCorrelationId: string): string | undefined {
     if (!this.bus) return undefined;
     const correlationId = crypto.randomUUID();
+    // NOTE: skill-dispatcher targets by `payload.meta.agentId`, NOT top-level
+    // `payload.agentId`. Both Ava (a2a) and Quinn (proto-sdk) register
+    // bug_triage, and without explicit targeting the dispatcher picks the
+    // first-registered executor (Quinn — who is read-only and exits 53).
     this.bus.publish("agent.skill.request", {
       id: crypto.randomUUID(),
       correlationId,
@@ -519,9 +523,8 @@ Fetch the review comments via get_pr_feedback, address each point, and mark the 
       timestamp: Date.now(),
       payload: {
         skill: skillHint,
-        skillHint,
-        agentId: "ava",
         content,
+        meta: { agentId: "ava", skillHint },
       },
     });
     return correlationId;

--- a/src/pr-remediator.test.ts
+++ b/src/pr-remediator.test.ts
@@ -304,9 +304,11 @@ describe("PrRemediatorPlugin — fix_ci", () => {
     dispatch(bus, "pr.remediate.fix_ci");
     await flushMicrotasks();
     expect(dispatches.length).toBe(2);
-    const p0 = dispatches[0].payload as { skill: string; agentId: string; content: string };
+    const p0 = dispatches[0].payload as { skill: string; content: string; meta: { agentId: string; skillHint: string } };
     expect(p0.skill).toBe("bug_triage");
-    expect(p0.agentId).toBe("ava");
+    // skill-dispatcher routes by payload.meta.agentId, not top-level agentId
+    expect(p0.meta.agentId).toBe("ava");
+    expect(p0.meta.skillHint).toBe("bug_triage");
     expect(p0.content).toContain("#100");
     const p1 = dispatches[1].payload as { content: string };
     expect(p1.content).toContain("#300");


### PR DESCRIPTION
## The bug

The remediator's fix_ci / address_feedback paths were dispatching to **Quinn**, not Ava — so Ava's auto-fix workflow never actually fired for stuck PRs. We only noticed because I went looking at why protoMaker #3332 / #3333 weren't being remediated despite \`[pr-remediator] dispatching fix_ci\` logs showing the bus publish happened.

## Root cause

\`src/executor/skill-dispatcher-plugin.ts:76\`:

\`\`\`ts
if (typeof meta?.agentId === \"string\") {
  targets = [meta.agentId];
}
\`\`\`

The dispatcher reads the agent target from \`payload.meta.agentId\`. But \`_dispatchToAva()\` was setting it at the top of the payload:

\`\`\`ts
payload: {
  skill: skillHint,
  agentId: \"ava\",    // ← silently ignored
  content,
}
\`\`\`

With no targets, the dispatcher falls through to first-match by skill name. Both Ava (a2a executor) and Quinn (proto-sdk executor) register \`bug_triage\`. Quinn loads first → wins the match → gets the dispatch.

**Quinn is intentionally read-only by design** (\`excludeTools: [edit, write_file, run_shell_command, agent]\` in \`workspace/agents/quinn.yaml\`), so her \`bug_triage\` skill crashed with exit code 53 every single time. None of the fix_ci dispatches ever reached Ava.

Live trace from production:

\`\`\`
[pr-remediator] dispatching fix_ci for protoLabsAI/protoMaker#3333
[skill-dispatcher] Dispatching \"bug_triage\" via proto-sdk   ← Quinn
[skill-dispatcher] Unhandled error dispatching \"bug_triage\": CLI process exited with code 53
\`\`\`

## The fix

Move \`agentId\` into \`payload.meta\` so the dispatcher finds it. One-line change in \`_dispatchToAva()\`, plus updated test assertion.

Expected trace after deploy:

\`\`\`
[pr-remediator] dispatching fix_ci for protoLabsAI/protoMaker#3333
[skill-dispatcher] Dispatching \"bug_triage\" via a2a (targets: ava)
\`\`\`

## Verification

- \`bun test\` → **644 pass / 0 fail**
- \`bunx tsc --noEmit\` → clean
- Test assertion updated to check \`payload.meta.agentId === \"ava\"\`

## Test plan

- [ ] CI green
- [ ] Deploy, watch logs for \`Dispatching \"bug_triage\" via a2a (targets: ava)\`
- [ ] Verify Ava's board receives new bug_triage features for protoMaker #3332 and #3333
- [ ] Auto-mode picks up the features and runs fix agents
- [ ] Ava's remediation agents push commits to the PRs and turn CI green
- [ ] pr_pipeline.data.failingCi drops to 0
- [ ] remediator stops dispatching (in-flight state clears naturally once PRs leave the pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated internal request routing mechanism to improve system architecture and maintainability.

* **Tests**
  * Updated test coverage to verify the new request routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->