### PR TITLE
feat(task-73): migrate pr_review from in-process Quinn to A2A labs/quinn

### DIFF
--- a/workspace/agents.yaml
+++ b/workspace/agents.yaml
@@ -29,3 +29,20 @@ agents:
     skills:
       - name: chat
         description: Open-ended content + GTM dialogue with protoContent (Jon + Cindi)
+
+  # Quinn — standalone QA engineer (labs/quinn nanobot/LangGraph agent).
+  # Submits FORMAL GitHub reviews (APPROVE/REQUEST_CHANGES/COMMENT) via the
+  # pr_inspector tool, not narrative issue comments — closes the pr-remediator
+  # readyToMerge/changesRequested loop for non-safe-class PRs (task #73).
+  # Posts as @protoquinn[bot] via installation token minted in her entrypoint
+  # from QUINN_APP_ID + QUINN_APP_PRIVATE_KEY, refreshed every 45 min.
+  # In-process workspace/agents/quinn.yaml was retired to avoid name collision
+  # (executor registry was picking in-process before A2A). Uncovered: chat and
+  # security_triage — tracked as task #81.
+  - name: quinn
+    url: "${QUINN_BASE_URL}/a2a"
+    skills:
+      - name: pr_review
+        description: Review a pull request (CI, CodeRabbit threads, diff) and submit a formal APPROVE/REQUEST_CHANGES/COMMENT review via pr_inspector
+      - name: bug_triage
+        description: Triage a bug report, classify severity, file it on the Ava board via file_bug

--- a/workspace/agents/quinn.yaml.retired
+++ b/workspace/agents/quinn.yaml.retired
@@ -53,9 +53,13 @@ skills:
     description: Triage a bug report — severity, reproduction, root cause, Plane issue
     keywords: [bug, issue, broken, crash, error, fail, exception, triage, TypeError, ReferenceError, not working, regression]
 
-  - name: pr_review
-    description: Review a pull request diff for correctness and regressions
-    keywords: [pr, pull request, review, merge, /review, code review, lgtm, looks good]
+  # pr_review skill was migrated to the standalone labs/quinn A2A agent
+  # (workspace/agents.yaml:quinn). The standalone agent has pr_inspector +
+  # gh CLI + installation-token-based @protoquinn[bot] posting, so it can
+  # submit formal APPROVE/REQUEST_CHANGES reviews that close the
+  # pr-remediator readyToMerge / changesRequested loops. Task #73.
+  # Keeping chat/bug_triage/security_triage on the in-process agent for now
+  # pending a follow-up migration.
 
   - name: security_triage
     description: Triage a security incident — assess severity, draft remediation plan


### PR DESCRIPTION
## Summary

Migrates the \`pr_review\` skill from the in-process Quinn stub (\`workspace/agents/quinn.yaml\`) to the standalone labs/quinn A2A agent. Closes the pr-remediator \`readyToMerge\` / \`changesRequested\` / \`pr_address_feedback\` loops for non-safe-class PRs — task #73 keystone.

## Why

Before: in-process Quinn posted narrative review text as **issue comments**, which have no \`state\` field from GitHub's perspective. pr-remediator's \`pr_pipeline.readyToMerge\` / \`pr_pipeline.changesRequested\` fields only flip on formal PR reviews (APPROVED / CHANGES_REQUESTED). Result: her feedback was invisible to the autonomous merge loop.

After: labs/quinn has \`pr_inspector\` with \`review_approve\` / \`review_request_changes\` / \`review_comment\` actions that call \`gh pr review --approve/--request-changes/--comment\` — hitting the formal Reviews API. Her reviews now register as \`state: COMMENTED | APPROVED | CHANGES_REQUESTED\` and feed directly into pr-remediator's action dispatch.

## Changes

- **\`workspace/agents.yaml\`**: new \`quinn\` A2A entry pointing at \`\${QUINN_BASE_URL}/a2a\` with \`pr_review\` and \`bug_triage\` skills. No \`apiKeyEnv\` — handler is unauthenticated on the ai_default Docker network for now.
- **\`workspace/agents/quinn.yaml\` → \`.retired\`**: Renamed to stop agent-runtime from registering in-process Quinn. The executor registry was picking in-process first when both registrations used the same \`name: quinn\`, routing formal-review dispatches to the wrong executor. Fully retiring the stub removes the ambiguity.

## What's uncovered (task #81)

The retired in-process Quinn had 4 skills: \`chat\`, \`bug_triage\`, \`pr_review\`, \`security_triage\`. Migration coverage:
- \`pr_review\` → labs/quinn ✓
- \`bug_triage\` → labs/quinn ✓ (her agent card already claims it)
- \`chat\` — not yet on labs/quinn. Discord DM fallback (\`ROUTER_DM_DEFAULT_AGENT=quinn\`) will need to change to \`ava\` in env until migrated.
- \`security_triage\` — not yet on labs/quinn.

Task #81 tracks the remaining two.

## Verification

- \`[a2a] Loaded 3 agents: ava, protocontent, quinn\`
- \`[a2a] quinn skills: qa_report, board_audit, bug_triage, pr_review\`
- No \`[agent-runtime] Loaded agent "quinn"\` line (in-process path retired)
- End-to-end from bus: \`POST /publish agent.skill.request\` → \`[skill-dispatcher] Dispatching "pr_review" via a2a (targets: quinn)\` → 79s later, formal \`COMMENTED\` review landed on protoLabsAI/protoWorkstacean#119 by \`@protoquinn[bot]\`, full QA audit with VERDICT block

## Pairs with

- protoLabsAI/quinn#? — GitHub App JWT auth + gh CLI install in labs/quinn
- protoLabsAI/homelab-iac#? — \`QUINN_BASE_URL\` env var wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New "quinn" external agent is now available and ready for use. This agent delivers automated pull request review capabilities with formal GitHub integration, plus intelligent bug triage with automatic severity classification and project board filing. Streamlines code review processes and enhances issue management workflows for improved team productivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->