### PR TITLE
Context assembler + framing update

### DIFF
--- a/src/executor/__tests__/skill-dispatcher-plugin.test.ts
+++ b/src/executor/__tests__/skill-dispatcher-plugin.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
-import { SkillDispatcherPlugin } from "../skill-dispatcher-plugin.ts";
+import { SkillDispatcherPlugin, assembleContext } from "../skill-dispatcher-plugin.ts";
 import { ExecutorRegistry } from "../executor-registry.ts";
 import { FunctionExecutor } from "../executors/function-executor.ts";
 import type { BusMessage } from "../../../lib/types.ts";
 import type { SkillRequest, SkillResult } from "../types.ts";
 import type { GraphitiClient } from "../../../lib/memory/graphiti-client.ts";
+import type { ConversationTurn } from "../../../lib/plugins/logger.ts";
 
 // Minimal in-memory event bus for tests
 function makeBus() {
@@ -339,5 +340,96 @@ describe("SkillDispatcherPlugin — memory enrichment", () => {
     const reply = bus.published.find(m => m.topic === "reply.user");
     expect(reply).toBeDefined();
     expect((reply!.payload as Record<string, unknown>).content).toBe("ok anyway");
+  });
+});
+
+// ── assembleContext pure function ──────────────────────────────────────────────
+
+function makeTurn(overrides: Partial<ConversationTurn> = {}): ConversationTurn {
+  return {
+    role: "user",
+    content: "Hello",
+    channel: "discord",
+    skill: "chat",
+    createdAt: new Date("2024-01-01T12:00:00.000Z").getTime(),
+    ...overrides,
+  };
+}
+
+describe("assembleContext", () => {
+  it("emits only <current_message> when no memory and no turns", () => {
+    const result = assembleContext(undefined, [], "Hello there");
+    expect(result).toBe("<current_message>\nHello there\n</current_message>");
+    expect(result).not.toContain("<recalled_memory>");
+    expect(result).not.toContain("<recent_conversation>");
+  });
+
+  it("includes <recalled_memory> with instruction when memory is provided", () => {
+    const result = assembleContext("- User prefers bullets", [], "Hello");
+    expect(result).toContain("<recalled_memory>");
+    expect(result).toContain("</recalled_memory>");
+    expect(result).toContain("- User prefers bullets");
+    expect(result).toContain("do NOT repeat them back");
+    expect(result).toContain("<current_message>");
+    expect(result).not.toContain("<recent_conversation>");
+  });
+
+  it("includes <recent_conversation> when turns are provided", () => {
+    const turns = [
+      makeTurn({ role: "user", content: "What time is it?", channel: "discord" }),
+      makeTurn({ role: "assistant", content: "It is noon.", channel: "discord" }),
+    ];
+    const result = assembleContext(undefined, turns, "Thanks");
+    expect(result).toContain("<recent_conversation>");
+    expect(result).toContain("</recent_conversation>");
+    expect(result).toContain("What time is it?");
+    expect(result).toContain("It is noon.");
+    expect(result).not.toContain("<recalled_memory>");
+    expect(result).toContain("<current_message>");
+  });
+
+  it("labels turns with ISO timestamp, channel, and role", () => {
+    const ts = new Date("2024-06-15T09:30:00.000Z").getTime();
+    const turns = [
+      makeTurn({ role: "user", content: "Hi", channel: "slack", createdAt: ts }),
+    ];
+    const result = assembleContext(undefined, turns, "Next");
+    expect(result).toContain("2024-06-15T09:30:00.000Z");
+    expect(result).toContain("[slack]");
+    expect(result).toContain("User:");
+  });
+
+  it("omits channel suffix when channel is undefined", () => {
+    const turns = [makeTurn({ channel: undefined })];
+    const result = assembleContext(undefined, turns, "Next");
+    expect(result).not.toMatch(/\[undefined\]/);
+    expect(result).toContain("User:");
+  });
+
+  it("labels assistant turns correctly", () => {
+    const turns = [makeTurn({ role: "assistant", content: "Hello!" })];
+    const result = assembleContext(undefined, turns, "Next");
+    expect(result).toContain("Assistant:");
+  });
+
+  it("emits all three sections in correct order when all data present", () => {
+    const turns = [makeTurn({ content: "Previous question" })];
+    const result = assembleContext("Some facts", turns, "Current question");
+
+    const rmPos = result.indexOf("<recalled_memory>");
+    const rcPos = result.indexOf("<recent_conversation>");
+    const cmPos = result.indexOf("<current_message>");
+
+    expect(rmPos).toBeGreaterThanOrEqual(0);
+    expect(rcPos).toBeGreaterThanOrEqual(0);
+    expect(cmPos).toBeGreaterThanOrEqual(0);
+    expect(rmPos).toBeLessThan(rcPos);
+    expect(rcPos).toBeLessThan(cmPos);
+  });
+
+  it("does not emit empty <recalled_memory> when memory is empty string", () => {
+    const result = assembleContext("", [], "Hello");
+    expect(result).not.toContain("<recalled_memory>");
+    expect(result).toBe("<current_message>\nHello\n</current_message>");
   });
 });

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -19,6 +19,55 @@ import type { SkillRequest } from "./types.ts";
 import type { AgentSkillRequestPayload, FlowItemPayload } from "../event-bus/payloads.ts";
 import { GraphitiClient } from "../../lib/memory/graphiti-client.ts";
 import { IdentityRegistry } from "../../lib/identity/identity-registry.ts";
