### PR TITLE
fix(ci-health): derive failingMainCount from projects array (#163)

### DIFF
--- a/__tests__/ci-health-consistency.test.ts
+++ b/__tests__/ci-health-consistency.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Regression tests for issue #163 — failingMainCount disagrees with per-repo mainBranchLastPushGreen.
+ *
+ * Root cause: failingMainCount was an independent counter incremented inside the loop, separate
+ * from the mainBranchLastPushGreen field pushed into the projects array. In edge cases these
+ * could diverge, triggering false ci.main_last_push_green goal violations (~60 alerts/day).
+ *
+ * Fix: failingMainCount is now derived from projects.filter(p => !p.mainBranchLastPushGreen).length
+ * after the loop, making it impossible for the two signals to disagree.
+ */
+
+import { describe, test, expect } from "bun:test";
+
+// The shape returned by handleGetCiHealth
+interface CiHealthResponse {
+  successRate: number;
+  totalRuns: number;
+  failedRuns: number;
+  failingMainCount: number;
+  projects: Array<{
+    repo: string;
+    successRate: number;
+    totalRuns: number;
+    failedRuns: number;
+    latestConclusion: string | null;
+    mainBranchLastPushGreen: boolean;
+  }>;
+}
+
+/**
+ * Core invariant: failingMainCount must always equal the number of repos
+ * where mainBranchLastPushGreen is false. These are two representations of
+ * the same fact and must never disagree.
+ */
+function assertConsistency(response: CiHealthResponse): void {
+  const countFromProjects = response.projects.filter(p => !p.mainBranchLastPushGreen).length;
+  expect(response.failingMainCount).toBe(countFromProjects);
+}
+
+/**
+ * Mirrors the fixed computation from handleGetCiHealth: derive failingMainCount
+ * from the projects array rather than tracking it as a separate counter.
+ */
+function buildResponse(
+  projects: CiHealthResponse["projects"],
+): CiHealthResponse {
+  const totalRuns = projects.reduce((s, p) => s + p.totalRuns, 0);
+  const failedRuns = projects.reduce((s, p) => s + p.failedRuns, 0);
+  const successRate = totalRuns > 0 ? Math.round(((totalRuns - failedRuns) / totalRuns) * 100) / 100 : 1;
+  // Single source of truth — derived from projects, not a separate counter
+  const failingMainCount = projects.filter(p => !p.mainBranchLastPushGreen).length;
+  return { successRate, totalRuns, failedRuns, failingMainCount, projects };
+}
+
+describe("ci-health failingMainCount consistency (issue #163 regression)", () => {
+  test("all repos green — failingMainCount is 0", () => {
+    const response = buildResponse([
+      { repo: "protoLabsAI/rabbit-hole.io", successRate: 1.0, totalRuns: 5, failedRuns: 0, latestConclusion: "success", mainBranchLastPushGreen: true },
+      { repo: "protoLabsAI/protoMaker",     successRate: 1.0, totalRuns: 8, failedRuns: 0, latestConclusion: "success", mainBranchLastPushGreen: true },
+    ]);
+    expect(response.failingMainCount).toBe(0);
+    assertConsistency(response);
+  });
+
+  test("one repo red — failingMainCount is 1 and matches projects array", () => {
+    const response = buildResponse([
+      { repo: "protoLabsAI/rabbit-hole.io", successRate: 0.8, totalRuns: 5, failedRuns: 1, latestConclusion: "failure", mainBranchLastPushGreen: false },
+      { repo: "protoLabsAI/protoMaker",     successRate: 1.0, totalRuns: 8, failedRuns: 0, latestConclusion: "success", mainBranchLastPushGreen: true },
+    ]);
+    expect(response.failingMainCount).toBe(1);
+    assertConsistency(response);
+  });
+
+  test("all repos red — failingMainCount equals total repo count", () => {
+    const response = buildResponse([
+      { repo: "protoLabsAI/rabbit-hole.io", successRate: 0, totalRuns: 3, failedRuns: 3, latestConclusion: "failure", mainBranchLastPushGreen: false },
+      { repo: "protoLabsAI/protoMaker",     successRate: 0, totalRuns: 2, failedRuns: 2, latestConclusion: "failure", mainBranchLastPushGreen: false },
+      { repo: "protoLabsAI/protoUI",        successRate: 0, totalRuns: 4, failedRuns: 4, latestConclusion: "failure", mainBranchLastPushGreen: false },
+    ]);
+    expect(response.failingMainCount).toBe(3);
+    assertConsistency(response);
+  });
+
+  test("empty project list — failingMainCount is 0", () => {
+    const response = buildResponse([]);
+    expect(response.failingMainCount).toBe(0);
+    expect(response.successRate).toBe(1);
+    assertConsistency(response);
+  });
+
+  test("repos that errored on lookup default to mainBranchLastPushGreen: true (optimistic)", () => {
+    // Outer catch path: repo is unreachable, defaults to green to avoid false positives
+    const response = buildResponse([
+      { repo: "protoLabsAI/unreachable",    successRate: 0,   totalRuns: 0, failedRuns: 0, latestConclusion: null,      mainBranchLastPushGreen: true },
+      { repo: "protoLabsAI/rabbit-hole.io", successRate: 1.0, totalRuns: 5, failedRuns: 0, latestConclusion: "success", mainBranchLastPushGreen: true },
+    ]);
+    expect(response.failingMainCount).toBe(0);
+    assertConsistency(response);
+  });
+
+  test("invariant holds for any mix — failingMainCount never disagrees with projects", () => {
+    // Key invariant: the two representations of the same fact always agree.
+    const scenarios: CiHealthResponse["projects"][] = [
+      [
+        { repo: "a", successRate: 1, totalRuns: 1, failedRuns: 0, latestConclusion: "success", mainBranchLastPushGreen: true },
+        { repo: "b", successRate: 0, totalRuns: 1, failedRuns: 1, latestConclusion: "failure", mainBranchLastPushGreen: false },
+        { repo: "c", successRate: 1, totalRuns: 1, failedRuns: 0, latestConclusion: "skipped", mainBranchLastPushGreen: true },
+      ],
+      [],
+      [
+        { repo: "x", successRate: 0, totalRuns: 0, failedRuns: 0, latestConclusion: null, mainBranchLastPushGreen: true },
+      ],
+    ];
+
+    for (const projects of scenarios) {
+      const response = buildResponse(projects);
+      assertConsistency(response);
+    }
+  });
+});

--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -51,7 +51,6 @@ export function createRoutes(ctx: ApiContext): Route[] {
     }> = [];
     let totalAll = 0;
     let failedAll = 0;
-    let failingMainCount = 0;
 
     for (const repo of repoList) {
       try {
@@ -77,7 +76,6 @@ export function createRoutes(ctx: ApiContext): Route[] {
           ) as { workflow_runs?: Array<{ conclusion: string }> };
           const latestMain = mainRuns.workflow_runs?.[0];
           mainBranchLastPushGreen = !latestMain || latestMain.conclusion === "success" || latestMain.conclusion === "skipped";
-          if (!mainBranchLastPushGreen) failingMainCount += 1;
         } catch {
           // Keep optimistic default on lookup errors to avoid false positives.
         }
@@ -94,6 +92,13 @@ export function createRoutes(ctx: ApiContext): Route[] {
         projects.push({ repo, successRate: 0, totalRuns: 0, failedRuns: 0, latestConclusion: null, mainBranchLastPushGreen: true });
       }
     }
+
+    // Derive failingMainCount from the per-repo mainBranchLastPushGreen values so
+    // the two signals share a single source of truth and can't disagree. Previously
+    // this was an independent counter incremented inside the loop, which diverged
+    // from mainBranchLastPushGreen in edge cases and caused ~60 false alerts/day
+    // for the ci.main_last_push_green goal (see issue #163).
+    const failingMainCount = projects.filter(p => !p.mainBranchLastPushGreen).length;
 
     const successRate = totalAll > 0 ? Math.round(((totalAll - failedAll) / totalAll) * 100) / 100 : 1;
     return Response.json({ successRate, totalRuns: totalAll, failedRuns: failedAll, failingMainCount, projects });


### PR DESCRIPTION
## Summary

- `failingMainCount` was an independent counter incremented inside the loop, separate from the `mainBranchLastPushGreen` field stored on each project. In edge cases (multi-workflow pushes, GitHub API timing) the counter diverged from the per-repo flag, firing the `ci.main_last_push_green` goal even when every repo showed `mainBranchLastPushGreen: true` — ~60 false alerts/day.
- Fix: remove the independent counter. After the loop, compute `failingMainCount = projects.filter(p => !p.mainBranchLastPushGreen).length`. The aggregate and per-repo signals now share one source of truth and cannot disagree.
- Regression tests added in `__tests__/ci-health-consistency.test.ts` covering all-green, one-red, all-red, empty, and unreachable-repo cases.

Re-cut of #165 after it was closed for conflicts. Only the core CI-health change is included here — the unrelated rollcall script updates from that PR have already landed on dev (12d586b).

## Test plan

- [x] `bun test __tests__/ci-health-consistency.test.ts` — 6 pass
- [x] `bun test` — full suite 694 pass / 0 fail
- [ ] Verify `/api/ci-health` response: `failingMainCount` always equals the count of `projects[*].mainBranchLastPushGreen === false`
- [ ] Confirm `ci.main_last_push_green` goal violations stop firing false positives

Closes #163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistency in CI health status reporting where failing main branch count is now properly derived from actual project data.

* **Tests**
  * Added regression tests to verify CI health metrics remain consistent across various project scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->