### PR TITLE
fix: resolve deep-agent-executor type errors (LangChain + Langfuse v5)

### DIFF
--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -98,8 +98,11 @@ class WorldStateCache {
 
 const _worldCaches = new Map<string, WorldStateCache>();
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- LangChain tool()
+// generic params shift across minor versions; pinning to a concrete DynamicStructuredTool
+// generic breaks on every upgrade. The runtime contract is stable; only the TS generics drift.
 function createLangChainTools(toolNames: string[], http: HttpClient) {
-  const all: Record<string, unknown> = {
+  const all: Record<string, any> = {
     chat_with_agent: tool(
       async (input) => {
         console.log(`[deep-agent:tool] chat_with_agent called: agent=${input.agent}, skill=${input.skill ?? "auto"}, msg="${input.message.slice(0, 80)}"`);


### PR DESCRIPTION
## Summary
- Tool record typed as `any` — LangChain `tool()` generics shift across minor versions
- Langfuse v5 `ConstructorParams`: removed `publicKey`/`secretKey`/`baseUrl` (now env vars), use `traceMetadata`
- Removed manual `flushAsync` calls (v5 auto-flushes), fixed `callbacks` scope in catch block

Fixes the pre-existing CI type check failure.

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] 688 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved TypeScript compatibility with LangChain library through type adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->