### PR TITLE
feat: register protopen in agent delegation config

### DIFF
--- a/workspace/agents/ava.yaml.example
+++ b/workspace/agents/ava.yaml.example
@@ -21,6 +21,7 @@ systemPrompt: |
     - Quinn: code review, bug triage, QA
     - Frank: CI/CD, deployments, infrastructure
     - Researcher: deep context retrieval, analysis
+    - protopen: penetration testing, security assessments, RF/WiFi recon
     - Jon/Cindi: communications, summaries, content
 
   Always consider the project context (projectSlug) when routing work.
@@ -52,6 +53,7 @@ canDelegate:
   - quinn
   - frank
   - researcher
+  - protopen
 
 # Maximum agentic turns per invocation (-1 = unlimited)
 maxTurns: 20

--- a/workspace/agents/quinn.yaml.example
+++ b/workspace/agents/quinn.yaml.example
@@ -31,6 +31,9 @@ tools:
   - get_incidents
   - report_incident
 
+canDelegate:
+  - protopen
+
 maxTurns: 15
 
 skills:


### PR DESCRIPTION
## Summary
Re-cut of #140 (closed — conflicts + bugs). Fixes:
- **Name consistency**: uses `protopen` everywhere (not `protoPen`)
- **Targets dev** (not main)
- **agents.yaml not touched**: it's gitignored local config — operators add the A2A entry per-environment

Changes:
- `ava.yaml.example`: add protopen to delegation guide + canDelegate list
- `quinn.yaml.example`: add canDelegate with protopen

## Test plan
- [ ] CI passes
- [ ] Operator adds protopen to local `workspace/agents.yaml` separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated a new security agent supporting penetration testing, security assessments, and RF/WiFi reconnaissance capabilities.
  * Extended delegation permissions for two agents to support integration with the new security agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->