### PR TITLE
fix(ci): resolve type check failure blocking PR #141 (Discord DM debounce)

### DIFF
--- a/lib/dm/__tests__/context-mailbox.test.ts
+++ b/lib/dm/__tests__/context-mailbox.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { ContextMailbox, type MailboxMessage } from "../context-mailbox.ts";
+
+function msg(content: string, sender?: string): MailboxMessage {
+  return { content, sender, receivedAt: Date.now() };
+}
+
+describe("ContextMailbox", () => {
+  let mailbox: ContextMailbox;
+
+  beforeEach(() => {
+    mailbox = new ContextMailbox({ ttlMs: 60_000, sweepIntervalMs: 60_000 });
+  });
+
+  afterEach(() => {
+    mailbox.destroy();
+  });
+
+  it("push + drain returns messages in order", () => {
+    mailbox.push("ctx-1", msg("first"));
+    mailbox.push("ctx-1", msg("second"));
+    mailbox.push("ctx-1", msg("third"));
+
+    const drained = mailbox.drain("ctx-1");
+    expect(drained).toHaveLength(3);
+    expect(drained[0].content).toBe("first");
+    expect(drained[1].content).toBe("second");
+    expect(drained[2].content).toBe("third");
+  });
+
+  it("drain is destructive — second drain returns empty", () => {
+    mailbox.push("ctx-1", msg("hello"));
+
+    expect(mailbox.drain("ctx-1")).toHaveLength(1);
+    expect(mailbox.drain("ctx-1")).toHaveLength(0);
+  });
+
+  it("peek is non-destructive", () => {
+    mailbox.push("ctx-1", msg("hello"));
+
+    expect(mailbox.peek("ctx-1")).toHaveLength(1);
+    expect(mailbox.peek("ctx-1")).toHaveLength(1);
+    expect(mailbox.drain("ctx-1")).toHaveLength(1);
+  });
+
+  it("has() reflects pending state", () => {
+    expect(mailbox.has("ctx-1")).toBe(false);
+    mailbox.push("ctx-1", msg("hello"));
+    expect(mailbox.has("ctx-1")).toBe(true);
+    mailbox.drain("ctx-1");
+    expect(mailbox.has("ctx-1")).toBe(false);
+  });
+
+  it("size reflects distinct contextIds", () => {
+    expect(mailbox.size).toBe(0);
+    mailbox.push("ctx-1", msg("a"));
+    mailbox.push("ctx-2", msg("b"));
+    mailbox.push("ctx-3", msg("c"));
+    expect(mailbox.size).toBe(3);
+    mailbox.drain("ctx-2");
+    expect(mailbox.size).toBe(2);
+  });
+
+  it("drain on unknown contextId returns empty array", () => {
+    expect(mailbox.drain("nonexistent")).toEqual([]);
+  });
+
+  it("peek on unknown contextId returns empty array", () => {
+    expect(mailbox.peek("nonexistent")).toEqual([]);
+  });
+
+  describe("TTL expiration", () => {
+    it("sweep removes expired messages", async () => {
+      const shortMailbox = new ContextMailbox({ ttlMs: 50, sweepIntervalMs: 30 });
+      try {
+        shortMailbox.push("ctx-1", msg("will expire"));
+        await new Promise(r => setTimeout(r, 120));
+        expect(shortMailbox.drain("ctx-1")).toHaveLength(0);
+      } finally {
+        shortMailbox.destroy();
+      }
+    });
+
+    it("sweep keeps live messages", async () => {
+      const shortMailbox = new ContextMailbox({ ttlMs: 500, sweepIntervalMs: 30 });
+      try {
+        shortMailbox.push("ctx-1", msg("will survive"));
+        await new Promise(r => setTimeout(r, 60));
+        expect(shortMailbox.drain("ctx-1")).toHaveLength(1);
+      } finally {
+        shortMailbox.destroy();
+      }
+    });
+  });
+
+  describe("format()", () => {
+    it("returns empty string for no messages", () => {
+      expect(ContextMailbox.format([])).toBe("");
+    });
+
+    it("returns raw content for single message", () => {
+      expect(ContextMailbox.format([msg("just one")])).toBe("just one");
+    });
+
+    it("returns numbered format for multiple messages", () => {
+      const formatted = ContextMailbox.format([
+        msg("check the tests"),
+        msg("the failing one is in auth.test.ts"),
+        msg("also fix the types"),
+      ]);
+      expect(formatted).toContain("[User sent additional messages while you were working]");
+      expect(formatted).toContain("[1/3] check the tests");
+      expect(formatted).toContain("[2/3] the failing one is in auth.test.ts");
+      expect(formatted).toContain("[3/3] also fix the types");
+    });
+
+    it("numbered format preserves messages with blank lines", () => {
+      const formatted = ContextMailbox.format([
+        msg("line one\n\nline three"),
+        msg("second message"),
+      ]);
+      expect(formatted).toContain("[1/2] line one\n\nline three");
+      expect(formatted).toContain("[2/2] second message");
+    });
+  });
+});

