### PR TITLE
ci(task-82): add dashboard build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,33 @@ jobs:
       - name: Type check
         run: bun run tsc --noEmit
 
+  dashboard:
+    # Dashboard lives in a sub-project with its own tsconfig + build pipeline
+    # (Astro islands). The root `test` job does not cover `dashboard/src/` —
+    # discovered the hard way on 2026-04-11 when 31 unresolved git merge
+    # conflict markers landed on dev through the M3-M6 milestone merges
+    # because every PR CI went green while dashboard build would have blown
+    # up. See task #82 in the board. Keep this job fast (astro build is ~1s)
+    # and independent so the full CI cost is negligible.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dashboard deps
+        working-directory: dashboard
+        run: bun install --frozen-lockfile
+
+      - name: Build dashboard (astro build)
+        working-directory: dashboard
+        run: bun run build
+
   build-and-push:
-    needs: test
+    needs: [test, dashboard]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

Adds a CI \`dashboard\` job that runs \`astro build\` in \`dashboard/\`. The root \`test\` job covers src/ and lib/ via bun test + tsc, but does not touch dashboard/src/ — which let 31 unresolved git merge conflict markers land on dev through the M3-M6 milestone merges without any CI signal.

The dashboard build is ~1 second on the current codebase, so CI cost is negligible. The \`build-and-push\` job now depends on both \`test\` and \`dashboard\` passing.

Prevents the exact failure mode that cost 2+ hours of debugging earlier today. Pairs with the dashboard conflict resolution that shipped in PR #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration pipeline with an additional build validation step to ensure comprehensive quality checks before deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->