### PR TITLE
Extract and forward metrics in AgentExecutor

### DIFF
--- a/src/agent-runtime/agent-executor.ts
+++ b/src/agent-runtime/agent-executor.ts
@@ -16,7 +16,7 @@
  */
 
 import { query, createSdkMcpServer, isSDKResultMessage } from "@protolabsai/sdk";
-import type { SDKResultMessageSuccess, ExtendedUsage } from "@protolabsai/sdk";
+import type { SDKResultMessageSuccess, SDKResultMessageError, ExtendedUsage } from "@protolabsai/sdk";
 import type { AgentDefinition } from "./types.ts";
 import type { ToolRegistry } from "./tool-registry.ts";
 
@@ -111,6 +111,8 @@ export class AgentExecutor {
     let resultText = "";
     let isError = false;
     let stopReason: string | undefined;
+    let usage: ExtendedUsage | undefined;
+    let numTurns: number | undefined;
 
     for await (const message of session) {
       if (isSDKResultMessage(message)) {
@@ -121,10 +123,15 @@ export class AgentExecutor {
             resultText = success.result ?? "";
             const rawStopReason = (success as Record<string, unknown>).stop_reason;
             stopReason = typeof rawStopReason === "string" ? rawStopReason : undefined;
+            usage = success.usage;
+            numTurns = success.num_turns;
           } else if ("error" in message) {
             // SDKResultMessageError
+            const errMsg = message as SDKResultMessageError;
             isError = true;
-            resultText = String((message as { error: unknown }).error ?? "Unknown error");
+            resultText = String((errMsg as { error: unknown }).error ?? "Unknown error");
+            usage = errMsg.usage;
+            numTurns = errMsg.num_turns;
           }
         }
       }
@@ -147,6 +154,6 @@ export class AgentExecutor {
 
     if (resultText.length > 0) process.stdout.write("\n");
 
-    return { text: resultText, isError, stopReason };
+    return { text: resultText, isError, stopReason, usage, numTurns };
   }
 }

--- a/src/executor/executors/proto-sdk-executor.ts
+++ b/src/executor/executors/proto-sdk-executor.ts
@@ -36,6 +36,11 @@ export class ProtoSdkExecutor implements IExecutor {
       text: result.text,
       isError: result.isError,
       correlationId: req.correlationId,
+      data: {
+        usage: result.usage,
+        numTurns: result.numTurns,
+        stopReason: result.stopReason,
+      },
     };
   }
 


### PR DESCRIPTION
## Summary

**Milestone:** Usage + Turn Metrics

AgentExecutor already extracts usage/numTurns/stopReason from SDKResultMessage at line 118. Instead of discarding them, populate AgentRunResult.data with these values. Update ProtoSdkExecutor to pass through to SkillResult.

**Files to Modify:**
- src/agent-runtime/agent-executor.ts
- src/executor/executors/proto-sdk-executor.ts

**Acceptance Criteria:**
- [ ] AgentRunResult.data contains usage.input_tokens, usage.output_tokens, numTurns, stopReason when pres...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automated remediation now activates auto-mode following successful fixes
  * Intelligent escalation system detects and reports stuck remediation attempts to human review

* **Improvements**
  * Extended execution timeout for agent requests (now 300 seconds)
  * Enhanced logging with execution metrics and result previews
  * Better error handling and response parsing for agent interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->