### PR TITLE
fix(router): skip fire-and-forget skills to eliminate double dispatch

### DIFF
--- a/src/router/__tests__/router-plugin.test.ts
+++ b/src/router/__tests__/router-plugin.test.ts
@@ -321,6 +321,95 @@ describe("RouterPlugin", () => {
     });
   });
 
+  describe("fire-and-forget skip", () => {
+    const onboardingAgent = {
+      name: "ava",
+      role: "orchestrator",
+      model: "claude-opus-4-6",
+      systemPrompt: "You are Ava.",
+      tools: [],
+      skills: [
+        { name: "onboard_project", keywords: ["onboard"] },
+        { name: "plan",            keywords: ["plan"] },
+        { name: "deep_research",   keywords: ["research"] },
+      ],
+    };
+
+    test("skips onboard_project so workspace/a2a owns the dispatch", async () => {
+      const { workspaceDir, cleanup } = makeWorkspace({ agents: { "ava.yaml": onboardingAgent } });
+      try {
+        const bus = new InMemoryEventBus();
+        const plugin = new RouterPlugin({ workspaceDir });
+        plugin.install(bus);
+
+        const req = waitForSkillRequest(bus, 100);
+        bus.publish(
+          "message.inbound.discord.onboard-1",
+          makeInbound("message.inbound.discord.onboard-1", {
+            content: "onboard my/repo",
+            skillHint: "onboard_project",
+          }),
+        );
+        expect(await req).toBeNull();
+
+        plugin.uninstall();
+      } finally { cleanup(); }
+    });
+
+    test("skips plan, plan_resume, deep_research", async () => {
+      const { workspaceDir, cleanup } = makeWorkspace({ agents: { "ava.yaml": onboardingAgent } });
+      try {
+        const bus = new InMemoryEventBus();
+        const plugin = new RouterPlugin({ workspaceDir });
+        plugin.install(bus);
+
+        for (const skill of ["plan", "plan_resume", "deep_research"]) {
+          const req = waitForSkillRequest(bus, 80);
+          bus.publish(
+            "message.inbound.discord.faf",
+            makeInbound("message.inbound.discord.faf", {
+              content: `please ${skill}`,
+              skillHint: skill,
+            }),
+          );
+          expect(await req).toBeNull();
+        }
+
+        plugin.uninstall();
+      } finally { cleanup(); }
+    });
+
+    test("non-FAF skill with same agent still dispatches normally", async () => {
+      const avaWithMixed = {
+        ...onboardingAgent,
+        skills: [
+          ...onboardingAgent.skills,
+          { name: "sitrep", keywords: ["status", "sitrep"] },
+        ],
+      };
+      const { workspaceDir, cleanup } = makeWorkspace({ agents: { "ava.yaml": avaWithMixed } });
+      try {
+        const bus = new InMemoryEventBus();
+        const plugin = new RouterPlugin({ workspaceDir });
+        plugin.install(bus);
+
+        const req = waitForSkillRequest(bus);
+        bus.publish(
+          "message.inbound.discord.status",
+          makeInbound("message.inbound.discord.status", {
+            content: "status please",
+            skillHint: "sitrep",
+          }),
+        );
+        const result = await req;
+        expect(result).not.toBeNull();
+        expect((result!.payload as Record<string, unknown>).skill).toBe("sitrep");
+
+        plugin.uninstall();
+      } finally { cleanup(); }
+    });
+  });
+
   describe("uninstall", () => {
     test("stops routing after uninstall", async () => {
       const { workspaceDir, cleanup } = makeWorkspace({ agents: { "quinn.yaml": quinnAgent } });

--- a/src/router/faf-skills.ts
+++ b/src/router/faf-skills.ts
@@ -1,0 +1,27 @@
+/**
+ * Fire-and-forget skills — skills whose dispatch is owned entirely by the
+ * workspace A2A plugin (workspace/plugins/a2a.ts), NOT the router + skill
+ * dispatcher pipeline.
+ *
+ * These skills involve multi-step orchestration (external API chains, LLM
+ * plan-then-review loops) where the inbound message should be ack'd
+ * immediately and the agent posts back to the reply topic when done. The
+ * workspace a2a plugin has its own in-flight guard and ack pattern tuned
+ * for this shape.
+ *
+ * Why this matters: both the router and the workspace a2a plugin subscribe
+ * to `message.inbound.#`. Without symmetric filtering, a FAF skill would
+ * be dispatched twice — once through skill-dispatcher (blocks, holds a
+ * request slot) and once through the workspace plugin (acks immediately).
+ * The workspace plugin's inFlightFAF map masks the visible double-run but
+ * is race-prone. The correct fix is for the router to skip these skills
+ * entirely so only the workspace plugin handles them.
+ *
+ * Both files import this set so the allowlist can never drift.
+ */
+export const FIRE_AND_FORGET_SKILLS: ReadonlySet<string> = new Set([
+  "onboard_project",
+  "plan",
+  "plan_resume",
+  "deep_research",
+]);

--- a/src/router/router-plugin.ts
+++ b/src/router/router-plugin.ts
@@ -34,6 +34,7 @@ import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
 import type { InboundMessagePayload, CronPayload } from "../event-bus/payloads.ts";
 import { SkillResolver } from "./skill-resolver.ts";
 import { ProjectEnricher } from "./project-enricher.ts";
+import { FIRE_AND_FORGET_SKILLS } from "./faf-skills.ts";
 import { loadAgentDefinitions } from "../agent-runtime/agent-definition-loader.ts";
 import type { ChannelRegistry } from "../../lib/channels/channel-registry.ts";
 import { TTLCache } from "../../lib/ttl-cache.ts";
@@ -202,6 +203,20 @@ export class RouterPlugin implements Plugin {
         `[router] No skill match for topic "${msg.topic}"` +
         (content ? ` content="${content.slice(0, 60)}"` : "") +
         " — dropping",
+      );
+      return;
+    }
+
+    // Fire-and-forget skills are owned by workspace/plugins/a2a.ts, which has
+    // its own ack-immediately + in-flight dedup pipeline. If the router also
+    // dispatched them through skill-dispatcher the same inbound event would
+    // run twice — the workspace plugin's timing-based inFlightFAF guard can
+    // mask the visible dup but is race-prone. Skipping them here is the
+    // symmetric filter half of the fix.
+    const resolvedSkill = match?.skill ?? storedSession?.skill;
+    if (resolvedSkill && FIRE_AND_FORGET_SKILLS.has(resolvedSkill)) {
+      console.log(
+        `[router] Skill "${resolvedSkill}" is fire-and-forget — owned by workspace/a2a, skipping dispatch`,
       );
       return;
     }

--- a/workspace/plugins/a2a.ts
+++ b/workspace/plugins/a2a.ts
@@ -16,6 +16,7 @@
 import { readFileSync, watchFile, unwatchFile } from "node:fs";
 import { createSign } from "node:crypto";
 import { parse } from "yaml";
+import { FIRE_AND_FORGET_SKILLS } from "../../src/router/faf-skills.ts";
 
 // ── GitHub App auth ───────────────────────────────────────────────────────────
 // Ava posts chain responses as ava[bot] using her own App identity.
@@ -230,15 +231,10 @@ function routeToAgent(skill: string | null, agents: AgentDef[]): AgentDef | null
 
 // ── A2A protocol ────────────────────────────────────────────────────────────
 
-// Skills that involve multi-step orchestration (external APIs, agent chains).
-// These are dispatched fire-and-forget: workstacean acks immediately and the
-// agent posts back to the reply topic when done. No workstacean-side timeout.
-const FIRE_AND_FORGET_SKILLS = new Set([
-  "onboard_project",  // GitHub + Plane + Discord chain
-  "plan",             // SPARC PRD + antagonistic review
-  "plan_resume",      // checkpoint restore + feature creation
-  "deep_research",    // web + knowledge store traversal
-]);
+// FIRE_AND_FORGET_SKILLS is imported from src/router/faf-skills.ts so the
+// allowlist is owned in exactly one place — the router now filters the same
+// set (fix/router-skip-faf-skills) and both sides read from the shared module.
+// If you need to add a skill, do it there.
 
 // In-flight guard: tracks currently-running fire-and-forget operations.
 // Key: `{agentName}:{skill}:{contentHash}` — prevents duplicate concurrent runs
@@ -536,13 +532,10 @@ export default {
       // agent runs twice (observed on protoWorkstacean#104 as paired
       // @protoquinn[bot] review comments).
       //
-      // TODO(#75 router-faf-dedup): the router path does NOT skip FAF skills,
-      // so onboard_project / plan / plan_resume / deep_research are still
-      // double-dispatched today — masked only by the inFlightFAF timing guard
-      // below. That mask is race-prone (two fast events can both clear the
-      // check before either sets it). Proper fix needs symmetric filters on
-      // both sides OR consolidating the ack-immediately pattern into
-      // skill-dispatcher so FAF skills can live entirely in the router path.
+      // The symmetric half of this guard lives in src/router/router-plugin.ts
+      // where FIRE_AND_FORGET_SKILLS (from src/router/faf-skills.ts) is also
+      // filtered out — together they guarantee FAF dispatch is handled exactly
+      // once regardless of which subscriber fires first.
       if (!skill || !LOCALLY_OWNED_SKILLS.has(skill)) return;
 
       const agent = routeToAgent(skill, agents);


### PR DESCRIPTION
## Summary

- Introduces `src/router/faf-skills.ts` as the single source of truth for fire-and-forget skill names (`onboard_project`, `plan`, `plan_resume`, `deep_research`)
- `RouterPlugin` now skips dispatch for FAF skills — these are owned by `workspace/plugins/a2a.ts` which subscribes independently to `message.inbound.#`
- `workspace/plugins/a2a.ts` imports from the shared module instead of maintaining a duplicate inline set
- Adds 3 router tests covering the FAF-skip guard

## Root cause

Both `RouterPlugin` and `workspace/plugins/a2a.ts` subscribe to `message.inbound.#`. FAF skills were being dispatched twice — once by the router pipeline and once by `a2a.ts`. This fix makes the router yield ownership of FAF skills to `a2a.ts`.

## Test plan
- [ ] `bun test` passes (router FAF-skip tests green)
- [ ] `dashboard` CI job passes (`bun run build` in `dashboard/`)
- [ ] No double dispatch for `onboard_project`, `plan`, `plan_resume`, `deep_research`

🤖 Generated with [Claude Code](https://claude.com/claude-code)