### PR TITLE
fix(ci): pin dashboard job to Node 22 for Astro build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Astro requires Node.js >= 22.12 at build time. GHA runners default
+      # to Node 20, which `bun run build` inherits when it invokes astro,
+      # causing a hard "not supported" failure. Set Node explicitly so the
+      # astro build runs against a supported runtime.
+      - name: Setup Node (for Astro build)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
Dashboard CI was hard-failing on every PR because \`astro build\` requires Node >= 22.12 but GHA runners default to Node 20. Adds explicit \`setup-node@v4\` before the bun install so astro sees a supported runtime.

Tiny fix to unblock #123, #124, #125 which are all green except for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved CI/CD build failures caused by Node runtime version mismatch during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->