+import type { LoggerPlugin, ConversationTurn } from "../../lib/plugins/logger.ts";
+
+/**
+ * Assemble a structured context envelope for the agent prompt.
+ *
+ * Pure function — no side effects, suitable for unit testing.
+ *
+ * Sections emitted (in order, only when non-empty):
+ *   <recalled_memory>  — Graphiti facts retrieved for this user
+ *   <recent_conversation> — last N turns from LoggerPlugin
+ *   <current_message>  — the user's actual input (always emitted)
+ *
+ * When there is no history (no memory, no turns), only <current_message>
+ * is emitted — no empty XML tags.
+ */
+export function assembleContext(
+  recalledMemory: string | undefined,
+  recentTurns: ConversationTurn[],
+  currentMessage: string,
+): string {
+  const parts: string[] = [];
+
+  if (recalledMemory) {
+    parts.push(
+      `<recalled_memory>\n` +
+      `The following facts were retrieved from your memory about this user. ` +
+      `Use them as background context if relevant — do NOT repeat them back ` +
+      `to the user or reference them unless the user's message specifically ` +
+      `asks about something they relate to. Focus your response on what the ` +
+      `user is actually saying below.\n\n` +
+      `${recalledMemory}\n` +
+      `</recalled_memory>`,
+    );
+  }
+
+  if (recentTurns.length > 0) {
+    const turnLines = recentTurns.map(turn => {
+      const ts = new Date(turn.createdAt).toISOString();
+      const channelSuffix = turn.channel ? ` [${turn.channel}]` : "";
+      const label = turn.role === "user" ? "User" : "Assistant";
+      return `[${ts}${channelSuffix}] ${label}: ${turn.content}`;
+    });
+    parts.push(`<recent_conversation>\n${turnLines.join("\n")}\n</recent_conversation>`);
+  }
+
+  parts.push(`<current_message>\n${currentMessage}\n</current_message>`);
+
+  return parts.join("\n\n");
+}
 
 /**
  * Classify a skill name into a flow item type for distribution tracking.
@@ -43,15 +92,19 @@ export class SkillDispatcherPlugin implements Plugin {
   private readonly subscriptionIds: string[] = [];
   private readonly graphiti: GraphitiClient;
   private readonly identityRegistry: IdentityRegistry;
+  private readonly loggerPlugin: LoggerPlugin | undefined;
 
   constructor(
     private readonly registry: ExecutorRegistry,
     workspaceDir: string,
     /** Injectable for testing — defaults to a real GraphitiClient. */
     graphiti?: GraphitiClient,
+    /** Injectable for testing — provides recent conversation turns. */
+    loggerPlugin?: LoggerPlugin,
   ) {
     this.graphiti = graphiti ?? new GraphitiClient();
     this.identityRegistry = new IdentityRegistry(workspaceDir);
+    this.loggerPlugin = loggerPlugin;
   }
 
   install(bus: EventBus): void {
@@ -164,18 +217,18 @@ export class SkillDispatcherPlugin implements Plugin {
         agentGroupId ? this.graphiti.getContextBlock(agentGroupId, rawContent).catch(() => "") : Promise.resolve(""),
       ]);
       const combined = [sharedCtx, agentCtx].filter(Boolean).join("\n");
-      if (combined) {
-        rawContent =
-          `<recalled_memory>\n` +
-          `The following facts were retrieved from your memory about this user. ` +
-          `Use them as background context if relevant — do NOT repeat them back ` +
-          `to the user or reference them unless the user's message specifically ` +
-          `asks about something they relate to. Focus your response on what the ` +
-          `user is actually saying below.\n\n` +
-          `${combined}\n` +
-          `</recalled_memory>\n\n` +
-          rawContent;
-      }
+
+      // Retrieve recent turns for human-originated messages only
+      const recentTurns: ConversationTurn[] = (this.loggerPlugin && sourceUserId)
+        ? this.loggerPlugin.getRecentTurnsForUser(
+            sourceUserId,
+            targets[0] ?? "",
+            8,
+            24 * 60 * 60 * 1000,
+          )
+        : [];
+
+      rawContent = assembleContext(combined || undefined, recentTurns, rawContent);
     }
     // ── End memory enrichment ─────────────────────────────────────────────────
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,9 +95,11 @@ for (const action of actionRegistry.getAll()) {
 const debugPlugin = new DebugPlugin();
 debugPlugin.install(bus);
 
+const loggerPlugin = new LoggerPlugin(dataDir);
+
 const corePlugins: Plugin[] = [
   debugPlugin,
-  new LoggerPlugin(dataDir),
+  loggerPlugin,
   new CLIPlugin(),
   new SignalPlugin(),
   new SchedulerPlugin(dataDir),
@@ -236,7 +238,7 @@ const pluginRegistry: PluginRegistryEntry[] = [
     condition: () => true,
     factory: async () => {
       const { SkillDispatcherPlugin } = await import("./executor/skill-dispatcher-plugin.js");
-      return new SkillDispatcherPlugin(executorRegistry, workspaceDir);
+      return new SkillDispatcherPlugin(executorRegistry, workspaceDir, undefined, loggerPlugin);
     },
   },
   {


### PR DESCRIPTION
## Summary

**Milestone:** Turn Retrieval + Context Assembly

In skill-dispatcher-plugin.ts, replace the raw Graphiti prepend with a structured context assembler. Calls LoggerPlugin.getRecentTurnsForUser() (injected or imported), formats the full context envelope: <recalled_memory> wrapping Graphiti facts with 'use as background, do not repeat back' instruction (already partially done in PR #135), <recent_conversation> wrapping the last 8 turns with channel + timestamp labels, <current_message> wrapping the...

---
*Recovered automatically by Automaker post-agent hook*