### PR TITLE
fix(agent-executor): break out of SDK stream after result message

### DIFF
--- a/src/agent-runtime/agent-executor.ts
+++ b/src/agent-runtime/agent-executor.ts
@@ -133,6 +133,7 @@ export class AgentExecutor {
             usage = errMsg.usage;
             numTurns = errMsg.num_turns;
           }
+          break;
         }
       }
       // Stream text blocks for logging / debugging


### PR DESCRIPTION
## Root cause

The \`for await\` loop in \`AgentExecutor.run()\` continued iterating after receiving the SDK result message. The CLI subprocess pipe stayed open, the process hung until killed by timeout, and the next dispatch saw \`CLI process exited with code 1\`.

## Fix

One line: \`break\` after extracting the result. The loop already had the result data — it was just not exiting.

## Test plan

- [x] \`bun test\` — 663 pass
- [ ] Post-deploy: DM Ava, confirm response arrives in Discord instead of hanging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agent runtime to properly halt message processing after receiving a final result, preventing unnecessary downstream processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->