### PR TITLE
feat(goap): close the feedback loops — flow, outcome, learning

### DIFF
--- a/lib/plugins/flow-monitor.ts
+++ b/lib/plugins/flow-monitor.ts
@@ -201,18 +201,25 @@ export class FlowMonitorPlugin implements Plugin {
     const id = typeof p.id === "string" ? p.id : crypto.randomUUID();
     const type = this._parseItemType(p.type);
     const stage = typeof p.stage === "string" ? p.stage : "backlog";
+    const status = typeof p.status === "string" ? this._parseItemStatus(p.status) : "queued";
+    const createdAt = typeof p.createdAt === "number" ? p.createdAt : Date.now();
 
     const item: FlowItem = {
       id,
       type,
-      status: "queued",
+      status,
       stage,
-      createdAt: typeof p.createdAt === "number" ? p.createdAt : Date.now(),
+      createdAt,
+      // If item is created in "active" state, startedAt marks when the work began.
+      // Without this, efficiency computes 0 because activeMs = 0.
+      ...(status === "active" && {
+        startedAt: typeof p.startedAt === "number" ? p.startedAt : createdAt,
+      }),
       meta: typeof p.meta === "object" && p.meta !== null ? (p.meta as Record<string, unknown>) : undefined,
     };
 
     this.items.set(id, item);
-    console.log(`[flow-monitor] Item created: ${id} (${type}, stage: ${stage})`);
+    console.log(`[flow-monitor] Item created: ${id} (${type}, stage: ${stage}, status: ${status})`);
     this._tickMetrics();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -303,6 +303,14 @@ const pluginRegistry: PluginRegistryEntry[] = [
       return new FlowMonitorPlugin();
     },
   },
+  {
+    name: "outcome-analysis",
+    condition: () => true,
+    factory: async () => {
+      const { OutcomeAnalysisPlugin } = await import("./plugins/outcome-analysis-plugin.js");
+      return new OutcomeAnalysisPlugin();
+    },
+  },
   // Built-ins: opt-in via ENABLED_PLUGINS=echo,...
   {
     name: "echo",
@@ -445,6 +453,32 @@ bus.subscribe("world.action.queue_full", "alert-bridge", (msg) => {
     topic: "message.outbound.discord.alert",
     timestamp: Date.now(),
     payload: { text, level: "warn", source: "action-dispatcher" },
+  });
+});
+
+// Outcome analysis alerts — chronic failures and repeated HITL escalations
+bus.subscribe("ops.alert.action_quality", "alert-bridge", (msg) => {
+  const p = (msg.payload ?? {}) as Record<string, unknown>;
+  const rate = typeof p.successRate === "number" ? (p.successRate * 100).toFixed(0) : "?";
+  const text = `🔻 Action quality alert — \`${p.actionId}\` success rate ${rate}% (${p.success}/${p.total}). ${p.recommendation ?? ""}`;
+  bus.publish("message.outbound.discord.alert", {
+    id: crypto.randomUUID(),
+    correlationId: msg.correlationId,
+    topic: "message.outbound.discord.alert",
+    timestamp: Date.now(),
+    payload: { text, level: "warn", source: "outcome-analysis" },
+  });
+});
+
+bus.subscribe("ops.alert.hitl_escalation", "alert-bridge", (msg) => {
+  const p = (msg.payload ?? {}) as Record<string, unknown>;
+  const text = `🔧 Feature-request signal — \`${p.kind}\` escalated to HITL ${p.count}× for \`${p.target}\`. ${p.recommendation ?? ""}`;
+  bus.publish("message.outbound.discord.alert", {
+    id: crypto.randomUUID(),
+    correlationId: msg.correlationId,
+    topic: "message.outbound.discord.alert",
+    timestamp: Date.now(),
+    payload: { text, level: "warn", source: "outcome-analysis" },
   });
 });
 

--- a/src/plugins/action-dispatcher-plugin.ts
+++ b/src/plugins/action-dispatcher-plugin.ts
@@ -313,6 +313,19 @@ export class ActionDispatcherPlugin implements Plugin {
       payload: outcomePayload,
     });
 
