### PR TITLE
refactor: rename ava_board/ava_pipeline domains → protomaker_*

### DIFF
--- a/docs/guides/add-a-domain.md
+++ b/docs/guides/add-a-domain.md
@@ -42,7 +42,7 @@ Example with URL and header interpolation:
 
 ```yaml
 domains:
-  - name: ava_board
+  - name: protomaker_board
     url: "${AVA_BASE_URL}/api/world/board"
     tickMs: 60000
     headers:

--- a/docs/guides/integrate-external-app.md
+++ b/docs/guides/integrate-external-app.md
@@ -193,14 +193,14 @@ curl http://localhost:3000/api/world-state | jq '.data.extensions.myapp_health_a
 curl http://localhost:3000/api/outcomes | jq '.recent[] | select(.actionId | startswith("myapp"))'
 ```
 
-## Reference: Ava integration
+## Reference: protoMaker team integration
 
-The Ava (protoMaker Studio) integration is the canonical example. It demonstrates:
+The protoMaker team integration (the multi-agent board runtime reached via AVA_BASE_URL) is the canonical example. It demonstrates:
 
-- **Two domains**: `ava_board` (blocked features) and `ava_pipeline` (auto-mode, running agents)
+- **Two domains**: `protomaker_board` (blocked features) and `protomaker_pipeline` (auto-mode, running agents)
 - **Five A2A skills**: sitrep, board_health, auto_mode, manage_feature, bug_triage
 - **Two goals**: board health (max 3 blocked) and auto-mode active
-- **Three actions**: alert on blocked, dispatch Ava to triage, alert auto-mode off
+- **Three actions**: alert on blocked, dispatch the protoMaker team to triage, alert auto-mode off
 
 Files:
 - `workspace/domains.yaml` — domain definitions

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -141,7 +141,7 @@ Any environment variable can be interpolated into domain URLs and headers in `wo
 
 ```yaml
 domains:
-  - name: ava_board
+  - name: protomaker_board
     url: "${AVA_BASE_URL}/api/world/board"
     headers:
       X-API-Key: "${AVA_API_KEY}"

