### PR TITLE
feat: protoBot — in-process Discord operations agent

### DIFF
--- a/lib/plugins/discord.ts
+++ b/lib/plugins/discord.ts
@@ -271,7 +271,8 @@ export class DiscordPlugin implements Plugin {
   readonly description = "Discord gateway — routes messages to/from the A2A agent fleet";
   readonly capabilities = ["discord-inbound", "discord-outbound"];
 
-  private client!: Client;
+  /** Exposed for API routes (discord operations agent). */
+  client!: Client;
   private busRef!: EventBus;
   private config!: DiscordConfig;
   private workspaceDir: string;

--- a/src/api/discord.ts
+++ b/src/api/discord.ts
@@ -1,0 +1,169 @@
+/**
+ * Discord operations API — exposes Discord server management via HTTP.
+ *
+ * Backing routes for protoBot's DeepAgent tools. The DiscordPlugin holds
+ * the Client reference; these routes find it in the plugin list and call
+ * Discord.js methods through it.
+ *
+ * Routes:
+ *   GET  /api/discord/server-stats      — member count, channel count, boost level
+ *   GET  /api/discord/channels          — list all channels with type and category
+ *   POST /api/discord/channels/create   — create a channel (text/voice/category)
+ *   POST /api/discord/send              — send a message to a channel
+ *   GET  /api/discord/members           — list members (paginated)
+ */
+
+import type { Route, ApiContext } from "./types.ts";
+
+function getDiscordClient(ctx: ApiContext) {
+  const plugin = ctx.plugins.find(p => p.name === "discord") as any;
+  return plugin?.client ?? null;
+}
+
+function getGuildId(): string {
+  return process.env.DISCORD_GUILD_ID ?? "";
+}
+
+export function createRoutes(ctx: ApiContext): Route[] {
+  return [
+    {
+      method: "GET",
+      path: "/api/discord/server-stats",
+      handler: async () => {
+        const client = getDiscordClient(ctx);
+        if (!client) return Response.json({ success: false, error: "Discord not connected" }, { status: 503 });
+
+        const guild = client.guilds.cache.get(getGuildId());
+        if (!guild) return Response.json({ success: false, error: "Guild not found" }, { status: 404 });
+
+        return Response.json({
+          success: true,
+          data: {
+            name: guild.name,
+            memberCount: guild.memberCount,
+            channelCount: guild.channels.cache.size,
+            roleCount: guild.roles.cache.size,
+            boostLevel: guild.premiumTier,
+            boostCount: guild.premiumSubscriptionCount,
+            createdAt: guild.createdAt.toISOString(),
+          },
+        });
+      },
+    },
+    {
+      method: "GET",
+      path: "/api/discord/channels",
+      handler: async () => {
+        const client = getDiscordClient(ctx);
+        if (!client) return Response.json({ success: false, error: "Discord not connected" }, { status: 503 });
+
+        const guild = client.guilds.cache.get(getGuildId());
+        if (!guild) return Response.json({ success: false, error: "Guild not found" }, { status: 404 });
+
+        const channels = guild.channels.cache.map((ch: any) => ({
+          id: ch.id,
+          name: ch.name,
+          type: ch.type,
+          parentId: ch.parentId,
+          parentName: ch.parent?.name ?? null,
+          position: ch.position,
+        }));
+
+        return Response.json({ success: true, data: channels });
+      },
+    },
+    {
+      method: "POST",
+      path: "/api/discord/channels/create",
+      handler: async (req) => {
+        const client = getDiscordClient(ctx);
+        if (!client) return Response.json({ success: false, error: "Discord not connected" }, { status: 503 });
+
+        const guild = client.guilds.cache.get(getGuildId());
+        if (!guild) return Response.json({ success: false, error: "Guild not found" }, { status: 404 });
+
+        let body: { name?: string; type?: string; parent?: string; topic?: string };
+        try { body = await req.json() as typeof body; }
+        catch { return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 }); }
+
+        if (!body.name) return Response.json({ success: false, error: "name is required" }, { status: 400 });
+
+        // Map friendly type names to Discord.js ChannelType values
+        const typeMap: Record<string, number> = { text: 0, voice: 2, category: 4, announcement: 5, forum: 15 };
+        const channelType = typeMap[body.type ?? "text"] ?? 0;
+
+        try {
+          const options: any = { name: body.name, type: channelType };
+          if (body.parent) {
+            const parent = guild.channels.cache.find((ch: any) => ch.name === body.parent || ch.id === body.parent);
+            if (parent) options.parent = parent.id;
+          }
+          if (body.topic) options.topic = body.topic;
+
+          const created = await guild.channels.create(options);
+          return Response.json({
+            success: true,
+            data: { id: created.id, name: created.name, type: created.type },
+          });
+        } catch (e) {
+          return Response.json({ success: false, error: e instanceof Error ? e.message : String(e) }, { status: 500 });
+        }
+      },
+    },
+    {
+      method: "POST",
+      path: "/api/discord/send",
+      handler: async (req) => {
+        const client = getDiscordClient(ctx);
+        if (!client) return Response.json({ success: false, error: "Discord not connected" }, { status: 503 });
+
+        let body: { channelId?: string; channelName?: string; content?: string };
+        try { body = await req.json() as typeof body; }
+        catch { return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 }); }
+
+        if (!body.content) return Response.json({ success: false, error: "content is required" }, { status: 400 });
+
+        const guild = client.guilds.cache.get(getGuildId());
+        let channel: any = null;
+
+        if (body.channelId) {
+          channel = client.channels.cache.get(body.channelId);
+        } else if (body.channelName && guild) {
+          channel = guild.channels.cache.find((ch: any) => ch.name === body.channelName);
+        }
+
+        if (!channel?.send) return Response.json({ success: false, error: "Channel not found or not text-based" }, { status: 404 });
+
+        try {
+          const msg = await channel.send({ content: body.content });
+          return Response.json({ success: true, data: { messageId: msg.id, channelId: channel.id } });
+        } catch (e) {
+          return Response.json({ success: false, error: e instanceof Error ? e.message : String(e) }, { status: 500 });
+        }
+      },
+    },
+    {
+      method: "GET",
+      path: "/api/discord/members",
+      handler: async () => {
+        const client = getDiscordClient(ctx);
+        if (!client) return Response.json({ success: false, error: "Discord not connected" }, { status: 503 });
+
+        const guild = client.guilds.cache.get(getGuildId());
+        if (!guild) return Response.json({ success: false, error: "Guild not found" }, { status: 404 });
+
+        // Use cached members (no API fetch — respects rate limits)
+        const members = guild.members.cache.map((m: any) => ({
+          id: m.id,
+          username: m.user.username,
+          displayName: m.displayName,
+          bot: m.user.bot,
+          roles: m.roles.cache.filter((r: any) => r.name !== "@everyone").map((r: any) => r.name),
+          joinedAt: m.joinedAt?.toISOString() ?? null,
+        }));
+
+        return Response.json({ success: true, data: members });
+      },
+    },
+  ];
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -15,6 +15,7 @@ import { createRoutes as planeRoutes } from "./plane.ts";
 import { createRoutes as avaToolRoutes } from "./ava-tools.ts";
 import { createRoutes as boardRoutes } from "./board.ts";
 import { createRoutes as mailboxRoutes } from "./mailbox.ts";
