### PR TITLE
fix(pr-remediator): target Ava dispatches to the owning project + require start_auto_mode

### DIFF
--- a/lib/plugins/pr-remediator.ts
+++ b/lib/plugins/pr-remediator.ts
@@ -84,6 +84,21 @@ const AUTO_MERGE_AUTHORS = new Set(["dependabot[bot]", "renovate[bot]"]);
 const AUTO_MERGE_TITLE_PREFIXES = ["promote:", "chore(deps"];
 const AUTO_MERGE_LABEL = "auto-merge";
 
+/**
+ * Derive the workstacean/ava project slug from a GitHub `owner/repo` string.
+ * Matches the slugs in workspace/projects.yaml: lowercase repo name with dots
+ * replaced by dashes (e.g. `rabbit-hole.io` → `rabbit-hole-io`).
+ *
+ * Returns empty string if the repo slug is malformed — caller should fall
+ * back to including the full `owner/repo` in the message content so Ava
+ * can disambiguate via `list_projects` if needed.
+ */
+function deriveProjectSlug(repo: string): string {
+  const parts = repo.split("/");
+  if (parts.length !== 2 || !parts[1]) return "";
+  return parts[1].toLowerCase().replace(/\./g, "-");
+}
+
 // ── Domain data shape (mirrors src/api/github.ts handleGetPrPipeline) ────────
 
 interface PrDomainEntry {
@@ -373,22 +388,30 @@ export class PrRemediatorPlugin implements Plugin {
         console.log(`[pr-remediator] skip fix_ci ${pr.repo}#${pr.number}: ${gate.reason}`);
         continue;
       }
-      console.log(`[pr-remediator] dispatching fix_ci for ${pr.repo}#${pr.number}`);
+      const projectSlug = deriveProjectSlug(pr.repo);
+      console.log(`[pr-remediator] dispatching fix_ci for ${pr.repo}#${pr.number} (slug: ${projectSlug})`);
       const correlationId = this._dispatchToAva(
-        `PR ${pr.repo}#${pr.number} has failing CI — investigate and remediate.
+        `PR ${pr.repo}#${pr.number} has failing CI on the **${projectSlug}** project — investigate and dispatch a fix.
 
-Title: ${pr.title}
+Project: ${projectSlug}  (github: ${pr.repo})
+PR: #${pr.number} — ${pr.title}
 Branch: ${pr.baseRef} ← head ${pr.headSha.slice(0, 7)}
 Author: ${pr.author}
 CI status: ${pr.ciStatus}
 Mergeable: ${pr.mergeable}
 
-Read the failing workflow logs, identify the root cause, and either:
-- File a bug ticket on the board with the root cause analysis
-- Dispatch a fix to the owning agent via auto-mode
-- Escalate to HITL if the failure is outside agent capability.`,
+REQUIRED STEPS — execute in order, do not stop until all are done:
+
+1. Call \`check_pr_status\` with projectPath for the "${projectSlug}" project to confirm the failure and read the failing workflow name(s).
+2. Call \`get_pr_feedback\` to fetch any review comments and check logs.
+3. Call \`create_feature\` on the "${projectSlug}" project (NOT the default project — you must pass the correct projectPath) with a root-cause analysis and a clear "fix this" title.
+4. Call \`start_auto_mode\` on the "${projectSlug}" project so an agent immediately picks up the new feature and begins work.
+5. Reply with a one-line summary: "Filed feature <id> on ${projectSlug}, auto-mode started."
+
+Do NOT just file the ticket and stop — the ticket must be followed by \`start_auto_mode\` or nothing will actually happen. Only escalate via reply if one of the tool calls returns an unrecoverable error.`,
         "bug_triage",
         msg.correlationId,
+        { projectSlug, projectRepo: pr.repo, prNumber: pr.number },
       );
       if (correlationId) {
         this._recordDispatch(pr.repo, pr.number, "fix_ci", correlationId);
@@ -410,19 +433,29 @@ Read the failing workflow logs, identify the root cause, and either:
         console.log(`[pr-remediator] skip address_feedback ${pr.repo}#${pr.number}: ${gate.reason}`);
         continue;
       }
-      console.log(`[pr-remediator] dispatching address_feedback for ${pr.repo}#${pr.number}`);
+      const projectSlug = deriveProjectSlug(pr.repo);
+      console.log(`[pr-remediator] dispatching address_feedback for ${pr.repo}#${pr.number} (slug: ${projectSlug})`);
       const correlationId = this._dispatchToAva(
-        `PR ${pr.repo}#${pr.number} has CHANGES_REQUESTED review feedback — address and resolve.
+        `PR ${pr.repo}#${pr.number} on the **${projectSlug}** project has CHANGES_REQUESTED review feedback — address and resolve.
 
-Title: ${pr.title}
+Project: ${projectSlug}  (github: ${pr.repo})
+PR: #${pr.number} — ${pr.title}
 Branch: ${pr.baseRef}
 Author: ${pr.author}
 Mergeable: ${pr.mergeable}
 CI: ${pr.ciStatus}
 
-Fetch the review comments via get_pr_feedback, address each point, and mark the review threads resolved.`,
+REQUIRED STEPS — execute in order, do not stop until all are done:
+
+1. Call \`get_pr_feedback\` for PR #${pr.number} on the "${projectSlug}" project to fetch every unresolved review thread.
+2. Call \`create_feature\` on the "${projectSlug}" project (NOT the default project — you must pass the correct projectPath) with a summary of the feedback and a title like "Address review on PR #${pr.number}".
+3. Call \`start_auto_mode\` on the "${projectSlug}" project so an agent immediately picks up the new feature.
+4. Reply with a one-line summary: "Filed feature <id> on ${projectSlug}, auto-mode started."
+
+Do NOT just file the ticket and stop — the ticket must be followed by \`start_auto_mode\` or nothing will actually happen. Only escalate via reply if a tool call returns an unrecoverable error.`,
         "bug_triage",
         msg.correlationId,
+        { projectSlug, projectRepo: pr.repo, prNumber: pr.number },
       );
       if (correlationId) {
         this._recordDispatch(pr.repo, pr.number, "address_feedback", correlationId);
@@ -508,13 +541,22 @@ Fetch the review comments via get_pr_feedback, address each point, and mark the 
     }
   }
 
