### PR TITLE
feat(a2a): Phase 3 — push notification webhooks (/api/a2a/callback/:taskId)

### DIFF
--- a/src/api/__tests__/a2a-callback.test.ts
+++ b/src/api/__tests__/a2a-callback.test.ts
@@ -1,0 +1,158 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { TaskTracker } from "../../executor/task-tracker.ts";
+import type { A2AExecutor } from "../../executor/executors/a2a-executor.ts";
+import { createRoutes } from "../a2a-callback.ts";
+import type { ApiContext } from "../types.ts";
+
+function fakeExecutor(): A2AExecutor {
+  return {
+    type: "a2a",
+    execute: async () => ({ text: "", isError: false, correlationId: "" }),
+    pollTask: async () => ({ text: "", isError: false, correlationId: "", data: { taskState: "working" } }),
+    cancelTask: async () => ({ text: "", isError: false, correlationId: "" }),
+    resubscribeTask: async () => { throw new Error("not used"); },
+    registerPushNotification: async () => false,
+  } as unknown as A2AExecutor;
+}
+
+describe("/api/a2a/callback/:taskId", () => {
+  let bus: InMemoryEventBus;
+  let tracker: TaskTracker;
+  let handler: (req: Request, params: Record<string, string>) => Promise<Response> | Response;
+  let received: Array<{ topic: string; payload: unknown }>;
+  const ctx = { taskTracker: undefined } as unknown as ApiContext;
+
+  beforeEach(() => {
+    bus = new InMemoryEventBus();
+    received = [];
+    bus.subscribe("agent.skill.response.#", "test", (msg) => {
+      received.push({ topic: msg.topic, payload: msg.payload });
+    });
+    tracker = new TaskTracker({ bus, sweepIntervalMs: 60_000, defaultPollIntervalMs: 60_000 });
+    const routes = createRoutes(tracker, ctx);
+    const route = routes[0];
+    handler = route.handler;
+  });
+
+  afterEach(() => {
+    tracker.destroy();
+  });
+
+  test("404 for unknown taskId", async () => {
+    const req = new Request("http://x/api/a2a/callback/unknown", { method: "POST", body: "{}" });
+    const resp = await handler(req, { taskId: "unknown" });
+    expect(resp.status).toBe(404);
+  });
+
+  test("401 when token missing or wrong", async () => {
+    tracker.track({
+      correlationId: "c1", taskId: "t1", agentName: "quinn",
+      replyTopic: "agent.skill.response.c1", executor: fakeExecutor(), callbackToken: "secret",
+    });
+
+    // No token
+    const r1 = await handler(
+      new Request("http://x/api/a2a/callback/t1", { method: "POST", body: JSON.stringify({}) }),
+      { taskId: "t1" },
+    );
+    expect(r1.status).toBe(401);
+
+    // Wrong token
+    const r2 = await handler(
+      new Request("http://x/api/a2a/callback/t1", {
+        method: "POST",
+        headers: { "x-a2a-notification-token": "wrong" },
+        body: JSON.stringify({}),
+      }),
+      { taskId: "t1" },
+    );
+    expect(r2.status).toBe(401);
+  });
+
+  test("200 + publishes response on terminal Task callback (via X-A2A-Notification-Token)", async () => {
+    tracker.track({
+      correlationId: "c1", taskId: "t1", agentName: "quinn",
+      replyTopic: "agent.skill.response.c1", executor: fakeExecutor(), callbackToken: "secret",
+    });
+
+    const body = {
+      id: "t1",
+      kind: "task",
+      status: { state: "completed" },
+      artifacts: [{ artifactId: "a1", parts: [{ kind: "text", text: "all good" }] }],
+    };
+    const resp = await handler(
+      new Request("http://x/api/a2a/callback/t1", {
+        method: "POST",
+        headers: { "x-a2a-notification-token": "secret", "content-type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+      { taskId: "t1" },
+    );
+    expect(resp.status).toBe(200);
+    expect(received).toHaveLength(1);
+    expect((received[0].payload as { content: string }).content).toBe("all good");
+    expect(tracker.size).toBe(0);
+  });
+
+  test("accepts Bearer token as alternative", async () => {
+    tracker.track({
+      correlationId: "c1", taskId: "t1", agentName: "quinn",
+      replyTopic: "agent.skill.response.c1", executor: fakeExecutor(), callbackToken: "secret",
+    });
+
+    const body = { id: "t1", kind: "task", status: { state: "completed" } };
+    const resp = await handler(
+      new Request("http://x/api/a2a/callback/t1", {
+        method: "POST",
+        headers: { authorization: "Bearer secret", "content-type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+      { taskId: "t1" },
+    );
+    expect(resp.status).toBe(200);
+  });
+
+  test("non-terminal callback just updates lastPolledAt, no publish", async () => {
+    tracker.track({
+      correlationId: "c1", taskId: "t1", agentName: "quinn",
+      replyTopic: "agent.skill.response.c1", executor: fakeExecutor(), callbackToken: "secret",
+    });
+
+    const body = { id: "t1", kind: "task", status: { state: "working" } };
+    const resp = await handler(
+      new Request("http://x/api/a2a/callback/t1", {
+        method: "POST",
+        headers: { "x-a2a-notification-token": "secret" },
+        body: JSON.stringify(body),
+      }),
+      { taskId: "t1" },
+    );
+    expect(resp.status).toBe(200);
+    expect(received).toHaveLength(0);
+    expect(tracker.size).toBe(1);
+  });
+
+  test("failed state surfaces as error in published response", async () => {
+    tracker.track({
+      correlationId: "c1", taskId: "t1", agentName: "quinn",
+      replyTopic: "agent.skill.response.c1", executor: fakeExecutor(), callbackToken: "secret",
+    });
+
+    const body = {
+      id: "t1", kind: "task",
+      status: { state: "failed", message: { parts: [{ kind: "text", text: "kaboom" }] } },
+    };
+    await handler(
+      new Request("http://x/api/a2a/callback/t1", {
+        method: "POST",
+        headers: { "x-a2a-notification-token": "secret" },
+        body: JSON.stringify(body),
+      }),
+      { taskId: "t1" },
+    );
+    expect(received).toHaveLength(1);
+    expect((received[0].payload as { error: string }).error).toBe("kaboom");
+  });
+});

--- a/src/api/a2a-callback.ts
+++ b/src/api/a2a-callback.ts
@@ -1,0 +1,68 @@
+/**
+ * A2A push notification callback — webhook endpoint for long-running tasks.
+ *
+ * External agents POST Task snapshots here when they reach terminal state
+ * (or at configurable checkpoints). This closes the loop without requiring
+ * workstacean to hold an HTTP connection open for minutes.
+ *
+ * Flow:
+ *   1. A2AExecutor registers a PushNotificationConfig with the agent when
+ *      dispatching a task: { url: WORKSTACEAN_BASE_URL/api/a2a/callback/{taskId},
+ *      token: random-per-task-secret }
+ *   2. Agent POSTs Task JSON here with Bearer token
+ *   3. We verify token, look up task in TaskTracker, publish response to
+ *      original replyTopic
+ *
+ * Security: token is a per-task HMAC-unguessable shared secret. Without the
+ * right token the request is dropped. Broken callbacks don't surface to agents
+ * (they're not expected to retry here).
+ */
+
+import type { Route, ApiContext } from "./types.ts";
+import type { TaskTracker } from "../executor/task-tracker.ts";
+
+export function createRoutes(tracker: TaskTracker, _ctx: ApiContext): Route[] {
+  return [
+    {
+      method: "POST",
+      path: "/api/a2a/callback/:taskId",
+      handler: async (req, params) => {
+        const taskId = params.taskId;
+        if (!taskId) {
+          return Response.json({ success: false, error: "taskId required" }, { status: 400 });
+        }
+
+        // Token from Authorization: Bearer <token> OR X-A2A-Notification-Token header.
+        // A2A spec uses X-A2A-Notification-Token for the unauthenticated case.
+        const authHeader = req.headers.get("authorization") ?? "";
+        const bearer = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+        const notifToken = req.headers.get("x-a2a-notification-token") ?? "";
+        const providedToken = bearer || notifToken;
+
+        const tracked = tracker.getAll().find(t => t.taskId === taskId);
+        if (!tracked) {
+          return Response.json({ success: false, error: "Unknown taskId" }, { status: 404 });
+        }
+
+        const expectedToken = tracker.getCallbackToken(tracked.correlationId);
+        if (!expectedToken || providedToken !== expectedToken) {
+          return Response.json({ success: false, error: "Invalid notification token" }, { status: 401 });
+        }
+
+        let body: Record<string, unknown>;
+        try {
+          body = (await req.json()) as Record<string, unknown>;
+        } catch {
+          return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 });
+        }
+
+        // The A2A spec says the webhook receives the full Task object (not a delta).
+        // We route it through the tracker so terminal-state handling is identical
+        // to the polling path.
+        tracker.handleCallback(tracked.correlationId, body);
+
+        return Response.json({ success: true });
+      },
+    },
+  ];
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -16,6 +16,7 @@ import { createRoutes as avaToolRoutes } from "./ava-tools.ts";
 import { createRoutes as boardRoutes } from "./board.ts";
 import { createRoutes as mailboxRoutes } from "./mailbox.ts";
 import { createRoutes as discordRoutes } from "./discord.ts";
+import { createRoutes as a2aCallbackRoutes } from "./a2a-callback.ts";
 
 export { matchPath } from "./types.ts";
 export type { Route, ApiContext } from "./types.ts";
@@ -31,5 +32,6 @@ export function createAllRoutes(ctx: ApiContext): Route[] {
     ...boardRoutes(ctx),
     ...(ctx.mailbox ? mailboxRoutes(ctx.mailbox, ctx) : []),
     ...discordRoutes(ctx),
+    ...(ctx.taskTracker ? a2aCallbackRoutes(ctx.taskTracker, ctx) : []),
   ];
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -12,6 +12,7 @@ import type { Plugin, EventBus } from "../../lib/types.ts";
 import type { ExecutorRegistry } from "../executor/executor-registry.ts";
 import type { TelemetryService } from "../telemetry/telemetry-service.ts";
 import type { ContextMailbox } from "../../lib/dm/context-mailbox.ts";
+import type { TaskTracker } from "../executor/task-tracker.ts";
 
 export type Params = Record<string, string>;
 export type RouteHandler = (req: Request, params: Params) => Response | Promise<Response>;
@@ -34,6 +35,7 @@ export interface ApiContext {
   telemetry?: TelemetryService;
   apiKey?: string;
   mailbox?: ContextMailbox;
+  taskTracker?: TaskTracker;
 }
 
 /** Match a path against a pattern like "/api/foo/:id/run". Returns params or null. */

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -62,6 +62,8 @@ export const EnvSchema = z
     DM_DEBOUNCE_MS:               z.string().optional(),
     /** TTL (ms) for pending mailbox messages before they're swept (default: 10 min). */
     MAILBOX_TTL_MS:               z.string().optional(),
+    /** Public URL of workstacean API — used by A2A push-notification webhooks (e.g. http://workstacean:3000). */
+    WORKSTACEAN_BASE_URL:         z.string().optional(),
 
     // GitHub
     GITHUB_TOKEN:          z.string().optional(),

--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -33,6 +33,21 @@ export interface A2AAgentConfig {
   streaming?: boolean;
   /** Callback for intermediate streaming updates (e.g. publish to bus). */
   onStreamUpdate?: (update: { type: string; text?: string; state?: string }) => void;
+  /**
+   * Public base URL of the workstacean API server (e.g. http://workstacean:3000
+   * on the docker network). Required to register push notification webhooks.
+   * If unset, push notifications are skipped and we fall back to polling.
+   */
+  callbackBaseUrl?: string;
+}
+
+export interface ExecuteOptions {
+  /**
+   * If provided and the agent supports push notifications, the executor
+   * registers a push-notification config pointing at this taskId + token
+   * so the agent can POST task updates back via /api/a2a/callback/:taskId.
+   */
+  callback?: { taskId: string; token: string };
 }
 
 /**
@@ -104,6 +119,32 @@ export class A2AExecutor implements IExecutor {
         isError: true,
         correlationId: req.correlationId,
       };
+    }
+  }
+
+  /**
+   * Register a push-notification webhook for a task. Agent will POST Task
+   * snapshots to the URL with the given token in X-A2A-Notification-Token
+   * when the task state changes. Silently no-ops if the agent doesn't
+   * support push notifications (we fall back to polling).
+   */
+  async registerPushNotification(
+    taskId: string,
+    callbackUrl: string,
+    token: string,
+    correlationId: string,
+    parentId?: string,
+  ): Promise<boolean> {
+    try {
+      const client = await this._buildClient(correlationId, parentId);
+      await client.setTaskPushNotificationConfig({
+        taskId,
+        pushNotificationConfig: { url: callbackUrl, token },
+      });
+      return true;
+    } catch {
+      // Agent doesn't support push notifications — tracker falls back to polling
+      return false;
     }
   }
 

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -306,14 +306,30 @@ export class SkillDispatcherPlugin implements Plugin {
         && taskId
         && executor.type === "a2a"
       ) {
+        const a2aExecutor = executor as A2AExecutor;
+        const callbackToken = crypto.randomUUID();
         this.taskTracker.track({
           correlationId,
           taskId,
           agentName: targets[0] ?? "unknown",
           replyTopic,
-          executor: executor as A2AExecutor,
+          executor: a2aExecutor,
           parentId,
+          callbackToken,
         });
+
+        // Try to register a push-notification webhook so the agent can POST
+        // completion back instead of us polling. Falls back to polling silently.
+        const callbackBaseUrl = process.env.WORKSTACEAN_BASE_URL;
+        if (callbackBaseUrl) {
+          const callbackUrl = `${callbackBaseUrl.replace(/\/$/, "")}/api/a2a/callback/${encodeURIComponent(taskId)}`;
+          void a2aExecutor.registerPushNotification(taskId, callbackUrl, callbackToken, correlationId, parentId)
+            .then(ok => {
+              if (ok) console.log(`[skill-dispatcher] Push-notification registered for ${taskId.slice(0, 8)}…`);
+            })
+            .catch(err => console.debug("[skill-dispatcher] push-notification register failed:", err));
+        }
+
         this._publishFlowEvent("flow.item.updated", {
           id: flowItemId,
           status: "active",

--- a/src/executor/task-tracker.ts
+++ b/src/executor/task-tracker.ts
@@ -28,6 +28,8 @@ export interface TrackedTask {
   registeredAt: number;
   lastPolledAt: number;
   pollIntervalMs: number;
+  /** Per-task secret for authenticating push-notification callbacks. */
+  callbackToken?: string;
 }
 
 export interface TaskTrackerOptions {
@@ -67,6 +69,8 @@ export class TaskTracker {
     executor: A2AExecutor;
     parentId?: string;
     pollIntervalMs?: number;
+    /** Per-task token for authenticating push callbacks. Generated if omitted. */
+    callbackToken?: string;
   }): void {
     const now = Date.now();
     this.tasks.set(params.correlationId, {
@@ -79,9 +83,54 @@ export class TaskTracker {
       registeredAt: now,
       lastPolledAt: now,
       pollIntervalMs: params.pollIntervalMs ?? this.defaultPollIntervalMs,
+      callbackToken: params.callbackToken ?? crypto.randomUUID(),
     });
     console.log(
       `[task-tracker] Tracking ${params.agentName} task ${params.taskId.slice(0, 8)}… (correlationId: ${params.correlationId.slice(0, 8)}…)`,
+    );
+  }
+
+  /** Look up the callback token for a tracked task. Used by the webhook route. */
+  getCallbackToken(correlationId: string): string | undefined {
+    return this.tasks.get(correlationId)?.callbackToken;
+  }
+
+  /**
+   * Handle an incoming push notification. Body is the A2A Task object.
+   * If the task is terminal, we publish the response and untrack. Otherwise
+   * we update lastPolledAt so the polling loop gives the task more time.
+   */
+  handleCallback(correlationId: string, body: Record<string, unknown>): void {
+    const task = this.tasks.get(correlationId);
+    if (!task) return;
+
+    const status = (body.status ?? {}) as { state?: string; message?: { parts?: Array<{ kind?: string; text?: string }> } };
+    const state = typeof status.state === "string" ? status.state : undefined;
+
+    task.lastPolledAt = Date.now();
+
+    if (!state || !TERMINAL_STATES.has(state)) {
+      // Non-terminal update — just refresh the polled timestamp
+      return;
+    }
+
+    // Extract text from artifacts (primary) or status.message (fallback)
+    const artifacts = (body.artifacts ?? []) as Array<{ parts?: Array<{ kind?: string; text?: string }> }>;
+    const artifactText = artifacts
+      .flatMap(a => a.parts ?? [])
+      .filter((p): p is { kind: "text"; text: string } => p.kind === "text" && typeof p.text === "string")
+      .map(p => p.text)
+      .join("\n");
+    const statusText = status.message?.parts
+      ? status.message.parts.filter(p => p.kind === "text").map(p => p.text ?? "").join("")
+      : "";
+    const content = artifactText || statusText;
+    const isError = state === "failed" || state === "rejected";
+
+    this._publishResponse(task, isError ? undefined : content, isError ? (content || state) : undefined);
+    this.tasks.delete(correlationId);
+    console.log(
+      `[task-tracker] Callback for ${task.taskId.slice(0, 8)}… → terminal state "${state}" (via webhook)`,
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -512,6 +512,7 @@ const apiContext: ApiContext = {
   telemetry,
   apiKey: API_KEY,
   mailbox: contextMailbox,
+  taskTracker,
 };
 
 const routes = createAllRoutes(apiContext);


### PR DESCRIPTION
## Summary

Long-running A2A agents can now POST completion back instead of us polling. Per-task token auth via X-A2A-Notification-Token or Authorization: Bearer.

**New:**
- \`POST /api/a2a/callback/:taskId\` — receives A2A Task snapshot, verifies token, forwards to TaskTracker
- \`TaskTracker.handleCallback(correlationId, body)\` — terminal-state publish
- \`A2AExecutor.registerPushNotification(taskId, url, token, ...)\` — SDK's setTaskPushNotificationConfig
- Dispatcher auto-registers webhook when handing off to tracker (if \`WORKSTACEAN_BASE_URL\` set)

**Security:**
- Per-task token from crypto.randomUUID at track time
- Wrong/missing → 401
- Unknown taskId → 404

## Test plan
- [x] 6 new callback route tests: 404/401/200, Bearer, non-terminal, failed-state
- [x] 519 total tests pass
- [x] tsc clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)