### PR TITLE
refactor: decompose lib/plugins/discord.ts (1259 lines) into focused modules

### DIFF
--- a/lib/plugins/discord.ts
+++ b/lib/plugins/discord.ts
@@ -1,257 +1,62 @@
 /**
- * DiscordPlugin — bridges Discord gateway events to/from the Workstacean bus.
- *
- * Inbound:
- *   @mentions, DMs → message.inbound.discord.{channelId}
- *   📋 reactions   → message.inbound.discord.{channelId}  (skill hint: bug_triage)
- *   slash commands → message.inbound.discord.slash.{interactionId}
- *
- * Outbound:
- *   message.outbound.discord.#  → reply to originating message/interaction
- *   message.outbound.discord.push.{channelId} → unprompted post (cron, etc.)
- *
- * Config: workspace/discord.yaml (channels, moderation, commands)
- *
- * Env vars:
- *   DISCORD_BOT_TOKEN       (required)
- *   DISCORD_GUILD_ID        (required for slash command registration)
- *   DISCORD_DIGEST_CHANNEL  fallback channel ID for cron-triggered posts
+ * DiscordPlugin — wires discord/* submodules into the Workstacean bus.
+ * See discord/core.ts for config types, discord/inbound.ts for handlers, etc.
  */
 
-import { readFileSync, existsSync, watchFile, unwatchFile, mkdirSync } from "node:fs";
-import type { ChannelRegistry } from "../channels/channel-registry.ts";
+import { watchFile, unwatchFile, existsSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { parse as parseYaml } from "yaml";
-import { Database } from "bun:sqlite";
-import {
-  Client,
-  GatewayIntentBits,
-  Partials,
-  Events,
-  EmbedBuilder,
-  ActionRowBuilder,
-  ButtonBuilder,
-  ButtonStyle,
-  type Message,
-  type ChatInputCommandInteraction,
-  type TextChannel,
-} from "discord.js";
-import type { EventBus, BusMessage, Plugin, HITLRequest } from "../types.ts";
+import { Events, type TextChannel } from "discord.js";
+import type { EventBus, Plugin } from "../types.ts";
+import type { ChannelRegistry } from "../channels/channel-registry.ts";
 import type { HITLPlugin } from "./hitl.ts";
 import { ConversationManager } from "../conversation/conversation-manager.ts";
-import { ConversationTracer, type TurnData } from "../conversation/conversation-tracer.ts";
+import { ConversationTracer } from "../conversation/conversation-tracer.ts";
 import { GraphitiClient } from "../memory/graphiti-client.ts";
 import { IdentityRegistry } from "../identity/identity-registry.ts";
-
-// ── Config types ──────────────────────────────────────────────────────────────
-
-interface CommandOption {
-  name: string;
-  description: string;
-  type: "string" | "integer" | "boolean";
-  required?: boolean;
-  /** When true, Discord sends autocomplete interactions for this option. */
-  autocomplete?: boolean;
-}
-
-interface Subcommand {
-  name: string;
-  description: string;
-  content: string;
-  skillHint?: string;
-  options?: CommandOption[];
-}
-
-interface CommandConfig {
-  name: string;
-  description: string;
-  /** Subcommand-based commands (mutually exclusive with top-level `options`). */
-  subcommands?: Subcommand[];
-  /** Top-level options for flat commands (no subcommands). */
-  options?: CommandOption[];
-  /** Content template for flat commands — supports {optionName} placeholders. */
-  content?: string;
-  skillHint?: string;
-}
-
-interface DiscordConfig {
-  channels: {
-    digest?: string;
-    welcome?: string;
-    modLog?: string;
-  };
-  moderation: {
-    rateLimit: {
-      maxMessages: number;
-      windowSeconds: number;
-    };
-    spamPatterns: string[];
-  };
-  commands: CommandConfig[];
-  admins?: string[];
-}
-
-function loadConfig(workspaceDir: string): DiscordConfig {
-  const configPath = join(workspaceDir, "discord.yaml");
-  if (!existsSync(configPath)) {
-    console.log("[discord] No discord.yaml found — using defaults");
-    return {
-      channels: {},
-      moderation: {
-        rateLimit: { maxMessages: 5, windowSeconds: 10 },
-        spamPatterns: [],
-      },
-      commands: [],
-    };
-  }
-  return parseYaml(readFileSync(configPath, "utf8")) as DiscordConfig;
-}
-
-// ── Discord option type codes ─────────────────────────────────────────────────
-
-const OPTION_TYPE_CODES: Record<string, number> = {
-  string: 3,
-  integer: 4,
-  boolean: 5,
-};
-
-// ── Spam pattern compilation ──────────────────────────────────────────────────
-
-/**
- * Compile spam pattern strings to RegExp objects.
- * Invalid or catastrophically-backtracking patterns are skipped with a warning
- * rather than crashing the plugin.
- */
-function compileSpamPatterns(patterns: string[]): RegExp[] {
-  return patterns.flatMap(p => {
-    try {
-      // Basic ReDoS guard: reject patterns with nested quantifiers like (a+)+
-      if (/(\([^)]*[+*][^)]*\))[+*?]/.test(p)) {
-        console.warn(`[discord] Skipping potentially unsafe spam pattern (nested quantifiers): "${p}"`);
-        return [];
-      }
-      return [new RegExp(p, "i")];
-    } catch (err) {
-      console.warn(`[discord] Skipping invalid spam pattern "${p}":`, err);
-      return [];
-    }
-  });
-}
-
-// ── Pending reply handles ─────────────────────────────────────────────────────
-// Kept outside the bus payload so the SQLite logger never tries to serialize them.
-
-const pendingReplies = new Map<
-  string,
-  { message?: Message; interaction?: ChatInputCommandInteraction }
->();
-
-function makeId(): string {
-  return crypto.randomUUID();
-}
-
-// ── Agent client pool types ──────────────────────────────────────────────────
-
-interface AgentPoolEntry {
-  name: string;
-  discordBotTokenEnvKey?: string;
-}
-
-interface AgentsYaml {
-  agents: AgentPoolEntry[];
-}
-
-function loadAgentPoolDefs(workspaceDir: string): AgentPoolEntry[] {
-  const agentsPath = join(workspaceDir, "agents.yaml");
-  if (!existsSync(agentsPath)) return [];
-  try {
-    const raw = readFileSync(agentsPath, "utf8");
-    const parsed = parseYaml(raw) as AgentsYaml;
-    return parsed.agents ?? [];
-  } catch (err) {
-    console.error("[discord] Failed to parse agents.yaml:", err);
-    return [];
-  }
-}
-
-// ── Projects loader (for autocomplete + project resolution) ───────────────────
-
-interface ProjectEntry {
-  slug: string;
-  title: string;
-  github?: string;
-  status?: string;
-  discord?: { general?: string; updates?: string; dev?: string };
-}
-
-interface ProjectsYaml {
-  projects: ProjectEntry[];
-}
-
-function loadProjectsDefs(workspaceDir: string): ProjectEntry[] {
-  const projectsPath = join(workspaceDir, "projects.yaml");
-  if (!existsSync(projectsPath)) return [];
-  try {
-    const raw = readFileSync(projectsPath, "utf8");
-    const parsed = parseYaml(raw) as ProjectsYaml;
-    return (parsed.projects ?? []).filter(
-      p => p.status !== "archived" && p.status !== "suspended"
-    );
-  } catch (err) {
-    console.error("[discord] Failed to parse projects.yaml:", err);
-    return [];
-  }
-}
-
-// ── Plugin ────────────────────────────────────────────────────────────────────
+import {
+  loadConfig, compileSpamPatterns, createMainClient, registerSlashCommands,
+  type DiscordConfig, type PendingReply,
+} from "./discord/core.ts";
+import { createRateLimiter, type RateLimiter } from "./discord/rate-limit.ts";
+import { createAgentPool, type AgentPool } from "./discord/agent-pool.ts";
+import { warmDmChannels } from "./discord/dm-warming.ts";
+import { handleDM, setupInboundHandlers } from "./discord/inbound.ts";
+import { setupSlashCommandHandlers, type HitlEntry } from "./discord/slash-commands.ts";
+import { setupOutboundSubscription, setupHITLRenderer } from "./discord/outbound.ts";
 
 export class DiscordPlugin implements Plugin {
   readonly name = "discord";
   readonly description = "Discord gateway — routes messages to/from the A2A agent fleet";
   readonly capabilities = ["discord-inbound", "discord-outbound"];
 
-  private client!: Client;
+  private client = createMainClient();
   private busRef!: EventBus;
   private config!: DiscordConfig;
   private workspaceDir: string;
-
-  // Per-agent Discord client pool (agentName → Client)
-  private agentClients = new Map<string, Client>();
-
-  // correlationId → agentName — tracks which agent should reply for a pending message
-  private pendingAgents = new Map<string, string>();
-
+  private dataDir: string | null;
+  private agentPool!: AgentPool;
+  private rateLimiter!: RateLimiter;
   private channelRegistry?: ChannelRegistry;
   private hitlPlugin?: HITLPlugin;
-
-  // correlationId → { message, replyTopic } for active HITL approvals
-  private pendingHITLMessages = new Map<string, { message: Message; replyTopic: string }>();
-
-  // Multi-turn conversation tracking
+  private pendingReplies = new Map<string, PendingReply>();
+  private pendingAgents = new Map<string, string>();
+  private pendingHITLMessages = new Map<string, HitlEntry>();
+  private pendingTurns = new Map<string, import("../conversation/conversation-tracer.ts").TurnData>();
   private conversationManager = new ConversationManager();
   private conversationTracer = new ConversationTracer();
   private graphiti = new GraphitiClient();
   private identityRegistry: IdentityRegistry | null = null;
-  // correlationId (= conversationId for conv turns) → pending Langfuse turn data
-  private pendingTurns = new Map<string, TurnData>();
 
-  // Runtime rate-limit state (built from config on install)
-  private rateLimits = new Map<string, number[]>();
-  private rateMaxMessages = 5;
-  private rateWindowMs = 10_000;
-  private spamPatterns: RegExp[] = [];
-
-  // Persistent rate-limit DB
-  private rlDb: Database | null = null;
-  private dataDir: string | null = null;
-
-  constructor(workspaceDir: string, dataDir?: string, channelRegistry?: ChannelRegistry, hitlPlugin?: HITLPlugin) {
+  constructor(
+    workspaceDir: string,
+    dataDir?: string,
+    channelRegistry?: ChannelRegistry,
+    hitlPlugin?: HITLPlugin,
+  ) {
     this.workspaceDir = workspaceDir;
     this.dataDir = dataDir ? resolve(dataDir) : null;
     this.channelRegistry = channelRegistry;
     this.hitlPlugin = hitlPlugin;
-
-    // When a conversation times out, finalize its Langfuse trace
     this.conversationManager.setTimeoutCallback((entry) => {
       this.conversationTracer.endTrace({
         conversationId: entry.conversationId,
@@ -271,350 +76,51 @@ export class DiscordPlugin implements Plugin {
     this.config = loadConfig(this.workspaceDir);
     this.identityRegistry = new IdentityRegistry(this.workspaceDir);
 
-    // Apply moderation config
     const { rateLimit, spamPatterns } = this.config.moderation;
-    this.rateMaxMessages = rateLimit.maxMessages;
-    this.rateWindowMs = rateLimit.windowSeconds * 1_000;
-    this.spamPatterns = compileSpamPatterns(spamPatterns);
-
-    // Open persistent rate-limit store
-    this._openRateLimitDb();
-
-    this.client = new Client({
-      intents: [
-        GatewayIntentBits.Guilds,
-        GatewayIntentBits.GuildMessages,
-        GatewayIntentBits.GuildMessageReactions,
-        GatewayIntentBits.GuildMembers,
-        GatewayIntentBits.MessageContent,
-        GatewayIntentBits.DirectMessages,
-      ],
-      partials: [Partials.Channel, Partials.Message, Partials.Reaction],
+    this.rateLimiter = createRateLimiter({
+      dataDir: this.dataDir,
+      maxMessages: rateLimit.maxMessages,
+      windowMs: rateLimit.windowSeconds * 1_000,
+      spamPatterns: compileSpamPatterns(spamPatterns),
     });
 
-    // ── Ready ────────────────────────────────────────────────────────────────
+    this.agentPool = createAgentPool({
+      workspaceDir: this.workspaceDir,
+      channelRegistry: this.channelRegistry,
+      busRef: bus,
+    });
+
     this.client.once(Events.ClientReady, async client => {
       console.log(`[discord] Logged in as ${client.user.tag}`);
-      await this._registerSlashCommands();
-      // Pre-warm DM channels for known users so Discord delivers gateway events.
-      // Discord only sends MESSAGE_CREATE for DM channels in this session's
-      // private_channels list; calling createDM() subscribes to the channel.
-      this._warmDmChannels(client).catch(() => {});
+      await registerSlashCommands(this.client, this.config);
+      warmDmChannels(client, this.identityRegistry).catch(() => {});
     });
 
-    // ── Message create ───────────────────────────────────────────────────────
-    this.client.on(Events.MessageCreate, async message => {
-      if (message.author.bot) return;
+    const inboundCtx = {
+      getConfig: () => this.config,
+      rateLimiter: this.rateLimiter,
+      conversationManager: this.conversationManager,
+      conversationTracer: this.conversationTracer,
+      pendingReplies: this.pendingReplies,
+      pendingAgents: this.pendingAgents,
+      pendingTurns: this.pendingTurns,
+      channelRegistry: this.channelRegistry,
+    };
+    const dmHandler = (message: import("discord.js").Message, agentName: string | undefined, b: EventBus) =>
+      handleDM(message, agentName, b, inboundCtx);
 
-      // DMs — auto conversation, no @mention needed, main bot has no assigned agent
-      if (!message.guild) {
-        await this._handleDM(message, undefined, bus);
-        return;
-      }
+    setupInboundHandlers(this.client, bus, inboundCtx, dmHandler);
 
-      const isMentioned = message.mentions.has(this.client.user!);
-      const userId = message.author.id;
-
-      // Look up channel config early — needed for conversation settings check
-      const channelEntry = this.channelRegistry?.findByTopic(`message.inbound.discord.${message.channelId}`);
-      const convConfig = channelEntry?.conversation;
-      const convEnabled = convConfig?.enabled === true;
-
-      // Allow continuing an active conversation without an @mention
-      const continueWithoutMention =
-        convEnabled &&
-        convConfig?.requireMentionAfterFirst !== true &&
-        this.conversationManager.has(message.channelId, userId);
-
-      if (!isMentioned && !continueWithoutMention) return;
-
-      if (!this._isAdmin(userId)) {
-        console.log(`[discord] message from ${userId} ignored — not in admins list`);
-        return;
-      }
-
-      if (this._isSpam(message.content)) {
-        await message.delete().catch(() => {});
-        return;
-      }
-      if (this._isRateLimited(userId)) {
-        await message.reply("Easy there — you're sending messages too quickly.").catch(() => {});
-        return;
-      }
-
-      await message.react("👀").catch(() => {});
-
-      // Determine correlationId — stable across turns when conversation is enabled
-      let correlationId: string;
-      let isNewConversation = false;
-      let turnNumber = 1;
-
-      if (convEnabled) {
-        const conv = this.conversationManager.getOrCreate(
-          message.channelId,
-          userId,
-          convConfig?.timeoutMs ?? 5 * 60_000,
-          channelEntry?.agent,
-        );
-        correlationId = conv.conversationId;
-        isNewConversation = conv.isNew;
-        turnNumber = conv.turnNumber;
-      } else {
-        correlationId = makeId();
-      }
-
-      pendingReplies.set(correlationId, { message });
-
-      if (channelEntry?.agent) {
-        this.pendingAgents.set(correlationId, channelEntry.agent);
-      }
-
-      const content = message.cleanContent
-        .replace(/<@!?\d+>/g, "")
-        .trim();
-
-      // Langfuse conversation tracing
-      if (convEnabled) {
-        if (isNewConversation) {
-          this.conversationTracer.startTrace({
-            conversationId: correlationId,
-            userId,
-            channelId: message.channelId,
-            agentName: channelEntry?.agent,
-            platform: "discord",
-          }).catch(err => console.error("[discord] Langfuse startTrace error:", err));
-        }
-        // Store turn data — log raw content, not the memory-prefixed version
-        this.pendingTurns.set(correlationId, {
-          conversationId: correlationId,
-          turnNumber,
-          input: content,
-          userId,
-          agentName: channelEntry?.agent,
-          startTime: new Date(),
-        });
-      }
-
-      bus.publish(`message.inbound.discord.${message.channelId}`, {
-        id: message.id,
-        correlationId,
-        topic: `message.inbound.discord.${message.channelId}`,
-        timestamp: Date.now(),
-        payload: {
-          sender: userId,
-          channel: message.channelId,
-          content,
-          isThread: message.channel.isThread(),
-          guildId: message.guildId,
-          ...(channelEntry?.agent ? { agentId: channelEntry.agent } : {}),
-        },
-        source: { interface: "discord" as const, channelId: message.channelId, userId },
-        reply: { topic: `message.outbound.discord.${message.channelId}` },
-      });
+    setupSlashCommandHandlers(this.client, bus, {
+      workspaceDir: this.workspaceDir,
+      getConfig: () => this.config,
+      graphiti: this.graphiti,
+      identityRegistry: this.identityRegistry,
+      pendingReplies: this.pendingReplies,
+      pendingAgents: this.pendingAgents,
+      pendingHITLMessages: this.pendingHITLMessages,
     });
 
-    // ── 📋 reaction → bug triage ─────────────────────────────────────────────
-    this.client.on(Events.MessageReactionAdd, async (reaction, user) => {
-      if (user.bot) return;
-      if (reaction.emoji.name !== "📋") return;
-      if (!this._isAdmin(user.id)) {
-        console.log(`[discord] reaction from ${user.id} ignored — not in admins list`);
-        return;
-      }
-
-      const message = reaction.partial
-        ? await reaction.message.fetch()
-        : reaction.message as Message;
-
-      await message.react("👀").catch(() => {});
-
-      const correlationId = makeId();
-      pendingReplies.set(correlationId, { message });
-
-      bus.publish(`message.inbound.discord.${message.channelId}`, {
-        id: `${message.id}-clip`,
-        correlationId,
-        topic: `message.inbound.discord.${message.channelId}`,
-        timestamp: Date.now(),
-        payload: {
-          sender: user.id,
-          channel: message.channelId,
-          content: message.content,
-          skillHint: "bug_triage",
-          isReaction: true,
-        },
-        source: { interface: "discord" as const, channelId: message.channelId, userId: user.id },
-        reply: { topic: `message.outbound.discord.${message.channelId}` },
-      });
-    });
-
-    // ── Slash commands + autocomplete ────────────────────────────────────────
-    this.client.on(Events.InteractionCreate, async interaction => {
-      // ── Autocomplete: filter projects.yaml by typed value ─────────────────
-      if (interaction.isAutocomplete()) {
-        const cmdConfig = this.config.commands.find(c => c.name === interaction.commandName);
-        if (!cmdConfig) return;
-
-        const focused = interaction.options.getFocused(true);
-        if (focused.name === "project") {
-          const projects = loadProjectsDefs(this.workspaceDir);
-          const typed = focused.value.toLowerCase();
-          const choices = projects
-            .filter(p =>
-              p.slug.toLowerCase().includes(typed) ||
-              p.title.toLowerCase().includes(typed)
-            )
-            .slice(0, 25)
-            .map(p => ({ name: p.title, value: p.slug }));
-          await interaction.respond(choices).catch(console.error);
-        }
-        return;
-      }
-
-      // ── HITL button interactions ─────────────────────────────────────────
-      if (interaction.isButton() && interaction.customId.startsWith("hitl:")) {
-        const [, decision, correlationId] = interaction.customId.split(":");
-        await interaction.deferUpdate();
-
-        const entry = this.pendingHITLMessages.get(correlationId);
-        const replyTopic = entry?.replyTopic
-          ?? `hitl.response.${correlationId.split("-")[0]}.${correlationId}`;
-
-        bus.publish(replyTopic, {
-          id: crypto.randomUUID(),
-          correlationId,
-          topic: replyTopic,
-          timestamp: Date.now(),
-          payload: {
-            type: "hitl_response",
-            correlationId,
-            decision: decision as "approve" | "reject" | "modify",
-            decidedBy: interaction.user.id,
-          },
-        });
-
-        if (entry) this.pendingHITLMessages.delete(correlationId);
-
-        const COLOR_APPROVE = 0x22c55e;
-        const COLOR_REJECT = 0xef4444;
-        const COLOR_NEUTRAL = 0x6b7280;
-        let color: number;
-        if (decision === "approve") color = COLOR_APPROVE;
-        else if (decision === "reject") color = COLOR_REJECT;
-        else color = COLOR_NEUTRAL;
-        const label = decision.charAt(0).toUpperCase() + decision.slice(1);
-        const decidedEmbed = new EmbedBuilder()
-          .setTitle(interaction.message.embeds[0]?.title ?? "Decision recorded")
-          .setDescription(`**${label}** by <@${interaction.user.id}>`)
-          .setColor(color);
-
-        await interaction.message.edit({ embeds: [decidedEmbed], components: [] }).catch(console.error);
-        return;
-      }
-
-      if (!interaction.isChatInputCommand()) return;
-
-      // Pre-warm DM channel so subsequent DMs from this user are delivered via gateway.
-      this.client.users.createDM(interaction.user.id).catch(() => {});
-
-      const cmdConfig = this.config.commands.find(c => c.name === interaction.commandName);
-      if (!cmdConfig) return;
-
-      if (!this._isAdmin(interaction.user.id)) {
-        console.log(`[discord] slash command from ${interaction.user.id} ignored — not in admins list`);
-        await interaction.reply({ content: "Not authorised.", ephemeral: true }).catch(() => {});
-        return;
-      }
-
-      // ── /memory — native handler (no bus dispatch) ────────────────────────
-      if (interaction.commandName === "memory") {
-        await interaction.deferReply({ ephemeral: true });
-        await this._handleMemoryCommand(interaction);
-        return;
-      }
-
-      await interaction.deferReply();
-
-      // ── Flat command (top-level options, no subcommands) ─────────────────
-      const isFlatCommand = !!cmdConfig.options?.length && !cmdConfig.subcommands?.length;
-      if (isFlatCommand) {
-        // Resolve project metadata from projects.yaml if a `project` option is present
-        const projectSlug = interaction.options.getString("project");
-        let devChannelId: string | undefined;
-        let projectRepo: string | undefined;
-
-        if (projectSlug) {
-          const projects = loadProjectsDefs(this.workspaceDir);
-          const project = projects.find(p => p.slug === projectSlug);
-          if (project) {
-            devChannelId = project.discord?.dev || undefined;
-            projectRepo = project.github || undefined;
-          }
-        }
-
-        const content = this._interpolateContent(
-          cmdConfig.content ?? "",
-          cmdConfig.options ?? [],
-          interaction,
-        );
-
-        const correlationId = makeId();
-        pendingReplies.set(correlationId, { interaction });
-
-        const topicSuffix = `slash.${interaction.id}`;
-        bus.publish(`message.inbound.discord.${topicSuffix}`, {
-          id: interaction.id,
-          correlationId,
-          topic: `message.inbound.discord.${topicSuffix}`,
-          timestamp: Date.now(),
-          payload: {
-            sender: interaction.user.id,
-            channel: interaction.channelId,
-            content,
-            skillHint: cmdConfig.skillHint,
-            ...(devChannelId ? { devChannelId } : {}),
-            ...(projectRepo ? { projectRepo } : {}),
-          },
-          source: { interface: "discord" as const, channelId: interaction.channelId, userId: interaction.user.id },
-          reply: { topic: `message.outbound.discord.${topicSuffix}` },
-        });
-        return;
-      }
-
-      // ── Subcommand-based command (existing behaviour) ─────────────────────
-      const subcommands = cmdConfig.subcommands ?? [];
-      const subName = interaction.options.getSubcommand(false) ?? subcommands[0]?.name;
-      const subConfig = subcommands.find(s => s.name === subName) ?? subcommands[0];
-
-      if (!subConfig) {
-        await interaction.editReply("Unknown subcommand.").catch(console.error);
-        return;
-      }
-
-      // Interpolate {optionName} placeholders from config content template
-      const content = this._interpolateContent(subConfig.content, subConfig.options ?? [], interaction);
-
-      const correlationId = makeId();
-      pendingReplies.set(correlationId, { interaction });
-
-      const topicSuffix = `slash.${interaction.id}`;
-      bus.publish(`message.inbound.discord.${topicSuffix}`, {
-        id: interaction.id,
-        correlationId,
-        topic: `message.inbound.discord.${topicSuffix}`,
-        timestamp: Date.now(),
-        payload: {
-          sender: interaction.user.id,
-          channel: interaction.channelId,
-          content,
-          skillHint: subConfig.skillHint,
-        },
-        source: { interface: "discord" as const, channelId: interaction.channelId, userId: interaction.user.id },
-        reply: { topic: `message.outbound.discord.${topicSuffix}` },
-      });
-    });
-
-    // ── Welcome new members ──────────────────────────────────────────────────
     this.client.on(Events.GuildMemberAdd, async member => {
       const channelId = this.config.channels.welcome || process.env.DISCORD_WELCOME_CHANNEL;
       if (!channelId) return;
@@ -622,171 +128,42 @@ export class DiscordPlugin implements Plugin {
       await ch?.send(`Welcome to the protoLabs community, <@${member.id}>! 👋`).catch(() => {});
     });
 
-    // ── Outbound: reply to pending messages / interactions ───────────────────
-    bus.subscribe("message.outbound.discord.#", "discord-outbound", async (msg: BusMessage) => {
-      const payload = msg.payload as Record<string, unknown>;
-      const content = String(payload.content ?? "").slice(0, 2000);
-      if (!content) return; // drop empty outbound messages silently
-      const correlationId = msg.correlationId;
-
-      // Resolve agent-specific client — payload.agentId wins, then pendingAgents map
-      const agentId = (payload.agentId as string | undefined)
-        ?? (correlationId ? this.pendingAgents.get(correlationId) : undefined);
-      const agentClient = agentId ? this.agentClients.get(agentId) : undefined;
-      if (agentId && !agentClient) {
-        console.debug(`[discord] No pool client for agent "${agentId}" — falling back to bus client`);
-      }
-
-      // 1. Pending reply from a prior inbound message
-      if (correlationId) {
-        const pending = pendingReplies.get(correlationId);
-        if (pending) {
-          pendingReplies.delete(correlationId);
-          this.pendingAgents.delete(correlationId);
-
-          // Finalize Langfuse generation + store episode in Graphiti
-          const pendingTurn = this.pendingTurns.get(correlationId);
-          if (pendingTurn) {
-            this.pendingTurns.delete(correlationId);
-            this.conversationTracer.traceTurn({
-              ...pendingTurn,
-              output: content,
-              endTime: new Date(),
-            }).catch(err => console.error("[discord] Langfuse traceTurn error:", err));
-
-            // Note: Graphiti addEpisode is handled by SkillDispatcherPlugin for all channels.
-          }
-
-          if (pending.interaction) {
-            // Slash command interactions always use the bus client
-            await pending.interaction.editReply({ content }).catch(console.error);
-            return;
-          }
-
-          if (pending.message) {
-            const isDM = !pending.message.guild;
-
-            if (isDM) {
-              // DMs: reply directly through the message's own channel (works for any bot client)
-              await (pending.message.channel as TextChannel).send({ content }).catch(console.error);
-            } else if (agentClient) {
-              // Guild message via agent's bot identity
-              const ch = agentClient.channels.cache.get(pending.message.channelId) as TextChannel | undefined;
-              if (ch) {
-                console.debug(`[discord] Routing reply via agent client "${agentId}"`);
-                await ch.send({ content }).catch(console.error);
-              } else {
-                console.warn(`[discord] Agent "${agentId}" channel cache miss — falling back to bus client`);
-                await pending.message.reply({ content }).catch(console.error);
-              }
-            } else {
-              const reply = await pending.message.reply({ content }).catch(console.error);
-              // Start a thread on first guild response if not already in one
-              if (reply && !pending.message.channel.isThread()) {
-                await reply.startThread({ name: content.slice(0, 50) || "Response" }).catch(() => {});
-              }
-            }
-
-            // Reactions: only in guild channels (the main client owns them there)
-            if (!isDM) {
-              await pending.message.reactions.resolve("👀")?.users.remove(this.client.user!).catch(() => {});
-              await pending.message.react("✅").catch(() => {});
-            }
-            return;
-          }
-        }
-      }
-
-      // 2. Unprompted push (cron, proactive notification)
-      const channelId = String(
-        payload.channel ?? payload.recipient
-          ?? this.config.channels.digest
-          ?? process.env.DISCORD_DIGEST_CHANNEL
-          ?? ""
-      );
-      if (channelId) {
-        const sendClient = agentClient ?? this.client;
-        if (agentClient) {
-          console.debug(`[discord] Routing push to channel ${channelId} via agent client "${agentId}"`);
-        }
-        const ch = sendClient.channels.cache.get(channelId) as TextChannel | undefined;
-        await ch?.send({ content }).catch(console.error);
-      }
+    setupOutboundSubscription(bus, {
+      client: this.client,
+      agentPool: this.agentPool,
+      pendingReplies: this.pendingReplies,
+      pendingAgents: this.pendingAgents,
+      pendingTurns: this.pendingTurns,
+      conversationTracer: this.conversationTracer,
+      getConfig: () => this.config,
     });
 
-    // ── HITL renderer registration ───────────────────────────────────────────
-    if (this.hitlPlugin) {
-      this.hitlPlugin.registerRenderer("discord", {
-        render: async (request, _busRef) => {
-          const channelId = request.sourceMeta?.channelId;
-          if (!channelId) {
-            console.warn(`[discord] HITL ${request.correlationId} missing channelId — cannot render`);
-            return;
-          }
-          const ch = this.client.channels.cache.get(channelId) as TextChannel | undefined;
-          if (!ch) {
-            console.warn(`[discord] HITL channel ${channelId} not in cache — cannot render`);
-            return;
-          }
-          const embed = this._buildHITLEmbed(request);
-          const row = this._buildHITLButtons(request);
-          const msg = await ch.send({ embeds: [embed], components: [row] });
-          this.pendingHITLMessages.set(request.correlationId, {
-            message: msg,
-            replyTopic: request.replyTopic,
-          });
-          console.log(`[discord] HITL ${request.correlationId} rendered in channel ${channelId}`);
-        },
-        onExpired: async (request, _busRef) => {
-          const entry = this.pendingHITLMessages.get(request.correlationId);
-          if (!entry) return;
-          this.pendingHITLMessages.delete(request.correlationId);
-          const expiredEmbed = new EmbedBuilder()
-            .setTitle(request.title)
-            .setDescription("**Approval expired** — re-trigger if still needed.")
-            .setColor(0x6b7280);
-          await entry.message.edit({ embeds: [expiredEmbed], components: [] }).catch(console.error);
-          console.log(`[discord] HITL ${request.correlationId} marked expired`);
-        },
-      });
-    }
+    setupHITLRenderer(this.hitlPlugin, this.client, bus, this.pendingHITLMessages);
 
-    // ── Hot-reload discord.yaml ───────────────────────────────────────────────
-    // watchFile works even if the file doesn't exist yet (detects creation too).
     const configPath = join(this.workspaceDir, "discord.yaml");
     watchFile(configPath, { interval: 5_000 }, async () => {
       const prev = this.config;
       this.config = loadConfig(this.workspaceDir);
-
-      // Apply updated moderation config
-      const { rateLimit, spamPatterns } = this.config.moderation;
-      this.rateMaxMessages = rateLimit.maxMessages;
-      this.rateWindowMs = rateLimit.windowSeconds * 1_000;
-      this.spamPatterns = compileSpamPatterns(spamPatterns);
-
-      // Re-register slash commands if command list changed
+      const { rateLimit: rl, spamPatterns: sp } = this.config.moderation;
+      this.rateLimiter.reconfigure(rl.maxMessages, rl.windowSeconds * 1_000, compileSpamPatterns(sp));
       const prevCmds = JSON.stringify(prev.commands ?? []);
       const newCmds = JSON.stringify(this.config.commands ?? []);
       if (prevCmds !== newCmds && this.client?.isReady()) {
         console.log("[discord] discord.yaml changed — re-registering slash commands");
-        await this._registerSlashCommands().catch(console.error);
+        await registerSlashCommands(this.client, this.config).catch(console.error);
       } else {
         console.log("[discord] discord.yaml reloaded");
       }
     });
 
-    // ── Bus client login ────────────────────────────────────────────────────
     this.client.login(process.env.DISCORD_BOT_TOKEN);
+    this.agentPool.init(dmHandler);
 
-    // ── Agent client pool initialization ────────────────────────────────────
-    this._initAgentPool();
-
-    // ── Hot-reload agent pool on agents.yaml changes ────────────────────────
     const agentsPath = join(this.workspaceDir, "agents.yaml");
     if (existsSync(agentsPath)) {
       watchFile(agentsPath, { interval: 5_000 }, () => {
         console.log("[discord] agents.yaml changed — reloading agent client pool");
-        this._reloadAgentPool();
+        this.agentPool.reload();
       });
     }
   }
@@ -795,470 +172,10 @@ export class DiscordPlugin implements Plugin {
     this.conversationManager.destroy();
     this.pendingTurns.clear();
     this.pendingHITLMessages.clear();
-
-    // Destroy agent pool clients
-    for (const [name, client] of this.agentClients) {
-      client.destroy();
-      console.log(`[discord] Destroyed agent client: ${name}`);
-    }
-    this.agentClients.clear();
-
-    // Stop watching config files
+    this.agentPool?.destroy();
     unwatchFile(join(this.workspaceDir, "discord.yaml"));
     unwatchFile(join(this.workspaceDir, "agents.yaml"));
-
     this.client?.destroy();
-
-    if (this.rlDb) {
-      this.rlDb.close();
-      this.rlDb = null;
-    }
-  }
-
-  // ── Private helpers ─────────────────────────────────────────────────────────
-
-  /**
-   * Pre-warm DM channels for all users in the identity registry that have a
-   * Discord ID set. Discord's gateway only delivers MESSAGE_CREATE for DM
-   * channels that appear in the session's private_channels list (sent in READY).
-   * Calling createDM() subscribes the bot to that channel for this session.
-   */
-  private async _warmDmChannels(client: Client<true>): Promise<void> {
-    // Collect all Discord IDs from the identity registry
-    const discordIds = this.identityRegistry
-      ?.memoryEnabledUsers()
-      .map(u => u.identities.discord)
-      .filter((id): id is string => !!id)
-      ?? [];
-    if (!discordIds.length) return;
-    let warmed = 0;
-    for (const discordId of discordIds) {
-      try {
-        await client.users.createDM(discordId);
-        warmed++;
-      } catch { /* skip if user not reachable */ }
-    }
-    if (warmed) console.log(`[discord] Pre-warmed ${warmed} DM channel(s)`);
-  }
-
-  private _isAdmin(userId: string): boolean {
-    if (!this.config.admins?.length) return true; // open if no list configured
-    return this.config.admins.includes(userId);
-  }
-
-  private _openRateLimitDb(): void {
-    if (!this.dataDir) return;
-
-    try {
-      if (!existsSync(this.dataDir)) {
-        mkdirSync(this.dataDir, { recursive: true });
-      }
-
-      this.rlDb = new Database(join(this.dataDir, "events.db"));
-      this.rlDb.exec("PRAGMA journal_mode=WAL");
-      this.rlDb.exec(`
-        CREATE TABLE IF NOT EXISTS rate_limits (
-          user_id TEXT NOT NULL,
-          ts INTEGER NOT NULL
-        )
-      `);
-      this.rlDb.exec("CREATE INDEX IF NOT EXISTS idx_rate_limits_user_ts ON rate_limits(user_id, ts)");
-
-      // Load persisted windows into memory
-      const cutoff = Date.now() - this.rateWindowMs;
-      const rows = this.rlDb
-        .query("SELECT user_id, ts FROM rate_limits WHERE ts > ?")
-        .all(cutoff) as { user_id: string; ts: number }[];
-
-      for (const row of rows) {
-        const hits = this.rateLimits.get(row.user_id) ?? [];
-        hits.push(row.ts);
-        this.rateLimits.set(row.user_id, hits);
-      }
-
-      console.log(`[discord] Rate-limit DB opened (${rows.length} persisted hit(s) loaded)`);
-    } catch (err) {
-      console.warn("[discord] Could not open rate-limit DB — falling back to in-memory only:", err);
-      this.rlDb = null;
-    }
-  }
-
-  private _isRateLimited(userId: string): boolean {
-    const now = Date.now();
-    const hits = (this.rateLimits.get(userId) ?? []).filter(t => now - t < this.rateWindowMs);
-    hits.push(now);
-    this.rateLimits.set(userId, hits);
-
-    // Persist new hit to DB (fire-and-forget; errors are non-fatal)
-    if (this.rlDb) {
-      try {
-        this.rlDb.run("INSERT INTO rate_limits (user_id, ts) VALUES (?, ?)", [userId, now]);
-        // Prune expired rows for this user to keep the table tidy
-        this.rlDb.run("DELETE FROM rate_limits WHERE user_id = ? AND ts <= ?", [userId, now - this.rateWindowMs]);
-      } catch (err) {
-        console.warn("[discord] Failed to persist rate-limit hit:", err);
-      }
-    }
-
-    return hits.length > this.rateMaxMessages;
-  }
-
-  private _isSpam(content: string): boolean {
-    return this.spamPatterns.some(p => p.test(content));
-  }
-
-  /** Replace {optionName} tokens in a content template with actual interaction values. */
-  private _interpolateContent(
-    template: string,
-    options: CommandOption[],
-    interaction: ChatInputCommandInteraction,
-  ): string {
-    let result = template;
-    for (const opt of options) {
-      const placeholder = `{${opt.name}}`;
-      if (!result.includes(placeholder)) continue;
-
-      let value = "";
-      if (opt.type === "string") {
-        value = interaction.options.getString(opt.name) ?? "";
-      } else if (opt.type === "integer") {
-        value = String(interaction.options.getInteger(opt.name) ?? "");
-      } else if (opt.type === "boolean") {
-        value = String(interaction.options.getBoolean(opt.name) ?? "");
-      }
-      result = result.replaceAll(placeholder, value);
-    }
-    return result.trim();
-  }
-
-  private async _handleMemoryCommand(interaction: ChatInputCommandInteraction): Promise<void> {
-    const userId = interaction.user.id;
-
-    if (!this.identityRegistry) {
-      await interaction.editReply("Memory not available.").catch(console.error);
-      return;
-    }
-
-    const groupId = this.identityRegistry.groupId("discord", userId);
-    const subName = interaction.options.getSubcommand(false);
-
-    if (!subName || subName === "show") {
-      const facts = await this.graphiti.search(groupId, "preferences habits goals context", 20).catch(() => []);
-      if (facts.length === 0) {
-        await interaction.editReply("No memory stored yet.").catch(console.error);
-        return;
-      }
-      const now = Date.now();
-      const active = facts.filter(f => {
-        if (f.invalid_at && new Date(f.invalid_at).getTime() <= now) return false;
-        if (f.expired_at && new Date(f.expired_at).getTime() <= now) return false;
-        return true;
-      });
-      if (active.length === 0) {
-        await interaction.editReply("No active memory facts.").catch(console.error);
-        return;
-      }
-      const lines = active.map((f, i) => `**${i + 1}.** ${f.fact}`).join("\n");
-      await interaction.editReply(`**Memory** (${active.length} facts):\n${lines}`.slice(0, 2000)).catch(console.error);
-
-    } else if (subName === "search") {
-      const query = interaction.options.getString("query", true);
-      const facts = await this.graphiti.search(groupId, query, 10).catch(() => []);
-      if (facts.length === 0) {
-        await interaction.editReply(`No facts found for: "${query}"`).catch(console.error);
-        return;
-      }
-      const lines = facts.map((f, i) => `**${i + 1}.** ${f.fact}`).join("\n");
-      await interaction.editReply(`**"${query}"** — ${facts.length} fact(s):\n${lines}`.slice(0, 2000)).catch(console.error);
-
-    } else if (subName === "clear") {
-      await this.graphiti.clearUser(groupId);
-      await interaction.editReply("Memory cleared.").catch(console.error);
-    }
-  }
-
-  private _buildHITLEmbed(request: HITLRequest): EmbedBuilder {
-    const embed = new EmbedBuilder()
-      .setTitle(request.title)
-      .setDescription(request.summary.slice(0, 4096))
-      .setColor(0xf59e0b);
-
-    if (request.avaVerdict) {
-      embed.addFields({
-        name: `Ava verdict (score: ${request.avaVerdict.score})`,
-        value: request.avaVerdict.verdict.slice(0, 1024),
-        inline: false,
-      });
-    }
-    if (request.jonVerdict) {
-      embed.addFields({
-        name: `Jon verdict (score: ${request.jonVerdict.score})`,
-        value: request.jonVerdict.verdict.slice(0, 1024),
-        inline: false,
-      });
-    }
-    if (request.escalationContext) {
-      const ctx = request.escalationContext;
-      embed.addFields({
-        name: "Cost",
-        value: `Est: **$${ctx.estimatedCost.toFixed(4)}** | Max: $${ctx.maxCost.toFixed(4)} | Tier: ${ctx.tier}`,
-        inline: false,
-      });
-    }
-
-    embed.setFooter({ text: `Expires ${new Date(request.expiresAt).toLocaleString()}` });
-    return embed;
-  }
-
-  private _buildHITLButtons(request: HITLRequest): ActionRowBuilder<ButtonBuilder> {
-    const row = new ActionRowBuilder<ButtonBuilder>();
-    const STYLE_BY_OPTION: Record<string, ButtonStyle> = {
-      approve: ButtonStyle.Success,
-      reject: ButtonStyle.Danger,
-    };
-    for (const option of request.options) {
-      const style = STYLE_BY_OPTION[option] ?? ButtonStyle.Secondary;
-      row.addComponents(
-        new ButtonBuilder()
-          .setCustomId(`hitl:${option}:${request.correlationId}`)
-          .setLabel(option.charAt(0).toUpperCase() + option.slice(1))
-          .setStyle(style),
-      );
-    }
-    return row;
-  }
-
-  /**
-   * Handle an inbound DM — called from both the main bot and agent pool bots.
-   *
-   * DMs are always conversation-enabled (no channels.yaml entry needed).
-   * The stable conversationId becomes the A2A contextId, giving the agent
-   * full memory of the exchange across turns.
-   *
-   * agentName is undefined when the main bus bot receives the DM (routed by
-   * A2A keyword matching). When an agent pool bot receives it, agentName is
-   * the specific agent so the A2A layer routes directly.
-   */
-  private async _handleDM(message: Message, agentName: string | undefined, bus: EventBus): Promise<void> {
-    const userId = message.author.id;
-
-    if (!this._isAdmin(userId)) return;
-    if (this._isSpam(message.content)) { await message.delete().catch(() => {}); return; }
-    if (this._isRateLimited(userId)) {
-      await (message.channel as TextChannel).send("Easy there — you're sending messages too quickly.").catch(() => {});
-      return;
-    }
-
-    const timeoutMs = Number(process.env.DM_CONVERSATION_TIMEOUT_MS ?? 15 * 60_000);
-    const conv = this.conversationManager.getOrCreate(message.channelId, userId, timeoutMs, agentName);
-    const { conversationId, isNew, turnNumber } = conv;
-
-    pendingReplies.set(conversationId, { message });
-    if (agentName) this.pendingAgents.set(conversationId, agentName);
-
-    const content = message.cleanContent.replace(/<@!?\d+>/g, "").trim();
-    if (!content) return;
-
-    // Langfuse tracing
-    if (isNew) {
-      this.conversationTracer.startTrace({
-        conversationId,
-        userId,
-        channelId: message.channelId,
-        agentName,
-        platform: "discord-dm",
-      }).catch(err => console.error("[discord] Langfuse startTrace error:", err));
-    }
-    this.pendingTurns.set(conversationId, {
-      conversationId,
-      turnNumber,
-      input: content,
-      userId,
-      agentName,
-      startTime: new Date(),
-    });
-
-    bus.publish(`message.inbound.discord.${message.channelId}`, {
-      id: message.id,
-      correlationId: conversationId,
-      topic: `message.inbound.discord.${message.channelId}`,
-      timestamp: Date.now(),
-      payload: {
-        sender: userId,
-        channel: message.channelId,
-        content,
-        isDM: true,
-        ...(agentName ? { agentId: agentName } : {}),
-      },
-      source: { interface: "discord" as const, channelId: message.channelId, userId },
-      reply: { topic: `message.outbound.discord.${message.channelId}` },
-    });
-  }
-
-  private _initAgentPool(): void {
-    // Sources: agents.yaml (legacy) + channels.yaml (preferred)
-    const agentsYamlEntries = loadAgentPoolDefs(this.workspaceDir)
-      .filter(a => a.discordBotTokenEnvKey)
-      .map(a => ({ name: a.name, tokenEnvKey: a.discordBotTokenEnvKey! }));
-
-    const channelEntries = this.channelRegistry
-      ? Array.from(this.channelRegistry.getDiscordBotTokenEnvs().entries())
-          .map(([name, tokenEnvKey]) => ({ name, tokenEnvKey }))
-      : [];
-
-    // Merge — channels.yaml wins on conflict
-    const byName = new Map<string, string>();
-    for (const { name, tokenEnvKey } of [...agentsYamlEntries, ...channelEntries]) {
-      byName.set(name, tokenEnvKey);
-    }
-
-    let created = 0;
-    for (const [agentName, tokenEnvKey] of byName) {
-      const token = process.env[tokenEnvKey];
-      if (!token) {
-        console.warn(`[discord] No token for agent "${agentName}" (env: ${tokenEnvKey}) — will use bus bot`);
-        continue;
-      }
-
-      try {
-        const agentClient = new Client({
-          intents: [
-            GatewayIntentBits.Guilds,
-            GatewayIntentBits.GuildMessages,
-            GatewayIntentBits.MessageContent,
-            GatewayIntentBits.DirectMessages,
-          ],
-          partials: [Partials.Channel, Partials.Message],
-        });
-
-        agentClient.once(Events.ClientReady, c => {
-          console.log(`[discord] Agent client "${agentName}" logged in as ${c.user.tag}`);
-        });
-
-        // Handle DMs sent directly to this agent's bot
-        agentClient.on(Events.MessageCreate, async (message) => {
-          if (message.author.bot) return;
-          if (message.guild) return; // guild messages handled by main client
-          await this._handleDM(message, agentName, this.busRef!);
-        });
-
-        agentClient.login(token).catch(err => {
-          console.warn(`[discord] Agent client "${agentName}" login failed:`, err);
-          this.agentClients.delete(agentName);
-        });
-
-        this.agentClients.set(agentName, agentClient);
-        created++;
-      } catch (err) {
-        console.warn(`[discord] Failed to create client for agent "${agentName}":`, err);
-      }
-    }
-
-    console.log(`[discord] Agent client pool: ${created} client(s) initialized (${byName.size} agents configured)`);
-  }
-
-  private _reloadAgentPool(): void {
-    const agents = loadAgentPoolDefs(this.workspaceDir);
-    const newAgentNames = new Set(
-      agents.filter(a => a.discordBotTokenEnvKey && process.env[a.discordBotTokenEnvKey!])
-        .map(a => a.name)
-    );
-
-    // Remove clients for agents no longer in config
-    for (const [name, client] of this.agentClients) {
-      if (!newAgentNames.has(name)) {
-        client.destroy();
-        this.agentClients.delete(name);
-        console.log(`[discord] Pool: removed agent client "${name}"`);
-      }
-    }
-
-    // Add clients for new agents
-    for (const agent of agents) {
-      if (!agent.discordBotTokenEnvKey) continue;
-      if (this.agentClients.has(agent.name)) continue; // already active
-
-      const token = process.env[agent.discordBotTokenEnvKey];
-      if (!token) continue;
-
-      try {
-        const agentClient = new Client({
-          intents: [GatewayIntentBits.Guilds],
-        });
-
-        agentClient.once(Events.ClientReady, c => {
-          console.log(`[discord] Agent client "${agent.name}" logged in as ${c.user.tag}`);
-        });
-
-        agentClient.login(token).catch(err => {
-          console.warn(`[discord] Agent client "${agent.name}" login failed:`, err);
-          this.agentClients.delete(agent.name);
-        });
-
-        this.agentClients.set(agent.name, agentClient);
-        console.log(`[discord] Pool: added agent client "${agent.name}"`);
-      } catch (err) {
-        console.warn(`[discord] Failed to create client for agent "${agent.name}":`, err);
-      }
-    }
-
-    console.log(`[discord] Pool reloaded: ${this.agentClients.size} active agent client(s)`);
-  }
-
-  private async _registerSlashCommands(): Promise<void> {
-    const guildId = process.env.DISCORD_GUILD_ID;
-    if (!guildId) {
-      console.log("[discord] DISCORD_GUILD_ID not set — skipping slash command registration");
-      return;
-    }
-
-    const guild = this.client.guilds.cache.get(guildId);
-    if (!guild) {
-      console.log(`[discord] Guild ${guildId} not found`);
-      return;
-    }
-
-    if (!this.config.commands.length) {
-      console.log("[discord] No commands configured in discord.yaml");
-      return;
-    }
-
-    const commandData = this.config.commands.map(cmd => {
-      // Flat command: top-level options with optional autocomplete (no subcommands)
-      if (cmd.options?.length && !cmd.subcommands?.length) {
-        return {
-          name: cmd.name,
-          description: cmd.description,
-          options: cmd.options.map(opt => ({
-            name: opt.name,
-            description: opt.description,
-            type: OPTION_TYPE_CODES[opt.type] ?? 3,
-            required: opt.required ?? false,
-            autocomplete: opt.autocomplete ?? false,
-          })),
-        };
-      }
-      // Subcommand-based command (existing behaviour)
-      return {
-        name: cmd.name,
-        description: cmd.description,
-        options: (cmd.subcommands ?? []).map(sub => ({
-          name: sub.name,
-          type: 1, // SUB_COMMAND
-          description: sub.description,
-          options: (sub.options ?? []).map(opt => ({
-            name: opt.name,
-            description: opt.description,
-            type: OPTION_TYPE_CODES[opt.type] ?? 3,
-            required: opt.required ?? false,
-          })),
-        })),
-      };
-    });
-
-    await guild.commands.set(commandData);
-    console.log(
-      `[discord] Registered ${commandData.length} command(s): ${commandData.map(c => `/${c.name}`).join(", ")}`
-    );
+    this.rateLimiter?.close();
   }
 }

--- a/lib/plugins/discord/agent-pool.ts
+++ b/lib/plugins/discord/agent-pool.ts
@@ -1,0 +1,181 @@
+/**
+ * discord/agent-pool.ts — multi-bot client pool (DISCORD_BOT_TOKEN_* env vars).
+ *
+ * Each agent can have a dedicated Discord bot identity. The pool manages
+ * creation, hot-reload, and teardown of those per-agent Client instances.
+ */
+
+import {
+  Client,
+  GatewayIntentBits,
+  Partials,
+  Events,
+  type Message,
+} from "discord.js";
+import type { EventBus } from "../../types.ts";
+import type { ChannelRegistry } from "../../channels/channel-registry.ts";
+import { loadAgentPoolDefs } from "./core.ts";
+
+export type HandleDMFn = (
+  message: Message,
+  agentName: string | undefined,
+  bus: EventBus,
+) => Promise<void>;
+
+export interface AgentPool {
+  /** Initialize the pool, creating clients for all configured agents. */
+  init(handleDM: HandleDMFn): void;
+  /** Hot-reload: remove clients for agents removed from config, add new ones. */
+  reload(): void;
+  getClient(agentId: string): Client | undefined;
+  entries(): IterableIterator<[string, Client]>;
+  destroy(): void;
+}
+
+export function createAgentPool(opts: {
+  workspaceDir: string;
+  channelRegistry?: ChannelRegistry;
+  busRef: EventBus;
+}): AgentPool {
+  const { workspaceDir, channelRegistry, busRef } = opts;
+  const agentClients = new Map<string, Client>();
+  let _handleDM: HandleDMFn | null = null;
+
+  // Full intents + DM handler — used during initial pool creation
+  function spawnForInit(agentName: string, token: string): void {
+    try {
+      const agentClient = new Client({
+        intents: [
+          GatewayIntentBits.Guilds,
+          GatewayIntentBits.GuildMessages,
+          GatewayIntentBits.MessageContent,
+          GatewayIntentBits.DirectMessages,
+        ],
+        partials: [Partials.Channel, Partials.Message],
+      });
+
+      agentClient.once(Events.ClientReady, c => {
+        console.log(`[discord] Agent client "${agentName}" logged in as ${c.user.tag}`);
+      });
+
+      // Handle DMs sent directly to this agent's bot
+      agentClient.on(Events.MessageCreate, async (message) => {
+        if (message.author.bot) return;
+        if (message.guild) return; // guild messages handled by main client
+        await _handleDM!(message, agentName, busRef);
+      });
+
+      agentClient.login(token).catch(err => {
+        console.warn(`[discord] Agent client "${agentName}" login failed:`, err);
+        agentClients.delete(agentName);
+      });
+
+      agentClients.set(agentName, agentClient);
+    } catch (err) {
+      console.warn(`[discord] Failed to create client for agent "${agentName}":`, err);
+    }
+  }
+
+  // Minimal intents, no DM handler — used during hot-reload for new agents
+  function spawnForReload(agentName: string, token: string): void {
+    try {
+      const agentClient = new Client({
+        intents: [GatewayIntentBits.Guilds],
+      });
+
+      agentClient.once(Events.ClientReady, c => {
+        console.log(`[discord] Agent client "${agentName}" logged in as ${c.user.tag}`);
+      });
+
+      agentClient.login(token).catch(err => {
+        console.warn(`[discord] Agent client "${agentName}" login failed:`, err);
+        agentClients.delete(agentName);
+      });
+
+      agentClients.set(agentName, agentClient);
+      console.log(`[discord] Pool: added agent client "${agentName}"`);
+    } catch (err) {
+      console.warn(`[discord] Failed to create client for agent "${agentName}":`, err);
+    }
+  }
+
+  return {
+    init(handleDM: HandleDMFn): void {
+      _handleDM = handleDM;
+
+      // Sources: agents.yaml (legacy) + channels.yaml (preferred)
+      const agentsYamlEntries = loadAgentPoolDefs(workspaceDir)
+        .filter(a => a.discordBotTokenEnvKey)
+        .map(a => ({ name: a.name, tokenEnvKey: a.discordBotTokenEnvKey! }));
+
+      const channelEntries = channelRegistry
+        ? Array.from(channelRegistry.getDiscordBotTokenEnvs().entries())
+            .map(([name, tokenEnvKey]) => ({ name, tokenEnvKey }))
+        : [];
+
+      // Merge — channels.yaml wins on conflict
+      const byName = new Map<string, string>();
+      for (const { name, tokenEnvKey } of [...agentsYamlEntries, ...channelEntries]) {
+        byName.set(name, tokenEnvKey);
+      }
+
+      let created = 0;
+      for (const [agentName, tokenEnvKey] of byName) {
+        const token = process.env[tokenEnvKey];
+        if (!token) {
+          console.warn(`[discord] No token for agent "${agentName}" (env: ${tokenEnvKey}) — will use bus bot`);
+          continue;
+        }
+        spawnForInit(agentName, token);
+        created++;
+      }
+
+      console.log(`[discord] Agent client pool: ${created} client(s) initialized (${byName.size} agents configured)`);
+    },
+
+    reload(): void {
+      const agents = loadAgentPoolDefs(workspaceDir);
+      const newAgentNames = new Set(
+        agents
+          .filter(a => a.discordBotTokenEnvKey && process.env[a.discordBotTokenEnvKey!])
+          .map(a => a.name)
+      );
+
+      // Remove clients for agents no longer in config
+      for (const [name, client] of agentClients) {
+        if (!newAgentNames.has(name)) {
+          client.destroy();
+          agentClients.delete(name);
+          console.log(`[discord] Pool: removed agent client "${name}"`);
+        }
+      }
+
+      // Add clients for new agents
+      for (const agent of agents) {
+        if (!agent.discordBotTokenEnvKey) continue;
+        if (agentClients.has(agent.name)) continue; // already active
+        const token = process.env[agent.discordBotTokenEnvKey];
+        if (!token) continue;
+        spawnForReload(agent.name, token);
+      }
+
+      console.log(`[discord] Pool reloaded: ${agentClients.size} active agent client(s)`);
+    },
+
+    getClient(agentId: string): Client | undefined {
+      return agentClients.get(agentId);
+    },
+
+    entries(): IterableIterator<[string, Client]> {
+      return agentClients.entries();
+    },
+
+    destroy(): void {
+      for (const [name, client] of agentClients) {
+        client.destroy();
+        console.log(`[discord] Destroyed agent client: ${name}`);
+      }
+      agentClients.clear();
+    },
+  };
+}

--- a/lib/plugins/discord/core.ts
+++ b/lib/plugins/discord/core.ts
@@ -1,0 +1,257 @@
+/**
+ * discord/core.ts — config types, loaders, and shared utilities.
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import {
+  Client,
+  GatewayIntentBits,
+  Partials,
+  type ChatInputCommandInteraction,
+} from "discord.js";
+
+// ── Config types ───────────────────────────────────────────────────────────────
+
+export interface CommandOption {
+  name: string;
+  description: string;
+  type: "string" | "integer" | "boolean";
+  required?: boolean;
+  /** When true, Discord sends autocomplete interactions for this option. */
+  autocomplete?: boolean;
+}
+
+export interface Subcommand {
+  name: string;
+  description: string;
+  content: string;
+  skillHint?: string;
+  options?: CommandOption[];
+}
+
+export interface CommandConfig {
+  name: string;
+  description: string;
+  /** Subcommand-based commands (mutually exclusive with top-level `options`). */
+  subcommands?: Subcommand[];
+  /** Top-level options for flat commands (no subcommands). */
+  options?: CommandOption[];
+  /** Content template for flat commands — supports {optionName} placeholders. */
+  content?: string;
+  skillHint?: string;
+}
+
+export interface DiscordConfig {
+  channels: {
+    digest?: string;
+    welcome?: string;
+    modLog?: string;
+  };
+  moderation: {
+    rateLimit: {
+      maxMessages: number;
+      windowSeconds: number;
+    };
+    spamPatterns: string[];
+  };
+  commands: CommandConfig[];
+  admins?: string[];
+}
+
+// ── Agent pool types ──────────────────────────────────────────────────────────
+
+export interface AgentPoolEntry {
+  name: string;
+  discordBotTokenEnvKey?: string;
+}
+
+export interface AgentsYaml {
+  agents: AgentPoolEntry[];
+}
+
+// ── Project types ─────────────────────────────────────────────────────────────
+
+export interface ProjectEntry {
+  slug: string;
+  title: string;
+  github?: string;
+  status?: string;
+  discord?: { general?: string; updates?: string; dev?: string };
+}
+
+export interface ProjectsYaml {
+  projects: ProjectEntry[];
+}
+
+// ── Shared handle type ────────────────────────────────────────────────────────
+
+export type PendingReply = {
+  message?: import("discord.js").Message;
+  interaction?: ChatInputCommandInteraction;
+};
+
+// ── Discord option type codes ─────────────────────────────────────────────────
+
+export const OPTION_TYPE_CODES: Record<string, number> = {
+  string: 3,
+  integer: 4,
+  boolean: 5,
+};
+
+// ── Config loaders ─────────────────────────────────────────────────────────────
+
+export function loadConfig(workspaceDir: string): DiscordConfig {
+  const configPath = join(workspaceDir, "discord.yaml");
+  if (!existsSync(configPath)) {
+    console.log("[discord] No discord.yaml found — using defaults");
+    return {
+      channels: {},
+      moderation: {
+        rateLimit: { maxMessages: 5, windowSeconds: 10 },
+        spamPatterns: [],
+      },
+      commands: [],
+    };
+  }
+  return parseYaml(readFileSync(configPath, "utf8")) as DiscordConfig;
+}
+
+export function loadAgentPoolDefs(workspaceDir: string): AgentPoolEntry[] {
+  const agentsPath = join(workspaceDir, "agents.yaml");
+  if (!existsSync(agentsPath)) return [];
+  try {
+    const raw = readFileSync(agentsPath, "utf8");
+    const parsed = parseYaml(raw) as AgentsYaml;
+    return parsed.agents ?? [];
+  } catch (err) {
+    console.error("[discord] Failed to parse agents.yaml:", err);
+    return [];
+  }
+}
+
+export function loadProjectsDefs(workspaceDir: string): ProjectEntry[] {
+  const projectsPath = join(workspaceDir, "projects.yaml");
+  if (!existsSync(projectsPath)) return [];
+  try {
+    const raw = readFileSync(projectsPath, "utf8");
+    const parsed = parseYaml(raw) as ProjectsYaml;
+    return (parsed.projects ?? []).filter(
+      p => p.status !== "archived" && p.status !== "suspended"
+    );
+  } catch (err) {
+    console.error("[discord] Failed to parse projects.yaml:", err);
+    return [];
+  }
+}
+
+// ── Spam pattern compilation ──────────────────────────────────────────────────
+
+/**
+ * Compile spam pattern strings to RegExp objects.
+ * Invalid or catastrophically-backtracking patterns are skipped with a warning.
+ */
+export function compileSpamPatterns(patterns: string[]): RegExp[] {
+  return patterns.flatMap(p => {
+    try {
+      // Basic ReDoS guard: reject patterns with nested quantifiers like (a+)+
+      if (/(\([^)]*[+*][^)]*\))[+*?]/.test(p)) {
+        console.warn(`[discord] Skipping potentially unsafe spam pattern (nested quantifiers): "${p}"`);
+        return [];
+      }
+      return [new RegExp(p, "i")];
+    } catch (err) {
+      console.warn(`[discord] Skipping invalid spam pattern "${p}":`, err);
+      return [];
+    }
+  });
+}
+
+// ── Utilities ─────────────────────────────────────────────────────────────────
+
+export function makeId(): string {
+  return crypto.randomUUID();
+}
+
+export function isAdmin(userId: string, admins?: string[]): boolean {
+  if (!admins?.length) return true; // open if no list configured
+  return admins.includes(userId);
+}
+
+// ── Slash command utilities ────────────────────────────────────────────────────
+
+/** Replace {optionName} tokens in a content template with actual interaction values. */
+export function interpolateContent(
+  template: string,
+  options: CommandOption[],
+  interaction: ChatInputCommandInteraction,
+): string {
+  let result = template;
+  for (const opt of options) {
+    const placeholder = `{${opt.name}}`;
+    if (!result.includes(placeholder)) continue;
+    let value = "";
+    if (opt.type === "string") value = interaction.options.getString(opt.name) ?? "";
+    else if (opt.type === "integer") value = String(interaction.options.getInteger(opt.name) ?? "");
+    else if (opt.type === "boolean") value = String(interaction.options.getBoolean(opt.name) ?? "");
+    result = result.replaceAll(placeholder, value);
+  }
+  return result.trim();
+}
+
+/** Register slash commands with the Discord guild. */
+export async function registerSlashCommands(client: Client, config: DiscordConfig): Promise<void> {
+  const guildId = process.env.DISCORD_GUILD_ID;
+  if (!guildId) {
+    console.log("[discord] DISCORD_GUILD_ID not set — skipping slash command registration");
+    return;
+  }
+  const guild = client.guilds.cache.get(guildId);
+  if (!guild) { console.log(`[discord] Guild ${guildId} not found`); return; }
+  if (!config.commands.length) { console.log("[discord] No commands configured in discord.yaml"); return; }
+
+  const commandData = config.commands.map(cmd => {
+    if (cmd.options?.length && !cmd.subcommands?.length) {
+      return {
+        name: cmd.name,
+        description: cmd.description,
+        options: cmd.options.map(opt => ({
+          name: opt.name, description: opt.description,
+          type: OPTION_TYPE_CODES[opt.type] ?? 3,
+          required: opt.required ?? false, autocomplete: opt.autocomplete ?? false,
+        })),
+      };
+    }
+    return {
+      name: cmd.name,
+      description: cmd.description,
+      options: (cmd.subcommands ?? []).map(sub => ({
+        name: sub.name, type: 1, description: sub.description,
+        options: (sub.options ?? []).map(opt => ({
+          name: opt.name, description: opt.description,
+          type: OPTION_TYPE_CODES[opt.type] ?? 3, required: opt.required ?? false,
+        })),
+      })),
+    };
+  });
+
+  await guild.commands.set(commandData);
+  console.log(`[discord] Registered ${commandData.length} command(s): ${commandData.map(c => `/${c.name}`).join(", ")}`);
+}
+
+// ── Main client factory ───────────────────────────────────────────────────────
+
+export function createMainClient(): Client {
+  return new Client({
+    intents: [
+      GatewayIntentBits.Guilds,
+      GatewayIntentBits.GuildMessages,
+      GatewayIntentBits.GuildMessageReactions,
+      GatewayIntentBits.GuildMembers,
+      GatewayIntentBits.MessageContent,
+      GatewayIntentBits.DirectMessages,
+    ],
+    partials: [Partials.Channel, Partials.Message, Partials.Reaction],
+  });
+}

--- a/lib/plugins/discord/dm-warming.ts
+++ b/lib/plugins/discord/dm-warming.ts
@@ -1,0 +1,37 @@
+/**
+ * discord/dm-warming.ts — DM channel pre-warming logic.
+ *
+ * Discord only delivers MESSAGE_CREATE gateway events for DM channels that
+ * appear in the session's private_channels list (sent in READY). Calling
+ * createDM() subscribes the bot to that channel for the current session.
+ */
+
+import type { Client } from "discord.js";
+import type { IdentityRegistry } from "../../identity/identity-registry.ts";
+
+/**
+ * Pre-warm DM channels for all users in the identity registry that have a
+ * Discord ID set.
+ */
+export async function warmDmChannels(
+  client: Client<true>,
+  identityRegistry: IdentityRegistry | null,
+): Promise<void> {
+  const discordIds = identityRegistry
+    ?.memoryEnabledUsers()
+    .map(u => u.identities.discord)
+    .filter((id): id is string => !!id)
+    ?? [];
+
+  if (!discordIds.length) return;
+
+  let warmed = 0;
+  for (const discordId of discordIds) {
+    try {
+      await client.users.createDM(discordId);
+      warmed++;
+    } catch { /* skip if user not reachable */ }
+  }
+
+  if (warmed) console.log(`[discord] Pre-warmed ${warmed} DM channel(s)`);
+}

--- a/lib/plugins/discord/inbound.ts
+++ b/lib/plugins/discord/inbound.ts
@@ -1,0 +1,272 @@
+/**
+ * discord/inbound.ts — DM and guild message handlers.
+ *
+ * Handles:
+ *   MessageCreate  → @mention in guilds + DMs → message.inbound.discord.{channelId}
+ *   MessageReactionAdd (📋) → bug triage → message.inbound.discord.{channelId}
+ */
+
+import {
+  Events,
+  type Client,
+  type Message,
+  type TextChannel,
+} from "discord.js";
+import type { EventBus } from "../../types.ts";
+import type { ChannelRegistry } from "../../channels/channel-registry.ts";
+import type { ConversationManager } from "../../conversation/conversation-manager.ts";
+import type { ConversationTracer, TurnData } from "../../conversation/conversation-tracer.ts";
+import type { RateLimiter } from "./rate-limit.ts";
+import type { DiscordConfig, PendingReply } from "./core.ts";
+import { isAdmin, makeId } from "./core.ts";
+
+export type HandleDMFn = (
+  message: Message,
+  agentName: string | undefined,
+  bus: EventBus,
+) => Promise<void>;
+
+export interface InboundContext {
+  getConfig: () => DiscordConfig;
+  rateLimiter: RateLimiter;
+  conversationManager: ConversationManager;
+  conversationTracer: ConversationTracer;
+  pendingReplies: Map<string, PendingReply>;
+  pendingAgents: Map<string, string>;
+  pendingTurns: Map<string, TurnData>;
+  channelRegistry?: ChannelRegistry;
+}
+
+/**
+ * Handle an inbound DM — called from both the main bot and agent pool bots.
+ *
+ * DMs are always conversation-enabled (no channels.yaml entry needed).
+ * The stable conversationId becomes the A2A contextId, giving the agent
+ * full memory of the exchange across turns.
+ *
+ * agentName is undefined when the main bus bot receives the DM (routed by
+ * A2A keyword matching). When an agent pool bot receives it, agentName is
+ * the specific agent so the A2A layer routes directly.
+ */
+export async function handleDM(
+  message: Message,
+  agentName: string | undefined,
+  bus: EventBus,
+  ctx: InboundContext,
+): Promise<void> {
+  const userId = message.author.id;
+  const { getConfig, rateLimiter, conversationManager, conversationTracer,
+    pendingReplies, pendingAgents, pendingTurns } = ctx;
+
+  if (!isAdmin(userId, getConfig().admins)) return;
+  if (rateLimiter.isSpam(message.content)) { await message.delete().catch(() => {}); return; }
+  if (rateLimiter.isRateLimited(userId)) {
+    await (message.channel as TextChannel).send("Easy there — you're sending messages too quickly.").catch(() => {});
+    return;
+  }
+
+  const timeoutMs = Number(process.env.DM_CONVERSATION_TIMEOUT_MS ?? 15 * 60_000);
+  const conv = conversationManager.getOrCreate(message.channelId, userId, timeoutMs, agentName);
+  const { conversationId, isNew, turnNumber } = conv;
+
+  pendingReplies.set(conversationId, { message });
+  if (agentName) pendingAgents.set(conversationId, agentName);
+
+  const content = message.cleanContent.replace(/<@!?\d+>/g, "").trim();
+  if (!content) return;
+
+  // Langfuse tracing
+  if (isNew) {
+    conversationTracer.startTrace({
+      conversationId,
+      userId,
+      channelId: message.channelId,
+      agentName,
+      platform: "discord-dm",
+    }).catch(err => console.error("[discord] Langfuse startTrace error:", err));
+  }
+  pendingTurns.set(conversationId, {
+    conversationId,
+    turnNumber,
+    input: content,
+    userId,
+    agentName,
+    startTime: new Date(),
+  });
+
+  bus.publish(`message.inbound.discord.${message.channelId}`, {
+    id: message.id,
+    correlationId: conversationId,
+    topic: `message.inbound.discord.${message.channelId}`,
+    timestamp: Date.now(),
+    payload: {
+      sender: userId,
+      channel: message.channelId,
+      content,
+      isDM: true,
+      ...(agentName ? { agentId: agentName } : {}),
+    },
+    source: { interface: "discord" as const, channelId: message.channelId, userId },
+    reply: { topic: `message.outbound.discord.${message.channelId}` },
+  });
+}
+
+/**
+ * Register MessageCreate and MessageReactionAdd handlers on the main client.
+ */
+export function setupInboundHandlers(
+  client: Client,
+  bus: EventBus,
+  ctx: InboundContext,
+  dmHandler: HandleDMFn,
+): void {
+  const { getConfig, rateLimiter, conversationManager, conversationTracer,
+    pendingReplies, pendingAgents, pendingTurns, channelRegistry } = ctx;
+
+  // ── Message create ─────────────────────────────────────────────────────────
+  client.on(Events.MessageCreate, async message => {
+    if (message.author.bot) return;
+
+    // DMs — auto conversation, no @mention needed, main bot has no assigned agent
+    if (!message.guild) {
+      await dmHandler(message, undefined, bus);
+      return;
+    }
+
+    const isMentioned = message.mentions.has(client.user!);
+    const userId = message.author.id;
+
+    // Look up channel config early — needed for conversation settings check
+    const channelEntry = channelRegistry?.findByTopic(`message.inbound.discord.${message.channelId}`);
+    const convConfig = channelEntry?.conversation;
+    const convEnabled = convConfig?.enabled === true;
+
+    // Allow continuing an active conversation without an @mention
+    const continueWithoutMention =
+      convEnabled &&
+      convConfig?.requireMentionAfterFirst !== true &&
+      conversationManager.has(message.channelId, userId);
+
+    if (!isMentioned && !continueWithoutMention) return;
+
+    const config = getConfig();
+    if (!isAdmin(userId, config.admins)) {
+      console.log(`[discord] message from ${userId} ignored — not in admins list`);
+      return;
+    }
+
+    if (rateLimiter.isSpam(message.content)) {
+      await message.delete().catch(() => {});
+      return;
+    }
+    if (rateLimiter.isRateLimited(userId)) {
+      await message.reply("Easy there — you're sending messages too quickly.").catch(() => {});
+      return;
+    }
+
+    await message.react("👀").catch(() => {});
+
+    // Determine correlationId — stable across turns when conversation is enabled
+    let correlationId: string;
+    let isNewConversation = false;
+    let turnNumber = 1;
+
+    if (convEnabled) {
+      const conv = conversationManager.getOrCreate(
+        message.channelId,
+        userId,
+        convConfig?.timeoutMs ?? 5 * 60_000,
+        channelEntry?.agent,
+      );
+      correlationId = conv.conversationId;
+      isNewConversation = conv.isNew;
+      turnNumber = conv.turnNumber;
+    } else {
+      correlationId = makeId();
+    }
+
+    pendingReplies.set(correlationId, { message });
+
+    if (channelEntry?.agent) {
+      pendingAgents.set(correlationId, channelEntry.agent);
+    }
+
+    const content = message.cleanContent
+      .replace(/<@!?\d+>/g, "")
+      .trim();
+
+    // Langfuse conversation tracing
+    if (convEnabled) {
+      if (isNewConversation) {
+        conversationTracer.startTrace({
+          conversationId: correlationId,
+          userId,
+          channelId: message.channelId,
+          agentName: channelEntry?.agent,
+          platform: "discord",
+        }).catch(err => console.error("[discord] Langfuse startTrace error:", err));
+      }
+      // Store turn data — log raw content, not the memory-prefixed version
+      pendingTurns.set(correlationId, {
+        conversationId: correlationId,
+        turnNumber,
+        input: content,
+        userId,
+        agentName: channelEntry?.agent,
+        startTime: new Date(),
+      });
+    }
+
+    bus.publish(`message.inbound.discord.${message.channelId}`, {
+      id: message.id,
+      correlationId,
+      topic: `message.inbound.discord.${message.channelId}`,
+      timestamp: Date.now(),
+      payload: {
+        sender: userId,
+        channel: message.channelId,
+        content,
+        isThread: message.channel.isThread(),
+        guildId: message.guildId,
+        ...(channelEntry?.agent ? { agentId: channelEntry.agent } : {}),
+      },
+      source: { interface: "discord" as const, channelId: message.channelId, userId },
+      reply: { topic: `message.outbound.discord.${message.channelId}` },
+    });
+  });
+
+  // ── 📋 reaction → bug triage ───────────────────────────────────────────────
+  client.on(Events.MessageReactionAdd, async (reaction, user) => {
+    if (user.bot) return;
+    if (reaction.emoji.name !== "📋") return;
+    if (!isAdmin(user.id, getConfig().admins)) {
+      console.log(`[discord] reaction from ${user.id} ignored — not in admins list`);
+      return;
+    }
+
+    const message = reaction.partial
+      ? await reaction.message.fetch()
+      : reaction.message as Message;
+
+    await message.react("👀").catch(() => {});
+
+    const correlationId = makeId();
+    pendingReplies.set(correlationId, { message });
+
+    bus.publish(`message.inbound.discord.${message.channelId}`, {
+      id: `${message.id}-clip`,
+      correlationId,
+      topic: `message.inbound.discord.${message.channelId}`,
+      timestamp: Date.now(),
+      payload: {
+        sender: user.id,
+        channel: message.channelId,
+        content: message.content,
+        skillHint: "bug_triage",
+        isReaction: true,
+      },
+      source: { interface: "discord" as const, channelId: message.channelId, userId: user.id },
+      reply: { topic: `message.outbound.discord.${message.channelId}` },
+    });
+  });
+}

--- a/lib/plugins/discord/outbound.ts
+++ b/lib/plugins/discord/outbound.ts
@@ -1,0 +1,232 @@
+/**
+ * discord/outbound.ts — reply handling, HITL rendering, and outbound routing.
+ *
+ * Handles:
+ *   message.outbound.discord.#  → reply to pending messages / interactions
+ *   message.outbound.discord.push.{channelId} → unprompted post (cron, etc.)
+ *
+ * Also registers the HITL Discord renderer with the HITL plugin.
+ */
+
+import {
+  EmbedBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  type Client,
+  type TextChannel,
+  type Message,
+} from "discord.js";
+import type { EventBus, BusMessage, HITLRequest } from "../../types.ts";
+import type { HITLPlugin } from "../hitl.ts";
+import type { ConversationTracer, TurnData } from "../../conversation/conversation-tracer.ts";
+import type { AgentPool } from "./agent-pool.ts";
+import type { HitlEntry } from "./slash-commands.ts";
+import type { DiscordConfig, PendingReply } from "./core.ts";
+
+export interface OutboundContext {
+  client: Client;
+  agentPool: AgentPool;
+  pendingReplies: Map<string, PendingReply>;
+  pendingAgents: Map<string, string>;
+  pendingTurns: Map<string, TurnData>;
+  conversationTracer: ConversationTracer;
+  getConfig: () => DiscordConfig;
+}
+
+export function buildHITLEmbed(request: HITLRequest): EmbedBuilder {
+  const embed = new EmbedBuilder()
+    .setTitle(request.title)
+    .setDescription(request.summary.slice(0, 4096))
+    .setColor(0xf59e0b);
+
+  if (request.avaVerdict) {
+    embed.addFields({
+      name: `Ava verdict (score: ${request.avaVerdict.score})`,
+      value: request.avaVerdict.verdict.slice(0, 1024),
+      inline: false,
+    });
+  }
+  if (request.jonVerdict) {
+    embed.addFields({
+      name: `Jon verdict (score: ${request.jonVerdict.score})`,
+      value: request.jonVerdict.verdict.slice(0, 1024),
+      inline: false,
+    });
+  }
+  if (request.escalationContext) {
+    const ctx = request.escalationContext;
+    embed.addFields({
+      name: "Cost",
+      value: `Est: **$${ctx.estimatedCost.toFixed(4)}** | Max: $${ctx.maxCost.toFixed(4)} | Tier: ${ctx.tier}`,
+      inline: false,
+    });
+  }
+
+  embed.setFooter({ text: `Expires ${new Date(request.expiresAt).toLocaleString()}` });
+  return embed;
+}
+
+export function buildHITLButtons(request: HITLRequest): ActionRowBuilder<ButtonBuilder> {
+  const row = new ActionRowBuilder<ButtonBuilder>();
+  const STYLE_BY_OPTION: Record<string, ButtonStyle> = {
+    approve: ButtonStyle.Success,
+    reject: ButtonStyle.Danger,
+  };
+  for (const option of request.options) {
+    const style = STYLE_BY_OPTION[option] ?? ButtonStyle.Secondary;
+    row.addComponents(
+      new ButtonBuilder()
+        .setCustomId(`hitl:${option}:${request.correlationId}`)
+        .setLabel(option.charAt(0).toUpperCase() + option.slice(1))
+        .setStyle(style),
+    );
+  }
+  return row;
+}
+
+/**
+ * Subscribe to outbound discord messages on the bus and route them to the
+ * appropriate Discord channel / interaction reply.
+ */
+export function setupOutboundSubscription(bus: EventBus, ctx: OutboundContext): void {
+  const { client, agentPool, pendingReplies, pendingAgents, pendingTurns,
+    conversationTracer, getConfig } = ctx;
+
+  bus.subscribe("message.outbound.discord.#", "discord-outbound", async (msg: BusMessage) => {
+    const payload = msg.payload as Record<string, unknown>;
+    const content = String(payload.content ?? "").slice(0, 2000);
+    if (!content) return; // drop empty outbound messages silently
+    const correlationId = msg.correlationId;
+
+    // Resolve agent-specific client — payload.agentId wins, then pendingAgents map
+    const agentId = (payload.agentId as string | undefined)
+      ?? (correlationId ? pendingAgents.get(correlationId) : undefined);
+    const agentClient = agentId ? agentPool.getClient(agentId) : undefined;
+    if (agentId && !agentClient) {
+      console.debug(`[discord] No pool client for agent "${agentId}" — falling back to bus client`);
+    }
+
+    // 1. Pending reply from a prior inbound message
+    if (correlationId) {
+      const pending = pendingReplies.get(correlationId);
+      if (pending) {
+        pendingReplies.delete(correlationId);
+        pendingAgents.delete(correlationId);
+
+        // Finalize Langfuse generation
+        const pendingTurn = pendingTurns.get(correlationId);
+        if (pendingTurn) {
+          pendingTurns.delete(correlationId);
+          conversationTracer.traceTurn({
+            ...pendingTurn,
+            output: content,
+            endTime: new Date(),
+          }).catch(err => console.error("[discord] Langfuse traceTurn error:", err));
+
+          // Note: Graphiti addEpisode is handled by SkillDispatcherPlugin for all channels.
+        }
+
+        if (pending.interaction) {
+          // Slash command interactions always use the bus client
+          await pending.interaction.editReply({ content }).catch(console.error);
+          return;
+        }
+
+        if (pending.message) {
+          const isDM = !pending.message.guild;
+
+          if (isDM) {
+            // DMs: reply directly through the message's own channel (works for any bot client)
+            await (pending.message.channel as TextChannel).send({ content }).catch(console.error);
+          } else if (agentClient) {
+            // Guild message via agent's bot identity
+            const ch = agentClient.channels.cache.get(pending.message.channelId) as TextChannel | undefined;
+            if (ch) {
+              console.debug(`[discord] Routing reply via agent client "${agentId}"`);
+              await ch.send({ content }).catch(console.error);
+            } else {
+              console.warn(`[discord] Agent "${agentId}" channel cache miss — falling back to bus client`);
+              await pending.message.reply({ content }).catch(console.error);
+            }
+          } else {
+            const reply = await pending.message.reply({ content }).catch(console.error);
+            // Start a thread on first guild response if not already in one
+            if (reply && !pending.message.channel.isThread()) {
+              await reply.startThread({ name: content.slice(0, 50) || "Response" }).catch(() => {});
+            }
+          }
+
+          // Reactions: only in guild channels (the main client owns them there)
+          if (!isDM) {
+            await pending.message.reactions.resolve("👀")?.users.remove(client.user!).catch(() => {});
+            await pending.message.react("✅").catch(() => {});
+          }
+          return;
+        }
+      }
+    }
+
+    // 2. Unprompted push (cron, proactive notification)
+    const channelId = String(
+      payload.channel ?? payload.recipient
+        ?? getConfig().channels.digest
+        ?? process.env.DISCORD_DIGEST_CHANNEL
+        ?? ""
+    );
+    if (channelId) {
+      const sendClient = agentClient ?? client;
+      if (agentClient) {
+        console.debug(`[discord] Routing push to channel ${channelId} via agent client "${agentId}"`);
+      }
+      const ch = sendClient.channels.cache.get(channelId) as TextChannel | undefined;
+      await ch?.send({ content }).catch(console.error);
+    }
+  });
+}
+
+/**
+ * Register the Discord HITL renderer with the HITL plugin.
+ */
+export function setupHITLRenderer(
+  hitlPlugin: HITLPlugin | undefined,
+  client: Client,
+  bus: EventBus,
+  pendingHITLMessages: Map<string, HitlEntry>,
+): void {
+  if (!hitlPlugin) return;
+
+  hitlPlugin.registerRenderer("discord", {
+    render: async (request, _busRef) => {
+      const channelId = request.sourceMeta?.channelId;
+      if (!channelId) {
+        console.warn(`[discord] HITL ${request.correlationId} missing channelId — cannot render`);
+        return;
+      }
+      const ch = client.channels.cache.get(channelId) as TextChannel | undefined;
+      if (!ch) {
+        console.warn(`[discord] HITL channel ${channelId} not in cache — cannot render`);
+        return;
+      }
+      const embed = buildHITLEmbed(request);
+      const row = buildHITLButtons(request);
+      const msg = await ch.send({ embeds: [embed], components: [row] });
+      pendingHITLMessages.set(request.correlationId, {
+        message: msg,
+        replyTopic: request.replyTopic,
+      });
+      console.log(`[discord] HITL ${request.correlationId} rendered in channel ${channelId}`);
+    },
+    onExpired: async (request, _busRef) => {
+      const entry = pendingHITLMessages.get(request.correlationId);
+      if (!entry) return;
+      pendingHITLMessages.delete(request.correlationId);
+      const expiredEmbed = new EmbedBuilder()
+        .setTitle(request.title)
+        .setDescription("**Approval expired** — re-trigger if still needed.")
+        .setColor(0x6b7280);
+      await entry.message.edit({ embeds: [expiredEmbed], components: [] }).catch(console.error);
+      console.log(`[discord] HITL ${request.correlationId} marked expired`);
+    },
+  });
+}

--- a/lib/plugins/discord/rate-limit.ts
+++ b/lib/plugins/discord/rate-limit.ts
@@ -1,0 +1,98 @@
+/**
+ * discord/rate-limit.ts — in-memory + SQLite rate limiter and spam detection.
+ */
+
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+
+export interface RateLimiter {
+  isRateLimited(userId: string): boolean;
+  isSpam(content: string): boolean;
+  reconfigure(maxMessages: number, windowMs: number, spamPatterns: RegExp[]): void;
+  close(): void;
+}
+
+export function createRateLimiter(opts: {
+  dataDir: string | null;
+  maxMessages: number;
+  windowMs: number;
+  spamPatterns: RegExp[];
+}): RateLimiter {
+  let { maxMessages, windowMs, spamPatterns } = opts;
+  const rateLimits = new Map<string, number[]>();
+  let rlDb: Database | null = null;
+
+  if (opts.dataDir) {
+    try {
+      if (!existsSync(opts.dataDir)) {
+        mkdirSync(opts.dataDir, { recursive: true });
+      }
+
+      rlDb = new Database(join(opts.dataDir, "events.db"));
+      rlDb.exec("PRAGMA journal_mode=WAL");
+      rlDb.exec(`
+        CREATE TABLE IF NOT EXISTS rate_limits (
+          user_id TEXT NOT NULL,
+          ts INTEGER NOT NULL
+        )
+      `);
+      rlDb.exec("CREATE INDEX IF NOT EXISTS idx_rate_limits_user_ts ON rate_limits(user_id, ts)");
+
+      // Load persisted windows into memory
+      const cutoff = Date.now() - windowMs;
+      const rows = rlDb
+        .query("SELECT user_id, ts FROM rate_limits WHERE ts > ?")
+        .all(cutoff) as { user_id: string; ts: number }[];
+
+      for (const row of rows) {
+        const hits = rateLimits.get(row.user_id) ?? [];
+        hits.push(row.ts);
+        rateLimits.set(row.user_id, hits);
+      }
+
+      console.log(`[discord] Rate-limit DB opened (${rows.length} persisted hit(s) loaded)`);
+    } catch (err) {
+      console.warn("[discord] Could not open rate-limit DB — falling back to in-memory only:", err);
+      rlDb = null;
+    }
+  }
+
+  return {
+    isRateLimited(userId: string): boolean {
+      const now = Date.now();
+      const hits = (rateLimits.get(userId) ?? []).filter(t => now - t < windowMs);
+      hits.push(now);
+      rateLimits.set(userId, hits);
+
+      if (rlDb) {
+        try {
+          rlDb.run("INSERT INTO rate_limits (user_id, ts) VALUES (?, ?)", [userId, now]);
+          // Prune expired rows for this user to keep the table tidy
+          rlDb.run("DELETE FROM rate_limits WHERE user_id = ? AND ts <= ?", [userId, now - windowMs]);
+        } catch (err) {
+          console.warn("[discord] Failed to persist rate-limit hit:", err);
+        }
+      }
+
+      return hits.length > maxMessages;
+    },
+
+    isSpam(content: string): boolean {
+      return spamPatterns.some(p => p.test(content));
+    },
+
+    reconfigure(newMax: number, newWindow: number, newPatterns: RegExp[]): void {
+      maxMessages = newMax;
+      windowMs = newWindow;
+      spamPatterns = newPatterns;
+    },
+
+    close(): void {
+      if (rlDb) {
+        rlDb.close();
+        rlDb = null;
+      }
+    },
+  };
+}

--- a/lib/plugins/discord/slash-commands.ts
+++ b/lib/plugins/discord/slash-commands.ts
@@ -1,0 +1,269 @@
+/**
+ * discord/slash-commands.ts — /memory and future slash commands.
+ *
+ * Handles:
+ *   InteractionCreate — autocomplete, HITL button presses, slash command dispatch
+ */
+
+import {
+  Events,
+  EmbedBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  type Client,
+  type ChatInputCommandInteraction,
+  type Message,
+} from "discord.js";
+import type { EventBus } from "../../types.ts";
+import type { GraphitiClient } from "../../memory/graphiti-client.ts";
+import type { IdentityRegistry } from "../../identity/identity-registry.ts";
+import {
+  loadProjectsDefs,
+  isAdmin,
+  makeId,
+  interpolateContent,
+  type DiscordConfig,
+  type PendingReply,
+} from "./core.ts";
+
+export type HitlEntry = { message: Message; replyTopic: string };
+
+export interface SlashContext {
+  workspaceDir: string;
+  getConfig: () => DiscordConfig;
+  graphiti: GraphitiClient;
+  identityRegistry: IdentityRegistry | null;
+  pendingReplies: Map<string, PendingReply>;
+  pendingAgents: Map<string, string>;
+  pendingHITLMessages: Map<string, HitlEntry>;
+}
+
+async function handleMemoryCommand(
+  interaction: ChatInputCommandInteraction,
+  graphiti: GraphitiClient,
+  identityRegistry: IdentityRegistry | null,
+): Promise<void> {
+  const userId = interaction.user.id;
+
+  if (!identityRegistry) {
+    await interaction.editReply("Memory not available.").catch(console.error);
+    return;
+  }
+
+  const groupId = identityRegistry.groupId("discord", userId);
+  const subName = interaction.options.getSubcommand(false);
+
+  if (!subName || subName === "show") {
+    const facts = await graphiti.search(groupId, "preferences habits goals context", 20).catch(() => []);
+    if (facts.length === 0) {
+      await interaction.editReply("No memory stored yet.").catch(console.error);
+      return;
+    }
+    const now = Date.now();
+    const active = facts.filter(f => {
+      if (f.invalid_at && new Date(f.invalid_at).getTime() <= now) return false;
+      if (f.expired_at && new Date(f.expired_at).getTime() <= now) return false;
+      return true;
+    });
+    if (active.length === 0) {
+      await interaction.editReply("No active memory facts.").catch(console.error);
+      return;
+    }
+    const lines = active.map((f, i) => `**${i + 1}.** ${f.fact}`).join("\n");
+    await interaction.editReply(`**Memory** (${active.length} facts):\n${lines}`.slice(0, 2000)).catch(console.error);
+
+  } else if (subName === "search") {
+    const query = interaction.options.getString("query", true);
+    const facts = await graphiti.search(groupId, query, 10).catch(() => []);
+    if (facts.length === 0) {
+      await interaction.editReply(`No facts found for: "${query}"`).catch(console.error);
+      return;
+    }
+    const lines = facts.map((f, i) => `**${i + 1}.** ${f.fact}`).join("\n");
+    await interaction.editReply(`**"${query}"** — ${facts.length} fact(s):\n${lines}`.slice(0, 2000)).catch(console.error);
+
+  } else if (subName === "clear") {
+    await graphiti.clearUser(groupId);
+    await interaction.editReply("Memory cleared.").catch(console.error);
+  }
+}
+
+/**
+ * Register the InteractionCreate handler on the main client.
+ * Handles autocomplete, HITL button presses, and slash command dispatch.
+ */
+export function setupSlashCommandHandlers(
+  client: Client,
+  bus: EventBus,
+  ctx: SlashContext,
+): void {
+  const { workspaceDir, getConfig, graphiti, identityRegistry,
+    pendingReplies, pendingAgents, pendingHITLMessages } = ctx;
+
+  client.on(Events.InteractionCreate, async interaction => {
+    // ── Autocomplete: filter projects.yaml by typed value ──────────────────
+    if (interaction.isAutocomplete()) {
+      const cmdConfig = getConfig().commands.find(c => c.name === interaction.commandName);
+      if (!cmdConfig) return;
+
+      const focused = interaction.options.getFocused(true);
+      if (focused.name === "project") {
+        const projects = loadProjectsDefs(workspaceDir);
+        const typed = focused.value.toLowerCase();
+        const choices = projects
+          .filter(p =>
+            p.slug.toLowerCase().includes(typed) ||
+            p.title.toLowerCase().includes(typed)
+          )
+          .slice(0, 25)
+          .map(p => ({ name: p.title, value: p.slug }));
+        await interaction.respond(choices).catch(console.error);
+      }
+      return;
+    }
+
+    // ── HITL button interactions ──────────────────────────────────────────
+    if (interaction.isButton() && interaction.customId.startsWith("hitl:")) {
+      const [, decision, correlationId] = interaction.customId.split(":");
+      await interaction.deferUpdate();
+
+      const entry = pendingHITLMessages.get(correlationId);
+      const replyTopic = entry?.replyTopic
+        ?? `hitl.response.${correlationId.split("-")[0]}.${correlationId}`;
+
+      bus.publish(replyTopic, {
+        id: crypto.randomUUID(),
+        correlationId,
+        topic: replyTopic,
+        timestamp: Date.now(),
+        payload: {
+          type: "hitl_response",
+          correlationId,
+          decision: decision as "approve" | "reject" | "modify",
+          decidedBy: interaction.user.id,
+        },
+      });
+
+      if (entry) pendingHITLMessages.delete(correlationId);
+
+      const COLOR_APPROVE = 0x22c55e;
+      const COLOR_REJECT = 0xef4444;
+      const COLOR_NEUTRAL = 0x6b7280;
+      let color: number;
+      if (decision === "approve") color = COLOR_APPROVE;
+      else if (decision === "reject") color = COLOR_REJECT;
+      else color = COLOR_NEUTRAL;
+      const label = decision.charAt(0).toUpperCase() + decision.slice(1);
+      const decidedEmbed = new EmbedBuilder()
+        .setTitle(interaction.message.embeds[0]?.title ?? "Decision recorded")
+        .setDescription(`**${label}** by <@${interaction.user.id}>`)
+        .setColor(color);
+
+      await interaction.message.edit({ embeds: [decidedEmbed], components: [] }).catch(console.error);
+      return;
+    }
+
+    if (!interaction.isChatInputCommand()) return;
+
+    // Pre-warm DM channel so subsequent DMs from this user are delivered via gateway
+    client.users.createDM(interaction.user.id).catch(() => {});
+
+    const cmdConfig = getConfig().commands.find(c => c.name === interaction.commandName);
+    if (!cmdConfig) return;
+
+    if (!isAdmin(interaction.user.id, getConfig().admins)) {
+      console.log(`[discord] slash command from ${interaction.user.id} ignored — not in admins list`);
+      await interaction.reply({ content: "Not authorised.", ephemeral: true }).catch(() => {});
+      return;
+    }
+
+    // ── /memory — native handler (no bus dispatch) ──────────────────────────
+    if (interaction.commandName === "memory") {
+      await interaction.deferReply({ ephemeral: true });
+      await handleMemoryCommand(interaction, graphiti, identityRegistry);
+      return;
+    }
+
+    await interaction.deferReply();
+
+    // ── Flat command (top-level options, no subcommands) ────────────────────
+    const isFlatCommand = !!cmdConfig.options?.length && !cmdConfig.subcommands?.length;
+    if (isFlatCommand) {
+      // Resolve project metadata from projects.yaml if a `project` option is present
+      const projectSlug = interaction.options.getString("project");
+      let devChannelId: string | undefined;
+      let projectRepo: string | undefined;
+
+      if (projectSlug) {
+        const projects = loadProjectsDefs(workspaceDir);
+        const project = projects.find(p => p.slug === projectSlug);
+        if (project) {
+          devChannelId = project.discord?.dev || undefined;
+          projectRepo = project.github || undefined;
+        }
+      }
+
+      const content = interpolateContent(
+        cmdConfig.content ?? "",
+        cmdConfig.options ?? [],
+        interaction,
+      );
+
+      const correlationId = makeId();
+      pendingReplies.set(correlationId, { interaction });
+
+      const topicSuffix = `slash.${interaction.id}`;
+      bus.publish(`message.inbound.discord.${topicSuffix}`, {
+        id: interaction.id,
+        correlationId,
+        topic: `message.inbound.discord.${topicSuffix}`,
+        timestamp: Date.now(),
+        payload: {
+          sender: interaction.user.id,
+          channel: interaction.channelId,
+          content,
+          skillHint: cmdConfig.skillHint,
+          ...(devChannelId ? { devChannelId } : {}),
+          ...(projectRepo ? { projectRepo } : {}),
+        },
+        source: { interface: "discord" as const, channelId: interaction.channelId, userId: interaction.user.id },
+        reply: { topic: `message.outbound.discord.${topicSuffix}` },
+      });
+      return;
+    }
+
+    // ── Subcommand-based command (existing behaviour) ───────────────────────
+    const subcommands = cmdConfig.subcommands ?? [];
+    const subName = interaction.options.getSubcommand(false) ?? subcommands[0]?.name;
+    const subConfig = subcommands.find(s => s.name === subName) ?? subcommands[0];
+
+    if (!subConfig) {
+      await interaction.editReply("Unknown subcommand.").catch(console.error);
+      return;
+    }
+
+    // Interpolate {optionName} placeholders from config content template
+    const content = interpolateContent(subConfig.content, subConfig.options ?? [], interaction);
+
+    const correlationId = makeId();
+    pendingReplies.set(correlationId, { interaction });
+
+    const topicSuffix = `slash.${interaction.id}`;
+    bus.publish(`message.inbound.discord.${topicSuffix}`, {
+      id: interaction.id,
+      correlationId,
+      topic: `message.inbound.discord.${topicSuffix}`,
+      timestamp: Date.now(),
+      payload: {
+        sender: interaction.user.id,
+        channel: interaction.channelId,
+        content,
+        skillHint: subConfig.skillHint,
+      },
+      source: { interface: "discord" as const, channelId: interaction.channelId, userId: interaction.user.id },
+      reply: { topic: `message.outbound.discord.${topicSuffix}` },
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary

The Discord plugin has become a god file mixing too many concerns. Decompose into focused modules under `lib/plugins/discord/`:

- `lib/plugins/discord/core.ts` — client lifecycle, bot identity, connection status
- `lib/plugins/discord/inbound.ts` — DM and guild message handlers
- `lib/plugins/discord/slash-commands.ts` — /memory and future slash commands
- `lib/plugins/discord/outbound.ts` — reply handling, webhook posting, outbound routing
- `lib/plugins/discord/rate-limit.ts` — in-memory + SQ...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-11T08:24:52.071Z -->