### PR TITLE
feat: register protoPen agent in A2A fleet

### DIFF
--- a/workspace/agents.yaml
+++ b/workspace/agents.yaml
@@ -17,3 +17,18 @@ agents:
         description: Manage feature lifecycle (unblock, assign, status change)
       - name: bug_triage
         description: Triage a bug and file it on the board
+
+  - name: protopen
+    url: "http://steamdeck:7870/a2a"
+    apiKeyEnv: PROTOPEN_API_KEY
+    skills:
+      - name: passive_recon
+        description: "Passive reconnaissance — WiFi/RF/network enumeration, no active probing"
+      - name: active_pentest
+        description: "Active penetration test — PMKID capture, vuln scanning, RF replay (requires engagement mode)"
+      - name: security_report
+        description: "Generate security assessment report from engagement findings"
+      - name: deep_research
+        description: "Research a topic in depth using HuggingFace, GitHub, web, and knowledge store"
+      - name: summarize
+        description: "Summarize findings from the knowledge store"

--- a/workspace/agents/ava.yaml.example
+++ b/workspace/agents/ava.yaml.example
@@ -21,6 +21,7 @@ systemPrompt: |
     - Quinn: code review, bug triage, QA
     - Frank: CI/CD, deployments, infrastructure
     - Researcher: deep context retrieval, analysis
+    - protoPen: penetration testing, security assessments, RF/WiFi recon
     - Jon/Cindi: communications, summaries, content
 
   Always consider the project context (projectSlug) when routing work.
@@ -41,6 +42,7 @@ canDelegate:
   - quinn
   - frank
   - researcher
+  - protopen
 
 # Maximum agentic turns per invocation (-1 = unlimited)
 maxTurns: 20

--- a/workspace/agents/quinn.yaml
+++ b/workspace/agents/quinn.yaml
@@ -42,6 +42,10 @@ excludeTools:
   - agent
   - save_memory
 
+# Agents Quinn may delegate to
+canDelegate:
+  - protopen
+
 maxTurns: 15
 
 skills:


### PR DESCRIPTION
Adds protoPen (Steam Deck pentest agent) to the workstacean fleet.

**Changes:**
- `workspace/agents.yaml`: Register protopen at `steamdeck:7870` with 5 skills
- `workspace/agents/quinn.yaml`: Add protopen to Quinn's `canDelegate`
- `workspace/agents/ava.yaml.example`: Add protopen to Ava's delegation guide

**Why:** Quinn needs to delegate pentest/security tasks to protoPen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new external security assessment agent `protopen` with capabilities including penetration testing, security assessments, RF/WiFi reconnaissance, passive reconnaissance, and comprehensive research and reporting functions.
  * Updated orchestrator configurations to enable delegation of security-related tasks to the new agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->