### PR TITLE
feat(agents): rename ava → protomaker target, allow in-process Discord bot pool

### DIFF
--- a/lib/plugins/discord.ts
+++ b/lib/plugins/discord.ts
@@ -18,7 +18,7 @@
  *   DISCORD_DIGEST_CHANNEL  fallback channel ID for cron-triggered posts
  */
 
-import { readFileSync, existsSync, watchFile, unwatchFile, mkdirSync } from "node:fs";
+import { readFileSync, existsSync, watchFile, unwatchFile, mkdirSync, readdirSync } from "node:fs";
 import type { ChannelRegistry } from "../channels/channel-registry.ts";
 import { join, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
@@ -163,16 +163,60 @@ interface AgentsYaml {
 }
 
 function loadAgentPoolDefs(workspaceDir: string): AgentPoolEntry[] {
+  const seen = new Map<string, AgentPoolEntry>();
+
+  // 1. A2A registry — workspace/agents.yaml (external agents)
   const agentsPath = join(workspaceDir, "agents.yaml");
-  if (!existsSync(agentsPath)) return [];
-  try {
-    const raw = readFileSync(agentsPath, "utf8");
-    const parsed = parseYaml(raw) as AgentsYaml;
-    return parsed.agents ?? [];
-  } catch (err) {
-    console.error("[discord] Failed to parse agents.yaml:", err);
-    return [];
+  if (existsSync(agentsPath)) {
+    try {
+      const raw = readFileSync(agentsPath, "utf8");
+      const parsed = parseYaml(raw) as AgentsYaml;
+      for (const entry of parsed.agents ?? []) {
+        if (entry?.name) seen.set(entry.name, entry);
+      }
+    } catch (err) {
+      console.error("[discord] Failed to parse agents.yaml:", err);
+    }
   }
+
+  // 2. In-process agents — workspace/agents/*.yaml (runtime agents loaded
+  //    by AgentRuntimePlugin). Each can also declare discordBotTokenEnvKey
+  //    so the agent pool spins up a dedicated Client for it — without
+  //    this second scan, in-process agents can never get their own
+  //    Discord bot identity.
+  const agentsDir = join(workspaceDir, "agents");
+  if (existsSync(agentsDir)) {
+    try {
+      for (const file of readdirSync(agentsDir)) {
+        if (!(file.endsWith(".yaml") || file.endsWith(".yml"))) continue;
+        if (file.endsWith(".example") || file.endsWith(".retired")) continue;
+        const filePath = join(agentsDir, file);
+        try {
+          const parsed = parseYaml(readFileSync(filePath, "utf8")) as {
+            name?: string;
+            discordBotTokenEnvKey?: string;
+          };
+          if (parsed?.name && typeof parsed.discordBotTokenEnvKey === "string") {
+            // First source wins — A2A registry takes precedence so external
+            // agents with a Discord surface aren't silently overridden by
+            // an in-process agent of the same name.
+            if (!seen.has(parsed.name)) {
+              seen.set(parsed.name, {
+                name: parsed.name,
+                discordBotTokenEnvKey: parsed.discordBotTokenEnvKey,
+              });
+            }
+          }
+        } catch (err) {
+          console.error(`[discord] Failed to parse agent file ${file}:`, err);
+        }
+      }
+    } catch (err) {
+      console.error("[discord] Failed to enumerate workspace/agents/:", err);
+    }
+  }
+
+  return Array.from(seen.values());
 }
 
 // ── Projects loader (for autocomplete + project resolution) ───────────────────

--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -762,7 +762,7 @@ export class GitHubPlugin implements Plugin {
               trustTier,
               quarantine: { sanitized: false, patternsFound: [] },
               meta: {
-                agentId: "ava",
+                agentId: "protomaker",
                 skillHint: config.autoTriage.skillHint,
                 systemActor: "auto-triage-sweep",
               },

--- a/lib/plugins/onboarding.ts
+++ b/lib/plugins/onboarding.ts
@@ -68,7 +68,7 @@ interface OnboardRequest {
   github: string;            // "owner/repo"
   defaultBranch?: string;    // default: "main"
   team?: string;             // "dev" | "gtm" | etc.
-  agents?: string[];         // ["ava", "quinn", "frank"]
+  agents?: string[];         // ["protomaker", "quinn", "frank"]
   discord?: {
     general?: string;
     updates?: string;
@@ -499,7 +499,7 @@ export class OnboardingPlugin implements Plugin {
         defaultBranch: req.defaultBranch ?? "main",
         status: "active",
         onboardedAt: new Date().toISOString(),
-        agents: req.agents ?? ["ava", "quinn"],
+        agents: req.agents ?? ["protomaker", "quinn"],
         // Ensure discord.dev is always present (required by schema)
         discord: {
           dev: "",
@@ -568,7 +568,7 @@ export class OnboardingPlugin implements Plugin {
         github: req.github,
         defaultBranch: req.defaultBranch ?? "main",
         team: req.team ?? "dev",
-        agents: req.agents ?? ["ava", "quinn"],
+        agents: req.agents ?? ["protomaker", "quinn"],
         discord: req.discord ?? {},
         planeProjectId: steps.planeProject?.data?.projectId,
         driveFolderId: steps.driveFolder?.data?.folderId,

--- a/lib/plugins/pr-remediator.ts
+++ b/lib/plugins/pr-remediator.ts
@@ -1202,7 +1202,8 @@ Critical rules:
     //
     // A2AExecutor spreads the full payload into the JSON-RPC message metadata
     // (src/executor/executors/a2a-executor.ts line 58 — `...req.payload`), so
-    // anything in extraMeta reaches Ava's A2A handler as message.metadata.
+    // anything in extraMeta reaches the protoMaker team's A2A handler as
+    // message.metadata.
     this.bus.publish("agent.skill.request", {
       id: crypto.randomUUID(),
       correlationId,
@@ -1216,7 +1217,7 @@ Critical rules:
         // memory layer — skill-dispatcher writes episodes to
         // `system_pr-remediator` so the autonomous loop builds its own
         // episodic history separate from user-chat memory.
-        meta: { agentId: "ava", skillHint, systemActor: "pr-remediator" },
+        meta: { agentId: "protomaker", skillHint, systemActor: "pr-remediator" },
         ...(extraMeta ?? {}),
       },
     });

--- a/src/agent-runtime/agent-definition-loader.ts
+++ b/src/agent-runtime/agent-definition-loader.ts
@@ -97,6 +97,11 @@ export function parseAgentYaml(raw: RawAgentYaml, fileName: string): AgentDefini
         .filter((s): s is AgentSkillDefinition => s !== null)
     : [];
 
+  const discordBotTokenEnvKey =
+    typeof raw.discordBotTokenEnvKey === "string" && raw.discordBotTokenEnvKey.length > 0
+      ? raw.discordBotTokenEnvKey
+      : undefined;
+
   return {
     name: raw.name,
     role: raw.role,
@@ -108,6 +113,7 @@ export function parseAgentYaml(raw: RawAgentYaml, fileName: string): AgentDefini
     ...(canDelegate !== undefined ? { canDelegate } : {}),
     maxTurns,
     skills,
+    ...(discordBotTokenEnvKey ? { discordBotTokenEnvKey } : {}),
   };
 }
 

--- a/src/agent-runtime/types.ts
+++ b/src/agent-runtime/types.ts
@@ -83,6 +83,15 @@ export interface AgentDefinition {
 
   /** Skills this agent can handle (maps skill.name → AgentSkillDefinition). */
   skills: AgentSkillDefinition[];
+
+  /**
+   * Optional Discord bot token env var. When set, DiscordPlugin's agent
+   * pool spins up a dedicated Client() for this agent so users can @-mention
+   * or DM the agent's bot directly instead of routing through the shared
+   * protoBot listener. Only meaningful for in-process agents that want
+   * their own Discord identity.
+   */
+  discordBotTokenEnvKey?: string;
 }
 
 /**
@@ -98,4 +107,5 @@ export interface RawAgentYaml {
   canDelegate?: unknown;
   maxTurns?: unknown;
   skills?: unknown;
+  discordBotTokenEnvKey?: unknown;
 }

--- a/src/pr-remediator.test.ts
+++ b/src/pr-remediator.test.ts
@@ -262,7 +262,7 @@ describe("PrRemediatorPlugin — fix_ci", () => {
     };
     expect(p0.skill).toBe("bug_triage");
     // skill-dispatcher routes by payload.meta.agentId, not top-level agentId
-    expect(p0.meta.agentId).toBe("ava");
+    expect(p0.meta.agentId).toBe("protomaker");
     expect(p0.meta.skillHint).toBe("bug_triage");
     // Project targeting — reaches Ava via A2AExecutor's `...req.payload` spread
     expect(p0.projectSlug).toBe("protomaker");
@@ -320,7 +320,7 @@ describe("PrRemediatorPlugin — address_feedback", () => {
       meta: { agentId: string };
     };
     expect(p.skill).toBe("bug_triage");
-    expect(p.meta.agentId).toBe("ava");
+    expect(p.meta.agentId).toBe("protomaker");
     expect(p.projectSlug).toBe("protomaker");
     expect(p.projectRepo).toBe("protoLabsAI/protoMaker");
     expect(p.content).toContain("#55");

--- a/workspace/actions.yaml
+++ b/workspace/actions.yaml
@@ -315,7 +315,7 @@ actions:
     meta:
       topic: "agent.skill.request"
       skillHint: board_health
-      agentId: ava
+      agentId: protomaker
       fireAndForget: true
 
   - id: alert.ava_backlog_piling
@@ -359,7 +359,7 @@ actions:
     meta:
       topic: "agent.skill.request"
       skillHint: auto_mode
-      agentId: ava
+      agentId: protomaker
       fireAndForget: true
 
   # ── Branch protection ─────────────────────────────────────────────

--- a/workspace/agents.yaml
+++ b/workspace/agents.yaml
@@ -3,14 +3,17 @@
 # URL values support ${ENV_VAR} interpolation.
 
 agents:
-  - name: ava
+  # protoMaker team — the multi-agent runtime at AVA_BASE_URL (historically
+  # called "ava" internally). What we previously collapsed as a single agent
+  # is actually the protoMaker team coordinating board ops, feature lifecycle,
+  # bug triage, and planning. Output surfaces via the shared protoBot Discord
+  # client (DISCORD_BOT_TOKEN_PROTO — the primary listener) rather than a
+  # dedicated pool bot. The env var names (AVA_BASE_URL / AVA_API_KEY) stay
+  # unchanged to avoid a coordinated infisical rename; only the agent slug
+  # changes. Task #86 tracks the rest of the cross-repo terminology cleanup.
+  - name: protomaker
     url: "${AVA_BASE_URL}/a2a"
     apiKeyEnv: AVA_API_KEY
-    # Per-agent Discord bot — DiscordPlugin's agent pool spins up a
-    # dedicated Client() so users can @-mention or DM @ava-bot directly
-    # instead of routing through the shared workstacean bot. The token
-    # must already be present in process env.
-    discordBotTokenEnvKey: DISCORD_BOT_TOKEN_AVA
     skills:
       - name: sitrep
         description: Situation report — board state, running agents, escalations


### PR DESCRIPTION
## Summary

Terminology correction — what we've been calling "ava" is actually the **protoMaker team runtime**. "Ava" is a separate conversational agent that will run in-process with her own Discord bot identity. Collapsing both into one slug was causing confusion.

## Code changes

- \`AgentDefinition\` gains optional \`discordBotTokenEnvKey\` so in-process agents can claim their own Discord bot via the agent pool.
- \`DiscordPlugin.loadAgentPoolDefs\` now scans both \`workspace/agents.yaml\` (A2A registry) AND \`workspace/agents/*.yaml\` (in-process). A2A wins on name collision.
- \`pr-remediator\`, github triage, onboarding default targets flip \`ava\` → \`protomaker\`.
- \`workspace/actions.yaml\`: \`agentId: ava\` → \`protomaker\`.
- Tests updated.

## Workspace config (gitignored, applied per-host)

- \`workspace/agents.yaml\`: renamed A2A entry \`ava\` → \`protomaker\`, dropped its pool entry (protoMaker team outputs via shared protoBot).
- \`workspace/agents/ava.yaml\` (new): in-process agent — \`chat\` skill only, no tools, uses \`DISCORD_BOT_TOKEN_AVA\`. System prompt positions her as a thinking partner that suggests delegations rather than executing.

## Follow-up (task #86)

- Rename goal/domain IDs like \`ava_board\`, \`ava.board_healthy\` (cosmetic, no routing impact)
- protoMaker server agent-card \`name: 'ava'\` → \`'protomaker'\`
- Quinn SKILL.md playbook language "delegate to Ava" → "delegate to the protoMaker team"

## Test plan

- [x] \`bun test\` — 647 pass
- [ ] Post-restart: workspace/agents/ava.yaml loads, \`@ava\` client logs in via pool, DM routing confirms chat goes to in-process ava, pr-remediator dispatches to \`protomaker\` target

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent configuration now loads from multiple sources for better flexibility.
  * Added per-agent Discord bot token environment variable support.

* **Enhancements**
  * Updated agent routing targets across plugins and actions.
  * Improved error handling for missing configuration files (non-fatal fallback).

* **Tests**
  * Updated test assertions to reflect agent routing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->