+    // Close the outcome → state feedback loop: re-publish world.state so goals
+    // re-evaluate immediately instead of waiting for the next domain poll (60s).
+    // Prevents duplicate dispatches for the same violation that was just remediated.
+    if (success && action.effects && action.effects.length > 0) {
+      this.bus.publish("world.state.updated", {
+        id: crypto.randomUUID(),
+        correlationId: parentCorrelationId,
+        topic: "world.state.updated",
+        timestamp: completedAt,
+        payload: this.worldState,
+      });
+    }
+
     // Complete in WIP queue and dispatch next if available
     const next = this.queue.complete(correlationId);
     if (next) {

--- a/src/plugins/outcome-analysis-plugin.ts
+++ b/src/plugins/outcome-analysis-plugin.ts
@@ -1,0 +1,199 @@
+/**
+ * OutcomeAnalysisPlugin — closes the learning loop.
+ *
+ * Subscribes to world.action.outcome events, tracks per-action success rates
+ * and HITL escalation frequency, and emits signals on chronic issues:
+ *
+ *   - Actions with <50% success rate over 10+ attempts → publishes
+ *     ops.alert.action_quality so the fleet knows to investigate/replace it.
+ *   - Actions with repeated HITL escalations → treated as feature-request
+ *     signals ("what would have unblocked this automatically?") and logged
+ *     for Ava to file on the board.
+ *
+ * This is the "bottlenecks are growth" principle operationalized: the system's
+ * own failures become inputs to its own improvement backlog.
+ *
+ * Inbound:
+ *   world.action.outcome  — every action completion
+ *   hitl.escalation       — every HITL timeout/exhaustion (per pr-remediator)
+ *
+ * Outbound:
+ *   ops.alert.action_quality   — action with poor success rate
+ *   ops.alert.hitl_escalation  — repeated human-needed action
+ */
+
+import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
+
+interface ActionStats {
+  actionId: string;
+  total: number;
+  success: number;
+  failure: number;
+  timeout: number;
+  lastEvaluatedAt: number;
+  alertedAt?: number;
+}
+
+interface HitlStats {
+  kind: string;
+  target: string;
+  count: number;
+  firstSeenAt: number;
+  lastSeenAt: number;
+  alertedAt?: number;
+}
+
+const ANALYSIS_INTERVAL_MS = 5 * 60_000;            // 5 min
+const MIN_ATTEMPTS_BEFORE_ALERT = 10;               // don't flag until 10+ runs
+const POOR_SUCCESS_THRESHOLD = 0.5;                 // <50% success → alert
+const HITL_COUNT_THRESHOLD = 3;                     // 3+ escalations → feature signal
+const ALERT_COOLDOWN_MS = 60 * 60_000;              // 1 hour between repeat alerts
+
+export class OutcomeAnalysisPlugin implements Plugin {
+  readonly name = "outcome-analysis";
+  readonly description = "Analyzes action outcomes to detect chronic failures and escalation patterns";
+  readonly capabilities = ["outcome-analysis", "learning"];
+
+  private bus?: EventBus;
+  private readonly subscriptionIds: string[] = [];
+  private readonly actionStats = new Map<string, ActionStats>();
+  private readonly hitlStats = new Map<string, HitlStats>();
+  private analysisTimer?: ReturnType<typeof setInterval>;
+
+  install(bus: EventBus): void {
+    this.bus = bus;
+
+    this.subscriptionIds.push(
+      bus.subscribe("world.action.outcome", this.name, (msg) => this._onOutcome(msg)),
+    );
+    this.subscriptionIds.push(
+      bus.subscribe("hitl.escalation", this.name, (msg) => this._onHitlEscalation(msg)),
+    );
+
+    this.analysisTimer = setInterval(() => this._runAnalysis(), ANALYSIS_INTERVAL_MS);
+    console.log("[outcome-analysis] Installed — analyzing every 5 min");
+  }
+
+  uninstall(): void {
+    if (this.analysisTimer) clearInterval(this.analysisTimer);
+    if (this.bus) {
+      for (const id of this.subscriptionIds) this.bus.unsubscribe(id);
+    }
+    this.subscriptionIds.length = 0;
+    this.bus = undefined;
+  }
+
+  private _onOutcome(msg: BusMessage): void {
+    const p = msg.payload as Record<string, unknown> | undefined;
+    const actionId = typeof p?.actionId === "string" ? p.actionId : undefined;
+    if (!actionId) return;
+
+    const success = p?.success === true;
+    const error = typeof p?.error === "string" ? p.error : undefined;
+    const isTimeout = error?.toLowerCase().includes("timeout") ?? false;
+
+    const stats = this.actionStats.get(actionId) ?? {
+      actionId,
+      total: 0,
+      success: 0,
+      failure: 0,
+      timeout: 0,
+      lastEvaluatedAt: 0,
+    };
+
+    stats.total += 1;
+    if (success) stats.success += 1;
+    else if (isTimeout) stats.timeout += 1;
+    else stats.failure += 1;
+    stats.lastEvaluatedAt = Date.now();
+
+    this.actionStats.set(actionId, stats);
+  }
+
+  private _onHitlEscalation(msg: BusMessage): void {
+    const p = msg.payload as Record<string, unknown> | undefined;
+    const kind = typeof p?.kind === "string" ? p.kind : "unknown";
+    const target = typeof p?.target === "string" ? p.target : (typeof p?.prUrl === "string" ? p.prUrl : "unknown");
+    const key = `${kind}::${target}`;
+
+    const stats = this.hitlStats.get(key) ?? {
+      kind,
+      target,
+      count: 0,
+      firstSeenAt: Date.now(),
+      lastSeenAt: 0,
+    };
+    stats.count += 1;
+    stats.lastSeenAt = Date.now();
+    this.hitlStats.set(key, stats);
+  }
+
+  /** Per-action success rate snapshot, sorted worst-first. Exposed for /api. */
+  getActionStats(): Array<ActionStats & { successRate: number }> {
+    return Array.from(this.actionStats.values())
+      .map(s => ({ ...s, successRate: s.total > 0 ? s.success / s.total : 0 }))
+      .sort((a, b) => a.successRate - b.successRate);
+  }
+
+  /** HITL escalation clusters, sorted most-frequent first. */
+  getHitlStats(): HitlStats[] {
+    return Array.from(this.hitlStats.values())
+      .sort((a, b) => b.count - a.count);
+  }
+
+  private _runAnalysis(): void {
+    if (!this.bus) return;
+    const now = Date.now();
+
+    // Detect chronically-failing actions
+    for (const stats of this.actionStats.values()) {
+      if (stats.total < MIN_ATTEMPTS_BEFORE_ALERT) continue;
+      const rate = stats.success / stats.total;
+      if (rate >= POOR_SUCCESS_THRESHOLD) continue;
+
+      // Cooldown between repeat alerts for the same action
+      if (stats.alertedAt && now - stats.alertedAt < ALERT_COOLDOWN_MS) continue;
+
+      stats.alertedAt = now;
+      this.bus.publish("ops.alert.action_quality", {
+        id: crypto.randomUUID(),
+        correlationId: crypto.randomUUID(),
+        topic: "ops.alert.action_quality",
+        timestamp: now,
+        payload: {
+          actionId: stats.actionId,
+          successRate: rate,
+          total: stats.total,
+          success: stats.success,
+          failure: stats.failure,
+          timeout: stats.timeout,
+          recommendation: `Action "${stats.actionId}" succeeded ${stats.success}/${stats.total} times (${(rate * 100).toFixed(0)}%). Consider rewriting preconditions, replacing the skill, or filing a feature to build a better capability.`,
+        },
+      });
+      console.warn(`[outcome-analysis] chronic failure: ${stats.actionId} ${(rate * 100).toFixed(0)}% over ${stats.total} attempts`);
+    }
+
+    // Detect HITL escalation patterns (feature-request signals)
+    for (const stats of this.hitlStats.values()) {
+      if (stats.count < HITL_COUNT_THRESHOLD) continue;
+      if (stats.alertedAt && now - stats.alertedAt < ALERT_COOLDOWN_MS) continue;
+
+      stats.alertedAt = now;
+      this.bus.publish("ops.alert.hitl_escalation", {
+        id: crypto.randomUUID(),
+        correlationId: crypto.randomUUID(),
+        topic: "ops.alert.hitl_escalation",
+        timestamp: now,
+        payload: {
+          kind: stats.kind,
+          target: stats.target,
+          count: stats.count,
+          firstSeenAt: stats.firstSeenAt,
+          lastSeenAt: stats.lastSeenAt,
+          recommendation: `"${stats.kind}" has escalated to HITL ${stats.count} times for ${stats.target}. This is a feature-request signal — what capability would unblock this automatically?`,
+        },
+      });
+      console.warn(`[outcome-analysis] repeated HITL: ${stats.kind} × ${stats.count} for ${stats.target}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Three fixes to turn the GOAP system from a detector into an iterator:

**1. Flow metrics actually count active time** — flow-monitor was defaulting all new items to \`status: queued\` regardless of payload. Now honors \`p.status\` on item.created and sets \`startedAt\` when the item is born active. Fixes efficiency stuck at 0.

**2. Outcome → state feedback loop** — action-dispatcher now re-publishes \`world.state.updated\` immediately on successful action with effects. Goals re-evaluate without waiting 60s for the next domain poll. Prevents duplicate dispatch.

**3. OutcomeAnalysisPlugin (learning)** — new plugin that tracks per-action success rates and HITL escalation clusters. Every 5min:
- Actions <50% success over 10+ attempts → \`ops.alert.action_quality\`
- HITL escalations ≥3× for same kind/target → \`ops.alert.hitl_escalation\` (feature-request signals)
- Both alerts bridged to Discord so operators see chronic failures surface

This operationalizes "bottlenecks are growth" — the system's own failures become inputs to its improvement backlog.

## Test plan
- [x] 497 tests pass, tsc clean
- [ ] CI passes
- [ ] Deploy, observe flow efficiency > 0 after real skill dispatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added outcome analysis to automatically detect chronically failing actions and escalation patterns
  * New alerts for action quality issues and escalation clusters with built-in rate limiting

* **Improvements**
  * Enhanced item tracking with accurate status and timestamp data at creation
  * World state updates now published after successful action completion with effects

<!-- end of auto-generated comment: release notes by coderabbit.ai -->