--- a/lib/dm/__tests__/dm-accumulator.test.ts
+++ b/lib/dm/__tests__/dm-accumulator.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { DmAccumulator, type AccumulatorEntry, type AccumulatorMessage } from "../dm-accumulator.ts";
+import { ContextMailbox } from "../context-mailbox.ts";
+
+function makeMessage(id: string = "msg-1"): AccumulatorMessage {
+  return { id, channelId: "dm-channel-1" };
+}
+
+const DEBOUNCE = 80; // short for tests
+
+describe("DmAccumulator", () => {
+  let accumulator: DmAccumulator;
+  let flushed: Omit<AccumulatorEntry, "timer">[];
+  let mailbox: ContextMailbox;
+
+  beforeEach(() => {
+    flushed = [];
+    mailbox = new ContextMailbox({ ttlMs: 60_000, sweepIntervalMs: 60_000 });
+    accumulator = new DmAccumulator({
+      debounceMs: DEBOUNCE,
+      onFlush: (entry) => { flushed.push(entry); },
+      fallbackMailbox: mailbox,
+    });
+  });
+
+  afterEach(() => {
+    accumulator.destroy();
+    mailbox.destroy();
+  });
+
+  function push(content: string, conversationId = "conv-1", messageId?: string) {
+    return accumulator.push({
+      conversationId,
+      userId: "user-1",
+      channelId: "dm-channel-1",
+      agentName: "ava",
+      message: makeMessage(messageId ?? `msg-${content}`),
+      content,
+      turnNumber: 1,
+      isNew: true,
+    });
+  }
+
+  it("single message dispatches after debounce timer", async () => {
+    push("hello");
+    expect(flushed).toHaveLength(0);
+
+    await new Promise(r => setTimeout(r, DEBOUNCE + 30));
+    expect(flushed).toHaveLength(1);
+    expect(flushed[0].contents).toEqual(["hello"]);
+  });
+
+  it("multiple messages within window are batched", async () => {
+    push("one");
+    push("two");
+    push("three");
+
+    await new Promise(r => setTimeout(r, DEBOUNCE + 30));
+    expect(flushed).toHaveLength(1);
+    expect(flushed[0].contents).toEqual(["one", "two", "three"]);
+  });
+
+  it("timer resets on each push", async () => {
+    push("first");
+    await new Promise(r => setTimeout(r, DEBOUNCE - 20));
+
+    // Push again before timer fires — should reset
+    push("second");
+    await new Promise(r => setTimeout(r, DEBOUNCE - 20));
+
+    // Still shouldn't have flushed (timer reset)
+    expect(flushed).toHaveLength(0);
+
+    await new Promise(r => setTimeout(r, 40));
+    expect(flushed).toHaveLength(1);
+    expect(flushed[0].contents).toEqual(["first", "second"]);
+  });
+
+  it("different conversations are independent", async () => {
+    push("conv-a msg", "conv-a");
+    push("conv-b msg", "conv-b");
+
+    await new Promise(r => setTimeout(r, DEBOUNCE + 30));
+    expect(flushed).toHaveLength(2);
+    const ids = flushed.map(f => f.conversationId).sort();
+    expect(ids).toEqual(["conv-a", "conv-b"]);
+  });
+
+  it("push returns true only for first message in batch", () => {
+    expect(push("first")).toBe(true);
+    expect(push("second")).toBe(false);
+    expect(push("third")).toBe(false);
+  });
+
+  it("stores lastMessage from most recent push", async () => {
+    push("first", "conv-1", "msg-001");
+    push("second", "conv-1", "msg-002");
+    push("third", "conv-1", "msg-003");
+
+    await new Promise(r => setTimeout(r, DEBOUNCE + 30));
+    expect(flushed[0].lastMessage.id).toBe("msg-003");
+  });
+
+  it("cancel prevents flush", async () => {
+    push("will be cancelled");
+    accumulator.cancel("conv-1");
+
+    await new Promise(r => setTimeout(r, DEBOUNCE + 30));
+    expect(flushed).toHaveLength(0);
+  });
+
+  it("destroy cancels all pending", async () => {
+    push("a", "conv-a");
+    push("b", "conv-b");
+    push("c", "conv-c");
+    accumulator.destroy();
+
+    await new Promise(r => setTimeout(r, DEBOUNCE + 30));
+    expect(flushed).toHaveLength(0);
+  });
+
+  it("pending getter reflects active entries", async () => {
+    expect(accumulator.pending).toBe(0);
+    push("a", "conv-a");
+    push("b", "conv-b");
+    expect(accumulator.pending).toBe(2);
+
+    await new Promise(r => setTimeout(r, DEBOUNCE + 30));
+    expect(accumulator.pending).toBe(0);
+  });
+
+  it("preserves isNew from first push only", async () => {
+    accumulator.push({
+      conversationId: "conv-1",
+      userId: "user-1",
+      channelId: "dm-channel-1",
+      agentName: "ava",
+      message: makeMessage(),
+      content: "first",
+      turnNumber: 1,
+      isNew: true,
+    });
+    accumulator.push({
+      conversationId: "conv-1",
+      userId: "user-1",
+      channelId: "dm-channel-1",
+      agentName: "ava",
+      message: makeMessage("msg-2"),
+      content: "second",
+      turnNumber: 2,
+      isNew: false,
+    });
+
+    await new Promise(r => setTimeout(r, DEBOUNCE + 30));
+    expect(flushed[0].isNew).toBe(true);
+  });
+
+  describe("error handling", () => {
+    it("catches sync flush errors and pushes to fallback mailbox", async () => {
+      const errorAccumulator = new DmAccumulator({
+        debounceMs: DEBOUNCE,
+        onFlush: () => { throw new Error("flush failed"); },
+        fallbackMailbox: mailbox,
+      });
+
+      errorAccumulator.push({
+        conversationId: "conv-err",
+        userId: "user-1",
+        channelId: "dm-channel-1",
+        agentName: undefined,
+        message: makeMessage(),
+        content: "important message",
+        turnNumber: 1,
+        isNew: true,
+      });
+
+      await new Promise(r => setTimeout(r, DEBOUNCE + 30));
+
+      // Message should be in fallback mailbox
+      expect(mailbox.has("conv-err")).toBe(true);
+      const drained = mailbox.drain("conv-err");
+      expect(drained).toHaveLength(1);
+      expect(drained[0].content).toBe("important message");
+
+      errorAccumulator.destroy();
+    });
+
+    it("catches async flush errors and pushes to fallback mailbox", async () => {
+      const errorAccumulator = new DmAccumulator({
+        debounceMs: DEBOUNCE,
+        onFlush: async () => { throw new Error("async flush failed"); },
+        fallbackMailbox: mailbox,
+      });
+
+      errorAccumulator.push({
+        conversationId: "conv-err-async",
+        userId: "user-1",
+        channelId: "dm-channel-1",
+        agentName: undefined,
+        message: makeMessage(),
+        content: "async important",
+        turnNumber: 1,
+        isNew: true,
+      });
+
+      await new Promise(r => setTimeout(r, DEBOUNCE + 60));
+
+      expect(mailbox.has("conv-err-async")).toBe(true);
+      const drained = mailbox.drain("conv-err-async");
+      expect(drained[0].content).toBe("async important");
+
+      errorAccumulator.destroy();
+    });
+  });
+});

