### PR TITLE
fix(a2a): stop double-dispatching non-locally-owned skills

### DIFF
--- a/workspace/plugins/a2a.ts
+++ b/workspace/plugins/a2a.ts
@@ -210,19 +210,21 @@ function matchSkill(content: string, hint?: string): string | null {
 }
 
 function routeToAgent(skill: string | null, agents: AgentDef[]): AgentDef | null {
+  // Asymmetric fallback semantics — INTENTIONAL, do not "fix" to be symmetric:
+  //
+  //   explicit-skill + no claimant  → null   (caller skips and logs)
+  //   no-skill (free-form content)  → Ava   (Chief-of-Staff default)
+  //
+  // The split exists because a message with an explicit skill is a routing
+  // decision the sender has already made — falling back to a different agent
+  // silently misroutes (previously produced pr_review being answered by Ava
+  // despite not being in her agent card). But a message with no skill at all
+  // is free-form chat, and Ava is the correct default handler for that —
+  // she routes it further based on content. Keep the two paths distinct.
   if (skill) {
     const match = agents.find(a => a.skills.includes(skill));
-    if (match) return match;
-    // Skill is explicit but no registered A2A agent claims it — return null
-    // so the caller can escalate or skip. The previous behaviour of silently
-    // defaulting to Ava misrouted pr_review (an in-process proto-sdk skill on
-    // Quinn) to Ava, which then responded narratively because her LLM obliges
-    // any prompt regardless of its declared skill surface.
-    return null;
+    return match ?? null;
   }
-  // No skill at all — fall back to Ava as the Chief-of-Staff default for
-  // unstructured chat. This path is only reached for free-form content with
-  // no skillHint and no keyword match.
   return agents.find(a => a.name === "ava") ?? agents[0] ?? null;
 }
 
