### PR TITLE
feat(a2a): Phase 2 — long-running task primitives (getTask/cancelTask/resubscribeTask + TaskTracker)

### DIFF
--- a/src/executor/__tests__/task-tracker.test.ts
+++ b/src/executor/__tests__/task-tracker.test.ts
@@ -1,0 +1,180 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { TaskTracker } from "../task-tracker.ts";
+import type { A2AExecutor } from "../executors/a2a-executor.ts";
+import type { SkillResult } from "../types.ts";
+
+/** Minimal fake executor that lets tests drive pollTask responses. */
+function makeFakeExecutor(responses: SkillResult[] | (() => SkillResult)): A2AExecutor {
+  let idx = 0;
+  const nextResult = typeof responses === "function"
+    ? responses
+    : () => responses[Math.min(idx++, responses.length - 1)];
+  const fake = {
+    type: "a2a" as const,
+    execute: async () => ({ text: "", isError: false, correlationId: "" }),
+    pollTask: async () => nextResult(),
+    cancelTask: async () => ({ text: "canceled", isError: false, correlationId: "" }),
+    resubscribeTask: async () => { throw new Error("not used in tests"); },
+  };
+  // Cast — the tracker only needs pollTask, and A2AExecutor's private fields
+  // aren't part of the behavior being tested here.
+  return fake as unknown as A2AExecutor;
+}
+
+describe("TaskTracker", () => {
+  let bus: InMemoryEventBus;
+  let tracker: TaskTracker;
+  let received: Array<{ topic: string; payload: unknown }>;
+
+  beforeEach(() => {
+    bus = new InMemoryEventBus();
+    received = [];
+    bus.subscribe("agent.skill.response.#", "test-listener", (msg) => {
+      received.push({ topic: msg.topic, payload: msg.payload });
+    });
+  });
+
+  afterEach(() => {
+    tracker?.destroy();
+  });
+
+  test("publishes response when task reaches terminal state", async () => {
+    const executor = makeFakeExecutor([
+      { text: "still working", isError: false, correlationId: "c1", data: { taskState: "working", taskId: "t1", contextId: "ctx1" } },
+      { text: "all done", isError: false, correlationId: "c1", data: { taskState: "completed", taskId: "t1", contextId: "ctx1" } },
+    ]);
+
+    tracker = new TaskTracker({ bus, sweepIntervalMs: 30, defaultPollIntervalMs: 20 });
+    tracker.track({
+      correlationId: "c1",
+      taskId: "t1",
+      agentName: "quinn",
+      replyTopic: "agent.skill.response.c1",
+      executor,
+    });
+
+    // First sweep sees "working"; second sees "completed"
+    await new Promise(r => setTimeout(r, 90));
+
+    expect(received).toHaveLength(1);
+    expect(received[0].topic).toBe("agent.skill.response.c1");
+    expect((received[0].payload as { content: string }).content).toBe("all done");
+    expect(tracker.size).toBe(0);
+  });
+
+  test("surfaces failed state as error response", async () => {
+    const executor = makeFakeExecutor([
+      { text: "kaboom", isError: true, correlationId: "c1", data: { taskState: "failed", taskId: "t1" } },
+    ]);
+
+    tracker = new TaskTracker({ bus, sweepIntervalMs: 20, defaultPollIntervalMs: 10 });
+    tracker.track({
+      correlationId: "c1", taskId: "t1", agentName: "quinn",
+      replyTopic: "agent.skill.response.c1", executor,
+    });
+
+    await new Promise(r => setTimeout(r, 60));
+    expect(received).toHaveLength(1);
+    expect((received[0].payload as { error: string }).error).toBe("kaboom");
+    expect(tracker.size).toBe(0);
+  });
+
+  test("respects pollIntervalMs — doesn't poll on every sweep", async () => {
+    let polls = 0;
+    const executor = makeFakeExecutor(() => {
+      polls++;
+      return { text: "still going", isError: false, correlationId: "c1", data: { taskState: "working", taskId: "t1" } };
+    });
+
+    tracker = new TaskTracker({ bus, sweepIntervalMs: 20, defaultPollIntervalMs: 200 });
+    tracker.track({
+      correlationId: "c1", taskId: "t1", agentName: "quinn",
+      replyTopic: "agent.skill.response.c1", executor,
+    });
+
+    // 100ms: sweeps run 5 times (20ms each) but poll only fires once (200ms interval)
+    await new Promise(r => setTimeout(r, 100));
+    expect(polls).toBeLessThanOrEqual(2);
+  });
+
+  test("ages out tasks past maxTrackingMs with timeout error", async () => {
+    const executor = makeFakeExecutor([
+      { text: "still going", isError: false, correlationId: "c1", data: { taskState: "working", taskId: "t1" } },
+    ]);
+
+    tracker = new TaskTracker({ bus, sweepIntervalMs: 20, defaultPollIntervalMs: 10, maxTrackingMs: 50 });
+    tracker.track({
+      correlationId: "c1", taskId: "t1", agentName: "quinn",
+      replyTopic: "agent.skill.response.c1", executor,
+    });
+
+    await new Promise(r => setTimeout(r, 120));
+    expect(received).toHaveLength(1);
+    expect((received[0].payload as { error: string }).error).toMatch(/timeout/i);
+    expect(tracker.size).toBe(0);
+  });
+
+  test("untrack removes task without publishing", async () => {
+    const executor = makeFakeExecutor([
+      { text: "completed", isError: false, correlationId: "c1", data: { taskState: "completed", taskId: "t1" } },
+    ]);
+
+    tracker = new TaskTracker({ bus, sweepIntervalMs: 50, defaultPollIntervalMs: 30 });
+    tracker.track({
+      correlationId: "c1", taskId: "t1", agentName: "quinn",
+      replyTopic: "agent.skill.response.c1", executor,
+    });
+    tracker.untrack("c1");
+
+    await new Promise(r => setTimeout(r, 80));
+    expect(received).toHaveLength(0);
+    expect(tracker.size).toBe(0);
+  });
+
+  test("concurrent tasks stay isolated", async () => {
+    const executor = makeFakeExecutor(() => ({
+      text: "done", isError: false, correlationId: "", data: { taskState: "completed", taskId: "t" },
+    }));
+
+    tracker = new TaskTracker({ bus, sweepIntervalMs: 20, defaultPollIntervalMs: 10 });
+    for (let i = 0; i < 5; i++) {
+      tracker.track({
+        correlationId: `c${i}`, taskId: `t${i}`, agentName: "quinn",
+        replyTopic: `agent.skill.response.c${i}`, executor,
+      });
+    }
+
+    await new Promise(r => setTimeout(r, 80));
+    expect(received).toHaveLength(5);
+    const topics = received.map(r => r.topic).sort();
+    expect(topics).toEqual([
+      "agent.skill.response.c0",
+      "agent.skill.response.c1",
+      "agent.skill.response.c2",
+      "agent.skill.response.c3",
+      "agent.skill.response.c4",
+    ]);
+  });
+
+  test("poll failures don't crash the sweep", async () => {
+    const executor = {
+      type: "a2a" as const,
+      execute: async () => ({ text: "", isError: false, correlationId: "" }),
+      pollTask: async () => { throw new Error("network blip"); },
+      cancelTask: async () => ({ text: "", isError: false, correlationId: "" }),
+      resubscribeTask: async () => { throw new Error("not used"); },
+    } as unknown as A2AExecutor;
+
+    tracker = new TaskTracker({ bus, sweepIntervalMs: 20, defaultPollIntervalMs: 10 });
+    tracker.track({
+      correlationId: "c1", taskId: "t1", agentName: "quinn",
+      replyTopic: "agent.skill.response.c1", executor,
+    });
+
+    await new Promise(r => setTimeout(r, 80));
+    // Task still tracked (no terminal state seen); no response published
+    expect(received).toHaveLength(0);
+    expect(tracker.size).toBe(1);
+  });
+});

