### PR TITLE
feat(a2a): Phase 1 — adopt @a2a-js/sdk for A2A client

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "workstacean",
       "dependencies": {
+        "@a2a-js/sdk": "^0.3.13",
         "@langchain/core": "^1.1.39",
         "@langchain/langgraph": "^1.2.8",
         "@langchain/openai": "^1.4.4",
@@ -31,6 +32,8 @@
     "@biomejs/biome",
   ],
   "packages": {
+    "@a2a-js/sdk": ["@a2a-js/sdk@0.3.13", "", { "dependencies": { "uuid": "^11.1.0" }, "peerDependencies": { "@bufbuild/protobuf": "^2.10.2", "@grpc/grpc-js": "^1.11.0", "express": "^4.21.2 || ^5.1.0" }, "optionalPeers": ["@bufbuild/protobuf", "@grpc/grpc-js", "express"] }, "sha512-BZr0f9JVNQs3GKOM9xINWCh6OKIJWZFPyqqVqTym5mxO2Eemc6I/0zL7zWnljHzGdaf5aZQyQN5xa6PSH62q+A=="],
+
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.73.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw=="],
 
     "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@a2a-js/sdk": "^0.3.13",
     "@langchain/core": "^1.1.39",
     "@langchain/langgraph": "^1.2.8",
     "@langchain/openai": "^1.4.4",

--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -1,24 +1,33 @@
 /**
- * A2AExecutor — dispatches a skill to an external agent via A2A JSON-RPC (HTTP).
+ * A2AExecutor — dispatches a skill to an external agent via @a2a-js/sdk.
  *
- * Passes correlationId and parentId as HTTP headers (X-Correlation-Id, X-Parent-Id)
- * so the receiving service can propagate the distributed trace.
+ * Uses the new ClientFactory / Client API (JSON-RPC transport). The SDK handles:
+ *   - JSON-RPC request/response shape and error envelope unwrapping
+ *   - SSE streaming (sendMessageStream) with automatic fallback to sendMessage
+ *     when the agent card says capabilities.streaming !== true
+ *   - Agent card resolution (DefaultAgentCardResolver)
+ *   - Auth-handler pattern (wired per-instance via createAuthenticatingFetchWithRetry)
  *
  * Registered by SkillBrokerPlugin during install().
  */
 
+import { ClientFactory, JsonRpcTransportFactory, type Client } from "@a2a-js/sdk/client";
+import type {
+  Message,
+  Task,
+  TaskArtifactUpdateEvent,
+  TaskStatusUpdateEvent,
+} from "@a2a-js/sdk";
 import type { IExecutor, SkillRequest, SkillResult } from "../types.ts";
-import { HttpClient } from "../../services/http-client.ts";
 
 export interface A2AAgentConfig {
   /** Agent name (for logging). */
   name: string;
-  /** Full A2A endpoint URL. */
+  /** Full A2A endpoint URL (to agent root — card is fetched at /.well-known/agent-card.json). */
   url: string;
   /** Environment variable name holding the API key. Optional. */
   apiKeyEnv?: string;
-  /** Request timeout in ms. Default: 300_000 (5 min — agent-driven chats with
-   * multiple tool calls routinely exceed 2 min). */
+  /** Request timeout in ms. Default: 300_000 (5 min). */
   timeoutMs?: number;
   /** Whether the remote agent supports SSE streaming (from agent card). */
   streaming?: boolean;
@@ -26,219 +35,218 @@ export interface A2AAgentConfig {
   onStreamUpdate?: (update: { type: string; text?: string; state?: string }) => void;
 }
 
+/**
+ * Build a fetch wrapper that stamps API key + per-request trace headers.
+ * A new wrapper is built per executor.execute() call so each client sees
+ * the right correlationId without requiring a separate cached client per trace.
+ *
+ * The `as typeof fetch` cast is because TS types `typeof fetch` includes
+ * `preconnect` (a browser-only signature) that Node/Bun's fetch doesn't expose.
+ */
+function buildFetch(
+  apiKey: string,
+  timeoutMs: number,
+  correlationId: string,
+  parentId?: string,
+): typeof fetch {
+  const wrapped = async (input: string | URL | Request, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    if (apiKey) headers.set("X-API-Key", apiKey);
+    headers.set("X-Correlation-Id", correlationId);
+    if (parentId) headers.set("X-Parent-Id", parentId);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      return await fetch(input, { ...init, headers, signal: init?.signal ?? controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+  return wrapped as typeof fetch;
+}
+
 export class A2AExecutor implements IExecutor {
   readonly type = "a2a";
-  private readonly http: HttpClient;
 
-  constructor(private readonly config: A2AAgentConfig) {
-    this.http = new HttpClient({ timeoutMs: config.timeoutMs ?? 300_000 });
-  }
+  constructor(private readonly config: A2AAgentConfig) {}
 
   async execute(req: SkillRequest): Promise<SkillResult> {
-    const apiKey = this.config.apiKeyEnv
-      ? (process.env[this.config.apiKeyEnv] ?? "")
-      : "";
-
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-      // Distributed trace headers — received by ava's A2A handler
-      "X-Correlation-Id": req.correlationId,
-      ...(req.parentId ? { "X-Parent-Id": req.parentId } : {}),
-    };
-    if (apiKey) headers["X-API-Key"] = apiKey;
-
     const text = req.content ?? req.prompt ?? this._buildText(req);
 
-    const body = JSON.stringify({
-      jsonrpc: "2.0",
-      id: crypto.randomUUID(),
-      method: "message/send",
-      params: {
+    try {
+      // Per-request client so trace headers get stamped via the fetch wrapper.
+      const client = await this._buildClient(req.correlationId, req.parentId);
+
+      const params = {
         message: {
-          role: "user",
-          parts: [{ kind: "text", text }],
+          kind: "message" as const,
+          messageId: crypto.randomUUID(),
+          role: "user" as const,
+          parts: [{ kind: "text" as const, text }],
+          contextId: req.contextId ?? req.correlationId,
         },
-        // contextId carries conversation state; correlationId is the trace ID
-        contextId: req.contextId ?? req.correlationId,
         metadata: {
           skillHint: req.skill,
           correlationId: req.correlationId,
           parentId: req.parentId,
           ...req.payload,
         },
-      },
-    });
+      };
 
-    // If agent supports streaming, use SSE for intermediate updates
-    if (this.config.streaming) {
-      const streamBody = body.replace('"message/send"', '"message/sendStream"');
-      const streamHeaders = { ...headers, Accept: "text/event-stream" };
-      try {
-        const streamResult = await this._executeStream(streamHeaders, streamBody, req);
-        if (streamResult) return streamResult;
-      } catch {
-        // Fall through to blocking path
+      if (this.config.streaming) {
+        return await this._executeStream(client, params, req);
       }
-    }
-
-    const resp = await this.http.fetch(this.config.url, {
-      method: "POST",
-      headers,
-      body,
-    });
-
-    if (!resp.ok) {
-      const errText = await resp.text().catch(() => "(no body)");
+      return await this._executeBlocking(client, params, req);
+    } catch (err) {
       return {
-        text: "",
+        text: err instanceof Error ? err.message : String(err),
         isError: true,
         correlationId: req.correlationId,
       };
     }
+  }
 
-    // Google A2A protocol response shape:
-    //   result: {
-    //     id, contextId, status: { state: "completed" },
-    //     artifacts: [{ artifactId, parts: [{ kind: "text", text: "..." }] }]
-    //   }
-    //
-    // We flatten all text parts across all artifacts into a single string
-    // so callers (skill-dispatcher) get the actual agent reply, not a generic
-    // "accepted" stub. Fallback cascade: artifacts.parts.text → result.message
-    // (legacy shape) → generic placeholder. Also logs the parse path on debug
-    // so future regressions are visible.
-    const data = (await resp.json()) as {
-      error?: { message: string };
-      result?: {
-        id?: string;
-        contextId?: string;
-        status?: { state?: string } | string;
-        message?: string;
-        artifacts?: Array<{ parts?: Array<{ kind?: string; text?: string }> }>;
-        [key: string]: unknown;
+  /**
+   * Non-streaming path: client.sendMessage returns Message | Task.
+   */
+  private async _executeBlocking(
+    client: Client,
+    params: Parameters<Client["sendMessage"]>[0],
+    req: SkillRequest,
+  ): Promise<SkillResult> {
+    const result = await client.sendMessage(params);
+
+    // Result can be a Message (immediate agent reply, no task) or a Task (may still be working).
+    if (result.kind === "message") {
+      const text = this._textFromParts(result.parts);
+      return {
+        text,
+        isError: false,
+        correlationId: req.correlationId,
+        data: { taskState: "completed" },
       };
-    };
-
-    if (data.error) {
-      return { text: data.error.message, isError: true, correlationId: req.correlationId };
     }
 
-    const artifactTexts = (data.result?.artifacts ?? [])
-      .flatMap((a) => a.parts ?? [])
-      .filter((p) => p.kind === "text" && typeof p.text === "string")
-      .map((p) => p.text as string);
+    // Task — extract text from artifacts or status.message.parts
+    const task = result;
+    const artifactText = (task.artifacts ?? [])
+      .flatMap(a => a.parts)
+      .filter((p): p is { kind: "text"; text: string } => p.kind === "text" && typeof p.text === "string")
+      .map(p => p.text)
+      .join("\n");
 
-    const resultText =
-      artifactTexts.length > 0
-        ? artifactTexts.join("\n")
-        : data.result?.message ?? `Skill "${req.skill}" accepted by ${this.config.name}`;
+    const statusText = task.status.message
+      ? this._textFromParts(task.status.message.parts)
+      : "";
 
-    const statusObj = data.result?.status;
-    const taskState = typeof statusObj === "object" ? statusObj?.state : typeof statusObj === "string" ? statusObj : undefined;
+    const text = artifactText || statusText || `Skill "${req.skill}" accepted by ${this.config.name}`;
+    const taskState = task.status.state;
 
     return {
-      text: resultText,
-      isError: false,
+      text,
+      isError: taskState === "failed" || taskState === "rejected",
       correlationId: req.correlationId,
       data: {
-        ...(data.result?.data as Record<string, unknown> | undefined),
-        taskId: data.result?.id as string | undefined,
-        contextId: data.result?.contextId as string | undefined,
+        taskId: task.id,
+        contextId: task.contextId,
         taskState,
       },
     };
   }
 
   /**
-   * SSE streaming path — reads TaskStatusUpdateEvent / TaskArtifactUpdateEvent
-   * from the response stream. Returns null if the agent doesn't support streaming.
+   * Streaming path: iterates the SSE event stream, accumulates artifact text.
+   * Supports artifact chunking via append/lastChunk (Phase 5 honors this fully).
    */
   private async _executeStream(
-    headers: Record<string, string>,
-    body: string,
+    client: Client,
+    params: Parameters<Client["sendMessageStream"]>[0],
     req: SkillRequest,
-  ): Promise<SkillResult | null> {
-    const resp = await this.http.fetch(this.config.url, {
-      method: "POST",
-      headers,
-      body,
-    });
-
-    if (!resp.ok || !resp.body) return null;
-
-    const contentType = resp.headers.get("content-type") ?? "";
-    if (!contentType.includes("text/event-stream")) {
-      // Not SSE — let caller fall back to blocking path
-      return null;
-    }
-
+  ): Promise<SkillResult> {
     let resultText = "";
     let taskId: string | undefined;
     let contextId: string | undefined;
     let taskState = "working";
 
-    const reader = resp.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = "";
-
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() ?? "";
-
-        for (const line of lines) {
-          if (!line.startsWith("data: ")) continue;
-          const raw = line.slice(6).trim();
-          if (!raw || raw === "[DONE]") continue;
-
-          try {
-            const event = JSON.parse(raw) as {
-              id?: string;
-              contextId?: string;
-              status?: { state?: string; message?: { parts?: Array<{ text?: string }> } };
-              artifact?: { parts?: Array<{ kind?: string; text?: string }> };
-            };
-
-            taskId = event.id ?? taskId;
-            contextId = event.contextId ?? contextId;
-
-            if (event.status?.state) {
-              taskState = event.status.state;
-              const statusText = event.status.message?.parts
-                ?.map(p => p.text).filter(Boolean).join("") ?? "";
-              if (statusText) {
-                this.config.onStreamUpdate?.({ type: "status", text: statusText, state: taskState });
-              }
-            }
-
-            if (event.artifact) {
-              const artifactText = (event.artifact.parts ?? [])
-                .filter(p => p.kind === "text" && p.text)
-                .map(p => p.text).join("");
-              if (artifactText) {
-                resultText += (resultText ? "\n" : "") + artifactText;
-                this.config.onStreamUpdate?.({ type: "artifact", text: artifactText });
-              }
-            }
-          } catch {
-            // Skip malformed SSE lines
-          }
+    for await (const event of client.sendMessageStream(params)) {
+      if (event.kind === "message") {
+        // Terminal message — stream ends
+        resultText = this._textFromParts(event.parts);
+        taskState = "completed";
+        break;
+      }
+      if (event.kind === "task") {
+        taskId = event.id;
+        contextId = event.contextId;
+        taskState = event.status.state;
+        continue;
+      }
+      if (event.kind === "status-update") {
+        taskId = event.taskId;
+        contextId = event.contextId;
+        taskState = event.status.state;
+        const statusText = event.status.message ? this._textFromParts(event.status.message.parts) : "";
+        if (statusText) {
+          this.config.onStreamUpdate?.({ type: "status", text: statusText, state: taskState });
+        }
+        if (event.final) break;
+        continue;
+      }
+      if (event.kind === "artifact-update") {
+        taskId = event.taskId;
+        contextId = event.contextId;
+        const artifactText = this._textFromParts(event.artifact.parts);
+        if (artifactText) {
+          resultText += (resultText ? "\n" : "") + artifactText;
+          this.config.onStreamUpdate?.({ type: "artifact", text: artifactText });
         }
       }
-    } finally {
-      reader.releaseLock();
     }
 
     return {
       text: resultText || `Skill "${req.skill}" completed by ${this.config.name}`,
-      isError: taskState === "failed",
+      isError: taskState === "failed" || taskState === "rejected",
       correlationId: req.correlationId,
       data: { taskId, contextId, taskState },
     };
+  }
+
+  private _textFromParts(parts: Array<{ kind: string; text?: string }>): string {
+    return parts
+      .filter((p): p is { kind: "text"; text: string } => p.kind === "text" && typeof p.text === "string")
+      .map(p => p.text)
+      .join("");
+  }
+
+  /**
+   * Build a Client with per-request trace headers. A new client per-call is
+   * the simplest way to inject correlationId/parentId via the fetch layer —
+   * ClientFactory / ClientConfig don't expose a per-call header hook.
+   * The agent card fetch is the only cacheable cost; we accept the overhead
+   * today and can add card-level caching in Phase 4.
+   */
+  private async _buildClient(correlationId: string, parentId?: string): Promise<Client> {
+    const baseUrl = this.config.url.replace(/\/a2a\/?$/, "");
+    const apiKey = this.config.apiKeyEnv ? (process.env[this.config.apiKeyEnv] ?? "") : "";
+    const timeoutMs = this.config.timeoutMs ?? 300_000;
+
+    const customFetch = buildFetch(apiKey, timeoutMs, correlationId, parentId);
+    const factory = new ClientFactory({
+      transports: [new JsonRpcTransportFactory({ fetchImpl: customFetch })],
+    });
+
+    try {
+      return await factory.createFromUrl(baseUrl);
+    } catch (err) {
+      // Fallback to legacy path — some servers still serve /.well-known/agent.json
+      // instead of the newer /.well-known/agent-card.json
+      try {
+        return await factory.createFromUrl(baseUrl, "/.well-known/agent.json");
+      } catch {
+        throw err;
+      }
+    }
   }
 
   private _buildText(req: SkillRequest): string {


### PR DESCRIPTION
## Summary

Replaces our hand-rolled JSON-RPC client in \`a2a-executor.ts\` with the official \`@a2a-js/sdk\`. Foundation for the 8-phase A2A protocol adoption.

**What changes:**
- Add \`@a2a-js/sdk@0.3.13\`
- Rewrite executor using \`ClientFactory.createFromUrl()\` + \`JsonRpcTransportFactory\` with custom fetch for API-key auth + trace headers
- Stream path consumes \`AsyncGenerator<A2AStreamEventData>\` instead of manual SSE parsing
- Fixes latent bug: we sent \`"message/sendStream"\` (should be \`"message/stream"\` per spec)

**What stays the same:**
- Same \`SkillResult\` shape: \`taskId\`, \`contextId\`, \`taskState\`
- Same trace header propagation (\`X-Correlation-Id\`, \`X-Parent-Id\`)
- Same \`contextId\` semantics for multi-turn

**Next phases (separate PRs):**
- Phase 2: long-running task primitives (\`getTask\` polling, \`resubscribeTask\`)
- Phase 3: push notification webhooks
- Phase 6: \`input-required\` → native HITL
- Phase 4: agent card auto-discovery
- Phase 5: artifact chunking
- Phase 7: workstacean as A2A server
- Phase 8: auth + extensions foundation

## Test plan
- [x] 506 tests pass
- [x] \`tsc --noEmit\` clean
- [ ] CI passes
- [ ] Smoke test: \`curl /api/a2a/chat -d '{"agent":"quinn",...}'\` matches prior behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)