### PR TITLE
feat(agents): advertise security_triage on the Quinn A2A entry

### DIFF
--- a/workspace/agents.yaml
+++ b/workspace/agents.yaml
@@ -36,9 +36,8 @@ agents:
   # readyToMerge/changesRequested loop for non-safe-class PRs (task #73).
   # Posts as @protoquinn[bot] via installation token minted in her entrypoint
   # from QUINN_APP_ID + QUINN_APP_PRIVATE_KEY, refreshed every 45 min.
-  # In-process workspace/agents/quinn.yaml was retired to avoid name collision
-  # (executor registry was picking in-process before A2A). Uncovered: chat and
-  # security_triage — tracked as task #81.
+  # chat is uncovered here — Discord DMs fall through to ROUTER_DM_DEFAULT_AGENT
+  # (currently ava) for free-form conversation.
   - name: quinn
     url: "${QUINN_BASE_URL}/a2a"
     skills:
@@ -46,3 +45,5 @@ agents:
         description: Review a pull request (CI, CodeRabbit threads, diff) and submit a formal APPROVE/REQUEST_CHANGES/COMMENT review via pr_inspector
       - name: bug_triage
         description: Triage a bug report, classify severity, file it on the Ava board via file_bug
+      - name: security_triage
+        description: Triage a security incident (CVE, dependabot alert, vulnerability disclosure), classify severity, and file it on the board via report_incident — critical/high escalate to HITL before remediation


### PR DESCRIPTION
## Summary

- Adds \`security_triage\` to Quinn's skill surface in \`workspace/agents.yaml\` so the workstacean skill dispatcher routes incoming security triage requests to standalone Quinn.
- Pairs with Quinn PR protoLabsAI/quinn#3 (agent-card declaration + playbook) and a homelab-iac PR (ROUTER_DM_DEFAULT_AGENT flip to ava).
- Part of protoLabsAI/protoWorkstacean#81 — the migration closes when all three land.

## Test plan

- [x] Quinn's agent-card declares \`security_triage\` (protoLabsAI/quinn#3)
- [ ] Post-deploy: hit workstacean's \`get_projects\` + dispatch a security_triage skill, confirm it lands on Quinn rather than defaulting to Ava.

🤖 Generated with [Claude Code](https://claude.com/claude-code)