### PR TITLE
fix(router): route agent pool DMs directly to the target agent

### DIFF
--- a/src/router/router-plugin.ts
+++ b/src/router/router-plugin.ts
@@ -175,6 +175,13 @@ export class RouterPlugin implements Plugin {
     const content = workingPayload.content;
     const isDM = workingPayload.isDM === true;
 
+    // Agent pool DM — the Discord plugin sets agentId when an agent-specific bot
+    // receives a DM. This takes highest priority: the user DM'd that agent's bot
+    // directly, so route to that agent. No keyword matching, no fallback.
+    const agentPoolAgent = isDM && typeof workingPayload.agentId === "string"
+      ? workingPayload.agentId
+      : undefined;
+
     // Channel-based agent assignment — takes priority over keyword agent matching.
     // If channels.yaml assigns this channel to a specific agent, prefer that.
     const channelEntry = this.config.channelRegistry?.findByTopic(msg.topic);
@@ -198,7 +205,7 @@ export class RouterPlugin implements Plugin {
       }
     }
 
-    if (!match && !storedSession) {
+    if (!match && !storedSession && !agentPoolAgent) {
       console.log(
         `[router] No skill match for topic "${msg.topic}"` +
         (content ? ` content="${content.slice(0, 60)}"` : "") +
@@ -227,7 +234,11 @@ export class RouterPlugin implements Plugin {
     let agentName: string | undefined;
     let skill: string;
 
-    if (storedSession) {
+    if (agentPoolAgent) {
+      // Agent pool DM — route directly to the bot's agent, skip all other resolution.
+      agentName = agentPoolAgent;
+      skill = match?.skill ?? storedSession?.skill ?? "chat";
+    } else if (storedSession) {
       // Re-set TTL on every turn (sliding window)
       this.dmSessions.set(conversationId, storedSession);
       agentName = channelAgent ?? storedSession.agentName;


### PR DESCRIPTION
## Summary
- DMs to agent-specific bots (protoJon, Quinn, etc.) were falling through to `ROUTER_DM_DEFAULT_AGENT` (ava) instead of routing to the agent whose bot received the DM
- Root cause: router ignored `payload.agentId` set by the Discord agent pool DM handler
- Fix: `agentPoolAgent` takes highest priority in DM resolution — user DM'd that bot, route to that agent

Before: User DMs Jon → router → Ava → Ava calls `chat_with_agent("protocontent")` → Jon responds via Ava
After: User DMs Jon → router → Jon responds directly

## Test plan
- [x] 688 tests pass (30 router tests pass)
- [ ] CI passes
- [ ] DM protoJon → response comes from protocontent executor, not deep-agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved direct message routing to prevent messages from being incorrectly dropped when lacking keyword matches or existing sessions. Direct messages are now prioritized and properly routed regardless of prior interaction history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->