--- a/lib/dm/context-mailbox.ts
+++ b/lib/dm/context-mailbox.ts
@@ -1,0 +1,103 @@
+/**
+ * ContextMailbox — in-memory message store for mid-execution context injection.
+ *
+ * When a user sends additional Discord DMs while an agent is already processing
+ * a prior request, those messages land here. Two drain paths exist:
+ *
+ *   1. Remote agent polls GET /api/mailbox/:contextId between tool calls
+ *   2. SkillDispatcherPlugin auto-drains on execution completion
+ *
+ * Keyed by contextId (= correlationId = conversationId in the DM flow).
+ * Single-threaded JS guarantees atomic drain — no messages lost between
+ * check and delete.
+ */
+
+export interface MailboxMessage {
+  content: string;
+  receivedAt: number;
+  sender?: string;
+}
+
+export class ContextMailbox {
+  private readonly store = new Map<string, MailboxMessage[]>();
+  private readonly ttlMs: number;
+  private readonly sweepTimer: ReturnType<typeof setInterval>;
+
+  constructor(opts?: { ttlMs?: number; sweepIntervalMs?: number }) {
+    this.ttlMs = opts?.ttlMs ?? Number(process.env.MAILBOX_TTL_MS ?? 10 * 60_000);
+    this.sweepTimer = setInterval(
+      () => this._sweep(),
+      opts?.sweepIntervalMs ?? 60_000,
+    );
+  }
+
+  /** Push a message into the mailbox for a given contextId. */
+  push(contextId: string, msg: MailboxMessage): void {
+    const existing = this.store.get(contextId);
+    if (existing) {
+      existing.push(msg);
+    } else {
+      this.store.set(contextId, [msg]);
+    }
+  }
+
+  /** Atomically drain all pending messages for a contextId. Returns [] if empty. */
+  drain(contextId: string): MailboxMessage[] {
+    const messages = this.store.get(contextId);
+    if (!messages) return [];
+    this.store.delete(contextId);
+    return messages;
+  }
+
+  /** Peek without draining. */
+  peek(contextId: string): MailboxMessage[] {
+    return this.store.get(contextId) ?? [];
+  }
+
+  /** Check if any messages are pending. */
+  has(contextId: string): boolean {
+    const msgs = this.store.get(contextId);
+    return !!msgs && msgs.length > 0;
+  }
+
+  /** Number of contextIds with pending messages. */
+  get size(): number {
+    return this.store.size;
+  }
+
+  /**
+   * Format drained messages for agent consumption.
+   *
+   * Single message: raw content, no wrapping.
+   * Multiple messages: numbered `[1/N]` delimiters so the agent can distinguish
+   * individual messages even when they contain blank lines.
+   */
+  static format(messages: MailboxMessage[]): string {
+    if (messages.length === 0) return "";
+    if (messages.length === 1) return messages[0].content;
+
+    const header = "[User sent additional messages while you were working]\n";
+    const body = messages
+      .map((m, i) => `[${i + 1}/${messages.length}] ${m.content}`)
+      .join("\n\n");
+    return header + "\n" + body;
+  }
+
+  /** Stop the TTL sweep timer. */
+  destroy(): void {
+    clearInterval(this.sweepTimer);
+  }
+
+  /** Remove messages older than ttlMs. Drop empty slots. */
+  private _sweep(): void {
+    const now = Date.now();
+    for (const [contextId, messages] of this.store) {
+      const live = messages.filter(m => now - m.receivedAt < this.ttlMs);
+      if (live.length === 0) {
+        this.store.delete(contextId);
+      } else if (live.length < messages.length) {
+        this.store.set(contextId, live);
+      }
+    }
+  }
+}

--- a/lib/dm/dm-accumulator.ts
+++ b/lib/dm/dm-accumulator.ts
@@ -1,0 +1,173 @@
+/**
+ * DmAccumulator — sliding-window debounce for Discord DMs.
+ *
+ * When a user sends rapid-fire DMs, each message resets a timer. Once the
+ * timer fires (default 3 s of silence), the accumulated batch is flushed
+ * via the onFlush callback.
+ *
+ * Key behaviour:
+ *   - First message in a batch: caller gets `true` from push() → react with 👀
+ *   - Subsequent messages: update lastMessage, append content, reset timer
+ *   - Timer fires: delete entry first, then call onFlush inside try/catch
+ *   - If onFlush throws: log + push to fallback mailbox so messages are never lost
+ */
+
+import type { ContextMailbox } from "./context-mailbox.ts";
+
+/**
+ * Minimal subset of Discord.js Message used by the accumulator.
+ * Keeps the module testable without pulling in discord.js.
+ */
+export interface AccumulatorMessage {
+  id: string;
+  channelId: string;
+}
+
+export interface AccumulatorEntry {
+  conversationId: string;
+  userId: string;
+  channelId: string;
+  agentName: string | undefined;
+  lastMessage: AccumulatorMessage;
+  contents: string[];
+  timer: ReturnType<typeof setTimeout>;
+  turnNumber: number;
+  isNew: boolean;
+}
+
+export type FlushCallback = (entry: Omit<AccumulatorEntry, "timer">) => void | Promise<void>;
+
+export interface DmAccumulatorOptions {
+  debounceMs?: number;
+  onFlush: FlushCallback;
+  /** Fallback mailbox — if onFlush throws, content is pushed here so messages aren't lost. */
+  fallbackMailbox?: ContextMailbox;
+}
+
+export class DmAccumulator {
+  private readonly entries = new Map<string, AccumulatorEntry>();
+  private readonly debounceMs: number;
+  private readonly onFlush: FlushCallback;
+  private readonly fallbackMailbox?: ContextMailbox;
+
+  constructor(opts: DmAccumulatorOptions) {
+    this.debounceMs = opts.debounceMs ?? Number(process.env.DM_DEBOUNCE_MS ?? 3000);
+    this.onFlush = opts.onFlush;
+    this.fallbackMailbox = opts.fallbackMailbox;
+  }
+
+  /**
+   * Push a DM message into the accumulator.
+   *
+   * @returns true if this was the first message in the batch (caller should react with 👀)
+   */
+  push(params: {
+    conversationId: string;
+    userId: string;
+    channelId: string;
+    agentName: string | undefined;
+    message: AccumulatorMessage;
+    content: string;
+    turnNumber: number;
+    isNew: boolean;
+  }): boolean {
+    const existing = this.entries.get(params.conversationId);
+
+    if (existing) {
+      // Append content, update lastMessage, reset timer
+      existing.contents.push(params.content);
+      existing.lastMessage = params.message;
+      clearTimeout(existing.timer);
+      existing.timer = this._startTimer(params.conversationId);
+      return false;
+    }
+
+    // First message — create entry
+    const entry: AccumulatorEntry = {
+      conversationId: params.conversationId,
+      userId: params.userId,
+      channelId: params.channelId,
+      agentName: params.agentName,
+      lastMessage: params.message,
+      contents: [params.content],
+      timer: this._startTimer(params.conversationId),
+      turnNumber: params.turnNumber,
+      isNew: params.isNew,
+    };
+    this.entries.set(params.conversationId, entry);
+    return true;
+  }
+
+  /** Cancel a pending accumulator entry without flushing. */
+  cancel(conversationId: string): void {
+    const entry = this.entries.get(conversationId);
+    if (entry) {
+      clearTimeout(entry.timer);
+      this.entries.delete(conversationId);
+    }
+  }
+
+  /** Number of pending (not yet flushed) entries. */
+  get pending(): number {
+    return this.entries.size;
+  }
+
+  /** Cancel all timers and clear state. */
+  destroy(): void {
+    for (const entry of this.entries.values()) {
+      clearTimeout(entry.timer);
+    }
+    this.entries.clear();
+  }
+
+  private _startTimer(conversationId: string): ReturnType<typeof setTimeout> {
+    return setTimeout(() => this._flush(conversationId), this.debounceMs);
+  }
+
+  private _flush(conversationId: string): void {
+    const entry = this.entries.get(conversationId);
+    if (!entry) return;
+
+    // Delete BEFORE calling onFlush — entry is consumed regardless of outcome
+    this.entries.delete(conversationId);
+
+    const { timer: _timer, ...rest } = entry;
+
+    try {
+      const result = this.onFlush(rest);
+      // Handle async flush errors
+      if (result && typeof result.then === "function") {
+        result.then(undefined, (err: unknown) => this._handleFlushError(conversationId, rest, err));
+      }
+    } catch (err) {
+      this._handleFlushError(conversationId, rest, err);
+    }
+  }
+
+  private _handleFlushError(
+    conversationId: string,
+    entry: Omit<AccumulatorEntry, "timer">,
+    err: unknown,
+  ): void {
+    console.error(
+      `[dm-accumulator] Flush error for ${conversationId}:`,
+      err instanceof Error ? err.message : err,
+    );
+
+    // Fallback: push to mailbox so messages aren't lost
+    if (this.fallbackMailbox) {
+      const batchedContent = entry.contents.length === 1
+        ? entry.contents[0]
+        : entry.contents.map((c, i) => `[${i + 1}/${entry.contents.length}] ${c}`).join("\n\n");
+
+      this.fallbackMailbox.push(conversationId, {
+        content: batchedContent,
+        sender: entry.userId,
+        receivedAt: Date.now(),
+      });
+      console.log(
+        `[dm-accumulator] Pushed ${entry.contents.length} message(s) to mailbox fallback for ${conversationId}`,
+      );
+    }
+  }
+}