--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -108,6 +108,72 @@ export class A2AExecutor implements IExecutor {
   }
 
   /**
+   * Poll a task for its current state. Used by TaskTracker to check progress
+   * on long-running tasks without blocking the executor loop.
+   */
+  async pollTask(taskId: string, correlationId: string, parentId?: string): Promise<SkillResult> {
+    try {
+      const client = await this._buildClient(correlationId, parentId);
+      const task = await client.getTask({ id: taskId });
+      const artifactText = (task.artifacts ?? [])
+        .flatMap(a => a.parts)
+        .filter((p): p is { kind: "text"; text: string } => p.kind === "text" && typeof p.text === "string")
+        .map(p => p.text)
+        .join("\n");
+      const statusText = task.status.message ? this._textFromParts(task.status.message.parts) : "";
+      return {
+        text: artifactText || statusText || "",
+        isError: task.status.state === "failed" || task.status.state === "rejected",
+        correlationId,
+        data: { taskId: task.id, contextId: task.contextId, taskState: task.status.state },
+      };
+    } catch (err) {
+      return {
+        text: err instanceof Error ? err.message : String(err),
+        isError: true,
+        correlationId,
+      };
+    }
+  }
+
+  /**
+   * Cancel an in-flight task. Idempotent: already-terminal tasks throw
+   * TaskNotCancelableError which we surface as isError.
+   */
+  async cancelTask(taskId: string, correlationId: string, parentId?: string): Promise<SkillResult> {
+    try {
+      const client = await this._buildClient(correlationId, parentId);
+      const task = await client.cancelTask({ id: taskId });
+      return {
+        text: `Task ${taskId} canceled`,
+        isError: false,
+        correlationId,
+        data: { taskId: task.id, contextId: task.contextId, taskState: task.status.state },
+      };
+    } catch (err) {
+      return {
+        text: err instanceof Error ? err.message : String(err),
+        isError: true,
+        correlationId,
+      };
+    }
+  }
+
+  /**
+   * Resubscribe to a task's SSE stream after connection drops. Yields events
+   * just like sendMessageStream; TaskTracker can prefer this over polling
+   * when the agent card says capabilities.streaming: true.
+   */
+  async resubscribeTask(
+    taskId: string,
+    correlationId: string,
+    parentId?: string,
+  ): Promise<AsyncGenerator<Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent, void, undefined>> {
+    const client = await this._buildClient(correlationId, parentId);
+    return client.resubscribeTask({ id: taskId });
+  }
+
+  /**
    * Non-streaming path: client.sendMessage returns Message | Task.
    */
   private async _executeBlocking(

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -21,6 +21,10 @@ import { GraphitiClient } from "../../lib/memory/graphiti-client.ts";
 import { IdentityRegistry } from "../../lib/identity/identity-registry.ts";
 import type { LoggerPlugin, ConversationTurn } from "../../lib/plugins/logger.ts";
 import { ContextMailbox } from "../../lib/dm/context-mailbox.ts";
+import type { TaskTracker } from "./task-tracker.ts";
+import type { A2AExecutor } from "./executors/a2a-executor.ts";
+
+const WORKING_STATES = new Set(["submitted", "working"]);
 
 /**
  * Assemble a structured context envelope for the agent prompt.
@@ -95,6 +99,7 @@ export class SkillDispatcherPlugin implements Plugin {
   private readonly identityRegistry: IdentityRegistry;
   private readonly loggerPlugin: LoggerPlugin | undefined;
   private readonly mailbox: ContextMailbox | undefined;
+  private readonly taskTracker: TaskTracker | undefined;
 
   /**
    * In-flight execution tracking — set at the TOP of _dispatch() (before any
@@ -113,11 +118,14 @@ export class SkillDispatcherPlugin implements Plugin {
     loggerPlugin?: LoggerPlugin,
     /** Optional mailbox for mid-execution DM queuing. */
     mailbox?: ContextMailbox,
+    /** Optional tracker for long-running A2A tasks. */
+    taskTracker?: TaskTracker,
   ) {
     this.graphiti = graphiti ?? new GraphitiClient();
     this.identityRegistry = new IdentityRegistry(workspaceDir);
     this.loggerPlugin = loggerPlugin;
     this.mailbox = mailbox;
+    this.taskTracker = taskTracker;
   }
 
   /** Check if an execution is currently active for a given correlationId. */
