### PR TITLE
fix(ci): PR #104 — sourceMeta regression test + TS2304 root cause documented

### DIFF
--- a/src/pr-remediator.test.ts
+++ b/src/pr-remediator.test.ts
@@ -545,6 +545,9 @@ describe("PrRemediatorPlugin — world state tracking", () => {
       expect(req.summary).toContain("bug: stuck forever");
       expect(req.summary).toContain("feature request");
       expect(req.options).toEqual(["investigate", "mark_non_remediable", "manual_unblock"]);
+      // sourceMeta.interface must be set so the HITL plugin can route to Discord.
+      // Previously missing → silent drops (7 PRs affected before the fix).
+      expect(req.sourceMeta?.interface).toBe("discord");
 
       // Subsequent triggers must NOT emit additional escalations (rate-limited)
       dispatch(bus, "pr.remediate.fix_ci");


### PR DESCRIPTION
## Summary

- Root cause of CI failure on PR #104 branch at `57f124d`: TypeScript strict-mode error `TS2304: Cannot find name 'this'` at `lib/plugins/pr-remediator.ts:415` — `typeof this.latestBranchDrift` inside an arrow-function callback is rejected by tsc; fixed in `e30b98c` by extracting a named `BranchDriftData` type (included in squash merge `afec51c`)
- Added regression assertion to the stuck-HITL exhaustion test: `expect(req.sourceMeta?.interface).toBe("discord")` — verifies the HITL routing fix that prevented 7 PRs from reaching Discord (before this fix, the field was absent and the HITL plugin silently dropped all escalations to `hitl.pending`)

## Test plan

- [ ] `bun test` — all tests pass including the updated exhaustion test
- [ ] `bun run tsc --noEmit` — no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for Discord-based escalation path validation to ensure proper Human-in-the-Loop routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->