### PR TITLE
fix(discord): pre-warm DM channels on agent-pool client ready

### DIFF
--- a/lib/plugins/discord.ts
+++ b/lib/plugins/discord.ts
@@ -1170,14 +1170,25 @@ export class DiscordPlugin implements Plugin {
           partials: [Partials.Channel, Partials.Message],
         });
 
-        agentClient.once(Events.ClientReady, c => {
+        agentClient.once(Events.ClientReady, async c => {
           console.log(`[discord] Agent client "${agentName}" logged in as ${c.user.tag}`);
+          // Pre-warm DM channels so Discord delivers MESSAGE_CREATE to this
+          // client. Discord's gateway only pushes DM events for channels in
+          // the session's private_channels list (sent in READY), so a client
+          // that never opened a DM with a user gets zero events for that DM.
+          // The primary client already does this on its own ClientReady —
+          // agent pool clients need the same treatment or their bot appears
+          // online in Discord but silently drops every DM.
+          await this._warmDmChannels(c).catch(err =>
+            console.warn(`[discord] Agent client "${agentName}" DM pre-warm failed:`, err),
+          );
         });
 
         // Handle DMs sent directly to this agent's bot
         agentClient.on(Events.MessageCreate, async (message) => {
           if (message.author.bot) return;
           if (message.guild) return; // guild messages handled by main client
+          console.log(`[discord] Agent client "${agentName}" received DM from ${message.author.tag} (${message.author.id})`);
           await this._handleDM(message, agentName, this.busRef!);
         });
 


### PR DESCRIPTION
## Summary

Agent-pool clients (\`ava\`, \`jon\`, \`frank\`) were logging in fine but never receiving DM events — the primary client has always called \`_warmDmChannels\` on \`ClientReady\` but the agent pool init was missing it. Without the warm, Discord's gateway only pushes \`MESSAGE_CREATE\` for DM channels in the session's \`private_channels\` list (from READY), so a fresh bot session that has never opened a DM with a user gets zero events. The bot appears online but silently drops every DM.

## What changed

- Agent-pool \`ClientReady\` now runs \`_warmDmChannels(c)\` for each agent bot.
- Added a \`console.log\` in the agent-pool \`MessageCreate\` handler so we get positive confirmation when a DM lands on the right bot — useful diagnostic for future intent/permission issues.

## Test plan

- [x] Local rebuild + restart
- [ ] Post-deploy: \`docker logs workstacean | grep "Pre-warmed.*DM"\` shows warming for each agent client
- [ ] DM \`@ava\` → logs show \`[discord] Agent client "ava" received DM from ...\`
- [ ] DM reaches the router → skill-dispatcher → Ava's A2A surface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for Discord direct message initialization, with diagnostic warnings logged on failures.

* **Chores**
  * Enhanced logging for Discord direct message events, including sender identification details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->