### PR TITLE
fix(skill-dispatcher): skip Graphiti memory enrichment for chat skill

### DIFF
--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -158,7 +158,13 @@ export class SkillDispatcherPlugin implements Plugin {
       groupId = `system_${systemActor}`;
     }
 
-    if (groupId && rawContent) {
+    // Skills that are purely conversational (no tools, no board context needed)
+    // skip memory enrichment entirely. Prepending cross-agent episode history
+    // to a casual chat makes the agent parrot back stale context from prior
+    // Quinn / protoMaker dispatches instead of just answering the question.
+    const SKIP_MEMORY_SKILLS = new Set(["chat"]);
+
+    if (groupId && rawContent && !SKIP_MEMORY_SKILLS.has(skill)) {
       const [sharedCtx, agentCtx] = await Promise.all([
         this.graphiti.getContextBlock(groupId, rawContent).catch(() => ""),
         agentGroupId ? this.graphiti.getContextBlock(agentGroupId, rawContent).catch(() => "") : Promise.resolve(""),


### PR DESCRIPTION
Ava's chat responses were referencing pr-remediator details, add_episode fixes, and other cross-agent history because the skill-dispatcher prepends Graphiti memory context on every dispatch. For the conversational \`chat\` skill (no tools, no board context needed), this is pure noise.

Adds a \`SKIP_MEMORY_SKILLS\` set that gates the enrichment — \`chat\` skips the context fetch. Episodes are still written post-completion so memory accumulates for future reference; only the pre-dispatch context injection is skipped.

## Test plan

- [x] \`bun test\` — 647 pass
- [ ] Post-deploy: DM \`@ava\`, confirm her response addresses the message directly without referencing stale cross-agent context

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat skill no longer retrieves and includes memory context from other agents or shared context during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->