-  private _dispatchToAva(content: string, skillHint: string, parentCorrelationId: string): string | undefined {
+  private _dispatchToAva(
+    content: string,
+    skillHint: string,
+    parentCorrelationId: string,
+    extraMeta?: Record<string, unknown>,
+  ): string | undefined {
     if (!this.bus) return undefined;
     const correlationId = crypto.randomUUID();
     // NOTE: skill-dispatcher targets by `payload.meta.agentId`, NOT top-level
     // `payload.agentId`. Both Ava (a2a) and Quinn (proto-sdk) register
     // bug_triage, and without explicit targeting the dispatcher picks the
     // first-registered executor (Quinn — who is read-only and exits 53).
+    //
+    // A2AExecutor spreads the full payload into the JSON-RPC message metadata
+    // (src/executor/executors/a2a-executor.ts line 58 — `...req.payload`), so
+    // anything in extraMeta reaches Ava's A2A handler as message.metadata.
     this.bus.publish("agent.skill.request", {
       id: crypto.randomUUID(),
       correlationId,
@@ -525,6 +567,7 @@ Fetch the review comments via get_pr_feedback, address each point, and mark the 
         skill: skillHint,
         content,
         meta: { agentId: "ava", skillHint },
+        ...(extraMeta ?? {}),
       },
     });
     return correlationId;

--- a/src/pr-remediator.test.ts
+++ b/src/pr-remediator.test.ts
@@ -294,24 +294,43 @@ describe("PrRemediatorPlugin — fix_ci", () => {
 
   afterEach(() => plugin.uninstall());
 
-  test("dispatches to Ava for each failing-CI PR", async () => {
+  test("dispatches to Ava for each failing-CI PR with project targeting and directive prompt", async () => {
     pushWorldState(bus, [
-      makePr({ number: 100, ciStatus: "fail", title: "bug: foo" }),
-      makePr({ number: 200, ciStatus: "pass" }),  // should be skipped
-      makePr({ number: 300, ciStatus: "fail", title: "bug: bar" }),
+      makePr({ number: 100, ciStatus: "fail", title: "bug: foo", repo: "protoLabsAI/protoMaker" }),
+      makePr({ number: 200, ciStatus: "pass", repo: "protoLabsAI/protoMaker" }),  // should be skipped
+      makePr({ number: 300, ciStatus: "fail", title: "bug: bar", repo: "protoLabsAI/rabbit-hole.io" }),
     ]);
     const dispatches = captureOn(bus, "agent.skill.request");
     dispatch(bus, "pr.remediate.fix_ci");
     await flushMicrotasks();
     expect(dispatches.length).toBe(2);
-    const p0 = dispatches[0].payload as { skill: string; content: string; meta: { agentId: string; skillHint: string } };
+
+    const p0 = dispatches[0].payload as {
+      skill: string;
+      content: string;
+      meta: { agentId: string; skillHint: string };
+      projectSlug: string;
+      projectRepo: string;
+      prNumber: number;
+    };
     expect(p0.skill).toBe("bug_triage");
     // skill-dispatcher routes by payload.meta.agentId, not top-level agentId
     expect(p0.meta.agentId).toBe("ava");
     expect(p0.meta.skillHint).toBe("bug_triage");
+    // Project targeting — reaches Ava via A2AExecutor's `...req.payload` spread
+    expect(p0.projectSlug).toBe("protomaker");
+    expect(p0.projectRepo).toBe("protoLabsAI/protoMaker");
+    expect(p0.prNumber).toBe(100);
+    // Directive prompt: must demand start_auto_mode, not just create_feature
     expect(p0.content).toContain("#100");
-    const p1 = dispatches[1].payload as { content: string };
+    expect(p0.content).toContain("protomaker");
+    expect(p0.content).toContain("start_auto_mode");
+    expect(p0.content).toContain("REQUIRED STEPS");
+
+    const p1 = dispatches[1].payload as { content: string; projectSlug: string };
     expect(p1.content).toContain("#300");
+    // Verify slug derivation handles dotted repo names
+    expect(p1.projectSlug).toBe("rabbit-hole-io");
   });
 
   test("no-ops when no failing PRs exist", async () => {
@@ -335,19 +354,30 @@ describe("PrRemediatorPlugin — address_feedback", () => {
 
   afterEach(() => plugin.uninstall());
 
-  test("dispatches to Ava for changes_requested PRs", async () => {
+  test("dispatches to Ava for changes_requested PRs with project targeting", async () => {
     pushWorldState(bus, [
-      makePr({ number: 55, reviewState: "changes_requested" }),
-      makePr({ number: 56, reviewState: "approved" }),
+      makePr({ number: 55, reviewState: "changes_requested", repo: "protoLabsAI/protoMaker" }),
+      makePr({ number: 56, reviewState: "approved", repo: "protoLabsAI/protoMaker" }),
     ]);
     const dispatches = captureOn(bus, "agent.skill.request");
     dispatch(bus, "pr.remediate.address_feedback");
     await flushMicrotasks();
     expect(dispatches.length).toBe(1);
-    const p = dispatches[0].payload as { content: string; skill: string };
+    const p = dispatches[0].payload as {
+      content: string;
+      skill: string;
+      projectSlug: string;
+      projectRepo: string;
+      meta: { agentId: string };
+    };
     expect(p.skill).toBe("bug_triage");
+    expect(p.meta.agentId).toBe("ava");
+    expect(p.projectSlug).toBe("protomaker");
+    expect(p.projectRepo).toBe("protoLabsAI/protoMaker");
     expect(p.content).toContain("#55");
     expect(p.content).toContain("CHANGES_REQUESTED");
+    expect(p.content).toContain("start_auto_mode");
+    expect(p.content).toContain("REQUIRED STEPS");
   });
 });
 


### PR DESCRIPTION
## The bug (both on one PR)

After PR #90 fixed the Ava routing, dispatches started reaching her and she produced high-quality RCA analyses. But two new gaps surfaced when I checked the board state:

**1. Features filed on the wrong project.** Ava's \`create_feature\` landed tickets in \`/home/josh/dev/ava/.automaker/features/\` instead of \`/home/josh/dev/labs/protoMaker/.automaker/features/\`. Cause: the A2A dispatch carried the PR context only in the prose body (\`\"PR protoLabsAI/protoMaker#3333...\"\`), not as structured metadata. Ava defaulted to her own project context.

**2. No work dispatched.** Ava produced the RCA and stopped. The board showed the new feature in \`backlog\`, but \`running_count: 0\`, \`auto_mode: false\`. The old prompt was a menu (\"*file a bug OR dispatch a fix OR escalate*\") and she chose option one every time.

Confirmed in production — see the feature Ava created:

\`\`\`
/home/josh/dev/ava/.automaker/features/feature-1775845265088-kuz5kj02l/
  title: \"RCA: PR #3333 — \`checks\` CI failure from skipped local build verification\"
  status: backlog
\`\`\`

The RCA itself is excellent (she identified a sandbox symlink issue in \`node_modules/.bin\`), but the ticket is on the wrong board and no agent runs.

## Fixes in this PR

**\`deriveProjectSlug(repo)\`** — maps \`owner/repo\` to the workstacean slug used in \`workspace/projects.yaml\`. Lowercase repo name, dots replaced with dashes. Tested against protoMaker, rabbit-hole.io, etc.

**\`_dispatchToAva()\` accepts \`extraMeta\`** — spread into the payload alongside \`meta.agentId\`. The A2AExecutor already forwards \`...req.payload\` into the JSON-RPC \`metadata\` field (\`src/executor/executors/a2a-executor.ts:58\`), so \`projectSlug\`, \`projectRepo\`, and \`prNumber\` reach Ava's A2A handler as structured \`message.metadata.*\`.

**Directive prompts** — both \`_handleFixCi\` and \`_handleAddressFeedback\` rewritten from \"menu of three options\" to numbered REQUIRED STEPS:
1. Read the PR state via \`check_pr_status\` / \`get_pr_feedback\`
2. \`create_feature\` on the correct project (NOT default)
3. \`start_auto_mode\` on the correct project
4. Reply with a one-line summary

Explicitly: *\"Do NOT just file the ticket and stop — the ticket must be followed by \`start_auto_mode\` or nothing will actually happen.\"*

## Verification

- \`bun test\` → **644 pass** (12 new expect() calls for the targeting assertions)
- \`bunx tsc --noEmit\` → clean
- Tests assert \`payload.projectSlug === \"protomaker\"\` for protoMaker, \`\"rabbit-hole-io\"\` for rabbit-hole.io (verifying slug derivation handles dotted names)
- Tests assert the prompt body contains \`\"start_auto_mode\"\` and \`\"REQUIRED STEPS\"\`

## Test plan

- [ ] CI green
- [ ] Deploy, observe Ava's board:
  - New features land on the protomaker board (not ava)
  - \`auto_mode: true\` and \`running_count > 0\` after dispatch
  - PRs #3332 / #3333 get fresh fix attempts with new commits pushed
- [ ] pr_pipeline.data.failingCi eventually drops to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced project-specific targeting in remediation and feedback workflows with improved repository slug derivation
  * Added explicit required steps for tool automation sequencing, including status checks, feedback retrieval, feature creation, and auto-mode activation
  * Improved metadata propagation with project and PR-specific information now included in dispatch payloads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->