### PR TITLE
Publish metrics in SkillDispatcherPlugin flow events

### DIFF
--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -112,7 +112,12 @@ export class A2AExecutor implements IExecutor {
         ? artifactTexts.join("\n")
         : data.result?.message ?? `Skill "${req.skill}" accepted by ${this.config.name}`;
 
-    return { text: resultText, isError: false, correlationId: req.correlationId };
+    return {
+      text: resultText,
+      isError: false,
+      correlationId: req.correlationId,
+      data: data.result?.data as SkillResult["data"] | undefined,
+    };
   }
 
   private _buildText(req: SkillRequest): string {

--- a/src/executor/executors/proto-sdk-executor.ts
+++ b/src/executor/executors/proto-sdk-executor.ts
@@ -36,6 +36,11 @@ export class ProtoSdkExecutor implements IExecutor {
       text: result.text,
       isError: result.isError,
       correlationId: req.correlationId,
+      data: {
+        usage: result.usage,
+        numTurns: result.numTurns,
+        stopReason: result.stopReason,
+      },
     };
   }
 

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -178,12 +178,23 @@ export class SkillDispatcherPlugin implements Plugin {
         console.log(
           `[skill-dispatcher] Skill "${skill}" completed via ${executor.type} — ${(result.text ?? "").length} chars: ${preview}${(result.text ?? "").length > 300 ? "…" : ""}`,
         );
+        if (result.data?.stopReason === "max_turns") {
+          console.warn("[skill-dispatcher] Agent hit maxTurns limit");
+        }
         this._publishFlowEvent("flow.item.completed", {
           id: flowItemId,
           status: "complete",
           stage: "done",
           completedAt: Date.now(),
-          meta: { skill, executorType: executor.type, durationMs: Date.now() - dispatchedAt },
+          meta: {
+            skill,
+            executorType: executor.type,
+            durationMs: Date.now() - dispatchedAt,
+            inputTokens: result.data?.usage?.input_tokens,
+            outputTokens: result.data?.usage?.output_tokens,
+            numTurns: result.data?.numTurns,
+            stopReason: result.data?.stopReason,
+          },
         });
       }
 


### PR DESCRIPTION
## Summary

**Milestone:** Usage + Turn Metrics

In the flow.item.completed publish, include token counts and numTurns in meta. Log a warning when stopReason indicates the agent hit maxTurns. Update A2AExecutor to pass through any data field the remote returns.

**Files to Modify:**
- src/executor/skill-dispatcher-plugin.ts
- src/executor/executors/a2a-executor.ts

**Acceptance Criteria:**
- [ ] flow.item.completed meta includes { inputTokens, outputTokens, numTurns, stopReason } when available
- [ ] Log wa...

---
*Recovered automatically by Automaker post-agent hook*