### PR TITLE
LoggerPlugin turn query

### DIFF
--- a/lib/plugins/logger.test.ts
+++ b/lib/plugins/logger.test.ts
@@ -1,0 +1,162 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { rmSync } from "node:fs";
+import { LoggerPlugin } from "./logger";
+import type { BusMessage } from "../types";
+
+const TEST_DATA_DIR = "/tmp/logger-test-" + process.pid;
+
+function makeBus() {
+  const subs: Array<(msg: BusMessage) => void> = [];
+  return {
+    subscribe(_pattern: string, _name: string, handler: (msg: BusMessage) => void) {
+      subs.push(handler);
+      return "sub-id";
+    },
+    unsubscribe() {},
+    publish(_topic: string, msg: BusMessage) {
+      for (const h of subs) h(msg);
+    },
+    topics() { return []; },
+    consumers() { return []; },
+  };
+}
+
+function makeRequest(overrides: Partial<BusMessage> = {}): BusMessage {
+  return {
+    id: "req-1",
+    correlationId: "corr-1",
+    topic: "agent.skill.request",
+    timestamp: Date.now(),
+    payload: { skill: "chat", content: "Hello agent" },
+    source: { interface: "discord", userId: "user-abc", channelId: "ch-1" },
+    reply: { topic: "agent.skill.response.run-1" },
+    ...overrides,
+  };
+}
+
+function makeResponse(overrides: Partial<BusMessage> = {}): BusMessage {
+  return {
+    id: "res-1",
+    correlationId: "corr-1",
+    topic: "agent.skill.response.run-1",
+    timestamp: Date.now() + 100,
+    payload: { content: "Hi there!", correlationId: "corr-1" },
+    ...overrides,
+  };
+}
+
+describe("LoggerPlugin.getRecentTurnsForUser", () => {
+  let plugin: LoggerPlugin;
+  let bus: ReturnType<typeof makeBus>;
+
+  beforeEach(() => {
+    plugin = new LoggerPlugin(TEST_DATA_DIR);
+    bus = makeBus();
+    plugin.install(bus as never);
+  });
+
+  afterEach(() => {
+    plugin.uninstall();
+    try { rmSync(TEST_DATA_DIR, { recursive: true }); } catch {}
+  });
+
+  test("returns empty array when no events exist", () => {
+    const turns = plugin.getRecentTurnsForUser("user-abc", "", 10, 60_000);
+    expect(turns).toEqual([]);
+  });
+
+  test("returns user and assistant turns for a matching request+response", () => {
+    const req = makeRequest();
+    const res = makeResponse();
+
+    bus.publish(req.topic, req);
+    bus.publish(res.topic, res);
+
+    const turns = plugin.getRecentTurnsForUser("user-abc", "", 10, 60_000);
+
+    expect(turns.length).toBe(2);
+    expect(turns[0].role).toBe("user");
+    expect(turns[0].content).toBe("Hello agent");
+    expect(turns[0].skill).toBe("chat");
+    expect(turns[0].channel).toBe("discord");
+    expect(turns[0].createdAt).toBe(req.timestamp);
+
+    expect(turns[1].role).toBe("assistant");
+    expect(turns[1].content).toBe("Hi there!");
+    expect(turns[1].skill).toBe("chat");
+    expect(turns[1].channel).toBe("discord");
+  });
+
+  test("returns only user turn when no response exists", () => {
+    const req = makeRequest();
+    bus.publish(req.topic, req);
+
+    const turns = plugin.getRecentTurnsForUser("user-abc", "", 10, 60_000);
+
+    expect(turns.length).toBe(1);
+    expect(turns[0].role).toBe("user");
+  });
+
+  test("excludes events from other users", () => {
+    bus.publish("agent.skill.request", makeRequest({ source: { interface: "discord", userId: "other-user" } }));
+
+    const turns = plugin.getRecentTurnsForUser("user-abc", "", 10, 60_000);
+    expect(turns).toEqual([]);
+  });
+
+  test("excludes events older than maxAgeMs", () => {
+    const oldTimestamp = Date.now() - 120_000; // 2 min ago
+    bus.publish("agent.skill.request", makeRequest({ timestamp: oldTimestamp }));
+
+    const turns = plugin.getRecentTurnsForUser("user-abc", "", 10, 60_000); // 1 min window
+    expect(turns).toEqual([]);
+  });
+
+  test("filters by agentName when targets are specified", () => {
+    const reqTargeted = makeRequest({
+      id: "req-targeted",
+      correlationId: "corr-targeted",
+      payload: { skill: "chat", content: "Hello protomaker", targets: ["protomaker"] },
+    });
+    const reqOther = makeRequest({
+      id: "req-other",
+      correlationId: "corr-other",
+      payload: { skill: "chat", content: "Hello quinn", targets: ["quinn"] },
+    });
+
+    bus.publish(reqTargeted.topic, reqTargeted);
+    bus.publish(reqOther.topic, reqOther);
+
+    const turns = plugin.getRecentTurnsForUser("user-abc", "protomaker", 10, 60_000);
+
+    expect(turns.length).toBe(1);
+    expect(turns[0].content).toBe("Hello protomaker");
+  });
+
+  test("includes events with empty targets when agentName filter is set", () => {
+    // Empty targets = any agent — should be included even when agentName filter is set
+    const req = makeRequest({
+      payload: { skill: "chat", content: "Hello", targets: [] },
+    });
+    bus.publish(req.topic, req);
+
+    const turns = plugin.getRecentTurnsForUser("user-abc", "protomaker", 10, 60_000);
+    expect(turns.length).toBe(1);
+  });
+
+  test("respects limit parameter", () => {
+    // Insert 3 different correlationIds
+    for (let i = 0; i < 3; i++) {
+      bus.publish("agent.skill.request", makeRequest({
+        id: `req-${i}`,
+        correlationId: `corr-${i}`,
+        timestamp: Date.now() + i,
+        payload: { skill: "chat", content: `Message ${i}` },
+      }));
+    }
+
+    const turns = plugin.getRecentTurnsForUser("user-abc", "", 2, 60_000);
+    // 2 correlationIds * 1 user turn each = 2 turns
+    expect(turns.length).toBe(2);
+  });
+});

