### PR TITLE
refactor: eliminate 74 Record&lt;string, unknown&gt; with discriminated unions

### DIFF
--- a/src/agent-runtime/tools/bus-tools.ts
+++ b/src/agent-runtime/tools/bus-tools.ts
@@ -131,11 +131,13 @@ export function createBusTools(opts: BusToolsOptions = {}) {
     },
     async ({ title, severity, description, affectedProjects, projectSlug }) => {
       try {
-        const body: Record<string, unknown> = { title, severity };
-        if (description) body.description = description;
-        if (affectedProjects) body.affectedProjects = affectedProjects;
-        if (projectSlug) body.projectSlug = projectSlug;
-        const data = await http.post("/api/incidents", body);
+        const data = await http.post("/api/incidents", {
+          title,
+          severity,
+          ...(description ? { description } : {}),
+          ...(affectedProjects ? { affectedProjects } : {}),
+          ...(projectSlug ? { projectSlug } : {}),
+        });
         return ok(data);
       } catch (e) {
         return err(e instanceof Error ? e.message : String(e));

--- a/src/event-bus/payloads.ts
+++ b/src/event-bus/payloads.ts
@@ -1,0 +1,185 @@
+/**
+ * Typed payload interfaces for all EventBus topics.
+ *
+ * These replace `Record<string, unknown>` casts at publish/subscribe sites.
+ * Every BusMessage.payload should be one of these types, narrowed by topic.
+ *
+ * Existing action-event payloads live in ./action-events.ts and are re-exported
+ * here for a single import point.
+ */
+
+// Re-export action event payloads (already defined)
+export type {
+  ActionDispatchPayload,
+  ActionOutcomePayload,
+  ActionOscillationPayload,
+  ActionQueueFullPayload,
+  PlannerEscalatePayload,
+} from "./action-events.ts";
+
+// ── agent.skill.request ───────────────────────────────────────────────────────
+
+/**
+ * Payload for `agent.skill.request` — published by RouterPlugin,
+ * ActionDispatcherPlugin, or any surface that wants to invoke an agent skill.
+ *
+ * Fields beyond the listed ones are forwarded transparently from the originating
+ * inbound message payload (e.g. projectSlug, discordChannels, github metadata).
+ */
+export interface AgentSkillRequestPayload {
+  /** Skill name to execute (e.g. "bug_triage", "daily_standup"). */
+  skill?: string;
+  /** Natural language content / task description. */
+  content?: string;
+  /** Explicit prompt override. */
+  prompt?: string;
+  /** Target agent names to route to — empty means any registered executor. */
+  targets?: string[];
+  /** Internal router flag: message has already been routed, skip re-dispatch. */
+  _routed?: boolean;
+  /** Unique per-dispatch run identifier. */
+  runId?: string;
+  /** Project slug for multi-project routing. */
+  projectSlug?: string;
+  /** Explicit skill hint set by surface plugins before inbound routing. */
+  skillHint?: string;
+  /** Whether this message originated from a direct message conversation. */
+  isDM?: boolean;
+  /** GOAP action metadata forwarded from ActionDispatcherPlugin. */
+  meta?: {
+    agentId?: string;
+    skillHint?: string;
+    topic?: string;
+    context?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+  /** Allow additional forwarded payload fields from the originating message. */
+  [key: string]: unknown;
+}
+
+// ── agent.skill.response.* ───────────────────────────────────────────────────
+
+/** Payload for `agent.skill.response.*` — published by SkillDispatcherPlugin. */
+export interface AgentSkillResponsePayload {
+  /** Successful result text (undefined on error). */
+  content?: string;
+  /** Error message (undefined on success). */
+  error?: string;
+  /** Propagated trace ID. */
+  correlationId: string;
+}
+
+// ── message.inbound.* ────────────────────────────────────────────────────────
+
+/**
+ * Common fields present on all `message.inbound.*` payloads.
+ * Surface plugins (Discord, GitHub, Plane, etc.) extend this with their
+ * own platform-specific fields.
+ */
+export interface InboundMessagePayload {
+  /** Natural language content of the message. */
+  content?: string;
+  /** Explicit skill hint set by a surface plugin before routing. */
+  skillHint?: string;
+  /** True when the message came from a direct message / DM context. */
+  isDM?: boolean;
+  /** Internal router flag: skip re-routing if already dispatched. */
+  _routed?: boolean;
+  /** Project slug stamped by ProjectEnricher for GitHub messages. */
+  projectSlug?: string;
+  /** Discord channel IDs stamped by ProjectEnricher for GitHub messages. */
+  discordChannels?: {
+    general?: string;
+    updates?: string;
+    dev?: string;
+    alerts?: string;
+    releases?: string;
+  };
+  /** GitHub-specific metadata (present on message.inbound.github.*). */
+  github?: {
+    owner?: string;
+    repo?: string;
+    [key: string]: unknown;
+  };
+  /** Allow additional platform-specific fields. */
+  [key: string]: unknown;
+}
+
+// ── cron.* ───────────────────────────────────────────────────────────────────
+
+/** Payload for `cron.*` — published by SchedulerPlugin when a ceremony fires. */
+export interface CronPayload {
+  /** Optional content / prompt for the triggered ceremony. */
+  content?: string;
+  /** Explicit skill hint for RouterPlugin. */
+  skillHint?: string;
+  /** Reply channel for the scheduled action. Default: "cli". */
+  channel?: string;
+  /** Optional recipient for Signal/DM-style channels. */
+  recipient?: string;
+  /** Allow additional fields from ceremony YAML context. */
+  [key: string]: unknown;
+}
+
+// ── flow.item.* ──────────────────────────────────────────────────────────────
+
+/** Status values for flow items (Flow Framework). */
+export type FlowItemStatus = "active" | "blocked" | "complete";
+
+/** Stage labels for flow item lifecycle tracking. */
+export type FlowItemStage = "dispatched" | "running" | "error" | "done";
+
+/** Payload for `flow.item.created` / `flow.item.updated` / `flow.item.completed`. */
+export interface FlowItemPayload {
+  /** Unique flow item identifier. */
+  id: string;
+  /** Flow item type for classification. */
+  type?: "feature" | "defect" | "risk" | "debt";
+  /** Current lifecycle status. */
+  status?: FlowItemStatus;
+  /** Current pipeline stage. */
+  stage?: FlowItemStage;
+  /** Unix timestamp ms when item was created. */
+  createdAt?: number;
+  /** Unix timestamp ms when processing started. */
+  startedAt?: number;
+  /** Unix timestamp ms when item completed. */
+  completedAt?: number;
+  /** Arbitrary metadata (skill name, executor type, error messages, etc.). */
+  meta?: Record<string, unknown>;
+}
+
+// ── security.incident.reported ───────────────────────────────────────────────
+
+/** Severity level for security incidents. */
+export type IncidentSeverity = "critical" | "high" | "medium" | "low";
+
+/** Status for security incidents. */
+export type IncidentStatus = "open" | "investigating" | "resolved";
+
+/** Payload for `security.incident.reported`. */
+export interface IncidentReportedPayload {
+  incident: {
+    id: string;
+    title: string;
+    severity: IncidentSeverity;
+    status: IncidentStatus;
+    reportedAt: string;
+    description?: string;
+    affectedProjects?: string[];
+    assignee?: string;
+  };
+}
+
+// ── ceremony.*.execute ───────────────────────────────────────────────────────
+
+/** Payload for `ceremony.{id}.execute` — manual or scheduled ceremony trigger. */
+export interface CeremonyExecutePayload {
+  type: "manual.execute" | "scheduled.execute";
+  triggeredBy: "api" | "scheduler";
+  ceremonyId?: string;
+}
+
+// ── world.goal.violated ──────────────────────────────────────────────────────
+// Defined in src/types/events.ts — re-exported here for convenience.
+export type { GoalViolatedEventPayload } from "../types/events.ts";

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -16,6 +16,7 @@
 import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
 import type { ExecutorRegistry } from "./executor-registry.ts";
 import type { SkillRequest } from "./types.ts";
+import type { AgentSkillRequestPayload, FlowItemPayload } from "../event-bus/payloads.ts";
 import { GraphitiClient } from "../../lib/memory/graphiti-client.ts";
 import { IdentityRegistry } from "../../lib/identity/identity-registry.ts";
 
@@ -76,20 +77,17 @@ export class SkillDispatcherPlugin implements Plugin {
   }
 
   private async _dispatch(msg: BusMessage): Promise<void> {
-    const payload = (msg.payload ?? {}) as Record<string, unknown>;
+    const payload = (msg.payload ?? {}) as AgentSkillRequestPayload;
 
-    const skill = (payload.skill as string | undefined)
-      ?? (payload.meta as Record<string, unknown> | undefined)?.skillHint as string | undefined
+    const skill = payload.skill
+      ?? (typeof payload.meta?.skillHint === "string" ? payload.meta.skillHint : undefined)
       ?? "";
 
     let targets: string[] = [];
     if (Array.isArray(payload.targets)) {
-      targets = payload.targets as string[];
-    } else {
-      const meta = payload.meta as Record<string, unknown> | undefined;
-      if (typeof meta?.agentId === "string") {
-        targets = [meta.agentId];
-      }
+      targets = payload.targets;
+    } else if (typeof payload.meta?.agentId === "string") {
+      targets = [payload.meta.agentId];
     }
 
     const correlationId = msg.correlationId;
@@ -131,10 +129,14 @@ export class SkillDispatcherPlugin implements Plugin {
     // For (a) we also compute an agent-scoped group so each agent
     // accumulates its own relationship memory with the user on top of
     // the shared cross-agent baseline.
-    const sourceUserId = (msg.source as Record<string, unknown> | undefined)?.userId as string | undefined;
-    const sourcePlatform = (msg.source as Record<string, unknown> | undefined)?.interface as string | undefined;
-    const sourceChannelId = (msg.source as Record<string, unknown> | undefined)?.channelId as string | undefined;
-    const systemActor = (payload.meta as Record<string, unknown> | undefined)?.systemActor as string | undefined;
+    const sourceUserId: string | undefined =
+      typeof msg.source?.userId === "string" ? msg.source.userId : undefined;
+    const sourcePlatform: string | undefined =
+      typeof msg.source?.interface === "string" ? msg.source.interface : undefined;
+    const sourceChannelId: string | undefined =
+      typeof msg.source?.channelId === "string" ? msg.source.channelId : undefined;
+    const systemActor: string | undefined =
+      typeof payload.meta?.systemActor === "string" ? payload.meta.systemActor : undefined;
 
     let rawContent = typeof payload.content === "string" ? payload.content : undefined;
     const originalContent = rawContent; // preserved for episode storage — never includes context prefix
@@ -173,7 +175,7 @@ export class SkillDispatcherPlugin implements Plugin {
       correlationId,
       parentId,
       replyTopic,
-      payload: payload as Record<string, unknown>,
+      payload,
     };
 
     const flowItemId = `skill-${correlationId}`;
@@ -277,11 +279,11 @@ export class SkillDispatcherPlugin implements Plugin {
     }
   }
 
-  private _publishFlowEvent(topic: string, item: Record<string, unknown>): void {
+  private _publishFlowEvent(topic: string, item: FlowItemPayload): void {
     if (!this.bus) return;
     this.bus.publish(topic, {
       id: crypto.randomUUID(),
-      correlationId: item.id as string,
+      correlationId: item.id,
       topic,
       timestamp: Date.now(),
       payload: item,

--- a/src/executor/types.ts
+++ b/src/executor/types.ts
@@ -13,6 +13,8 @@ import type { ExtendedUsage } from "@protolabsai/sdk";
  *   parentId      = parent span ID (the bus message ID that triggered this request)
  */
 
+import type { AgentSkillRequestPayload } from "../event-bus/payloads.ts";
+
 // ── Request / Result ──────────────────────────────────────────────────────────
 
 export interface SkillRequest {
@@ -28,8 +30,8 @@ export interface SkillRequest {
   parentId?: string;
   /** Topic to publish the response on. */
   replyTopic: string;
-  /** Full original payload for executors that need extra fields. */
-  payload: Record<string, unknown>;
+  /** Full original bus message payload — typed with known agent.skill.request fields. */
+  payload: AgentSkillRequestPayload;
 }
 
 export interface SkillResult {

--- a/src/router/router-plugin.ts
+++ b/src/router/router-plugin.ts
@@ -31,6 +31,7 @@
 import { existsSync, watchFile, unwatchFile } from "node:fs";
 import { join } from "node:path";
 import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
+import type { InboundMessagePayload, CronPayload } from "../event-bus/payloads.ts";
 import { SkillResolver } from "./skill-resolver.ts";
 import { ProjectEnricher } from "./project-enricher.ts";
 import { loadAgentDefinitions } from "../agent-runtime/agent-definition-loader.ts";
@@ -155,7 +156,7 @@ export class RouterPlugin implements Plugin {
   private async _handleInbound(msg: BusMessage): Promise<void> {
     if (!this.bus) return;
 
-    const payload = msg.payload as Record<string, unknown>;
+    const payload = msg.payload as InboundMessagePayload;
 
     // Skip system/internal messages that surface plugins re-publish for their
     // own routing (e.g., enriched GitHub messages from the old A2APlugin).
@@ -167,10 +168,10 @@ export class RouterPlugin implements Plugin {
     // not a GitHub message, or the repo isn't in the project registry.
     const enriched = this.enricher.enrich(msg);
     const workingMsg = enriched ?? msg;
-    const workingPayload = workingMsg.payload as Record<string, unknown>;
+    const workingPayload = workingMsg.payload as InboundMessagePayload;
 
-    const skillHint = workingPayload.skillHint as string | undefined;
-    const content = workingPayload.content as string | undefined;
+    const skillHint = workingPayload.skillHint;
+    const content = workingPayload.content;
     const isDM = workingPayload.isDM === true;
 
     // Channel-based agent assignment — takes priority over keyword agent matching.
@@ -267,11 +268,11 @@ export class RouterPlugin implements Plugin {
   private async _handleCron(msg: BusMessage): Promise<void> {
     if (!this.bus) return;
 
-    const payload = msg.payload as Record<string, unknown>;
-    const content = payload.content as string | undefined;
-    const skillHint = payload.skillHint as string | undefined;
-    const channel = (payload.channel as string | undefined) ?? "cli";
-    const recipient = payload.recipient as string | undefined;
+    const payload = msg.payload as CronPayload;
+    const content = payload.content;
+    const skillHint = payload.skillHint;
+    const channel = payload.channel ?? "cli";
+    const recipient = payload.recipient;
 
     const match = this.resolver.resolve(skillHint, content);
 

--- a/src/schemas/yaml-schemas.ts
+++ b/src/schemas/yaml-schemas.ts
@@ -1,0 +1,249 @@
+/**
+ * Zod schemas for all workspace YAML files.
+ *
+ * Use these at API/loader boundaries for runtime validation with descriptive
+ * error messages, replacing manual `as Record<string, unknown>` coercions.
+ *
+ * Each schema matches the corresponding TypeScript interface while providing
+ * parse-time validation so bad config surfaces at startup, not silently later.
+ */
+
+import { z } from "zod";
+
+// ── workspace/agents/*.yaml ──────────────────────────────────────────────────
+
+export const AgentRoleSchema = z.enum([
+  "orchestrator",
+  "qa",
+  "devops",
+  "content",
+  "research",
+  "general",
+]);
+
+export const AgentSkillDefinitionSchema = z.object({
+  name: z.string().min(1, "Skill name must not be empty"),
+  description: z.string().optional(),
+  keywords: z.array(z.string()).optional(),
+  systemPromptOverride: z.string().optional(),
+});
+
+export const AgentDefinitionSchema = z.object({
+  name: z.string().min(1, "Agent name must not be empty"),
+  role: AgentRoleSchema,
+  model: z.string().min(1, "Model must not be empty"),
+  systemPrompt: z.string().min(1, "systemPrompt must not be empty"),
+  tools: z.array(z.string()).default([]),
+  allowedTools: z.array(z.string()).optional(),
+  excludeTools: z.array(z.string()).optional(),
+  canDelegate: z.array(z.string()).optional(),
+  maxTurns: z.number().int().refine(
+    (n) => n === -1 || n > 0,
+    "maxTurns must be -1 (unlimited) or a positive integer",
+  ).default(10),
+  skills: z.array(AgentSkillDefinitionSchema).default([]),
+});
+
+export type AgentDefinitionInput = z.input<typeof AgentDefinitionSchema>;
+export type AgentDefinitionOutput = z.output<typeof AgentDefinitionSchema>;
+
+// ── workspace/goals.yaml ─────────────────────────────────────────────────────
+
+export const SeveritySchema = z.enum(["low", "medium", "high", "critical"]);
+
+export const InvariantOperatorSchema = z.enum([
+  "eq",
+  "neq",
+  "truthy",
+  "falsy",
+  "in",
+  "not_in",
+]);
+
+const BaseGoalSchema = z.object({
+  id: z.string().min(1, "Goal id must not be empty"),
+  description: z.string().min(1, "Goal description must not be empty"),
+  severity: SeveritySchema.optional(),
+  enabled: z.boolean().optional(),
+  tags: z.array(z.string()).optional(),
+});
+
+export const InvariantGoalSchema = BaseGoalSchema.extend({
+  type: z.literal("Invariant"),
+  selector: z.string().min(1),
+  expected: z.unknown().optional(),
+  operator: InvariantOperatorSchema.optional(),
+});
+
+export const ThresholdGoalSchema = BaseGoalSchema.extend({
+  type: z.literal("Threshold"),
+  selector: z.string().min(1),
+  min: z.number().optional(),
+  max: z.number().optional(),
+});
+
+export const DistributionGoalSchema = BaseGoalSchema.extend({
+  type: z.literal("Distribution"),
+  selector: z.string().min(1),
+  pattern: z.string().optional(),
+  distribution: z.record(z.number()).optional(),
+  tolerance: z.number().min(0).max(1).optional(),
+});
+
+export const GoalSchema = z.discriminatedUnion("type", [
+  InvariantGoalSchema,
+  ThresholdGoalSchema,
+  DistributionGoalSchema,
+]);
+
+export const GoalsFileSchema = z.object({
+  version: z.string().optional(),
+  goals: z.array(GoalSchema),
+});
+
+export type GoalInput = z.input<typeof GoalSchema>;
+
+// ── workspace/actions.yaml ───────────────────────────────────────────────────
+
+export const ConditionOperatorSchema = z.enum([
+  "eq",
+  "neq",
+  "gt",
+  "gte",
+  "lt",
+  "lte",
+  "exists",
+  "not_exists",
+]);
+
+export const PreconditionSchema = z.object({
+  path: z.string().min(1, "Precondition path must not be empty"),
+  operator: ConditionOperatorSchema,
+  value: z.unknown().optional(),
+});
+
+export const EffectOperationSchema = z.enum([
+  "set",
+  "increment",
+  "decrement",
+  "delete",
+]);
+
+export const EffectSchema = z.object({
+  path: z.string().min(1, "Effect path must not be empty"),
+  operation: EffectOperationSchema,
+  value: z.unknown().optional(),
+});
+
+export const ActionMetaSchema = z.object({
+  topic: z.string().optional(),
+  agentId: z.string().optional(),
+  timeout: z.number().optional(),
+  context: z.record(z.unknown()).optional(),
+  fireAndForget: z.boolean().optional(),
+  skillHint: z.string().optional(),
+});
+
+export const ActionTierSchema = z.enum(["tier_0", "tier_1", "tier_2"]);
+
+export const ActionSchema = z.object({
+  id: z.string().min(1, "Action id must not be empty"),
+  name: z.string().min(1, "Action name must not be empty"),
+  description: z.string().default(""),
+  goalId: z.string().min(1, "Action goalId must not be empty"),
+  tier: ActionTierSchema,
+  preconditions: z.array(PreconditionSchema).default([]),
+  effects: z.array(EffectSchema).default([]),
+  cost: z.number().default(0),
+  priority: z.number().default(0),
+  meta: ActionMetaSchema.default({}),
+});
+
+export const ActionsFileSchema = z.object({
+  actions: z.array(ActionSchema),
+});
+
+export type ActionInput = z.input<typeof ActionSchema>;
+export type ActionOutput = z.output<typeof ActionSchema>;
+
+// ── workspace/ceremonies/*.yaml ──────────────────────────────────────────────
+
+export const CeremonySchema = z.object({
+  id: z.string().min(1, "Ceremony id must not be empty"),
+  name: z.string().min(1, "Ceremony name must not be empty"),
+  schedule: z.string().min(1, "Ceremony schedule must not be empty"),
+  skill: z.string().min(1, "Ceremony skill must not be empty"),
+  targets: z.array(z.string()).min(1, "Ceremony targets must be a non-empty array"),
+  notifyChannel: z.string().optional(),
+  enabled: z.boolean().default(true),
+});
+
+export type CeremonyInput = z.input<typeof CeremonySchema>;
+
+// ── workspace/channels.yaml ──────────────────────────────────────────────────
+
+export const ChannelPlatformSchema = z.enum([
+  "discord",
+  "github",
+  "signal",
+  "slack",
+  "plane",
+]);
+
+export const ConversationConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  timeoutSeconds: z.number().optional(),
+  requireMentionAfterFirst: z.boolean().optional(),
+});
+
+export const ChannelSchema = z.object({
+  id: z.string().min(1),
+  platform: ChannelPlatformSchema,
+  agent: z.string().optional(),
+  // Discord-specific
+  channelId: z.string().optional(),
+  guildId: z.string().optional(),
+  // GitHub-specific
+  repo: z.string().optional(),
+  // Signal-specific
+  groupId: z.string().optional(),
+  // Slack-specific
+  slackChannelId: z.string().optional(),
+  conversation: ConversationConfigSchema.optional(),
+});
+
+export const ChannelsFileSchema = z.object({
+  channels: z.array(ChannelSchema),
+});
+
+export type ChannelInput = z.input<typeof ChannelSchema>;
+
+// ── workspace/projects.yaml ──────────────────────────────────────────────────
+
+const ProjectDiscordChannelsSchema = z.object({
+  general: z.string().optional(),
+  updates: z.string().optional(),
+  dev: z.string().optional(),
+  alerts: z.string().optional(),
+  releases: z.string().optional(),
+});
+
+export const ProjectSchema = z.object({
+  slug: z.string().min(1, "Project slug must not be empty"),
+  title: z.string().optional(),
+  github: z.string().regex(/^[^/]+\/[^/]+$/, "github must be 'owner/repo' format"),
+  defaultBranch: z.string().default("main"),
+  status: z.enum(["active", "inactive", "archived", "suspended"]).default("active"),
+  agents: z.array(z.string()).optional(),
+  discord: z.union([
+    ProjectDiscordChannelsSchema,
+    z.object({ channels: ProjectDiscordChannelsSchema }),
+  ]).optional(),
+});
+
+export const ProjectsFileSchema = z.object({
+  projects: z.array(ProjectSchema),
+});
+
+export type ProjectInput = z.input<typeof ProjectSchema>;
+export type ProjectOutput = z.output<typeof ProjectSchema>;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,7 +1,8 @@
 import type { GoalViolation } from "./goals.ts";
+import type { WorldState } from "../../lib/types/world-state.ts";
 
 export interface GoalViolatedEventPayload {
   type: "world.goal.violated";
   violation: GoalViolation;
-  worldState?: Record<string, unknown>;
+  worldState?: WorldState;
 }


### PR DESCRIPTION
## Summary

74 instances of `Record<string, unknown>` used as catch-all typing for event payloads, CLI args, YAML objects, and API responses. Blocks exhaustive type checking and IDE autocompletion.

Approach:
1. Create `src/event-bus/payloads.ts` with discriminated unions for each event topic
2. Create zod schemas for all YAML files (agents, goals, actions, domains, channels, projects)
3. Replace Record<string, unknown> with explicit types in 80% of cases
4. Use zod parse for runtime validation at API bound...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive validation schemas for workspace YAML configuration (agents, goals, actions, ceremonies, channels, projects).

* **Refactor**
  * Centralized EventBus message payload type definitions for more consistent handling.
  * Enhanced type safety across messaging and execution paths to reduce runtime issues.
  * Streamlined incident reporting payload construction for more reliable reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->