--- a/src/executor/types.ts
+++ b/src/executor/types.ts
@@ -63,7 +63,7 @@ export interface ExecutorRegistration {
   /** Skill name this registration handles. null = default (catch-all). */
   skill: string | null;
   executor: IExecutor;
-  /** Agent name for target-based resolution (e.g. "ava", "quinn"). */
+  /** Agent name for target-based resolution (e.g. "ava", "protomaker", "quinn"). */
   agentName?: string;
   /** Higher priority wins when multiple registrations match the same skill. */
   priority: number;

--- a/workspace/actions.yaml
+++ b/workspace/actions.yaml
@@ -278,19 +278,19 @@ actions:
       topic: "message.outbound.discord.alert"
       fireAndForget: true
 
-  # ── Ava / protoMaker Studio ───────────────────────────────────────
+  # ── protoMaker team (multi-agent board runtime) ──────────────────
 
-  - id: alert.ava_board_blocked
-    goalId: ava.board_healthy
+  - id: alert.protomaker_board_blocked
+    goalId: protomaker.board_healthy
     tier: tier_0
     priority: 10
     cost: 0
     name: "Alert on excessive blocked features"
     preconditions:
-      - path: "extensions.ava_board_available"
+      - path: "extensions.protomaker_board_available"
         operator: eq
         value: true
-      - path: "domains.ava_board.data.blocked_count"
+      - path: "domains.protomaker_board.data.blocked_count"
         operator: gt
         value: 3
     effects: []
@@ -298,17 +298,17 @@ actions:
       topic: "message.outbound.discord.alert"
       fireAndForget: true
 
-  - id: action.ava_triage_blocked
-    goalId: ava.board_healthy
+  - id: action.protomaker_triage_blocked
+    goalId: protomaker.board_healthy
     tier: tier_0
     priority: 20
     cost: 1
-    name: "Dispatch board health triage to Ava"
+    name: "Dispatch board health triage to the protoMaker team"
     preconditions:
-      - path: "extensions.ava_board_available"
+      - path: "extensions.protomaker_board_available"
         operator: eq
         value: true
-      - path: "domains.ava_board.data.blocked_count"
+      - path: "domains.protomaker_board.data.blocked_count"
         operator: gt
         value: 3
     effects: []
@@ -318,17 +318,17 @@ actions:
       agentId: protomaker
       fireAndForget: true
 
-  - id: alert.ava_backlog_piling
-    goalId: ava.backlog_not_piling
+  - id: alert.protomaker_backlog_piling
+    goalId: protomaker.backlog_not_piling
     tier: tier_0
     priority: 15
     cost: 0
     name: "Alert when backlog exceeds 10 features"
     preconditions:
-      - path: "extensions.ava_board_available"
+      - path: "extensions.protomaker_board_available"
         operator: eq
         value: true
-      - path: "domains.ava_board.data.backlog_count"
+      - path: "domains.protomaker_board.data.backlog_count"
         operator: gt
         value: 10
     effects: []
@@ -336,23 +336,23 @@ actions:
       topic: "message.outbound.discord.alert"
       fireAndForget: true
 
-  - id: action.ava_start_auto_mode
-    goalId: ava.backlog_not_piling
+  - id: action.protomaker_start_auto_mode
+    goalId: protomaker.backlog_not_piling
     tier: tier_0
     priority: 30
     cost: 1
-    name: "Dispatch Ava to start auto-mode when backlog has work"
+    name: "Dispatch the protoMaker team to start auto-mode when backlog has work"
     preconditions:
-      - path: "extensions.ava_board_available"
+      - path: "extensions.protomaker_board_available"
         operator: eq
         value: true
-      - path: "extensions.ava_pipeline_available"
+      - path: "extensions.protomaker_pipeline_available"
         operator: eq
         value: true
-      - path: "domains.ava_pipeline.data.running_count"
+      - path: "domains.protomaker_pipeline.data.running_count"
         operator: eq
         value: 0
-      - path: "domains.ava_board.data.backlog_count"
+      - path: "domains.protomaker_board.data.backlog_count"
         operator: gt
         value: 0
     effects: []

--- a/workspace/domains.yaml
+++ b/workspace/domains.yaml
@@ -11,14 +11,18 @@
 #   5. Set env vars (APP_BASE_URL, APP_API_KEY)
 
 domains:
-  # ── Ava (protoMaker Studio) ────────────────────────────────────────
-  - name: ava_board
+  # ── protoMaker team (multi-agent board runtime) ────────────────────
+  # The AVA_* env var names are historical — they describe the HTTP
+  # server identity, not the logical agent slug. See docs/explanation/
+  # agent-identity.md for the full split between the protoMaker team
+  # and the in-process Ava chat agent.
+  - name: protomaker_board
     url: "${AVA_BASE_URL}/api/world/board"
     tickMs: 60000
     headers:
       X-API-Key: "${AVA_API_KEY}"
 
-  - name: ava_pipeline
+  - name: protomaker_pipeline
     url: "${AVA_BASE_URL}/api/world/agent-health"
     tickMs: 60000
     headers:

--- a/workspace/goals.yaml
+++ b/workspace/goals.yaml
@@ -94,18 +94,18 @@ goals:
     max: 30
     description: "No project should have more than 30 commits of branch drift"
 
-  # ── Ava / protoMaker Studio ──────────────────────────────────────
-  - id: ava.board_healthy
+  # ── protoMaker team (multi-agent board runtime) ──────────────────
+  - id: protomaker.board_healthy
     type: Threshold
     severity: high
-    selector: "domains.ava_board.data.blocked_count"
+    selector: "domains.protomaker_board.data.blocked_count"
     max: 3
     description: "No more than 3 features blocked simultaneously"
 
-  - id: ava.backlog_not_piling
+  - id: protomaker.backlog_not_piling
     type: Threshold
     severity: medium
-    selector: "domains.ava_board.data.backlog_count"
+    selector: "domains.protomaker_board.data.backlog_count"
     max: 10
     description: "Backlog should not exceed 10 features — work is piling up"
 


### PR DESCRIPTION
## Summary

Final cleanup for protoLabsAI/protoWorkstacean#86. These domain/goal/action IDs were the last lingering references where \`ava\` meant "the external board runtime at AVA_BASE_URL" rather than "the in-process conversational chat agent". Renames everything to \`protomaker_*\` so the agent-identity story is consistent end to end.

## What changed

- \`workspace/domains.yaml\`: \`ava_board\` → \`protomaker_board\`, \`ava_pipeline\` → \`protomaker_pipeline\`
- \`workspace/goals.yaml\`: \`ava.board_healthy\` → \`protomaker.board_healthy\`, \`ava.backlog_not_piling\` → \`protomaker.backlog_not_piling\` + selector paths
- \`workspace/actions.yaml\`: \`alert.ava_*\` + \`action.ava_*\` → \`alert.protomaker_*\` + \`action.protomaker_*\`, preconditions updated to the new domain paths
- \`docs/reference/env-vars.md\`, \`docs/guides/add-a-domain.md\`, \`docs/guides/integrate-external-app.md\`: example YAML + prose
- \`src/executor/types.ts\`: docstring example updated to \`"ava", "protomaker", "quinn"\`

## What deliberately stays 'ava'

- \`AVA_BASE_URL\`, \`AVA_API_KEY\` env vars (HTTP server identity, not a logical slug)
- The in-process \`ava\` chat agent — that's the new conversational agent
- Persona labels: timeline \`author: 'ava'\`, antagonistic review \`reviewer: 'ava'\`, strategic-review workflow \`role: 'ava'\`

## Backwards compat

None. Existing world-state snapshots stored under \`domains.ava_board.*\` become inaccessible. No action needed — domain state polls fresh every tick.

## Test plan

- [x] \`bun test\` — 647 pass, 0 fail
- [ ] Post-deploy: workstacean logs show \`domains.protomaker_board\` being polled, goals \`protomaker.board_healthy\` evaluating, actions \`alert.protomaker_board_blocked\` registering

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated integration guides and configuration examples to reference protoMaker team instead of Ava.

* **Configuration Updates**
  * Updated domain identifiers (ava_board → protomaker_board, ava_pipeline → protomaker_pipeline).
  * Updated goal and action identifiers to reference protoMaker.
  * Added protoMaker to example agent names.
  * All functionality and monitoring thresholds remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->