--- a/lib/plugins/logger.ts
+++ b/lib/plugins/logger.ts
@@ -3,6 +3,14 @@ import { mkdirSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import type { Plugin, EventBus, BusMessage } from "../types";
 
+export interface ConversationTurn {
+  role: "user" | "assistant";
+  content: string;
+  channel: string | undefined;
+  skill: string | undefined;
+  createdAt: number;
+}
+
 export class LoggerPlugin implements Plugin {
   name = "logger";
   description = "Event log subscriber - writes all messages to SQLite";
@@ -83,10 +91,98 @@ export class LoggerPlugin implements Plugin {
 
   getEventsByCorrelationId(correlationId: string): BusMessage[] {
     if (!this.db) return [];
-    
+
     const rows = this.db.query(
       "SELECT payload FROM events WHERE correlation_id = ? ORDER BY timestamp ASC"
     ).all(correlationId) as { payload: string }[];
     return rows.map(row => JSON.parse(row.payload));
+  }
+
+  /**
+   * Retrieve recent conversation turns for a canonical user.
+   *
+   * Uses only indexed columns (topic, timestamp, correlation_id) in SQL — no
+   * JSON_EXTRACT. Application-level filtering resolves userId from parsed payloads.
+   *
+   * @param canonicalUserId  The user's canonical ID (matches BusMessage.source.userId).
+   * @param agentName        Agent to scope turns to (matched against payload.targets).
+   *                         Pass empty string to include turns for any agent.
+   * @param limit            Maximum number of turns to return.
+   * @param maxAgeMs         Only include turns within this many ms of now.
+   */
+  getRecentTurnsForUser(
+    canonicalUserId: string,
+    agentName: string,
+    limit: number,
+    maxAgeMs: number,
+  ): ConversationTurn[] {
+    if (!this.db) return [];
+
+    const since = Date.now() - maxAgeMs;
+
+    // Step 1: Fetch recent agent.skill.request events by indexed columns only.
+    // Over-fetch so we have enough candidates after userId filtering.
+    const candidateRows = this.db.query(
+      "SELECT correlation_id, payload FROM events WHERE topic = 'agent.skill.request' AND timestamp >= ? ORDER BY timestamp DESC LIMIT ?"
+    ).all(since, limit * 10) as { correlation_id: string; payload: string }[];
+
+    // Step 2: Filter in application code — find correlationIds belonging to this user.
+    const seenCorrelationIds = new Set<string>();
+    const matchedCorrelationIds: string[] = [];
+
+    for (const row of candidateRows) {
+      if (matchedCorrelationIds.length >= limit) break;
+      if (seenCorrelationIds.has(row.correlation_id)) continue;
+      seenCorrelationIds.add(row.correlation_id);
+
+      const msg = JSON.parse(row.payload) as BusMessage;
+      if (msg.source?.userId !== canonicalUserId) continue;
+
+      // If agentName provided, check payload.targets includes it (empty targets = any agent).
+      if (agentName) {
+        const payload = msg.payload as { targets?: string[] };
+        const targets = payload?.targets;
+        if (targets && targets.length > 0 && !targets.includes(agentName)) continue;
+      }
+
+      matchedCorrelationIds.push(row.correlation_id);
+    }
+
+    if (matchedCorrelationIds.length === 0) return [];
+
+    // Step 3: Bulk-fetch all events for the matched correlationIds and assemble turns.
+    const turns: ConversationTurn[] = [];
+
+    for (const correlationId of matchedCorrelationIds) {
+      const events = this.getEventsByCorrelationId(correlationId);
+      const request = events.find(e => e.topic === "agent.skill.request");
+      const response = events.find(e => e.topic.startsWith("agent.skill.response."));
+
+      if (!request) continue;
+
+      const reqPayload = request.payload as { skill?: string; content?: string; targets?: string[] };
+      const channel = request.source?.interface;
+
+      turns.push({
+        role: "user",
+        content: reqPayload.content ?? "",
+        channel,
+        skill: reqPayload.skill,
+        createdAt: request.timestamp,
+      });
+
+      if (response) {
+        const resPayload = response.payload as { content?: string; error?: string };
+        turns.push({
+          role: "assistant",
+          content: resPayload.content ?? resPayload.error ?? "",
+          channel,
+          skill: reqPayload.skill,
+          createdAt: response.timestamp,
+        });
+      }
+    }
+
+    return turns;
   }
 }


### PR DESCRIPTION
## Summary

**Milestone:** Turn Retrieval + Context Assembly

Add getRecentTurnsForUser(canonicalUserId, agentName, limit, maxAgeMs) to LoggerPlugin. Query events.db using existing indexed columns (correlation_id, topic, timestamp) without JSON extraction. The approach: fetch recent agent.skill.request events where source.userId resolves to the canonical user, paired with their agent.skill.response.* replies. Use the existing getEventsByCorrelationId pattern — fetch correlationIds for the user's recent disp...

---
*Recovered automatically by Automaker post-agent hook*