### PR TITLE
feat: centralized HTTP client — eliminate 13 inline fetch() duplications

### DIFF
--- a/lib/plugins/world-state-engine.ts
+++ b/lib/plugins/world-state-engine.ts
@@ -36,6 +36,7 @@ import { mkdirSync, existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import type { Plugin, EventBus, BusMessage } from "../types.ts";
 import type { WorldState, WorldStateDomain, WorldStateSnapshot } from "../types/world-state.ts";
+import { HttpClient } from "../../src/services/http-client.ts";
 
 // ── Domain registration ───────────────────────────────────────────────────────
 
@@ -559,26 +560,11 @@ export function createHttpCollector(
   url: string,
   opts: { timeoutMs?: number; headers?: Record<string, string> } = {},
 ): DomainCollector {
-  return async () => {
-    const resp = await fetch(url, {
-      method: "GET",
-      headers: opts.headers,
-      signal: AbortSignal.timeout(opts.timeoutMs ?? 10_000),
-    });
-
-    if (!resp.ok) {
-      throw new Error(`HTTP ${resp.status} from ${url}`);
-    }
-
-    const json = await resp.json();
-
-    // Unwrap standard API envelope: { success, data } → data
-    if (json && typeof json === "object" && "data" in json && "success" in json) {
-      return json.data;
-    }
-
-    return json;
-  };
+  const http = new HttpClient({
+    timeoutMs: opts.timeoutMs ?? 10_000,
+    headers: opts.headers,
+  });
+  return () => http.get(url, { unwrapEnvelope: true });
 }
 
 // ── MCP tool factory ──────────────────────────────────────────────────────────

--- a/src/agent-runtime/tools/bus-tools.ts
+++ b/src/agent-runtime/tools/bus-tools.ts
@@ -15,6 +15,7 @@
 
 import { tool } from "@protolabsai/sdk";
 import { z } from "zod";
+import { HttpClient } from "../../services/http-client.ts";
 
 function ok(data: unknown) {
   return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
@@ -22,31 +23,6 @@ function ok(data: unknown) {
 
 function err(message: string) {
   return { content: [{ type: "text" as const, text: `Error: ${message}` }], isError: true };
-}
-
-async function apiGet(baseUrl: string, path: string, apiKey?: string): Promise<unknown> {
-  const headers: Record<string, string> = {};
-  if (apiKey) headers["X-API-Key"] = apiKey;
-  const resp = await fetch(`${baseUrl}${path}`, { headers });
-  if (!resp.ok) throw new Error(`HTTP ${resp.status} ${await resp.text()}`);
-  return resp.json();
-}
-
-async function apiPost(
-  baseUrl: string,
-  path: string,
-  body: unknown,
-  apiKey?: string,
-): Promise<unknown> {
-  const headers: Record<string, string> = { "Content-Type": "application/json" };
-  if (apiKey) headers["X-API-Key"] = apiKey;
-  const resp = await fetch(`${baseUrl}${path}`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(body),
-  });
-  if (!resp.ok) throw new Error(`HTTP ${resp.status} ${await resp.text()}`);
-  return resp.json();
 }
 
 export interface BusToolsOptions {
@@ -63,6 +39,10 @@ export interface BusToolsOptions {
 export function createBusTools(opts: BusToolsOptions = {}) {
   const baseUrl = opts.baseUrl ?? "http://localhost:3000";
   const apiKey = opts.apiKey;
+  const http = new HttpClient({
+    baseUrl,
+    ...(apiKey ? { auth: { type: "api-key" as const, key: apiKey } } : {}),
+  });
 
   const publishEvent = tool(
     "publish_event",
@@ -84,7 +64,7 @@ export function createBusTools(opts: BusToolsOptions = {}) {
           payload: projectSlug ? { ...payload, projectSlug } : payload,
           ...(projectSlug ? { source: { interface: "agent", projectSlug } } : {}),
         };
-        const data = await apiPost(baseUrl, "/publish", body, apiKey);
+        const data = await http.post("/publish", body);
         return ok(data);
       } catch (e) {
         return err(e instanceof Error ? e.message : String(e));
@@ -108,7 +88,7 @@ export function createBusTools(opts: BusToolsOptions = {}) {
     async ({ domain }) => {
       try {
         const path = domain ? `/api/world-state/${domain}` : "/api/world-state";
-        const data = await apiGet(baseUrl, path, apiKey);
+        const data = await http.get(path);
         return ok(data);
       } catch (e) {
         return err(e instanceof Error ? e.message : String(e));
@@ -122,7 +102,7 @@ export function createBusTools(opts: BusToolsOptions = {}) {
     {},
     async () => {
       try {
-        const data = await apiGet(baseUrl, "/api/incidents", apiKey);
+        const data = await http.get("/api/incidents");
         return ok(data);
       } catch (e) {
         return err(e instanceof Error ? e.message : String(e));
@@ -155,7 +135,7 @@ export function createBusTools(opts: BusToolsOptions = {}) {
         if (description) body.description = description;
         if (affectedProjects) body.affectedProjects = affectedProjects;
         if (projectSlug) body.projectSlug = projectSlug;
-        const data = await apiPost(baseUrl, "/api/incidents", body, apiKey);
+        const data = await http.post("/api/incidents", body);
         return ok(data);
       } catch (e) {
         return err(e instanceof Error ? e.message : String(e));
@@ -170,7 +150,7 @@ export function createBusTools(opts: BusToolsOptions = {}) {
     {},
     async () => {
       try {
-        const data = await apiGet(baseUrl, "/api/projects", apiKey);
+        const data = await http.get("/api/projects");
         return ok(data);
       } catch (e) {
         return err(e instanceof Error ? e.message : String(e));
@@ -185,7 +165,7 @@ export function createBusTools(opts: BusToolsOptions = {}) {
     {},
     async () => {
       try {
-        const data = await apiGet(baseUrl, "/api/ci-health", apiKey);
+        const data = await http.get("/api/ci-health");
         return ok(data);
       } catch (e) {
         return err(e instanceof Error ? e.message : String(e));
@@ -200,7 +180,7 @@ export function createBusTools(opts: BusToolsOptions = {}) {
     {},
     async () => {
       try {
-        const data = await apiGet(baseUrl, "/api/pr-pipeline", apiKey);
+        const data = await http.get("/api/pr-pipeline");
         return ok(data);
       } catch (e) {
         return err(e instanceof Error ? e.message : String(e));
@@ -214,7 +194,7 @@ export function createBusTools(opts: BusToolsOptions = {}) {
     {},
     async () => {
       try {
-        const data = await apiGet(baseUrl, "/api/branch-drift", apiKey);
+        const data = await http.get("/api/branch-drift");
         return ok(data);
       } catch (e) {
         return err(e instanceof Error ? e.message : String(e));
@@ -229,7 +209,7 @@ export function createBusTools(opts: BusToolsOptions = {}) {
     {},
     async () => {
       try {
-        const data = await apiGet(baseUrl, "/api/outcomes", apiKey);
+        const data = await http.get("/api/outcomes");
         return ok(data);
       } catch (e) {
         return err(e instanceof Error ? e.message : String(e));
@@ -243,7 +223,7 @@ export function createBusTools(opts: BusToolsOptions = {}) {
     {},
     async () => {
       try {
-        const data = await apiGet(baseUrl, "/api/ceremonies", apiKey);
+        const data = await http.get("/api/ceremonies");
         return ok(data);
       } catch (e) {
         return err(e instanceof Error ? e.message : String(e));
@@ -262,7 +242,7 @@ export function createBusTools(opts: BusToolsOptions = {}) {
     },
     async ({ ceremonyId }) => {
       try {
-        const data = await apiPost(baseUrl, `/api/ceremonies/${ceremonyId}/run`, {}, apiKey);
+        const data = await http.post(`/api/ceremonies/${ceremonyId}/run`, {});
         return ok(data);
       } catch (e) {
         return err(e instanceof Error ? e.message : String(e));

--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -7,8 +7,18 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
 import type { Route, ApiContext } from "./types.ts";
+import { HttpClient } from "../services/http-client.ts";
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+
+const ghHttp = new HttpClient({
+  baseUrl: "https://api.github.com",
+  timeoutMs: 15_000,
+  headers: {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  },
+});
 
 function loadProjectRepos(workspaceDir: string): string[] {
   const projectsPath = join(workspaceDir, "projects.yaml");
@@ -21,16 +31,7 @@ function loadProjectRepos(workspaceDir: string): string[] {
 
 async function ghApi(path: string): Promise<unknown> {
   if (!GITHUB_TOKEN) throw new Error("GITHUB_TOKEN not set");
-  const resp = await fetch(`https://api.github.com${path}`, {
-    headers: {
-      Authorization: `Bearer ${GITHUB_TOKEN}`,
-      Accept: "application/vnd.github+json",
-      "X-GitHub-Api-Version": "2022-11-28",
-    },
-    signal: AbortSignal.timeout(15_000),
-  });
-  if (!resp.ok) throw new Error(`GitHub API ${resp.status}: ${path}`);
-  return resp.json();
+  return ghHttp.get(path, { auth: { type: "bearer", token: GITHUB_TOKEN } });
 }
 
 export function createRoutes(ctx: ApiContext): Route[] {

--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -8,6 +8,7 @@
  */
 
 import type { IExecutor, SkillRequest, SkillResult } from "../types.ts";
+import { HttpClient } from "../../services/http-client.ts";
 
 export interface A2AAgentConfig {
   /** Agent name (for logging). */
@@ -23,8 +24,11 @@ export interface A2AAgentConfig {
 
 export class A2AExecutor implements IExecutor {
   readonly type = "a2a";
+  private readonly http: HttpClient;
 
-  constructor(private readonly config: A2AAgentConfig) {}
+  constructor(private readonly config: A2AAgentConfig) {
+    this.http = new HttpClient({ timeoutMs: config.timeoutMs ?? 300_000 });
+  }
 
   async execute(req: SkillRequest): Promise<SkillResult> {
     const apiKey = this.config.apiKeyEnv
@@ -61,11 +65,10 @@ export class A2AExecutor implements IExecutor {
       },
     });
 
-    const resp = await fetch(this.config.url, {
+    const resp = await this.http.fetch(this.config.url, {
       method: "POST",
       headers,
       body,
-      signal: AbortSignal.timeout(this.config.timeoutMs ?? 300_000),
     });
 
     if (!resp.ok) {

--- a/src/github/reviewSubmitter.ts
+++ b/src/github/reviewSubmitter.ts
@@ -19,6 +19,7 @@ import type {
 } from "./types.ts";
 import { toGitHubComment } from "./types.ts";
 import type { ValidatedComment } from "../diff/types.ts";
+import { HttpClient } from "../services/http-client.ts";
 
 const GITHUB_API_BASE = "https://api.github.com";
 const USER_AGENT = "protoWorkstacean/1.0";
@@ -26,9 +27,18 @@ const API_VERSION = "2022-11-28";
 
 export class GitHubReviewSubmitter {
   private readonly getToken: (owner: string, repo: string) => Promise<string>;
+  private readonly http: HttpClient;
 
   constructor(getToken: (owner: string, repo: string) => Promise<string>) {
     this.getToken = getToken;
+    this.http = new HttpClient({
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": USER_AGENT,
+        "X-GitHub-Api-Version": API_VERSION,
+        "Content-Type": "application/json",
+      },
+    });
   }
 
   /**
@@ -71,15 +81,9 @@ export class GitHubReviewSubmitter {
 
     let res: Response;
     try {
-      res = await fetch(url, {
+      res = await this.http.fetch(url, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-          Accept: "application/vnd.github+json",
-          "User-Agent": USER_AGENT,
-          "X-GitHub-Api-Version": API_VERSION,
-        },
+        headers: { Authorization: `Bearer ${token}` },
         body: JSON.stringify(payload),
       });
     } catch (err) {

--- a/src/integrations/discord_logger.ts
+++ b/src/integrations/discord_logger.ts
@@ -1,4 +1,5 @@
 import type { GoalViolation } from "../types/goals.ts";
+import { HttpClient } from "../services/http-client.ts";
 
 const SEVERITY_COLORS: Record<string, number> = {
   low: 0x3498db,      // blue
@@ -14,9 +15,11 @@ const SEVERITY_COLORS: Record<string, number> = {
  */
 export class DiscordLogger {
   private webhookUrl: string | null;
+  private readonly http: HttpClient;
 
   constructor(webhookUrl?: string) {
     this.webhookUrl = webhookUrl ?? process.env.DISCORD_GOALS_WEBHOOK_URL ?? null;
+    this.http = new HttpClient({ timeoutMs: 10_000 });
     if (!this.webhookUrl) {
       console.info("[discord-logger] DISCORD_GOALS_WEBHOOK_URL not set — using console fallback");
     }
@@ -32,18 +35,7 @@ export class DiscordLogger {
     const embed = this._buildEmbed(violation);
 
     try {
-      const resp = await fetch(this.webhookUrl, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ embeds: [embed] }),
-        signal: AbortSignal.timeout(10_000),
-      });
-
-      if (!resp.ok) {
-        const body = await resp.text().catch(() => "");
-        throw new Error(`Discord webhook error ${resp.status}: ${body}`);
-      }
-
+      await this.http.post(this.webhookUrl, { embeds: [embed] });
       return true;
     } catch (err) {
       console.error("[discord-logger] Discord integration error:", err);

--- a/src/integrations/langfuse_logger.ts
+++ b/src/integrations/langfuse_logger.ts
@@ -1,4 +1,5 @@
 import type { GoalViolation } from "../types/goals.ts";
+import { HttpClient } from "../services/http-client.ts";
 
 interface LangfuseConfig {
   publicKey: string;
@@ -24,6 +25,7 @@ interface LangfuseEvent {
 export class LangfuseLogger {
   private config: LangfuseConfig | null;
   private buffer: LangfuseEvent[] = [];
+  private readonly http: HttpClient;
 
   constructor() {
     const publicKey = process.env.LANGFUSE_PUBLIC_KEY;
@@ -36,6 +38,7 @@ export class LangfuseLogger {
     } else {
       this.config = { publicKey, secretKey, host };
     }
+    this.http = new HttpClient({ timeoutMs: 10_000 });
   }
 
   /** Log a goal violation event. Returns true if sent, false on error/fallback. */
@@ -124,19 +127,8 @@ export class LangfuseLogger {
     const { publicKey, secretKey, host } = this.config!;
     const credentials = btoa(`${publicKey}:${secretKey}`);
 
-    const resp = await fetch(`${host}/api/public/ingestion`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Basic ${credentials}`,
-      },
-      body: JSON.stringify({ batch: events }),
-      signal: AbortSignal.timeout(10_000),
+    await this.http.post(`${host}/api/public/ingestion`, { batch: events }, {
+      auth: { type: "basic", credentials },
     });
-
-    if (!resp.ok) {
-      const body = await resp.text().catch(() => "");
-      throw new Error(`Langfuse API error ${resp.status}: ${body}`);
-    }
   }
 }

--- a/src/llm/reviewOrchestrator.ts
+++ b/src/llm/reviewOrchestrator.ts
@@ -20,6 +20,13 @@ import { validateComments } from "../diff/validateComments.ts";
 import { buildSummaryPrompt, buildInlineReviewPrompt } from "./promptBuilder.ts";
 import type { PRFile, ReviewResult, ReviewBatch } from "./types.ts";
 import type { LLMComment, AnnotatedHunk } from "../diff/types.ts";
+import { HttpClient } from "../services/http-client.ts";
+
+const GH_HEADERS = {
+  Accept: "application/vnd.github+json",
+  "User-Agent": "protoWorkstacean/1.0",
+  "X-GitHub-Api-Version": "2022-11-28",
+};
 
 /** Token budget: 80% of ~100k Sonnet context window. */
 const TOKEN_BUDGET = 80_000;
@@ -94,23 +101,11 @@ async function fetchPRFiles(
   owner: string,
   repo: string,
   prNumber: number,
-  token: string,
+  http: HttpClient,
 ): Promise<PRFile[]> {
-  const url = `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/files?per_page=100`;
-  const res = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/vnd.github+json",
-      "User-Agent": "protoWorkstacean/1.0",
-      "X-GitHub-Api-Version": "2022-11-28",
-    },
-  });
-
-  if (!res.ok) {
-    throw new Error(`GitHub API error fetching PR files: ${res.status} ${await res.text()}`);
-  }
-
-  return res.json() as Promise<PRFile[]>;
+  return http.get(
+    `/repos/${owner}/${repo}/pulls/${prNumber}/files?per_page=100`,
+  ) as Promise<PRFile[]>;
 }
 
 /**
@@ -120,23 +115,9 @@ async function fetchPRMeta(
   owner: string,
   repo: string,
   prNumber: number,
-  token: string,
+  http: HttpClient,
 ): Promise<{ title: string; body: string; headSha: string; draft: boolean }> {
-  const url = `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}`;
-  const res = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/vnd.github+json",
-      "User-Agent": "protoWorkstacean/1.0",
-      "X-GitHub-Api-Version": "2022-11-28",
-    },
-  });
-
-  if (!res.ok) {
-    throw new Error(`GitHub API error fetching PR meta: ${res.status} ${await res.text()}`);
-  }
-
-  const data = await res.json() as {
+  const data = await http.get(`/repos/${owner}/${repo}/pulls/${prNumber}`) as {
     title: string;
     body: string | null;
     draft: boolean;
@@ -174,10 +155,16 @@ export async function review(
   const client = new Anthropic({ apiKey });
   const token = await getToken(owner, repo);
 
+  const ghHttp = new HttpClient({
+    baseUrl: "https://api.github.com",
+    headers: GH_HEADERS,
+    auth: { type: "bearer", token },
+  });
+
   // Fetch PR metadata and files
   const [meta, files] = await Promise.all([
-    fetchPRMeta(owner, repo, prNumber, token),
-    fetchPRFiles(owner, repo, prNumber, token),
+    fetchPRMeta(owner, repo, prNumber, ghHttp),
+    fetchPRFiles(owner, repo, prNumber, ghHttp),
   ]);
 
   // Skip draft PRs

--- a/src/services/codebase/symbol-fetcher.ts
+++ b/src/services/codebase/symbol-fetcher.ts
@@ -7,9 +7,14 @@
  */
 
 import type { ExtractedSymbol } from "../diff/symbol-extractor.ts";
+import { HttpClient } from "../http-client.ts";
 
-const GITHUB_RAW = "https://raw.githubusercontent.com";
 const CONTEXT_LINES = 10; // lines before and after the symbol definition
+
+const githubRawHttp = new HttpClient({
+  baseUrl: "https://raw.githubusercontent.com",
+  headers: { "User-Agent": "protoWorkstacean/1.0" },
+});
 
 export interface SymbolContext {
   symbol: ExtractedSymbol;
@@ -33,22 +38,11 @@ export async function fetchSymbolContext(
   const filePath = symbol.filePath ?? "";
   if (!filePath) return null;
 
-  const url = `${GITHUB_RAW}/${owner}/${repo}/${ref}/${filePath}`;
-
   try {
-    const res = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "User-Agent": "protoWorkstacean/1.0",
-      },
-    });
-
-    if (!res.ok) {
-      console.warn(`[symbol-fetcher] Could not fetch ${filePath} at ${ref}: ${res.status}`);
-      return null;
-    }
-
-    const text = await res.text();
+    const text = await githubRawHttp.get(`/${owner}/${repo}/${ref}/${filePath}`, {
+      auth: { type: "bearer", token },
+      responseType: "text",
+    }) as string;
     const lines = text.split("\n");
     const targetLine = symbol.line - 1; // convert to 0-based index
 

--- a/src/services/github/diff-fetcher.ts
+++ b/src/services/github/diff-fetcher.ts
@@ -3,6 +3,8 @@
  * the overall review decision (APPROVE / REQUEST_CHANGES) from the GitHub API.
  */
 
+import { HttpClient } from "../http-client.ts";
+
 const GITHUB_API = "https://api.github.com";
 const USER_AGENT = "protoWorkstacean/1.0";
 
@@ -37,13 +39,16 @@ export interface PRReviewData {
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
-function makeHeaders(token: string): Record<string, string> {
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: "application/vnd.github+json",
-    "User-Agent": USER_AGENT,
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
+function makeGitHubClient(token: string): HttpClient {
+  return new HttpClient({
+    baseUrl: GITHUB_API,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "User-Agent": USER_AGENT,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
 }
 
 // ── Fetchers ───────────────────────────────────────────────────────────────────
@@ -53,19 +58,17 @@ function makeHeaders(token: string): Record<string, string> {
  * Returns empty string if unavailable.
  */
 export async function fetchPRDiff(meta: PRMetadata, token: string): Promise<string> {
+  const client = makeGitHubClient(token);
   const url = `${GITHUB_API}/repos/${meta.owner}/${meta.repo}/pulls/${meta.prNumber}`;
   try {
-    const res = await fetch(url, {
-      headers: {
-        ...makeHeaders(token),
-        Accept: "application/vnd.github.diff",
-      },
+    const resp = await client.fetch(url, {
+      headers: { Accept: "application/vnd.github.diff" },
     });
-    if (!res.ok) {
-      console.error(`[diff-fetcher] fetchPRDiff failed ${res.status}`);
+    if (!resp.ok) {
+      console.error(`[diff-fetcher] fetchPRDiff failed ${resp.status}`);
       return "";
     }
-    return await res.text();
+    return await resp.text();
   } catch (err) {
     console.error("[diff-fetcher] fetchPRDiff error:", err);
     return "";
@@ -79,14 +82,11 @@ export async function fetchReviewComments(
   meta: PRMetadata,
   token: string,
 ): Promise<ReviewComment[]> {
-  const url = `${GITHUB_API}/repos/${meta.owner}/${meta.repo}/pulls/${meta.prNumber}/comments`;
+  const client = makeGitHubClient(token);
   try {
-    const res = await fetch(url, { headers: makeHeaders(token) });
-    if (!res.ok) {
-      console.error(`[diff-fetcher] fetchReviewComments failed ${res.status}`);
-      return [];
-    }
-    const raw = await res.json() as Array<{
+    const raw = await client.get(
+      `/repos/${meta.owner}/${meta.repo}/pulls/${meta.prNumber}/comments`,
+    ) as Array<{
       body?: string;
       path?: string;
       line?: number | null;
@@ -115,12 +115,11 @@ export async function fetchReviewDecision(
   meta: PRMetadata,
   token: string,
 ): Promise<ReviewDecision> {
-  const url = `${GITHUB_API}/repos/${meta.owner}/${meta.repo}/pulls/${meta.prNumber}/reviews`;
+  const client = makeGitHubClient(token);
   try {
-    const res = await fetch(url, { headers: makeHeaders(token) });
-    if (!res.ok) return "PENDING";
-
-    const reviews = await res.json() as Array<{
+    const reviews = await client.get(
+      `/repos/${meta.owner}/${meta.repo}/pulls/${meta.prNumber}/reviews`,
+    ) as Array<{
       state?: string;
       submitted_at?: string;
     }>;

--- a/src/services/http-client.ts
+++ b/src/services/http-client.ts
@@ -1,0 +1,192 @@
+/**
+ * Shared HTTP client — centralizes fetch(), error handling, timeouts,
+ * auth headers, optional retry with exponential backoff, and envelope unwrapping.
+ *
+ * Usage:
+ *   const client = new HttpClient({
+ *     baseUrl: "https://api.github.com",
+ *     timeoutMs: 15_000,
+ *     auth: { type: "bearer", token },
+ *   });
+ *   const data = await client.get("/repos/foo/bar");
+ *   const result = await client.post("/path", { key: "val" });
+ *   const resp = await client.fetch("https://example.com/raw", { method: "GET" });
+ */
+
+export type AuthConfig =
+  | { type: "bearer"; token: string }
+  | { type: "api-key"; key: string }
+  | { type: "basic"; credentials: string }
+  | { type: "custom"; header: string; value: string };
+
+export interface RetryConfig {
+  attempts: number;
+  baseDelayMs?: number;
+}
+
+export interface HttpClientOptions {
+  /** Base URL prepended to all paths in get() and post(). Default: "". */
+  baseUrl?: string;
+  /** Default timeout in ms applied to every request. Default: 30_000. */
+  timeoutMs?: number;
+  /** Default headers merged into every request. */
+  headers?: Record<string, string>;
+  /** Auth applied to every request (can be overridden per-request). */
+  auth?: AuthConfig;
+  /** Optional retry policy for get() and post(). Default: no retry. */
+  retry?: RetryConfig;
+}
+
+export interface RequestOptions {
+  /** Per-request headers merged over client defaults (per-request wins). */
+  headers?: Record<string, string>;
+  /** Per-request timeout override. */
+  timeoutMs?: number;
+  /** Per-request auth override. */
+  auth?: AuthConfig;
+  /** Parse response body as plain text instead of JSON. Default: false. */
+  responseType?: "json" | "text";
+  /**
+   * Unwrap standard API envelope: { success, data } → data.
+   * Only applied when responseType is "json" (default). Default: false.
+   */
+  unwrapEnvelope?: boolean;
+}
+
+function applyAuth(headers: Record<string, string>, auth: AuthConfig): void {
+  switch (auth.type) {
+    case "bearer":
+      headers["Authorization"] = `Bearer ${auth.token}`;
+      break;
+    case "api-key":
+      headers["X-API-Key"] = auth.key;
+      break;
+    case "basic":
+      headers["Authorization"] = `Basic ${auth.credentials}`;
+      break;
+    case "custom":
+      headers[auth.header] = auth.value;
+      break;
+  }
+}
+
+export class HttpClient {
+  private readonly baseUrl: string;
+  private readonly defaultTimeoutMs: number;
+  private readonly defaultHeaders: Record<string, string>;
+  private readonly defaultAuth: AuthConfig | undefined;
+  private readonly retry: RetryConfig | undefined;
+
+  constructor(opts: HttpClientOptions = {}) {
+    this.baseUrl = opts.baseUrl ?? "";
+    this.defaultTimeoutMs = opts.timeoutMs ?? 30_000;
+    this.defaultHeaders = opts.headers ?? {};
+    this.defaultAuth = opts.auth;
+    this.retry = opts.retry;
+  }
+
+  /**
+   * Low-level fetch — merges client default headers with per-request headers
+   * (per-request wins) and applies the configured timeout.
+   *
+   * Returns the raw Response for callers that need custom response handling
+   * (e.g. special HTTP status codes, text bodies, non-standard error shapes).
+   */
+  async fetch(url: string, init: RequestInit & { timeoutMs?: number } = {}): Promise<Response> {
+    const { timeoutMs, headers: initHeaders, ...rest } = init;
+
+    const merged: Record<string, string> = { ...this.defaultHeaders };
+    if (this.defaultAuth) applyAuth(merged, this.defaultAuth);
+    if (initHeaders) {
+      const extra = initHeaders instanceof Headers
+        ? Object.fromEntries(initHeaders.entries())
+        : (initHeaders as Record<string, string>);
+      Object.assign(merged, extra);
+    }
+
+    return fetch(url, {
+      ...rest,
+      headers: merged,
+      signal: AbortSignal.timeout(timeoutMs ?? this.defaultTimeoutMs),
+    });
+  }
+
+  /**
+   * GET request — throws on non-2xx.
+   * Returns parsed JSON (or plain text if responseType: "text").
+   */
+  async get(url: string, opts: RequestOptions = {}): Promise<unknown> {
+    return this._request("GET", this.baseUrl + url, undefined, opts);
+  }
+
+  /**
+   * POST request — serializes body as JSON, throws on non-2xx.
+   * Returns parsed JSON (or plain text if responseType: "text").
+   */
+  async post(url: string, body: unknown, opts: RequestOptions = {}): Promise<unknown> {
+    return this._request("POST", this.baseUrl + url, body, opts);
+  }
+
+  private async _request(
+    method: string,
+    url: string,
+    body: unknown,
+    opts: RequestOptions,
+  ): Promise<unknown> {
+    const timeoutMs = opts.timeoutMs ?? this.defaultTimeoutMs;
+    const auth = opts.auth ?? this.defaultAuth;
+
+    const headers: Record<string, string> = { ...this.defaultHeaders };
+    if (body !== undefined) headers["Content-Type"] = "application/json";
+    if (auth) applyAuth(headers, auth);
+    if (opts.headers) Object.assign(headers, opts.headers);
+
+    const doFetch = async (): Promise<unknown> => {
+      const resp = await fetch(url, {
+        method,
+        headers,
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+
+      if (!resp.ok) {
+        const errText = await resp.text().catch(() => "");
+        throw new Error(`HTTP ${resp.status} ${errText}`);
+      }
+
+      if (opts.responseType === "text") {
+        return resp.text();
+      }
+
+      const json = await resp.json();
+
+      if (
+        opts.unwrapEnvelope &&
+        json !== null &&
+        typeof json === "object" &&
+        "data" in json &&
+        "success" in json
+      ) {
+        return (json as { data: unknown }).data;
+      }
+
+      return json;
+    };
+
+    if (!this.retry) return doFetch();
+
+    let lastErr: unknown;
+    for (let i = 0; i < this.retry.attempts; i++) {
+      try {
+        return await doFetch();
+      } catch (err) {
+        lastErr = err;
+        if (i < this.retry.attempts - 1) {
+          const delay = (this.retry.baseDelayMs ?? 100) * Math.pow(2, i);
+          await new Promise<void>(r => setTimeout(r, delay));
+        }
+      }
+    }
+    throw lastErr;
+  }
+}

--- a/src/services/qdrant/client.ts
+++ b/src/services/qdrant/client.ts
@@ -7,8 +7,12 @@
  * Base URL: QDRANT_URL env var (default: http://qdrant:6333)
  */
 
+import { HttpClient } from "../http-client.ts";
+
 const QDRANT_URL = process.env.QDRANT_URL ?? "http://qdrant:6333";
 const TIMEOUT_MS = 5_000;
+
+const http = new HttpClient({ timeoutMs: TIMEOUT_MS });
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -29,18 +33,6 @@ export interface QdrantCollectionConfig {
   distance?: "Cosine" | "Euclid" | "Dot";
 }
 
-// ── Helpers ────────────────────────────────────────────────────────────────────
-
-async function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
-  try {
-    return await fetch(url, { ...init, signal: controller.signal });
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
 // ── Collection management ──────────────────────────────────────────────────────
 
 /**
@@ -52,7 +44,7 @@ export async function ensureCollection(
   config: QdrantCollectionConfig,
 ): Promise<boolean> {
   try {
-    const res = await fetchWithTimeout(`${QDRANT_URL}/collections/${name}`, {
+    const res = await http.fetch(`${QDRANT_URL}/collections/${name}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -81,7 +73,7 @@ export async function ensureCollection(
  */
 export async function listCollections(): Promise<string[]> {
   try {
-    const res = await fetchWithTimeout(`${QDRANT_URL}/collections`, { method: "GET" });
+    const res = await http.fetch(`${QDRANT_URL}/collections`, { method: "GET" });
     if (!res.ok) return [];
     const data = await res.json() as { result?: { collections?: { name: string }[] } };
     return data.result?.collections?.map(c => c.name) ?? [];
@@ -102,7 +94,7 @@ export async function upsertPoints(
 ): Promise<boolean> {
   if (points.length === 0) return true;
   try {
-    const res = await fetchWithTimeout(`${QDRANT_URL}/collections/${collection}/points`, {
+    const res = await http.fetch(`${QDRANT_URL}/collections/${collection}/points`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ points }),
@@ -136,7 +128,7 @@ export async function searchPoints(
     };
     if (filter) body.filter = filter;
 
-    const res = await fetchWithTimeout(`${QDRANT_URL}/collections/${collection}/points/search`, {
+    const res = await http.fetch(`${QDRANT_URL}/collections/${collection}/points/search`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
@@ -159,7 +151,7 @@ export async function searchPoints(
  */
 export async function countPoints(collection: string): Promise<number> {
   try {
-    const res = await fetchWithTimeout(`${QDRANT_URL}/collections/${collection}/points/count`, {
+    const res = await http.fetch(`${QDRANT_URL}/collections/${collection}/points/count`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ exact: false }),
@@ -177,7 +169,7 @@ export async function countPoints(collection: string): Promise<number> {
  */
 export async function checkHealth(): Promise<boolean> {
   try {
-    const res = await fetchWithTimeout(`${QDRANT_URL}/healthz`, { method: "GET" });
+    const res = await http.fetch(`${QDRANT_URL}/healthz`, { method: "GET" });
     return res.ok;
   } catch {
     return false;


### PR DESCRIPTION
## Summary

13 files call fetch() directly with duplicated error handling, headers, timeout, and response parsing. Create a shared HTTP client to centralize this.

Files to consolidate:
- src/agent-runtime/tools/bus-tools.ts (apiGet/apiPost helpers)
- src/executor/executors/a2a-executor.ts
- src/api/github.ts (_ghApi)
- src/llm/reviewOrchestrator.ts
- src/github/reviewSubmitter.ts
- src/services/codebase/symbol-fetcher.ts
- src/services/github/diff-fetcher.ts
- src/integrations/discord_logger.ts
- src/integ...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved HTTP request handling consistency and reliability across internal API integrations and services, including better error handling and timeout management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->