### PR TITLE
bug: GOAP goal-violated dispatch bypasses action preconditions

### DIFF
--- a/src/plugins/planner-plugin-l0.test.ts
+++ b/src/plugins/planner-plugin-l0.test.ts
@@ -222,6 +222,82 @@ describe("PlannerPluginL0", () => {
     expect(dispatched[0].actionId).toBe("high-prio");
   });
 
+  test("goal.violated: skips action when preconditions fail against cached world state", () => {
+    const action = makeAction({
+      goalId: "guarded-goal",
+      id: "guarded-action",
+      preconditions: [{ path: "extensions.domain_available", operator: "eq", value: true }],
+    });
+    registry.register(action);
+
+    const dispatched: BusMessage[] = [];
+    bus.subscribe(TOPICS.WORLD_ACTION_DISPATCH, "test", (msg) => { dispatched.push(msg); });
+
+    // Seed world state with domain_available = false
+    const worldState = makeWorldState({ extensions: { domain_available: false } });
+    bus.publish(TOPICS.WORLD_STATE_UPDATED, {
+      id: "ws-1",
+      correlationId: "corr-ws",
+      topic: TOPICS.WORLD_STATE_UPDATED,
+      timestamp: Date.now(),
+      payload: worldState,
+    });
+
+    // Clear dispatches from world state update (preconditions fail there too)
+    dispatched.length = 0;
+
+    // Fire goal violation
+    bus.publish("world.goal.violated", {
+      id: "gv-1",
+      correlationId: "corr-gv",
+      topic: "world.goal.violated",
+      timestamp: Date.now(),
+      payload: { type: "world.goal.violated", violation: { goalId: "guarded-goal", description: "test", severity: "warn", timestamp: Date.now() } },
+    });
+
+    expect(dispatched).toHaveLength(0);
+  });
+
+  test("goal.violated: dispatches action when preconditions pass against cached world state", () => {
+    const action = makeAction({
+      goalId: "guarded-goal",
+      id: "guarded-action",
+      preconditions: [{ path: "extensions.domain_available", operator: "eq", value: true }],
+    });
+    registry.register(action);
+
+    const dispatched: BusMessage[] = [];
+    bus.subscribe(TOPICS.WORLD_ACTION_DISPATCH, "test", (msg) => { dispatched.push(msg); });
+
+    // Seed world state with domain_available = true
+    const worldState = makeWorldState({ extensions: { domain_available: true } });
+    bus.publish(TOPICS.WORLD_STATE_UPDATED, {
+      id: "ws-1",
+      correlationId: "corr-ws",
+      topic: TOPICS.WORLD_STATE_UPDATED,
+      timestamp: Date.now(),
+      payload: worldState,
+    });
+
+    // Clear dispatches from world state update
+    dispatched.length = 0;
+
+    // Fire goal violation — goal is now in-flight from world state update, clear it
+    planner["inFlightGoals"].clear();
+
+    bus.publish("world.goal.violated", {
+      id: "gv-1",
+      correlationId: "corr-gv",
+      topic: "world.goal.violated",
+      timestamp: Date.now(),
+      payload: { type: "world.goal.violated", violation: { goalId: "guarded-goal", description: "test", severity: "warn", timestamp: Date.now() } },
+    });
+
+    expect(dispatched).toHaveLength(1);
+    const payload = dispatched[0].payload as ActionDispatchPayload;
+    expect(payload.actionId).toBe("guarded-action");
+  });
+
   test("uninstall removes subscriptions", () => {
     const action = makeAction();
     registry.register(action);

--- a/src/plugins/planner-plugin-l0.ts
+++ b/src/plugins/planner-plugin-l0.ts
@@ -23,7 +23,7 @@ import type {
 import type { GoalViolatedEventPayload } from "../types/events.ts";
 import { TOPICS } from "../event-bus/topics.ts";
 import { ActionRegistry } from "../planner/action-registry.ts";
-import { matchActions } from "../planner/pattern-matcher.ts";
+import { matchActions, evaluatePrecondition } from "../planner/pattern-matcher.ts";
 import { LoopDetector } from "../planner/loop-detector.ts";
 import { CooldownManager } from "../planner/cooldown-manager.ts";
 
@@ -52,6 +52,9 @@ export class PlannerPluginL0 implements Plugin {
   /** Tracks correlationIds currently in-flight to avoid double-dispatch. */
   private readonly inFlightGoals = new Set<string>();
 
+  /** Latest world state snapshot, used for precondition checks on goal violations. */
+  private lastWorldState: WorldState | null = null;
+
   constructor(
     private readonly registry: ActionRegistry,
     private readonly pluginConfig: PlannerPluginL0Config = {}
@@ -70,6 +73,7 @@ export class PlannerPluginL0 implements Plugin {
       this.name,
       (msg: BusMessage) => {
         const worldState = msg.payload as WorldState;
+        this.lastWorldState = worldState;
         this.evaluate(worldState, msg.correlationId);
       }
     );
@@ -95,6 +99,7 @@ export class PlannerPluginL0 implements Plugin {
         const payload = msg.payload as GoalViolatedEventPayload;
         const violation = payload.violation;
         const matchingActions = this.registry.getByGoal(violation.goalId);
+        const currentState = this.lastWorldState;
         for (const action of matchingActions) {
           if (this.inFlightGoals.has(action.goalId)) continue;
           if (this.cooldownManager.isOnCooldown(action.goalId, action.id)) continue;
@@ -102,8 +107,12 @@ export class PlannerPluginL0 implements Plugin {
             this.handleOscillation(action.goalId, action.id, msg.correlationId);
             continue;
           }
+          // Check preconditions against current world state before dispatching
+          if (currentState !== null && !action.preconditions.every((p) => evaluatePrecondition(p, currentState))) {
+            continue;
+          }
           this.inFlightGoals.add(action.goalId);
-          this.dispatchAction(action, {} as WorldState, msg.correlationId);
+          this.dispatchAction(action, currentState ?? ({} as WorldState), msg.correlationId);
         }
       }
     );


### PR DESCRIPTION
## Summary

## Observed

When a goal violation event fires, the L0 planner dispatches matching actions by goalId WITHOUT running the action's precondition checks. This bypasses availability guards and causes actions to fire against stale/absent domain data.

## Evidence

Current world state:
```json
'extensions': {
  'ava_board_available': false,
  'ava_pipeline_available': false,
  'branch_drift_available': false,
  ...
}
```

Yet `/api/outcomes` shows these actions firing repeatedly:
```
alert.ava_board_b...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for goal violation handling, including scenarios with and without available domain extensions.

* **Bug Fixes**
  * Improved goal violation handling to properly evaluate action preconditions against the current world state before dispatch.
  * Enhanced action dispatch to use the current world state context instead of an empty state when responding to goal violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->