+import { createRoutes as discordRoutes } from "./discord.ts";
 
 export { matchPath } from "./types.ts";
 export type { Route, ApiContext } from "./types.ts";
@@ -29,5 +30,6 @@ export function createAllRoutes(ctx: ApiContext): Route[] {
     ...avaToolRoutes(ctx),
     ...boardRoutes(ctx),
     ...(ctx.mailbox ? mailboxRoutes(ctx.mailbox, ctx) : []),
+    ...discordRoutes(ctx),
   ];
 }

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -269,6 +269,44 @@ function createLangChainTools(toolNames: string[], http: HttpClient): Structured
         schema: z.object({ query: z.string().describe("Search query") }),
       },
     ),
+    // ── Discord operations (protoBot agent) ──────────────────────────────────
+    discord_server_stats: tool(
+      async () => JSON.stringify(await http.get("/api/discord/server-stats")),
+      { name: "discord_server_stats", description: "Discord server stats: members, channels, roles, boost level.", schema: z.object({}) },
+    ),
+    discord_list_channels: tool(
+      async () => JSON.stringify(await http.get("/api/discord/channels")),
+      { name: "discord_list_channels", description: "List all Discord channels with type and category.", schema: z.object({}) },
+    ),
+    discord_create_channel: tool(
+      async (input) => JSON.stringify(await http.post("/api/discord/channels/create", input)),
+      {
+        name: "discord_create_channel",
+        description: "Create a Discord channel. Types: text, voice, category, announcement, forum.",
+        schema: z.object({
+          name: z.string().describe("Channel name (lowercase, hyphens)"),
+          type: z.enum(["text", "voice", "category", "announcement", "forum"]).optional().describe("Channel type (default: text)"),
+          parent: z.string().optional().describe("Parent category name or ID"),
+          topic: z.string().optional().describe("Channel topic/description"),
+        }),
+      },
+    ),
+    discord_send: tool(
+      async (input) => JSON.stringify(await http.post("/api/discord/send", input)),
+      {
+        name: "discord_send",
+        description: "Send a message to a Discord channel by name or ID.",
+        schema: z.object({
+          content: z.string().describe("Message content (markdown supported, max 2000 chars)"),
+          channelId: z.string().optional().describe("Channel ID"),
+          channelName: z.string().optional().describe("Channel name (alternative to ID)"),
+        }),
+      },
+    ),
+    discord_list_members: tool(
+      async () => JSON.stringify(await http.get("/api/discord/members")),
+      { name: "discord_list_members", description: "List Discord server members with roles.", schema: z.object({}) },
+    ),
   };
 
   return toolNames.map(n => all[n]).filter(Boolean) as StructuredToolInterface[];

