### PR TITLE
fix(skill-dispatcher): frame memory context so agents know it's recalled, not user input

### DIFF
--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -163,8 +163,19 @@ export class SkillDispatcherPlugin implements Plugin {
         this.graphiti.getContextBlock(groupId, rawContent).catch(() => ""),
         agentGroupId ? this.graphiti.getContextBlock(agentGroupId, rawContent).catch(() => "") : Promise.resolve(""),
       ]);
-      const combined = [sharedCtx, agentCtx].filter(Boolean).join("");
-      if (combined) rawContent = `${combined}${rawContent}`;
+      const combined = [sharedCtx, agentCtx].filter(Boolean).join("\n");
+      if (combined) {
+        rawContent =
+          `<recalled_memory>\n` +
+          `The following facts were retrieved from your memory about this user. ` +
+          `Use them as background context if relevant — do NOT repeat them back ` +
+          `to the user or reference them unless the user's message specifically ` +
+          `asks about something they relate to. Focus your response on what the ` +
+          `user is actually saying below.\n\n` +
+          `${combined}\n` +
+          `</recalled_memory>\n\n` +
+          rawContent;
+      }
     }
     // ── End memory enrichment ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Memory context from Graphiti was prepended as raw text with only a terse \`[User context — group_id]\` header. Agents couldn't tell where memory ends and the user's message begins — Ava was parroting back pr-remediator details and add_episode fixes in casual chat because she treated the context dump as part of the user's question.

Wraps the context block in \`<recalled_memory>\` tags with explicit framing: "use as background if relevant, do NOT repeat back to the user, focus on what they're actually saying below." Gives the model a clear boundary.

## Before

\`\`\`
[User context — user_discord_12345]
- user mentioned pr-remediator restart worked
- user fixed graphiti add_episode group_id issue
hey ava, how's it going?
\`\`\`

## After

\`\`\`
<recalled_memory>
The following facts were retrieved from your memory about this user.
Use them as background context if relevant — do NOT repeat them back
to the user or reference them unless the user's message specifically
asks about something they relate to. Focus your response on what the
user is actually saying below.

[User context — user_discord_12345]
- user mentioned pr-remediator restart worked
- user fixed graphiti add_episode group_id issue
</recalled_memory>

hey ava, how's it going?
\`\`\`

## Test plan

- [x] \`bun test\` — 647 pass
- [ ] Post-deploy: DM Ava, confirm she responds to the message directly without parroting back stale memory facts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced memory context formatting with improved spacing between retrieved context blocks for better readability
  * Recalled memory is now presented with structured formatting and clearer usage guidelines to ensure proper context handling
  * Better organization of enriched content when memory retrieval is involved

<!-- end of auto-generated comment: release notes by coderabbit.ai -->