### PR TITLE
Add validateAgentTools to ToolRegistry and call on registration

### DIFF
--- a/src/agent-runtime/__tests__/agent-runtime-plugin.test.ts
+++ b/src/agent-runtime/__tests__/agent-runtime-plugin.test.ts
@@ -6,7 +6,7 @@
  * and end-to-end dispatch via SkillDispatcherPlugin.
  */
 
-import { describe, test, expect, mock } from "bun:test";
+import { describe, test, expect, mock, spyOn } from "bun:test";
 import { mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -145,6 +145,61 @@ describe("AgentRuntimePlugin", () => {
         expect(executor).not.toBeNull();
         expect(executor!.type).toBe("proto-sdk");
 
+        plugin.uninstall();
+      } finally {
+        cleanup();
+      }
+    });
+  });
+
+  describe("validateAgentTools warnings", () => {
+    test("logs warning for unknown tools", async () => {
+      const agentWithUnknownTools = {
+        ...quinnAgent,
+        tools: ["nonexistent_tool", "another_missing"],
+      };
+      const { workspaceDir, cleanup } = makeTempWorkspace({
+        "quinn-unknown.yaml": agentWithUnknownTools,
+      });
+      try {
+        const { AgentRuntimePlugin } = await import("../agent-runtime-plugin.ts");
+        const bus = new InMemoryEventBus();
+        const registry = new ExecutorRegistry();
+        const warnSpy = spyOn(console, "warn");
+        const plugin = new AgentRuntimePlugin({ workspaceDir }, registry);
+        plugin.install(bus);
+
+        const warnCalls = warnSpy.mock.calls.map(c => c[0] as string);
+        const warningCall = warnCalls.find(msg => msg.includes("[agent-runtime] WARNING:"));
+        expect(warningCall).toBeDefined();
+        expect(warningCall).toContain("quinn");
+        expect(warningCall).toContain("nonexistent_tool");
+        expect(warningCall).toContain("another_missing");
+
+        warnSpy.mockRestore();
+        plugin.uninstall();
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("no warning when all tools are known or tools list is empty", async () => {
+      const { workspaceDir, cleanup } = makeTempWorkspace({
+        "quinn.yaml": quinnAgent,
+      });
+      try {
+        const { AgentRuntimePlugin } = await import("../agent-runtime-plugin.ts");
+        const bus = new InMemoryEventBus();
+        const registry = new ExecutorRegistry();
+        const warnSpy = spyOn(console, "warn");
+        const plugin = new AgentRuntimePlugin({ workspaceDir }, registry);
+        plugin.install(bus);
+
+        const warnCalls = warnSpy.mock.calls.map(c => c[0] as string);
+        const hasAgentWarning = warnCalls.some(msg => msg.includes("[agent-runtime] WARNING:"));
+        expect(hasAgentWarning).toBe(false);
+
+        warnSpy.mockRestore();
         plugin.uninstall();
       } finally {
         cleanup();

--- a/src/agent-runtime/__tests__/tool-registry.test.ts
+++ b/src/agent-runtime/__tests__/tool-registry.test.ts
@@ -87,4 +87,22 @@ describe("ToolRegistry", () => {
     registry.registerAll([makeTool("x"), makeTool("y")]);
     expect(registry.all()).toHaveLength(2);
   });
+
+  describe("validateAgentTools()", () => {
+    test("returns empty array when all declared tools are known", () => {
+      registry.registerAll([makeTool("a"), makeTool("b")]);
+      expect(registry.validateAgentTools("my-agent", ["a", "b"])).toEqual([]);
+    });
+
+    test("returns unknown tool names", () => {
+      registry.register(makeTool("known"));
+      const unknowns = registry.validateAgentTools("my-agent", ["known", "missing-1", "missing-2"]);
+      expect(unknowns).toEqual(["missing-1", "missing-2"]);
+    });
+
+    test("returns empty array for empty declared list", () => {
+      registry.register(makeTool("a"));
+      expect(registry.validateAgentTools("my-agent", [])).toEqual([]);
+    });
+  });
 });

--- a/src/agent-runtime/agent-runtime-plugin.ts
+++ b/src/agent-runtime/agent-runtime-plugin.ts
@@ -52,6 +52,13 @@ export class AgentRuntimePlugin implements Plugin {
     const definitions = loadAgentDefinitions(this.config.workspaceDir);
 
     for (const def of definitions) {
+      const unknownTools = this.toolRegistry.validateAgentTools(def.name, def.tools ?? []);
+      if (unknownTools.length > 0) {
+        console.warn(
+          `[agent-runtime] WARNING: agent ${def.name} declares unknown tools: ${unknownTools.join(", ")}`,
+        );
+      }
+
       const executor = new ProtoSdkExecutor(def, this.toolRegistry, {
         gatewayUrl: this.config.gatewayUrl,
         gatewayApiKey: this.config.gatewayApiKey,

--- a/src/agent-runtime/tool-registry.ts
+++ b/src/agent-runtime/tool-registry.ts
@@ -72,6 +72,13 @@ export class ToolRegistry {
     return Array.from(this.tools.keys());
   }
 
+  /**
+   * Return tool names from declaredTools that are not registered.
+   */
+  validateAgentTools(_agentName: string, declaredTools: string[]): string[] {
+    return declaredTools.filter(name => !this.tools.has(name));
+  }
+
   get size(): number {
     return this.tools.size;
   }


### PR DESCRIPTION
## Summary

**Milestone:** Agent YAML Tool Validation

Add a validateAgentTools(agentName: string, declaredTools: string[]): string[] method to ToolRegistry that returns unknown tool names. Call this from AgentRuntimePlugin when registering each agent definition. Log a clear warning for any unknowns.

**Files to Modify:**
- src/agent-runtime/tool-registry.ts
- src/agent-runtime/agent-runtime-plugin.ts

**Acceptance Criteria:**
- [ ] validateAgentTools returns array of unknown tool names
- [ ] AgentRuntimePl...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-11T08:12:33.107Z -->