@@ -283,6 +291,39 @@ export class SkillDispatcherPlugin implements Plugin {
 
     try {
       const result = await executor.execute(req);
+
+      // Long-running A2A task — agent returned non-terminal state with a taskId.
+      // Hand off to TaskTracker; dispatcher exits without publishing response.
+      // Tracker will publish to replyTopic once the task reaches terminal state.
+      const taskState = result.data?.taskState;
+      const taskId = result.data?.taskId;
+      if (
+        this.taskTracker
+        && !result.isError
+        && taskState
+        && typeof taskState === "string"
+        && WORKING_STATES.has(taskState)
+        && taskId
+        && executor.type === "a2a"
+      ) {
+        this.taskTracker.track({
+          correlationId,
+          taskId,
+          agentName: targets[0] ?? "unknown",
+          replyTopic,
+          executor: executor as A2AExecutor,
+          parentId,
+        });
+        this._publishFlowEvent("flow.item.updated", {
+          id: flowItemId,
+          status: "active",
+          stage: "running",
+          meta: { skill, taskId, taskState, trackedBy: "task-tracker" },
+        });
+        // Don't publish a response — tracker will do it. Still fall through to
+        // finally block so activeExecutions gets cleaned up.
+        return;
+      }
 
       if (result.isError) {
         console.error(

--- a/src/executor/task-tracker.ts
+++ b/src/executor/task-tracker.ts
@@ -1,0 +1,162 @@
+/**
+ * TaskTracker — tracks long-running A2A tasks that returned non-terminal state.
+ *
+ * When an A2AExecutor gets a task back in "working" or "submitted" state
+ * (i.e., the agent is still processing and hasn't returned a final result),
+ * the dispatcher hands it to the tracker. The tracker polls each task
+ * periodically and, when the state becomes terminal, publishes the final
+ * response to the original reply topic.
+ *
+ * This closes the "5 min timeout → dropped result" gap without changing
+ * the bus-facing dispatch contract: callers still receive exactly one
+ * response on the reply topic, just later.
+ */
+
+import type { EventBus } from "../../lib/types.ts";
+import type { A2AExecutor } from "./executors/a2a-executor.ts";
+import type { AgentSkillResponsePayload } from "../event-bus/payloads.ts";
+
+const TERMINAL_STATES = new Set(["completed", "failed", "canceled", "rejected"]);
+
+export interface TrackedTask {
+  correlationId: string;
+  taskId: string;
+  agentName: string;
+  replyTopic: string;
+  executor: A2AExecutor;
+  parentId?: string;
+  registeredAt: number;
+  lastPolledAt: number;
+  pollIntervalMs: number;
+}
+
+export interface TaskTrackerOptions {
+  /** Event bus — tracker publishes responses here on terminal state. */
+  bus: EventBus;
+  /** How often to sweep the task map (ms). Default: 10s. */
+  sweepIntervalMs?: number;
+  /** Default per-task poll interval (ms). Default: 30s. */
+  defaultPollIntervalMs?: number;
+  /** Max time to track a task before giving up (ms). Default: 1hr. */
+  maxTrackingMs?: number;
+}
+
+export class TaskTracker {
+  private readonly tasks = new Map<string, TrackedTask>();
+  private readonly bus: EventBus;
+  private readonly sweepIntervalMs: number;
+  private readonly defaultPollIntervalMs: number;
+  private readonly maxTrackingMs: number;
+  private readonly sweepTimer: ReturnType<typeof setInterval>;
+
+  constructor(opts: TaskTrackerOptions) {
+    this.bus = opts.bus;
+    this.sweepIntervalMs = opts.sweepIntervalMs ?? 10_000;
+    this.defaultPollIntervalMs = opts.defaultPollIntervalMs ?? 30_000;
+    this.maxTrackingMs = opts.maxTrackingMs ?? 60 * 60_000;
+    this.sweepTimer = setInterval(() => { void this._sweep(); }, this.sweepIntervalMs);
+    this.sweepTimer.unref?.();
+  }
+
+  /** Register a task for tracking. Dispatcher calls this after executor returns working. */
+  track(params: {
+    correlationId: string;
+    taskId: string;
+    agentName: string;
+    replyTopic: string;
+    executor: A2AExecutor;
+    parentId?: string;
+    pollIntervalMs?: number;
+  }): void {
+    const now = Date.now();
+    this.tasks.set(params.correlationId, {
+      correlationId: params.correlationId,
+      taskId: params.taskId,
+      agentName: params.agentName,
+      replyTopic: params.replyTopic,
+      executor: params.executor,
+      parentId: params.parentId,
+      registeredAt: now,
+      lastPolledAt: now,
+      pollIntervalMs: params.pollIntervalMs ?? this.defaultPollIntervalMs,
+    });
+    console.log(
+      `[task-tracker] Tracking ${params.agentName} task ${params.taskId.slice(0, 8)}… (correlationId: ${params.correlationId.slice(0, 8)}…)`,
+    );
+  }
+
+  /** Stop tracking a task (e.g., on cancel). */
+  untrack(correlationId: string): void {
+    this.tasks.delete(correlationId);
+  }
+
+  /** Get snapshot of currently-tracked tasks — for API endpoint. */
+  getAll(): TrackedTask[] {
+    return Array.from(this.tasks.values());
+  }
+
+  get size(): number {
+    return this.tasks.size;
+  }
+
+  destroy(): void {
+    clearInterval(this.sweepTimer);
+    this.tasks.clear();
+  }
+
+  /**
+   * Sweep all tracked tasks. For each due (lastPolledAt + pollIntervalMs < now),
+   * fetch its current state. On terminal: publish response, untrack. On stuck
+   * past maxTrackingMs: publish timeout response, untrack.
+   */
+  private async _sweep(): Promise<void> {
+    const now = Date.now();
+
+    for (const task of this.tasks.values()) {
+      // Age-out: task has been working for too long
+      if (now - task.registeredAt > this.maxTrackingMs) {
+        this._publishResponse(task, undefined, `Task tracking timeout (>${Math.round(this.maxTrackingMs / 60_000)}min)`);
+        this.tasks.delete(task.correlationId);
+        continue;
+      }
+
+      // Not yet due
+      if (now - task.lastPolledAt < task.pollIntervalMs) continue;
+
+      task.lastPolledAt = now;
+
+      try {
+        const result = await task.executor.pollTask(task.taskId, task.correlationId, task.parentId);
+        const state = result.data?.taskState;
+
+        if (state && TERMINAL_STATES.has(state)) {
+          this._publishResponse(task, result.text, result.isError ? result.text : undefined);
+          this.tasks.delete(task.correlationId);
+          console.log(
+            `[task-tracker] Task ${task.taskId.slice(0, 8)}… reached terminal state "${state}" after ${Math.round((now - task.registeredAt) / 1000)}s`,
+          );
+        }
+      } catch (err) {
+        console.warn(
+          `[task-tracker] poll failed for ${task.taskId.slice(0, 8)}…:`,
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+  }
+
+  private _publishResponse(task: TrackedTask, content: string | undefined, error: string | undefined): void {
+    const payload: AgentSkillResponsePayload = {
+      content,
+      error,
+      correlationId: task.correlationId,
+    };
+    this.bus.publish(task.replyTopic, {
+      id: crypto.randomUUID(),
+      correlationId: task.correlationId,
+      topic: task.replyTopic,
+      timestamp: Date.now(),
+      payload,
+    });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,10 @@ const bus = new InMemoryEventBus();
 import { ContextMailbox } from "../lib/dm/context-mailbox.ts";
 const contextMailbox = new ContextMailbox();
 
+// --- Task tracker — tracks long-running A2A tasks that returned non-terminal state ---
+import { TaskTracker } from "./executor/task-tracker.ts";
+const taskTracker = new TaskTracker({ bus });
+
 // --- ChannelRegistry — loaded from workspace/channels.yaml, shared by RouterPlugin + DiscordPlugin ---
 import { ChannelRegistry } from "../lib/channels/channel-registry.js";
 const channelRegistry = new ChannelRegistry(join(workspaceDir, "channels.yaml"));
@@ -252,7 +256,7 @@ const pluginRegistry: PluginRegistryEntry[] = [
     condition: () => true,
     factory: async () => {
       const { SkillDispatcherPlugin } = await import("./executor/skill-dispatcher-plugin.js");
-      return new SkillDispatcherPlugin(executorRegistry, workspaceDir, undefined, loggerPlugin, contextMailbox);
+      return new SkillDispatcherPlugin(executorRegistry, workspaceDir, undefined, loggerPlugin, contextMailbox, taskTracker);
     },
   },
   {


### PR DESCRIPTION
## Summary

Closes the "5-min timeout → dropped result" gap for long-running A2A delegations. Agents that return a non-terminal task state (\`working\`, \`submitted\`) now get handed off to a TaskTracker that polls them in the background and publishes the response when they complete.

**A2AExecutor additions:**
- \`pollTask(taskId)\` — SDK's \`Client.getTask\`
- \`cancelTask(taskId)\` — idempotent
- \`resubscribeTask(taskId)\` — AsyncGenerator for SSE reconnect

**New: \`src/executor/task-tracker.ts\`**
- \`Map<correlationId, TrackedTask>\` with periodic sweep (default 10s)
- Per-task poll interval (default 30s)
- Terminal-state detection → publishes response to original \`replyTopic\`
- Stuck tasks time out after \`maxTrackingMs\` (default 1hr)

**Dispatcher rewiring:**
- On non-terminal A2A result with a \`taskId\`: tracker takes over, dispatcher returns without publishing
- flow.item stage updates to \`running\` with \`trackedBy: task-tracker\`

**Wiring:**
- Single \`TaskTracker\` instance in \`src/index.ts\` shared with dispatcher

## Test plan
- [x] 7 new tracker tests: terminal state, failures, poll intervals, timeouts, concurrent isolation, poll-crash recovery
- [x] 513 total tests pass
- [x] tsc clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)