@@ -342,6 +344,23 @@ function reactToGitHubIssue(gh: GitHubContext, reaction: string): void {
 // ── Local memory skill handler ───────────────────────────────────────────────
 
 const MEMORY_SKILLS = new Set(["memory_recall", "memory_store"]);
+
+// ── Locally-owned skill surface ──────────────────────────────────────────────
+//
+// Single source of truth for which skills this plugin dispatches from the
+// `message.inbound.#` subscriber. The inbound handler's guard and the
+// downstream branches both read from this set, so there's no way for the
+// allowlist to drift from the actual handler logic. Any skill NOT in this
+// set falls through to the router + skill-dispatcher canonical path.
+//
+// When adding a skill to this plugin, add it to one of the source sets
+// (MEMORY_SKILLS or FIRE_AND_FORGET_SKILLS) — never hard-code a new string
+// here. onboard_project is already covered because it lives in
+// FIRE_AND_FORGET_SKILLS.
+const LOCALLY_OWNED_SKILLS = new Set<string>([
+  ...MEMORY_SKILLS,
+  ...FIRE_AND_FORGET_SKILLS,
+]);
 
 async function handleMemorySkill(
   bus: EventBus,
@@ -509,23 +528,22 @@ export default {
         ?? `message.outbound.${msg.topic.split(".").slice(1).join(".")}`;
 
       // ── Local ownership guard ──────────────────────────────────────────────
-      // This plugin owns three narrow paths:
-      //   1. MEMORY_SKILLS — handled inline via handleMemorySkill
-      //   2. onboard_project — forwarded to OnboardingPlugin
-      //   3. FIRE_AND_FORGET_SKILLS — ack-immediately orchestration skills
-      //      (plan / plan_resume / deep_research) that the router path does
-      //      not have an equivalent ack pattern for yet.
+      // This plugin only handles skills in LOCALLY_OWNED_SKILLS (memory ops +
+      // fire-and-forget orchestration, incl. onboard_project). Everything else
+      // — including skillHint-tagged webhooks like pr_review from github.ts —
+      // is the router + skill-dispatcher pipeline's responsibility. Without
+      // this guard the same inbound event triggers *both* plugins and the
+      // agent runs twice (observed on protoWorkstacean#104 as paired
+      // @protoquinn[bot] review comments).
       //
-      // Everything else — including skillHint-tagged webhooks like pr_review
-      // from github.ts — is the router + skill-dispatcher pipeline's
-      // responsibility. Without this guard the same inbound event triggers
-      // *both* plugins and the agent runs twice (observed on
-      // protoWorkstacean#104 as paired @protoquinn[bot] review comments).
-      const isLocallyOwned =
-        (skill && MEMORY_SKILLS.has(skill)) ||
-        skill === "onboard_project" ||
-        (skill && FIRE_AND_FORGET_SKILLS.has(skill));
-      if (!isLocallyOwned) return;
+      // TODO(#75 router-faf-dedup): the router path does NOT skip FAF skills,
+      // so onboard_project / plan / plan_resume / deep_research are still
+      // double-dispatched today — masked only by the inFlightFAF timing guard
+      // below. That mask is race-prone (two fast events can both clear the
+      // check before either sets it). Proper fix needs symmetric filters on
+      // both sides OR consolidating the ack-immediately pattern into
+      // skill-dispatcher so FAF skills can live entirely in the router path.
+      if (!skill || !LOCALLY_OWNED_SKILLS.has(skill)) return;
 
       const agent = routeToAgent(skill, agents);
       if (!agent) {

--- a/workspace/plugins/a2a.ts
+++ b/workspace/plugins/a2a.ts
@@ -209,13 +209,21 @@ function matchSkill(content: string, hint?: string): string | null {
   return null;
 }
 
-function routeToAgent(skill: string | null, agents: AgentDef[]): AgentDef {
+function routeToAgent(skill: string | null, agents: AgentDef[]): AgentDef | null {
   if (skill) {
     const match = agents.find(a => a.skills.includes(skill));
     if (match) return match;
+    // Skill is explicit but no registered A2A agent claims it — return null
+    // so the caller can escalate or skip. The previous behaviour of silently
+    // defaulting to Ava misrouted pr_review (an in-process proto-sdk skill on
+    // Quinn) to Ava, which then responded narratively because her LLM obliges
+    // any prompt regardless of its declared skill surface.
+    return null;
   }
-  // Default: Ava (Chief of Staff — she delegates further)
-  return agents.find(a => a.name === "ava") ?? agents[0];
+  // No skill at all — fall back to Ava as the Chief-of-Staff default for
+  // unstructured chat. This path is only reached for free-form content with
+  // no skillHint and no keyword match.
+  return agents.find(a => a.name === "ava") ?? agents[0] ?? null;
 }
 
 // ── A2A protocol ────────────────────────────────────────────────────────────
@@ -497,9 +505,37 @@ export default {
 
       const channelKey = String(p.channel ?? msg.topic.split(".").slice(2).join("-"));
       const skill = matchSkill(content, p.skillHint as string | undefined);
-      const agent = routeToAgent(skill, agents);
       const outboundTopic = msg.reply?.topic
         ?? `message.outbound.${msg.topic.split(".").slice(1).join(".")}`;
+
+      // ── Local ownership guard ──────────────────────────────────────────────
+      // This plugin owns three narrow paths:
+      //   1. MEMORY_SKILLS — handled inline via handleMemorySkill
+      //   2. onboard_project — forwarded to OnboardingPlugin
+      //   3. FIRE_AND_FORGET_SKILLS — ack-immediately orchestration skills
+      //      (plan / plan_resume / deep_research) that the router path does
+      //      not have an equivalent ack pattern for yet.
+      //
+      // Everything else — including skillHint-tagged webhooks like pr_review
+      // from github.ts — is the router + skill-dispatcher pipeline's
+      // responsibility. Without this guard the same inbound event triggers
+      // *both* plugins and the agent runs twice (observed on
+      // protoWorkstacean#104 as paired @protoquinn[bot] review comments).
+      const isLocallyOwned =
+        (skill && MEMORY_SKILLS.has(skill)) ||
+        skill === "onboard_project" ||
+        (skill && FIRE_AND_FORGET_SKILLS.has(skill));
+      if (!isLocallyOwned) return;
+
+      const agent = routeToAgent(skill, agents);
+      if (!agent) {
+        // routeToAgent now returns null when an explicit skill has no A2A
+        // claimant (was previously silently defaulting to Ava). For locally-
+        // owned skills this should never happen — but log it if it does so
+        // we don't silently drop.
+        console.warn(`[a2a] no registered agent for locally-owned skill "${skill}" — skipping`);
+        return;
+      }
 
       // Memory skills are handled locally — never forwarded to an external agent
       if (skill && MEMORY_SKILLS.has(skill)) {
@@ -646,6 +682,10 @@ export default {
       const cronId = msg.topic.replace("cron.", "");
       const skill = matchSkill(content, p.skillHint as string | undefined);
       const agent = routeToAgent(skill, agents);
+      if (!agent) {
+        console.warn(`[a2a-cron] ${cronId} — no agent claims skill "${skill}" — dropping`);
+        return;
+      }
 
       console.log(`[a2a-cron] ${cronId} → ${agent.name}`);
 


### PR DESCRIPTION
## Summary

Two compounding bugs caused every github PR webhook to produce **duplicate Quinn review comments**. Observed on protoWorkstacean#104 as paired @protoquinn[bot] comments at 07:18:26+29, 07:25:19+35, and 07:28:13+13 across three force-pushes.

**Bug 1: No locally-owned-skill guard.** Both \`src/router/router-plugin.ts:116\` and \`workspace/plugins/a2a.ts:477\` subscribe to \`message.inbound.#\`. The workspace A2A plugin had an existing dedup guard at line 492 (\`if (meta?.agentId) return\`) written for the Discord slash command path, but github webhooks set \`skillHint\` instead of \`meta.agentId\` and fell right through. Both subscribers dispatched the same skill to the same agent in parallel.

**Bug 2: \`routeToAgent\` silently defaulted to Ava.** When no registered A2A agent claimed a skill, the function returned Ava as a fallback. Ava's LLM obliged \`pr_review\` prompts despite not claiming the skill, producing narrative "reviews" that posted as @protoquinn[bot] (outbound topic routes by channel, not author).

## Fix

- **\`workspace/plugins/a2a.ts\`**: explicit locally-owned-skill allowlist — plugin only handles \`MEMORY_SKILLS\`, \`onboard_project\`, and \`FIRE_AND_FORGET_SKILLS\`. Everything else falls through to the router + skill-dispatcher canonical path.
- **\`routeToAgent\`**: signature changed to \`AgentDef | null\`. Returns null when an explicit skill has no claimant. Cron + inbound handlers updated to log and skip when that happens. Free-form content with no skillHint still falls back to Ava (the original Chief-of-Staff default).

## Verification

- \`bun run tsc --noEmit\` — clean
- \`bun test\` — 637/637 passing
- Runtime: next force-push on a managed PR should produce exactly one @protoquinn[bot] comment

## Test plan

- [ ] Merge, redeploy workstacean
- [ ] Force-push any protoWorkstacean feature branch with an open PR
- [ ] Verify github.ts webhook fires once → one \`[router] ... → pr_review\` log line → one Quinn comment on the PR
- [ ] Verify no \`[a2a] ... → ava (skill: pr_review)\` log line for the same webhook

## Follow-ups (separate tasks)

- **Router should also skip FAF skills.** \`onboard_project / plan / plan_resume / deep_research\` are currently double-dispatched too, masked only by the workspace A2A plugin's \`inFlightFAF\` dedup. Proper fix needs symmetric filters or a single canonical dispatcher.
- **A2A agents should refuse skills not in their agent-card.** Ava silently answered \`pr_review\` despite not claiming it — a skill allowlist gap on the agent side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended fallback to an arbitrary agent when a requested skill isn't registered.
  * Added stricter ownership checks so unowned or unauthorized skills are ignored, avoiding improper processing.
  * Improved handling and logging for cases where no suitable agent exists, including scheduled tasks being safely skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->