--- a/workspace/agents/protobot.yaml.example
+++ b/workspace/agents/protobot.yaml.example
@@ -1,0 +1,68 @@
+# protoBot — Discord operations agent.
+#
+# The entity behind the main Discord bot. Owns the server: provisions channels,
+# tracks community activity, manages announcements, and serves as the default
+# DM contact for the fleet. When you DM the main bot, you're talking to protoBot.
+#
+# protoBot does NOT do product work — for that, ask Ava. protoBot controls
+# Discord itself: channels, roles, announcements, community pulse.
+
+name: protobot
+role: operations
+
+model: claude-sonnet-4-6
+
+systemPrompt: |
+  You are protoBot, the Discord operations agent for protoLabs.
+
+  You ARE the Discord server. You own it, you manage it, you know everything
+  happening in it. When someone talks to you, they're talking to the entity
+  that controls the server infrastructure.
+
+  ## Your domain
+
+  - Channel provisioning: create channels, categories, set topics
+  - Server awareness: member count, channel layout, roles, boost level
+  - Announcements: send messages to any channel
+  - Community pulse: who's active, what's being discussed, server health
+  - Fleet coordination: you know which agent bots are online
+
+  ## Your tools
+
+  **discord_server_stats** — Server overview: members, channels, roles, boosts.
+  **discord_list_channels** — Full channel list with categories and types.
+  **discord_create_channel** — Provision new channels (text, voice, category, forum).
+  **discord_send** — Post a message to any channel by name or ID.
+  **discord_list_members** — Who's in the server and their roles.
+  **chat_with_agent** — Talk to other agents when you need non-Discord context.
+  **get_world_state** — System health (for cross-referencing with Discord state).
+
+  ## Personality
+
+  You're the server itself talking. Efficient, helpful, slightly proud of
+  your server. You know the layout cold. When someone asks you to provision
+  something, you do it — no confirmation needed unless it's destructive
+  (deleting channels, mass actions).
+
+  ## What you DON'T do
+
+  - Product decisions — that's Ava
+  - Code review — that's Quinn
+  - Content creation — that's Jon
+  - If someone asks about those things, tell them which agent to talk to
+
+tools:
+  - discord_server_stats
+  - discord_list_channels
+  - discord_create_channel
+  - discord_send
+  - discord_list_members
+  - chat_with_agent
+  - get_world_state
+
+maxTurns: 8
+
+skills:
+  - name: chat
+    description: Discord operations — server stats, channel provisioning, announcements, community pulse
+    keywords: [discord, channel, server, provision, announce, members, roles, community]


### PR DESCRIPTION
## Summary
- **protoBot** is the entity behind the main Discord bot — owns the server
- LangGraph DeepAgent (Sonnet 4.6) with Discord-specific tools
- New HTTP API: `/api/discord/server-stats`, `/api/discord/channels`, `/api/discord/channels/create`, `/api/discord/send`, `/api/discord/members`
- 5 new DeepAgent tools: `discord_server_stats`, `discord_list_channels`, `discord_create_channel`, `discord_send`, `discord_list_members`
- Set `ROUTER_DM_DEFAULT_AGENT=protobot` to route main bot DMs to protoBot instead of Ava

## Test plan
- [x] 688 tests pass, tsc clean
- [ ] CI passes
- [ ] Deploy, set ROUTER_DM_DEFAULT_AGENT=protobot, DM the main bot — should respond as protoBot
- [ ] Test channel provisioning via DM

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Discord server management API with endpoints for querying statistics, listing and creating channels, sending messages, and viewing members
  * Introduced protobot agent for Discord operations, enabling automated server administration and management
  * Extended AI tools with five Discord-specific capabilities for server interaction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->