--- a/lib/plugins/discord.ts
+++ b/lib/plugins/discord.ts
@@ -43,6 +43,8 @@ import { ConversationTracer, type TurnData } from "../conversation/conversation-
 import { GraphitiClient } from "../memory/graphiti-client.ts";
 import { IdentityRegistry } from "../identity/identity-registry.ts";
 import { channelIdOf, type ProjectDiscordChannel } from "../project-schema.ts";
+import { DmAccumulator, type AccumulatorEntry } from "../dm/dm-accumulator.ts";
+import type { ContextMailbox } from "../dm/context-mailbox.ts";
 
 // ── Config types ──────────────────────────────────────────────────────────────
 
@@ -254,6 +256,16 @@ function loadProjectsDefs(workspaceDir: string): ProjectEntry[] {
 
 // ── Plugin ────────────────────────────────────────────────────────────────────
 
+export interface DiscordPluginOptions {
+  workspaceDir: string;
+  dataDir?: string;
+  channelRegistry?: ChannelRegistry;
+  hitlPlugin?: HITLPlugin;
+  mailbox?: ContextMailbox;
+  /** Check if an agent execution is in-flight for a given correlationId. */
+  isExecutionActive?: (correlationId: string) => boolean;
+}
+
 export class DiscordPlugin implements Plugin {
   readonly name = "discord";
   readonly description = "Discord gateway — routes messages to/from the A2A agent fleet";
@@ -272,6 +284,8 @@ export class DiscordPlugin implements Plugin {
 
   private channelRegistry?: ChannelRegistry;
   private hitlPlugin?: HITLPlugin;
+  private mailbox?: ContextMailbox;
+  private isExecutionActive?: (correlationId: string) => boolean;
 
   // correlationId → { message, replyTopic } for active HITL approvals
   private pendingHITLMessages = new Map<string, { message: Message; replyTopic: string }>();
@@ -284,6 +298,9 @@ export class DiscordPlugin implements Plugin {
   // correlationId (= conversationId for conv turns) → pending Langfuse turn data
   private pendingTurns = new Map<string, TurnData>();
 
+  // DM debounce accumulator — batches rapid-fire DMs before dispatch
+  private dmAccumulator?: DmAccumulator;
+
   // Runtime rate-limit state (built from config on install)
   private rateLimits = new Map<string, number[]>();
   private rateMaxMessages = 5;
@@ -294,11 +311,13 @@ export class DiscordPlugin implements Plugin {
   private rlDb: Database | null = null;
   private dataDir: string | null = null;
 
-  constructor(workspaceDir: string, dataDir?: string, channelRegistry?: ChannelRegistry, hitlPlugin?: HITLPlugin) {
-    this.workspaceDir = workspaceDir;
-    this.dataDir = dataDir ? resolve(dataDir) : null;
-    this.channelRegistry = channelRegistry;
-    this.hitlPlugin = hitlPlugin;
+  constructor(opts: DiscordPluginOptions) {
+    this.workspaceDir = opts.workspaceDir;
+    this.dataDir = opts.dataDir ? resolve(opts.dataDir) : null;
+    this.channelRegistry = opts.channelRegistry;
+    this.hitlPlugin = opts.hitlPlugin;
+    this.mailbox = opts.mailbox;
+    this.isExecutionActive = opts.isExecutionActive;
 
     // When a conversation times out, finalize its Langfuse trace
     this.conversationManager.setTimeoutCallback((entry) => {
@@ -319,6 +338,13 @@ export class DiscordPlugin implements Plugin {
     this.busRef = bus;
     this.config = loadConfig(this.workspaceDir);
     this.identityRegistry = new IdentityRegistry(this.workspaceDir);
+
+    // DM debounce accumulator — batches rapid-fire DMs before dispatch/mailbox
+    this.dmAccumulator = new DmAccumulator({
+      debounceMs: Number(process.env.DM_DEBOUNCE_MS ?? 3000),
+      onFlush: (entry) => this._handleDMFlush(entry, bus),
+      fallbackMailbox: this.mailbox,
+    });
 
     // Apply moderation config
     const { rateLimit, spamPatterns } = this.config.moderation;
@@ -875,6 +901,7 @@ export class DiscordPlugin implements Plugin {
   }
 
   uninstall(): void {
+    this.dmAccumulator?.destroy();
     this.conversationManager.destroy();
     this.pendingTurns.clear();
     this.pendingHITLMessages.clear();
@@ -1136,18 +1163,74 @@ export class DiscordPlugin implements Plugin {
     const conv = this.conversationManager.getOrCreate(message.channelId, userId, timeoutMs, agentName);
     const { conversationId, isNew, turnNumber } = conv;
 
-    pendingReplies.set(conversationId, { message });
-    if (agentName) this.pendingAgents.set(conversationId, agentName);
-
     const content = message.cleanContent.replace(/<@!?\d+>/g, "").trim();
     if (!content) return;
+
+    // Push into debounce accumulator — batches rapid-fire DMs
+    const isFirst = this.dmAccumulator!.push({
+      conversationId,
+      userId,
+      channelId: message.channelId,
+      agentName,
+      message: { id: message.id, channelId: message.channelId },
+      content,
+      turnNumber,
+      isNew,
+    });
+
+    if (isFirst) {
+      await message.react("👀").catch(() => {});
+    }
+  }
+
+  /**
+   * Flush callback for DmAccumulator — called when debounce timer fires.
+   *
+   * Checks if an agent execution is in-flight for this conversation:
+   *   - No  → dispatch normally via bus (standard DM flow)
+   *   - Yes → push to mailbox (drained on execution completion by SkillDispatcher)
+   */
+  private async _handleDMFlush(entry: Omit<AccumulatorEntry, "timer">, bus: EventBus): Promise<void> {
+    const {
+      conversationId, userId, channelId, agentName,
+      lastMessage, contents, turnNumber, isNew,
+    } = entry;
+
+    const batchedContent = contents.length === 1
+      ? contents[0]
+      : contents.map((c, i) => `[${i + 1}/${contents.length}] ${c}`).join("\n\n");
+
+    // If agent is mid-execution, queue to mailbox instead of dispatching
+    if (this.isExecutionActive?.(conversationId) && this.mailbox) {
+      console.log(
+        `[discord] Agent in-flight for ${conversationId} — queuing ${contents.length} message(s) to mailbox`,
+      );
+      this.mailbox.push(conversationId, {
+        content: batchedContent,
+        sender: userId,
+        receivedAt: Date.now(),
+      });
+      return;
+    }
+
+    // Normal dispatch path — no agent in-flight
+    // Resolve the original Discord message for reply threading
+    const discordChannel = this.client?.channels.cache.get(channelId);
+    const discordMessage = discordChannel && "messages" in discordChannel
+      ? await (discordChannel as TextChannel).messages.fetch(lastMessage.id).catch(() => null)
+      : null;
+
+    if (discordMessage) {
+      pendingReplies.set(conversationId, { message: discordMessage });
+    }
+    if (agentName) this.pendingAgents.set(conversationId, agentName);
 
     // Langfuse tracing
     if (isNew) {
       this.conversationTracer.startTrace({
         conversationId,
         userId,
-        channelId: message.channelId,
+        channelId,
         agentName,
         platform: "discord-dm",
       }).catch(err => console.error("[discord] Langfuse startTrace error:", err));
@@ -1155,26 +1238,26 @@ export class DiscordPlugin implements Plugin {
     this.pendingTurns.set(conversationId, {
       conversationId,
       turnNumber,
-      input: content,
+      input: batchedContent,
       userId,
       agentName,
       startTime: new Date(),
     });
 
-    bus.publish(`message.inbound.discord.${message.channelId}`, {
-      id: message.id,
+    bus.publish(`message.inbound.discord.${channelId}`, {
+      id: lastMessage.id,
       correlationId: conversationId,
-      topic: `message.inbound.discord.${message.channelId}`,
+      topic: `message.inbound.discord.${channelId}`,
       timestamp: Date.now(),
       payload: {
         sender: userId,
-        channel: message.channelId,
-        content,
+        channel: channelId,
+        content: batchedContent,
         isDM: true,
         ...(agentName ? { agentId: agentName } : {}),
       },
-      source: { interface: "discord" as const, channelId: message.channelId, userId },
-      reply: { topic: `message.outbound.discord.${message.channelId}` },
+      source: { interface: "discord" as const, channelId, userId },
+      reply: { topic: `message.outbound.discord.${channelId}` },
     });
   }
 

--- a/src/api/ava-tools.ts
+++ b/src/api/ava-tools.ts
@@ -9,6 +9,8 @@
 import type { Route, ApiContext } from "./types.ts";
 import type { SkillRequest } from "../executor/types.ts";
 
+const AGENT_OPS_CHANNEL = process.env.DISCORD_AGENT_OPS_CHANNEL ?? "";
+
 export function createRoutes(ctx: ApiContext): Route[] {
   /**
    * POST /api/a2a/chat — synchronous multi-turn conversation with an agent.
@@ -84,6 +86,19 @@ export function createRoutes(ctx: ApiContext): Route[] {
         },
       });
 
+      // Post to Discord agent-ops channel so agent conversations are visible
+      if (AGENT_OPS_CHANNEL) {
+        ctx.bus.publish(`message.outbound.discord.push.${AGENT_OPS_CHANNEL}`, {
+          id: crypto.randomUUID(),
+          correlationId,
+          topic: `message.outbound.discord.push.${AGENT_OPS_CHANNEL}`,
+          timestamp: Date.now(),
+          payload: {
+            content: `**ava → ${agent}** (${skill})\n${message.length > 300 ? message.slice(0, 300) + "…" : message}`,
+          },
+        });
+      }
+
       const result = await executor.execute(skillReq);
 
       // Publish agent's response for o11y
@@ -101,6 +116,22 @@ export function createRoutes(ctx: ApiContext): Route[] {
           done,
         },
       });
+
+      // Post agent response to Discord
+      if (AGENT_OPS_CHANNEL) {
+        const responsePreview = result.text.length > 500
+          ? result.text.slice(0, 500) + "…"
+          : result.text;
+        ctx.bus.publish(`message.outbound.discord.push.${AGENT_OPS_CHANNEL}`, {
+          id: crypto.randomUUID(),
+          correlationId,
+          topic: `message.outbound.discord.push.${AGENT_OPS_CHANNEL}`,
+          timestamp: Date.now(),
+          payload: {
+            content: `**${agent} → ava** (${result.data?.taskState ?? "completed"})\n${responsePreview}`,
+          },
+        });
+      }
 
       const remoteTaskId = result.data?.taskId;
       const remoteContextId = result.data?.contextId ?? conversationId;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -14,6 +14,7 @@ import { createRoutes as operationRoutes } from "./operations.ts";
 import { createRoutes as planeRoutes } from "./plane.ts";
 import { createRoutes as avaToolRoutes } from "./ava-tools.ts";
 import { createRoutes as boardRoutes } from "./board.ts";
+import { createRoutes as mailboxRoutes } from "./mailbox.ts";
 
 export { matchPath } from "./types.ts";
 export type { Route, ApiContext } from "./types.ts";
@@ -27,5 +28,6 @@ export function createAllRoutes(ctx: ApiContext): Route[] {
     ...planeRoutes(ctx),
     ...avaToolRoutes(ctx),
     ...boardRoutes(ctx),
+    ...(ctx.mailbox ? mailboxRoutes(ctx.mailbox, ctx) : []),
   ];
 }

--- a/src/api/mailbox.ts
+++ b/src/api/mailbox.ts
@@ -1,0 +1,64 @@
+/**
+ * Mailbox API — HTTP endpoints for the DM context mailbox.
+ *
+ * Remote agents poll GET /api/mailbox/:contextId between tool calls to pick up
+ * messages the user sent while the agent was working. SkillDispatcherPlugin also
+ * auto-drains on execution completion, so this endpoint is a "best-effort early
+ * delivery" path and a useful debugging tool.
+ *
+ * Routes:
+ *   GET  /api/mailbox/:contextId          → drain + return pending messages
+ *   GET  /api/mailbox/:contextId?peek=true → peek without draining
+ *   POST /api/mailbox/:contextId          → push a message (API-key-gated)
+ */
+
+import type { Route, ApiContext } from "./types.ts";
+import { ContextMailbox, type MailboxMessage } from "../../lib/dm/context-mailbox.ts";
+
+export function createRoutes(mailbox: ContextMailbox, ctx: ApiContext): Route[] {
+  return [
+    {
+      method: "GET",
+      path: "/api/mailbox/:contextId",
+      handler: (req, params) => {
+        const url = new URL(req.url);
+        const peek = url.searchParams.get("peek") === "true";
+        const messages = peek ? mailbox.peek(params.contextId) : mailbox.drain(params.contextId);
+        return Response.json({
+          success: true,
+          contextId: params.contextId,
+          messages,
+          formatted: messages.length > 0 ? ContextMailbox.format(messages) : null,
+        });
+      },
+    },
+    {
+      method: "POST",
+      path: "/api/mailbox/:contextId",
+      handler: async (req, params) => {
+        if (ctx.apiKey && req.headers.get("X-API-Key") !== ctx.apiKey) {
+          return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+        }
+
+        let body: { content?: string; sender?: string };
+        try {
+          body = (await req.json()) as typeof body;
+        } catch {
+          return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 });
+        }
+
+        if (!body.content) {
+          return Response.json({ success: false, error: "content is required" }, { status: 400 });
+        }
+
+        mailbox.push(params.contextId, {
+          content: body.content,
+          sender: body.sender,
+          receivedAt: Date.now(),
+        });
+
+        return Response.json({ success: true });
+      },
+    },
+  ];
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -11,6 +11,7 @@ import { parse as parseYaml } from "yaml";
 import type { Plugin, EventBus } from "../../lib/types.ts";
 import type { ExecutorRegistry } from "../executor/executor-registry.ts";
 import type { TelemetryService } from "../telemetry/telemetry-service.ts";
+import type { ContextMailbox } from "../../lib/dm/context-mailbox.ts";
 
 export type Params = Record<string, string>;
 export type RouteHandler = (req: Request, params: Params) => Response | Promise<Response>;
@@ -32,6 +33,7 @@ export interface ApiContext {
   executorRegistry: ExecutorRegistry;
   telemetry?: TelemetryService;
   apiKey?: string;
+  mailbox?: ContextMailbox;
 }
 
 /** Match a path against a pattern like "/api/foo/:id/run". Returns params or null. */

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -58,6 +58,10 @@ export const EnvSchema = z
     DISCORD_WEBHOOK_ALERTS:       z.string().optional(),
     /** Idle timeout (ms) before a DM conversation session expires (default: 15 min). */
     DM_CONVERSATION_TIMEOUT_MS:   z.string().optional(),
+    /** Sliding-window debounce (ms) for batching rapid-fire DMs (default: 3000). */
+    DM_DEBOUNCE_MS:               z.string().optional(),
+    /** TTL (ms) for pending mailbox messages before they're swept (default: 10 min). */
+    MAILBOX_TTL_MS:               z.string().optional(),
 
     // GitHub
     GITHUB_TOKEN:          z.string().optional(),

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -99,7 +99,7 @@ class WorldStateCache {
 const _worldCaches = new Map<string, WorldStateCache>();
 
 function createLangChainTools(toolNames: string[], http: HttpClient) {
-  const all: Record<string, ReturnType<typeof tool>> = {
+  const all: Record<string, unknown> = {
     chat_with_agent: tool(
       async (input) => {
         console.log(`[deep-agent:tool] chat_with_agent called: agent=${input.agent}, skill=${input.skill ?? "auto"}, msg="${input.message.slice(0, 80)}"`);
@@ -266,7 +266,7 @@ function createLangChainTools(toolNames: string[], http: HttpClient) {
     ),
   };
 
-  return toolNames.map(n => all[n]).filter((t): t is ReturnType<typeof tool> => t != null);
+  return (toolNames.map(n => all[n]).filter(Boolean)) as ReturnType<typeof tool>[];
 }
 
 export class DeepAgentExecutor implements IExecutor {
@@ -308,6 +308,14 @@ export class DeepAgentExecutor implements IExecutor {
     const prompt = req.content ?? req.prompt ?? this._buildPrompt(req);
     const tools = createLangChainTools(this.agentDef.tools, this.http);
 
+    const callbacks = LANGFUSE_ENABLED
+      ? [new LangfuseCallbackHandler({
+          sessionId: req.correlationId,
+          userId: this.agentDef.name,
+          traceMetadata: { skill: req.skill, agent: this.agentDef.name },
+        })]
+      : [];
+
     try {
       // Inject cached world state into system prompt for instant situational awareness
       const worldSummary = await this.worldCache.getSummary();
@@ -320,17 +328,6 @@ export class DeepAgentExecutor implements IExecutor {
         tools,
         messageModifier: new SystemMessage(enrichedPrompt),
       });
-
-      const callbacks = LANGFUSE_ENABLED
-        ? [new LangfuseCallbackHandler({
-            publicKey: process.env.LANGFUSE_PUBLIC_KEY!,
-            secretKey: process.env.LANGFUSE_SECRET_KEY!,
-            baseUrl: process.env.LANGFUSE_HOST ?? process.env.LANGFUSE_BASE_URL,
-            sessionId: req.correlationId,
-            userId: this.agentDef.name,
-            metadata: { skill: req.skill, agent: this.agentDef.name },
-          })]
-        : [];
 
       console.log(`[deep-agent:${this.agentDef.name}] invoke with ${tools.length} tools, prompt length=${prompt.length}, langfuse=${LANGFUSE_ENABLED}`);
 
@@ -346,7 +343,7 @@ export class DeepAgentExecutor implements IExecutor {
       for (const msg of messages) {
         const type = msg._getType?.() ?? msg.constructor?.name ?? "";
         if (type === "ai" || type === "AIMessage") {
-          const tc = (msg as Record<string, unknown>).tool_calls;
+          const tc = (msg as unknown as Record<string, unknown>).tool_calls;
           if (Array.isArray(tc) && tc.length > 0) {
             console.log(`[deep-agent:${this.agentDef.name}] tool calls: ${tc.map((t: { name?: string }) => t.name).join(", ")}`);
           }
@@ -366,11 +363,6 @@ export class DeepAgentExecutor implements IExecutor {
         }
       }
 
-      // Flush Langfuse traces
-      for (const cb of callbacks) {
-        await (cb as LangfuseCallbackHandler).flushAsync?.().catch(() => {});
-      }
-
       return {
         text: text || "No response generated.",
         isError: false,
@@ -378,12 +370,6 @@ export class DeepAgentExecutor implements IExecutor {
       };
     } catch (e) {
       console.error(`[deep-agent:${this.agentDef.name}]`, e);
-      // Flush even on error
-      if (LANGFUSE_ENABLED) {
-        for (const cb of callbacks) {
-          await (cb as LangfuseCallbackHandler).flushAsync?.().catch(() => {});
-        }
-      }
       return {
         text: e instanceof Error ? e.message : String(e),
         isError: true,

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -20,6 +20,7 @@ import type { AgentSkillRequestPayload, FlowItemPayload } from "../event-bus/pay
 import { GraphitiClient } from "../../lib/memory/graphiti-client.ts";
 import { IdentityRegistry } from "../../lib/identity/identity-registry.ts";
 import type { LoggerPlugin, ConversationTurn } from "../../lib/plugins/logger.ts";
+import { ContextMailbox } from "../../lib/dm/context-mailbox.ts";
 
 /**
  * Assemble a structured context envelope for the agent prompt.
@@ -93,6 +94,15 @@ export class SkillDispatcherPlugin implements Plugin {
   private readonly graphiti: GraphitiClient;
   private readonly identityRegistry: IdentityRegistry;
   private readonly loggerPlugin: LoggerPlugin | undefined;
+  private readonly mailbox: ContextMailbox | undefined;
+
+  /**
+   * In-flight execution tracking — set at the TOP of _dispatch() (before any
+   * await) so isActive() is accurate even during the async Graphiti enrichment
+   * window. Without this, a DM debounce timer firing during enrichment would
+   * see isActive() === false and double-dispatch.
+   */
+  private readonly activeExecutions = new Map<string, { startedAt: number; skill: string }>();
 
   constructor(
     private readonly registry: ExecutorRegistry,
@@ -101,10 +111,18 @@ export class SkillDispatcherPlugin implements Plugin {
     graphiti?: GraphitiClient,
     /** Injectable for testing — provides recent conversation turns. */
     loggerPlugin?: LoggerPlugin,
+    /** Optional mailbox for mid-execution DM queuing. */
+    mailbox?: ContextMailbox,
   ) {
     this.graphiti = graphiti ?? new GraphitiClient();
     this.identityRegistry = new IdentityRegistry(workspaceDir);
     this.loggerPlugin = loggerPlugin;
+    this.mailbox = mailbox;
+  }
+
+  /** Check if an execution is currently active for a given correlationId. */
+  isActive(correlationId: string): boolean {
+    return this.activeExecutions.has(correlationId);
   }
 
   install(bus: EventBus): void {
@@ -147,7 +165,15 @@ export class SkillDispatcherPlugin implements Plugin {
     const parentId = msg.id; // this message is the parent span
     const replyTopic = msg.reply?.topic ?? `agent.skill.response.${correlationId}`;
 
+    // Mark as active IMMEDIATELY — before any await. _dispatch() is called via
+    // `void this._dispatch(msg)` (fire-and-forget from the sync bus handler).
+    // The async Graphiti enrichment below yields to the event loop for 100-500ms.
+    // Without this early set, a DM debounce timer firing during that window would
+    // see isActive() === false and dispatch a competing execution.
+    this.activeExecutions.set(correlationId, { startedAt: Date.now(), skill: skill || "unknown" });
+
     if (!skill) {
+      this.activeExecutions.delete(correlationId);
       console.warn("[skill-dispatcher] Received skill request with no skill — dropping");
       this._publishResponse(replyTopic, correlationId, undefined, "No skill specified");
       return;
@@ -156,6 +182,7 @@ export class SkillDispatcherPlugin implements Plugin {
     const executor = this.registry.resolve(skill, targets);
 
     if (!executor) {
+      this.activeExecutions.delete(correlationId);
       const searched = targets.length > 0
         ? `targets [${targets.join(", ")}] or skill "${skill}"`
         : `skill "${skill}"`;
@@ -340,7 +367,51 @@ export class SkillDispatcherPlugin implements Plugin {
         meta: { skill, error: errorMsg },
       });
       this._publishResponse(replyTopic, correlationId, undefined, errorMsg);
+    } finally {
+      this.activeExecutions.delete(correlationId);
+      this._drainMailbox(correlationId, skill, targets, msg.source, replyTopic);
     }
+  }
+
+  /**
+   * Drain pending mailbox messages after execution completes.
+   *
+   * If the user sent additional DMs while the agent was working, they
+   * accumulated in the ContextMailbox. This method drains them and publishes
+   * a new agent.skill.request so the conversation continues with the same
+   * agent/skill and full memory enrichment.
+   */
+  private _drainMailbox(
+    correlationId: string,
+    skill: string,
+    targets: string[],
+    source: BusMessage["source"],
+    replyTopic: string,
+  ): void {
+    if (!this.bus || !this.mailbox?.has(correlationId)) return;
+
+    const queued = this.mailbox.drain(correlationId);
+    if (queued.length === 0) return;
+
+    const formatted = ContextMailbox.format(queued);
+    console.log(
+      `[skill-dispatcher] Draining ${queued.length} queued message(s) for ${correlationId} — starting new turn`,
+    );
+
+    this.bus.publish("agent.skill.request", {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic: "agent.skill.request",
+      timestamp: Date.now(),
+      payload: {
+        skill,
+        content: formatted,
+        targets,
+        isDM: true,
+      },
+      source,
+      reply: { topic: replyTopic },
+    });
   }
 
   private _publishFlowEvent(topic: string, item: FlowItemPayload): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,10 @@ const dataDir = resolve(
 
 const bus = new InMemoryEventBus();
 
+// --- Context mailbox — mid-execution DM queue for debounced message injection ---
+import { ContextMailbox } from "../lib/dm/context-mailbox.ts";
+const contextMailbox = new ContextMailbox();
+
 // --- ChannelRegistry — loaded from workspace/channels.yaml, shared by RouterPlugin + DiscordPlugin ---
 import { ChannelRegistry } from "../lib/channels/channel-registry.js";
 const channelRegistry = new ChannelRegistry(join(workspaceDir, "channels.yaml"));
@@ -147,7 +151,17 @@ const pluginRegistry: PluginRegistryEntry[] = [
     condition: () => !!process.env.DISCORD_BOT_TOKEN,
     factory: async () => {
       const { DiscordPlugin } = await import("../lib/plugins/discord");
-      return new DiscordPlugin(workspaceDir, dataDir, channelRegistry, hitlPlugin);
+      return new DiscordPlugin({
+        workspaceDir,
+        dataDir,
+        channelRegistry,
+        hitlPlugin,
+        mailbox: contextMailbox,
+        isExecutionActive: (correlationId: string) => {
+          const dispatcher = registeredPlugins.find(p => p.name === "skill-dispatcher");
+          return !!(dispatcher as any)?.isActive?.(correlationId);
+        },
+      });
     },
   },
   {
@@ -238,7 +252,7 @@ const pluginRegistry: PluginRegistryEntry[] = [
     condition: () => true,
     factory: async () => {
       const { SkillDispatcherPlugin } = await import("./executor/skill-dispatcher-plugin.js");
-      return new SkillDispatcherPlugin(executorRegistry, workspaceDir, undefined, loggerPlugin);
+      return new SkillDispatcherPlugin(executorRegistry, workspaceDir, undefined, loggerPlugin, contextMailbox);
     },
   },
   {
@@ -459,6 +473,7 @@ const apiContext: ApiContext = {
   executorRegistry,
   telemetry,
   apiKey: API_KEY,
+  mailbox: contextMailbox,
 };
 
 const routes = createAllRoutes(apiContext);

--- a/workspace/projects.yaml
+++ b/workspace/projects.yaml
@@ -69,6 +69,20 @@ projects:
         channelId: "1490978906419761262"
         webhook: "https://discord.com/api/webhooks/1491952347100876852/9DpUPDSRurXL18af1caqJY2oc8wflQ6j3xR0Gk9V8udeQWyewGFR-DUmyDLa7NEvM_iF"
 
+  - slug: ava
+    title: Ava
+    team: dev
+    github: protoLabsAI/ava
+    repoUrl: "https://github.com/protoLabsAI/ava"
+    projectPath: /home/josh/dev/labs/ava
+    defaultBranch: main
+    status: active
+    agents: [quinn]
+    discord:
+      dev:
+        channelId: ""
+        webhook: ""
+
   - slug: rabbit-hole-io
     title: rabbit-hole-io
     team: dev


### PR DESCRIPTION
## Summary

PR #141 (`feat(discord): DM debounce + context mailbox`) was blocked by a failing `Type check` step in CI. The test step passed — the failures were pre-existing TypeScript errors in `src/executor/executors/deep-agent-executor.ts` introduced by the Langfuse v5 + LangChain type update in commit `81f4fc1`.

- Remove `Record<string, ReturnType<typeof tool>>` annotation that caused `DynamicStructuredTool` generic mismatch after LangChain inference changes — use `Record<string, unknown>` + return cast instead
- Update `LangfuseCallbackHandler` constructor: remove `publicKey`/`secretKey`/`baseUrl` (v5 reads these from env vars); rename `metadata` → `traceMetadata`
- Remove `flushAsync` calls — v5 `CallbackHandler` doesn't expose this method
- Move `callbacks` declaration before `try/catch` to fix out-of-scope reference
- Fix `BaseMessage` cast via `unknown` intermediate to satisfy TS2352

This branch includes the PR #141 commit (`feat(discord)`) plus the type fix, so merging this to `dev` unblocks the Discord DM debounce feature.

## Test plan
- [x] `tsc --noEmit` exits 0 locally
- [ ] CI `test` job (bun test + type check) passes on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Discord DM message batching with configurable debounce for improved performance.
  * Introduced API endpoints to manage conversation message queues.
  * Added agent execution visibility via dedicated operations channel.

* **Tests**
  * Added comprehensive test coverage for message batching and queue management.

* **Chores**
  * Added configuration options for message debounce and retention policies.
  * Updated project workspace settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->