### PR TITLE
feat(a2a): Phases 4-8 — card discovery, chunking, HITL, server, auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,12 +166,30 @@ Copy `*.example` counterparts to bootstrap a new deployment.
 | `GET` | `/api/incidents` | Security incident list |
 | `POST` | `/api/incidents` | Report a new incident |
 | `POST` | `/api/incidents/:id/resolve` | Resolve an incident |
+| `GET` | `/.well-known/agent-card.json` | A2A agent card — discovery for external agents |
+| `POST` | `/a2a` | A2A JSON-RPC 2.0 endpoint (message/send, message/stream, tasks/*) |
+| `POST` | `/api/a2a/callback/:taskId` | Push-notification webhook for long-running A2A tasks |
+
+Full reference: [`docs/reference/http-api.md`](docs/reference/http-api.md).
+
+---
+
+## A2A protocol support
+
+protoWorkstacean is a first-class [A2A](https://a2a-protocol.org) client **and** server, built on [`@a2a-js/sdk`](https://www.npmjs.com/package/@a2a-js/sdk):
+
+- **Client** — `A2AExecutor` speaks the full A2A v0.3 protocol: `message/send`, `message/stream`, `tasks/get`, `tasks/cancel`, `tasks/resubscribe`, push notifications, artifact chunking, and native `input-required` HITL.
+- **Server** — workstacean exposes `/.well-known/agent-card.json` + `POST /a2a` so external agents can call it. Incoming calls bridge through the bus and back via `BusAgentExecutor`.
+- **Auth** — per-agent structured auth config in `workspace/agents.yaml` (apiKey / bearer / hmac schemes).
+- **Extensions** — `ExtensionRegistry` scaffolding for opt-in A2A extensions; no extensions shipped by default.
+
+See [`docs/guides/add-an-agent.md`](docs/guides/add-an-agent.md) for the full agent-onboarding flow.
 
 ---
 
 ## Testing
 
 ```bash
-bun test              # all 577 tests
+bun test              # all tests
 bun test --watch      # watch mode
 ```

--- a/docs/guides/a2a-streaming.md
+++ b/docs/guides/a2a-streaming.md
@@ -8,7 +8,7 @@ How to add Server-Sent Events (SSE) streaming to an A2A agent so consumers (like
 
 By default, A2A agents handle `message/send` — the client blocks until the agent finishes. For long-running skills (deep research, multi-step triage), this creates dead air. SSE streaming solves this:
 
-1. Client sends `message/sendStream` instead of `message/send`
+1. Client sends `message/stream` instead of `message/send`
 2. Agent returns `text/event-stream` with intermediate updates
 3. Client reads events as they arrive, publishes them to Discord for o11y
 4. Agent sends final artifact + `[DONE]` to close the stream
@@ -25,9 +25,9 @@ AGENT_CARD = {
 }
 ```
 
-### 2. Handle `message/sendStream` in your `/a2a` endpoint
+### 2. Handle `message/stream` in your `/a2a` endpoint
 
-Accept both `message/send` (blocking) and `message/sendStream` (SSE):
+Accept both `message/send` (blocking) and `message/stream` (SSE):
 
 ```python
 from fastapi.responses import StreamingResponse
@@ -37,7 +37,7 @@ import json, asyncio, queue
 async def a2a_handler(req: dict):
     method = req.get("method", "")
     
-    if method == "message/sendStream":
+    if method == "message/stream":
         return StreamingResponse(
             sse_generator(req),
             media_type="text/event-stream",
@@ -128,7 +128,7 @@ Ava calls chat_with_agent(agent="researcher", ...)
     ↓
 ava-tools.ts POST /api/a2a/chat → ExecutorRegistry → A2AExecutor
     ↓
-A2AExecutor sees streaming:true → sends message/sendStream
+A2AExecutor sees streaming:true → sends message/stream
     ↓
 protoResearcher returns text/event-stream:
     data: {"status":{"state":"working","message":"Scanning HuggingFace..."}}
@@ -155,3 +155,19 @@ Final artifact → returned as chat_with_agent response to Ava
 If the agent doesn't support streaming (card says `streaming: false` or omits it), A2AExecutor falls back to blocking `message/send`. No code changes needed on the client side.
 
 If the agent supports streaming but the SSE connection fails, the executor catches the error and falls back to `message/send` automatically.
+
+## Artifact chunking
+
+Agents can progressively stream a long artifact in multiple frames using `append` + `lastChunk` on `TaskArtifactUpdateEvent`:
+
+- `append: false` (or omitted) → the incoming `parts` **replace** the buffer for that `artifactId`
+- `append: true` → the incoming `parts` are **concatenated** to the existing buffer
+- `lastChunk: true` → finalize the artifact; A2AExecutor fires `onStreamUpdate({ type: "artifact_complete", ... })`
+
+This lets a researcher stream a 2000-word report as 20 × 100-word chunks. Each chunk surfaces live via `onStreamUpdate({ type: "artifact_chunk", ... })` to Discord, the dashboard, etc. The final concatenated text is what lands in the `SkillResult.text`.
+
+## Long-running tasks + input-required
+
+If your agent returns a non-terminal task (`working`, `submitted`, `input-required`) rather than a final result, workstacean's `TaskTracker` polls `tasks/get` (or uses `tasks/resubscribe` for streaming agents) and publishes the response on the original reply topic once terminal. No caller-side timeout tuning needed.
+
+For `input-required`, the tracker raises a HITL request automatically and resumes the task via `message/send` with the same `taskId` once a human decides. See [HITL guide](./hitl.md) for the full flow.

--- a/docs/guides/add-an-agent.md
+++ b/docs/guides/add-an-agent.md
@@ -125,9 +125,17 @@ agents:
   - name: my-service
     # Full URL of the agent's /a2a endpoint (JSON-RPC 2.0).
     url: http://my-service:8080/a2a
-    # Environment variable holding the API key. Optional.
-    apiKeyEnv: MY_SERVICE_API_KEY
-    # Skills this agent handles.
+    # Auth — either the legacy apiKeyEnv shorthand OR a structured auth block.
+    apiKeyEnv: MY_SERVICE_API_KEY   # legacy: X-API-Key: <env>
+    # auth:                          # preferred (Phase 8):
+    #   scheme: bearer               # "apiKey" | "bearer" | "hmac"
+    #   credentialsEnv: MY_SERVICE_TOKEN
+    # Optional: stamp static headers (e.g. opt in to A2A extensions).
+    # headers:
+    #   a2a-extensions: "https://a2a-protocol.org/ext/cost-v1"
+    # Whether the agent supports SSE streaming (card-derived fallback).
+    streaming: false
+    # Skills this agent handles. Omit to auto-discover from the agent card.
     skills:
       - name: analyze_data
         description: Analyze a dataset and return a summary
@@ -138,7 +146,13 @@ agents:
       - message.inbound.#
 ```
 
-The `apiKeyEnv` value is the **name** of the environment variable (not the key itself). At request time, `A2AExecutor` reads `process.env[apiKeyEnv]` and sends it as `X-API-Key`.
+Auth resolution:
+- `apiKeyEnv: X` → sends `X-API-Key: $X` on every request (legacy shorthand).
+- `auth.scheme: apiKey` + `credentialsEnv: X` → same header, explicit scheme.
+- `auth.scheme: bearer` + `credentialsEnv: X` → sends `Authorization: Bearer $X`.
+- `auth.scheme: hmac` → reserved for future HMAC-signing extension.
+
+At request time, `A2AExecutor` reads `process.env[credentialsEnv]` (or `apiKeyEnv` as fallback) and stamps the right header based on scheme.
 
 ### How the A2A call is made
 
@@ -174,9 +188,30 @@ X-API-Key: <resolved key>
 
 The receiving service should propagate `contextId` / `X-Correlation-Id` through its own spans.
 
-### Skills refreshed from /.well-known/agent.json
+### Skills refreshed from the agent card
 
-You can omit `skills` from `agents.yaml` if your service exposes a `/.well-known/agent.json` discovery endpoint. `SkillBrokerPlugin` will fetch it at startup and register the declared skills automatically.
+You can omit `skills` from `agents.yaml` if your service exposes a `/.well-known/agent-card.json` (or legacy `/.well-known/agent.json`) discovery endpoint. `SkillBrokerPlugin` fetches it at startup and registers declared skills automatically, then re-fetches every 10 min so new skills land without a restart. When both yaml skills and card skills are present, the yaml entries take precedence as explicit overrides.
+
+### Long-running tasks
+
+If your agent returns a non-terminal `Task` (state: `submitted` or `working`) instead of an immediate reply, `SkillDispatcherPlugin` hands the task to `TaskTracker` which polls `tasks/get` every 30s (or uses `tasks/resubscribe` for streaming agents). When the task reaches a terminal state, the tracker publishes the response on the original reply topic — the caller sees exactly one response, just later.
+
+For agents that support push notifications (`capabilities.pushNotifications: true` in the card), workstacean registers `PushNotificationConfig` with a per-task HMAC token pointing at `${WORKSTACEAN_BASE_URL}/api/a2a/callback/:taskId`. The agent POSTs Task snapshots to that URL when the state changes, which is faster and cheaper than polling.
+
+### input-required → HITL
+
+When your agent returns `Task.status.state == "input-required"`, the tracker automatically raises a HITL request (Discord approval UI by default). Once a human responds, the tracker resumes the task with `message/send` on the same `taskId` carrying the decision text. No custom `plan_resume` skill is needed — this is the native A2A state machine.
+
+---
+
+## Workstacean as an A2A server
+
+Workstacean itself is an A2A agent too. It exposes:
+
+- `GET /.well-known/agent-card.json` — lists every skill registered in `ExecutorRegistry`
+- `POST /a2a` — JSON-RPC 2.0 endpoint (supports `message/send`, `message/stream`, `tasks/*`)
+
+External agents can call workstacean by resolving the card and dispatching skills with a `skillHint` in the message metadata. Auth is the same `WORKSTACEAN_API_KEY` via `Authorization: Bearer <key>` or `X-API-Key`. See [HTTP API reference — POST /a2a](../../reference/http-api#post-a2a) for full details.
 
 ---
 

--- a/docs/guides/hitl.md
+++ b/docs/guides/hitl.md
@@ -10,16 +10,16 @@ HITL is the approval gate that sits between an autonomous decision and its perma
 
 ## Overview
 
-When any system component needs a human decision, it publishes an `HITLRequest` to the bus. `HITLPlugin` routes it to the registered renderer for the originating interface (Discord, Plane, Signal, API). A human responds. The interface plugin publishes an `HITLResponse`. `HITLPlugin` routes the response back to the requester via `replyTopic` (bus) and, if configured, calls the plan_resume agent via A2A.
+When any system component needs a human decision, it publishes an `HITLRequest` to the bus. `HITLPlugin` routes it to the registered renderer for the originating interface (Discord, Plane, Signal, API). A human responds. The interface plugin publishes an `HITLResponse`. The bus delivers it to whichever plugin subscribed to the `replyTopic`.
 
 Two types of HITL flow coexist on the same infrastructure:
 
 | Flow | Publisher | Callback path | Example |
 |---|---|---|---|
-| **Plan gate** | Ava | plan_resume A2A → Ava resumes feature creation | New project plan after SPARC PRD |
+| **Plan gate** | A2A agent returns `input-required` | `TaskTracker` sends `message/send` with same `taskId` | Ava asks for approval mid-task |
 | **Operational gate** | Any plugin | `replyTopic` on the bus | Budget L3 escalation, goal violation, queue saturation |
 
-Both use the same `HITLRequest`/`HITLResponse` shapes, the same topic conventions, and the same renderer interface.
+Both use the same `HITLRequest`/`HITLResponse` shapes, the same topic conventions, and the same renderer interface. The plan-gate path uses the native A2A `input-required` state machine — no custom `plan_resume` skill is required.
 
 ---
 
@@ -93,9 +93,9 @@ When a renderer publishes an `HITLResponse` to `request.replyTopic` (a `hitl.res
 
 1. **Bus delivery** — the message lands on `request.replyTopic`. Any plugin that subscribed to that topic receives it automatically through pub/sub. No re-routing by HITLPlugin is needed — the bus handles it.
 
-2. **A2A plan_resume** — HITLPlugin subscribes to `hitl.response.#` and intercepts every response. If `workspace/agents.yaml` contains an agent with the `plan_resume` skill (Ava), HITLPlugin calls that agent via JSON-RPC 2.0. This is Ava's plan gate path — Ava is an external service that doesn't subscribe to the bus directly.
+2. **A2A task resume** — `TaskTracker` subscribes to `hitl.response.#`. If the response correlates to a tracked task that entered `input-required`, the tracker calls `executor.resumeTask(taskId, ...)` with the decision text. The agent picks up in the same task/context — no custom skill is invoked.
 
-Both paths are triggered by the single publish from the renderer. The A2A call is a no-op if no plan_resume agent is configured.
+Both paths are triggered by the single publish from the renderer. The A2A resume is a no-op if no task is awaiting input for that `correlationId`.
 
 > **Convention:** `request.replyTopic` is always in the `hitl.response.#` namespace so HITLPlugin can intercept it. Renderers should publish to `request.replyTopic` directly rather than constructing the topic themselves.
 
@@ -283,27 +283,28 @@ The plan gate is one specific use of HITL, triggered after Ava generates a SPARC
 2. Ava generates SPARC PRD + antagonistic review
    - Ava verdict: operational feasibility, risk score
    - Jon verdict: strategic value, ROI score
-3. Ava checkpoints plan to PlanStore (SQLite, keyed by correlationId, 7-day TTL)
-4. Ava publishes hitl.request.plan.{correlationId} with replyTopic
-5. HITLPlugin routes to registered renderer (Discord embed shows PRD summary + verdicts)
+3. Ava returns Task { status: { state: "input-required", message: <PRD summary> } }
+4. TaskTracker detects input-required → raises HITLRequest
+5. HITLPlugin routes to the registered renderer (Discord embed)
 6. Human approves/rejects/modifies
-7. Renderer publishes hitl.response.plan.{correlationId}
-8. HITLPlugin:
-   a. Publishes response to replyTopic (bus)
-   b. Calls plan_resume via A2A → Ava restores checkpoint, executes decision
+7. Renderer publishes HITLResponse on hitl.response.{correlationId}
+8. TaskTracker intercepts the response → sends message/send with same taskId
+   carrying the decision text; Ava resumes the task natively
 ```
 
-### plan_resume decisions
+### plan decisions (resume payload)
+
+The decision is relayed verbatim as the resume message text. Ava parses it and takes the branch:
 
 | Decision | What happens |
 |---|---|
 | `approve` | Board features created, Plane issue → "In Progress", summary comment posted |
-| `reject` | Plan archived in PlanStore, rejection notice sent to originating channel |
-| `modify` | PRD re-drafted with `feedback` applied, antagonistic review re-run, new `HITLRequest` emitted with same `correlationId` |
+| `reject` | Plan archived, rejection notice sent to originating channel |
+| `modify` | PRD re-drafted with `feedback` applied, antagonistic review re-run, new `input-required` emitted |
 
 ### Auto-approve
 
-Plane issues with the `auto` label skip the gate entirely. `PlanePlugin` sets `autoApprove: true` in the bus message. Ava internally generates `HITLResponse { decision: "approve", decidedBy: "auto" }` and calls `plan_resume` directly.
+Plane issues with the `auto` label skip the gate entirely. `PlanePlugin` sets `autoApprove: true` in the bus message, and the agent either never enters `input-required` or short-circuits itself.
 
 ---
 

--- a/docs/integrations/plane.md
+++ b/docs/integrations/plane.md
@@ -80,10 +80,10 @@ Only `issue` events (create/update/delete) are subscribed. Project/cycle/module 
    f. Store {planeIssueId, planeProjectId} in pendingIssues Map keyed by correlationId
 4. RouterPlugin routes to Ava (skillHint "plan" → plan skill)
 5. Ava runs SPARC PRD + antagonistic review (Ava operational lens + Jon strategic lens)
-6. HITL gate:
-   - "auto" label → skip gate, emit HITLResponse(approve) internally
-   - "plan" label → emit HITLRequest to plane.reply.{correlationId}
-7. On approval: Ava's plan_resume creates board features, stamps correlationId
+6. HITL gate (native A2A):
+   - "auto" label → Ava short-circuits and returns a completed Task directly
+   - "plan" label → Ava returns Task with state "input-required" → TaskTracker raises HITLRequest on plane.reply.{correlationId}
+7. On approval: TaskTracker sends message/send with the same taskId, Ava resumes in-context and creates board features (same correlationId throughout)
 8. PlanePlugin outbound handler picks up plane.reply.# events → syncs back to Plane
 ```
 

--- a/docs/integrations/runtimes/a2a.md
+++ b/docs/integrations/runtimes/a2a.md
@@ -98,7 +98,7 @@ Accept: text/event-stream       (if streaming enabled)
 
 ## SSE streaming
 
-When the agent card declares `capabilities.streaming: true`, the executor sends `message/sendStream` and reads Server-Sent Events:
+When the agent card declares `capabilities.streaming: true`, the executor sends `message/stream` and reads Server-Sent Events:
 
 - **TaskStatusUpdateEvent** — intermediate status changes with optional message
 - **TaskArtifactUpdateEvent** — progressive artifact chunks
@@ -124,7 +124,7 @@ The executor resolves the API key from the environment variable named in `apiKey
 
 ## Agent card discovery
 
-On startup, `SkillBrokerPlugin` fetches `GET /.well-known/agent.json` from each agent's base URL (5s timeout). The card's `skills` array is merged into the executor registry, allowing runtime skill discovery.
+On startup, `SkillBrokerPlugin` fetches `GET /.well-known/agent-card.json` (with a fallback to the legacy `/.well-known/agent.json`) from each agent's base URL. The card's `skills` array is merged into the executor registry, allowing runtime skill discovery. The card is re-fetched every 10 min so new skills land without a restart; when the yaml lists skills too, the yaml entries take precedence as explicit overrides.
 
 ## Agent YAML entry
 

--- a/docs/reference/config-files.md
+++ b/docs/reference/config-files.md
@@ -164,7 +164,6 @@ agents:
       - board_health
       - onboard_project
       - plan
-      - plan_resume
 
   - name: quinn
     team: dev

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -745,6 +745,70 @@ Fire-and-forget task dispatch to a remote agent. Publishes to `agent.skill.reque
 
 ---
 
+## GET /.well-known/agent-card.json
+
+Served by `src/api/agent-card.ts`. Exposes workstacean as an A2A-compliant agent — external agents fetch this URL to discover what skills they can dispatch. Skills are aggregated from the `ExecutorRegistry`, so any skill registered (yaml-declared + auto-discovered Phase 4 skills) shows up without a restart.
+
+A legacy alias at `GET /.well-known/agent.json` returns the same body for clients that resolve the older path.
+
+**Auth**: None (discovery is always public)
+
+**Response** (`200`) — an [AgentCard](https://a2a-protocol.org/latest/specification/#agent-card):
+```json
+{
+  "name": "workstacean",
+  "description": "protoLabs Studio operational gateway...",
+  "protocolVersion": "0.3.0",
+  "version": "1.0.0",
+  "url": "https://workstacean.example.com/a2a",
+  "preferredTransport": "JSONRPC",
+  "capabilities": { "streaming": true, "pushNotifications": true },
+  "skills": [
+    { "id": "plan", "name": "plan", "description": "...", "tags": ["routed", "ava"] },
+    { "id": "bug_triage", "name": "bug_triage", "description": "...", "tags": ["routed", "quinn"] }
+  ]
+}
+```
+
+`url` is derived from `WORKSTACEAN_BASE_URL` (falling back to `http://localhost:$WORKSTACEAN_HTTP_PORT` when unset).
+
+---
+
+## POST /a2a
+
+A2A JSON-RPC 2.0 endpoint. Accepts every method in the A2A protocol (`message/send`, `message/stream`, `tasks/get`, `tasks/cancel`, `tasks/resubscribe`, `tasks/pushNotificationConfig/*`) and bridges them into the internal bus pipeline via `BusAgentExecutor` (`src/api/a2a-server.ts`).
+
+**Auth**: When `WORKSTACEAN_API_KEY` is set, callers must supply it as `Authorization: Bearer <key>` or `X-API-Key: <key>`. Unset → open access (dev mode).
+
+**Flow for `message/send`**:
+1. SDK `JsonRpcTransportHandler` receives the request
+2. `BusAgentExecutor.execute()` emits an initial `submitted` Task event, transitions to `working`, publishes to `agent.skill.request` on the bus
+3. `SkillDispatcherPlugin` resolves an executor via `ExecutorRegistry` and runs the skill
+4. Response lands on `agent.skill.response.{taskId}` → adapter emits a terminal `completed`/`failed` status update with the text in `status.message.parts`
+5. Response returns as `{ jsonrpc: "2.0", id, result: <Task> }`
+
+`message/stream` uses the same pipeline but returns a `text/event-stream` where each `data:` frame is a JSON-RPC response wrapping one A2A event.
+
+Skill routing: metadata fields control which skill is invoked.
+- `metadata.skillHint` or `metadata.skill` — skill name, defaults to `"chat"`
+- `metadata.targets` — array of agent names, passed through to `ExecutorRegistry.resolve()`
+
+---
+
+## POST /api/a2a/callback/:taskId
+
+Push-notification webhook for long-running A2A tasks (Phase 3). External agents POST Task snapshots here when they reach terminal state (or at configurable checkpoints) so workstacean doesn't need to hold an HTTP connection open for minutes.
+
+**Auth**: Per-task token passed as `Authorization: Bearer <token>` or `X-A2A-Notification-Token: <token>`. The token is generated per-task and registered with the agent when the skill is dispatched; workstacean looks it up by `taskId` in `TaskTracker`.
+
+**Request body**: Full A2A `Task` object (not a delta).
+
+**Response** (`200`): `{ "success": true }`
+
+Non-terminal states just refresh `lastPolledAt`. `input-required` states raise a HITL request. Terminal states publish the response and untrack the task.
+
+---
+
 ## POST /api/github/issues
 
 File an issue on a managed GitHub repository. Only repos listed in `projects.yaml` are allowed.

--- a/docs/reference/workspace-files.md
+++ b/docs/reference/workspace-files.md
@@ -14,11 +14,18 @@ External A2A agent registry. Read by `SkillBrokerPlugin`.
 agents:
   - name: string                    # Unique agent name
     url: string                     # Full A2A endpoint URL
-    apiKeyEnv?: string              # Env var name holding the API key
+    apiKeyEnv?: string              # Legacy shorthand — env var holding a value sent as X-API-Key
+    auth?:                          # Structured auth (Phase 8). Preferred over apiKeyEnv.
+      scheme: "apiKey" | "bearer" | "hmac"
+      credentialsEnv: string        # Env var holding the credential value
+    headers?: Record<string, string> # Static extra request headers (e.g. a2a-extensions opt-in)
+    streaming?: boolean             # Whether the agent supports SSE streaming
     discordBotTokenEnvKey?: string  # Optional Discord bot token env var — when set,
                                     # DiscordPlugin's agent pool spins up a dedicated
                                     # Client() for this agent so users can DM it directly
-    skills?:                        # Skills to register. Omit to use /.well-known/agent.json discovery.
+    skills?:                        # Skills to register. Omit to auto-discover from
+                                    # /.well-known/agent-card.json (falls back to agent.json).
+                                    # Yaml entries take precedence as explicit overrides.
       - name: string
         description?: string
     subscribesTo?:                  # Informational — bus topics this agent watches (not enforced)

--- a/lib/plugins/hitl.ts
+++ b/lib/plugins/hitl.ts
@@ -1,10 +1,11 @@
 /**
  * HITLPlugin — Human-in-the-Loop gate for the Workstacean bus.
  *
- * Dispatches HITLRequest messages to registered HITLRenderer instances (one per
- * interface), and routes HITLResponse messages back to requesters via two paths:
- *   1. Bus callback — publishes to request.replyTopic (operational callers)
- *   2. A2A plan_resume — calls Ava to resume a checkpointed plan
+ * Pure routing layer between HITL requests and registered renderers.
+ * TaskTracker owns the A2A native `input-required` resume path — when a
+ * response arrives for a tracked A2A task, the tracker re-sends via
+ * sendMessage(taskId, decisionText). This plugin just orchestrates the
+ * request/renderer/response bus plumbing.
  *
  * Interface plugins register a renderer during install():
  *   hitlPlugin.registerRenderer("discord", renderer)
@@ -16,27 +17,9 @@
  * Pending requests are tracked in-memory with expiry. On a 60s interval,
  * expired entries are removed, hitl.expired.{correlationId} is published,
  * and the renderer's onExpired() is called.
- *
- * Config: workspace/agents.yaml (to find Ava's A2A endpoint for plan_resume)
  */
 
-import { readFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
-import { parse as parseYaml } from "yaml";
 import type { EventBus, BusMessage, Plugin, HITLRequest, HITLResponse, HITLRenderer } from "../types.ts";
-
-// ── Agent registry (minimal — just enough to find Ava) ──────────────────────
-
-interface AgentDef {
-  name: string;
-  url: string;
-  apiKeyEnv?: string;
-  skills: string[];
-}
-
-interface AgentsYaml {
-  agents: AgentDef[];
-}
 
 // ── Renderer registry ─────────────────────────────────────────────────────────
 // Maps interface name → HITLRenderer.
@@ -56,58 +39,19 @@ const pendingRequests = new Map<string, HITLRequest>();
  */
 const unrenderedCorrelationIds = new Set<string>();
 
-// ── A2A call to Ava for plan_resume ──────────────────────────────────────────
-
-async function callPlanResume(agent: AgentDef, response: HITLResponse): Promise<void> {
-  const apiKey = agent.apiKeyEnv ? (process.env[agent.apiKeyEnv] ?? "") : "";
-  const headers: Record<string, string> = { "Content-Type": "application/json" };
-  if (apiKey) headers["X-API-Key"] = apiKey;
-
-  const content = [
-    `HITL Decision: ${response.decision}`,
-    response.feedback ? `Feedback: ${response.feedback}` : "",
-    `Decided by: ${response.decidedBy}`,
-  ].filter(Boolean).join("\n");
-
-  const resp = await fetch(agent.url, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: crypto.randomUUID(),
-      method: "message/send",
-      params: {
-        message: { role: "user", parts: [{ kind: "text", text: content }] },
-        contextId: response.correlationId,
-        metadata: { skillHint: "plan_resume", hitlResponse: response },
-      },
-    }),
-    signal: AbortSignal.timeout(120_000),
-  });
-
-  if (!resp.ok) {
-    const errText = await resp.text();
-    throw new Error(`plan_resume A2A call failed (${resp.status}): ${errText}`);
-  }
-
-  const data = (await resp.json()) as { error?: { message: string } };
-  if (data.error) throw new Error(data.error.message);
-}
-
 // ── Plugin ───────────────────────────────────────────────────────────────────
 
 export class HITLPlugin implements Plugin {
   readonly name = "hitl";
-  readonly description = "Human-in-the-Loop gate — routes approval requests to interface plugins and responses back to callers";
+  readonly description = "Human-in-the-Loop gate — routes approval requests to interface plugins";
   readonly capabilities = ["hitl-routing"];
 
-  private workspaceDir: string;
-  private agents: AgentDef[] = [];
   private expiryTimer: ReturnType<typeof setInterval> | null = null;
   private busRef: EventBus | null = null;
 
-  constructor(workspaceDir: string) {
-    this.workspaceDir = workspaceDir;
+  constructor(_workspaceDir: string) {
+    // workspaceDir retained for API compat with existing plugin constructors,
+    // but not used — HITL is pure bus routing now.
   }
 
   /** All currently pending (unexpired, undecided) HITL requests. */
@@ -138,8 +82,6 @@ export class HITLPlugin implements Plugin {
 
   install(bus: EventBus): void {
     this.busRef = bus;
-    this.agents = this._loadAgents();
-    console.log(`[hitl] Loaded ${this.agents.length} agent(s) for plan_resume routing`);
 
     // ── Expiry sweep: every 60s, remove expired pending requests ─────────
     this.expiryTimer = setInterval(() => {
@@ -212,40 +154,16 @@ export class HITLPlugin implements Plugin {
       );
     });
 
-    // ── Route HITLResponse back to Ava ───────────────────────────────────
-    bus.subscribe("hitl.response.#", this.name, async (msg: BusMessage) => {
+    // ── Clean up pending map when a response arrives ─────────────────────
+    // Bus delivery of the response is automatic — renderers published to
+    // request.replyTopic (a hitl.response.* topic) and callers subscribed
+    // directly. TaskTracker subscribes to hitl.response.# for A2A tasks
+    // and resumes via sendMessage(taskId, decisionText).
+    bus.subscribe("hitl.response.#", this.name, (msg: BusMessage) => {
       const resp = msg.payload as HITLResponse;
       if (resp?.type !== "hitl_response") return;
-
-      // Remove from pending map
-      const pending = pendingRequests.get(resp.correlationId);
-      if (pending) {
-        pendingRequests.delete(resp.correlationId);
-        unrenderedCorrelationIds.delete(resp.correlationId);
-      } else {
-        console.warn(`[hitl] No pending request for correlationId ${resp.correlationId} — processing anyway`);
-      }
-
-      // ── Bus delivery is automatic via pub/sub ────────────────────────────
-      // The renderer published to request.replyTopic (a hitl.response.* topic).
-      // Operational callers subscribed directly to that topic — they already
-      // received the message. No re-publish needed from HITLPlugin.
-
-      // Find agent with plan_resume skill (should be Ava)
-      const planAgent = this.agents.find(a => a.skills.includes("plan_resume"));
-      if (!planAgent) {
-        console.error("[hitl] No agent with plan_resume skill found — cannot route HITLResponse");
-        return;
-      }
-
-      console.log(`[hitl] Routing HITLResponse (${resp.correlationId}, decision: ${resp.decision}) → ${planAgent.name}`);
-
-      try {
-        await callPlanResume(planAgent, resp);
-        console.log(`[hitl] plan_resume call to ${planAgent.name} succeeded`);
-      } catch (err) {
-        console.error(`[hitl] plan_resume call to ${planAgent.name} failed:`, err);
-      }
+      pendingRequests.delete(resp.correlationId);
+      unrenderedCorrelationIds.delete(resp.correlationId);
     });
   }
 
@@ -255,22 +173,5 @@ export class HITLPlugin implements Plugin {
       this.expiryTimer = null;
     }
     this.busRef = null;
-  }
-
-  private _loadAgents(): AgentDef[] {
-    const agentsPath = join(this.workspaceDir, "agents.yaml");
-    if (!existsSync(agentsPath)) {
-      console.warn("[hitl] agents.yaml not found — HITL response routing will be unavailable");
-      return [];
-    }
-
-    try {
-      const raw = readFileSync(agentsPath, "utf8");
-      const parsed = parseYaml(raw) as AgentsYaml;
-      return parsed.agents ?? [];
-    } catch (err) {
-      console.error("[hitl] Failed to parse agents.yaml:", err);
-      return [];
-    }
   }
 }

--- a/src/api/__tests__/a2a-server.test.ts
+++ b/src/api/__tests__/a2a-server.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Phase 7 — A2A server adapter round-trips external JSON-RPC calls through
+ * the bus and back.
+ *
+ * Drive the BusAgentExecutor directly (no HTTP layer) so we can inspect the
+ * events it publishes to the SDK's ExecutionEventBus. The bus subscribes to
+ * agent.skill.request and publishes a response on the correlated reply topic
+ * — that's exactly the internal contract SkillDispatcherPlugin satisfies.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { DefaultExecutionEventBus } from "@a2a-js/sdk/server";
+import type { AgentExecutionEvent, RequestContext } from "@a2a-js/sdk/server";
+import type { Message } from "@a2a-js/sdk";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { ExecutorRegistry } from "../../executor/executor-registry.ts";
+import { BusAgentExecutor } from "../a2a-server.ts";
+import type { ApiContext } from "../types.ts";
+
+function makeUserMessage(text: string, metadata: Record<string, unknown> = {}): Message {
+  return {
+    kind: "message",
+    messageId: crypto.randomUUID(),
+    role: "user",
+    parts: [{ kind: "text", text }],
+    metadata,
+  };
+}
+
+function makeRequestContext(text: string, metadata: Record<string, unknown> = {}): RequestContext {
+  const userMessage = makeUserMessage(text, metadata);
+  const taskId = crypto.randomUUID();
+  const contextId = crypto.randomUUID();
+  return {
+    userMessage,
+    taskId,
+    contextId,
+  } as RequestContext;
+}
+
+describe("BusAgentExecutor (Phase 7)", () => {
+  test("publishes agent.skill.request and resolves with the reply content", async () => {
+    const bus = new InMemoryEventBus();
+    const ctx: ApiContext = {
+      workspaceDir: "/tmp",
+      bus,
+      plugins: [],
+      executorRegistry: new ExecutorRegistry(),
+    };
+
+    let requestPayload: Record<string, unknown> | undefined;
+    let replyTopic: string | undefined;
+    bus.subscribe("agent.skill.request", "test", (msg) => {
+      requestPayload = msg.payload as Record<string, unknown>;
+      replyTopic = msg.reply?.topic;
+      // Mimic SkillDispatcherPlugin: publish a response on the replyTopic
+      setTimeout(() => {
+        bus.publish(msg.reply!.topic!, {
+          id: crypto.randomUUID(),
+          correlationId: msg.correlationId,
+          topic: msg.reply!.topic!,
+          timestamp: Date.now(),
+          payload: { content: "42", correlationId: msg.correlationId },
+        });
+      }, 0);
+    });
+
+    const adapter = new BusAgentExecutor(ctx);
+    const eventBus = new DefaultExecutionEventBus();
+    const collected: AgentExecutionEvent[] = [];
+    eventBus.on("event", (e) => collected.push(e));
+    const done = new Promise<void>(resolve => eventBus.on("finished", () => resolve()));
+
+    const reqCtx = makeRequestContext("What is the answer?", { skillHint: "plan", targets: ["ava"] });
+
+    await adapter.execute(reqCtx, eventBus);
+    await done;
+
+    expect(requestPayload).toBeDefined();
+    expect((requestPayload as { skill: string }).skill).toBe("plan");
+    expect((requestPayload as { targets: string[] }).targets).toEqual(["ava"]);
+    expect((requestPayload as { content: string }).content).toBe("What is the answer?");
+    expect(replyTopic).toBe(`agent.skill.response.${reqCtx.taskId}`);
+
+    // Events in order: submitted task, working status, completed status (final)
+    const taskEvt = collected.find(e => e.kind === "task");
+    const workingEvt = collected.find(e => e.kind === "status-update" && "status" in e && (e as { status: { state: string } }).status.state === "working");
+    const completedEvt = collected.find(e => e.kind === "status-update" && "status" in e && (e as { status: { state: string } }).status.state === "completed");
+    expect(taskEvt).toBeDefined();
+    expect(workingEvt).toBeDefined();
+    expect(completedEvt).toBeDefined();
+
+    // Terminal event should carry the reply content + final: true
+    const finalEvt = completedEvt as { final: boolean; status: { message?: { parts: Array<{ text?: string }> } } };
+    expect(finalEvt.final).toBe(true);
+    const terminalText = finalEvt.status.message?.parts?.map(p => p.text ?? "").join("") ?? "";
+    expect(terminalText).toBe("42");
+  });
+
+  test("error response maps to failed status-update", async () => {
+    const bus = new InMemoryEventBus();
+    const ctx: ApiContext = {
+      workspaceDir: "/tmp",
+      bus,
+      plugins: [],
+      executorRegistry: new ExecutorRegistry(),
+    };
+
+    bus.subscribe("agent.skill.request", "test", (msg) => {
+      setTimeout(() => {
+        bus.publish(msg.reply!.topic!, {
+          id: crypto.randomUUID(),
+          correlationId: msg.correlationId,
+          topic: msg.reply!.topic!,
+          timestamp: Date.now(),
+          payload: { error: "boom", correlationId: msg.correlationId },
+        });
+      }, 0);
+    });
+
+    const adapter = new BusAgentExecutor(ctx);
+    const eventBus = new DefaultExecutionEventBus();
+    const collected: AgentExecutionEvent[] = [];
+    eventBus.on("event", (e) => collected.push(e));
+    const done = new Promise<void>(resolve => eventBus.on("finished", () => resolve()));
+
+    const reqCtx = makeRequestContext("Broken request", { skillHint: "chat" });
+    await adapter.execute(reqCtx, eventBus);
+    await done;
+
+    const failedEvt = collected.find(
+      e => e.kind === "status-update" && "status" in e && (e as { status: { state: string } }).status.state === "failed",
+    ) as { final: boolean; status: { message?: { parts: Array<{ text?: string }> } } } | undefined;
+    expect(failedEvt).toBeDefined();
+    expect(failedEvt!.final).toBe(true);
+    const text = failedEvt!.status.message?.parts?.map(p => p.text ?? "").join("") ?? "";
+    expect(text).toBe("boom");
+  });
+
+  test("cancelTask yields canceled status and unblocks execute()", async () => {
+    const bus = new InMemoryEventBus();
+    const ctx: ApiContext = {
+      workspaceDir: "/tmp",
+      bus,
+      plugins: [],
+      executorRegistry: new ExecutorRegistry(),
+    };
+
+    // Never respond — we'll cancel before a reply arrives
+    bus.subscribe("agent.skill.request", "test", () => {});
+
+    const adapter = new BusAgentExecutor(ctx);
+    const eventBus = new DefaultExecutionEventBus();
+    const collected: AgentExecutionEvent[] = [];
+    eventBus.on("event", (e) => collected.push(e));
+
+    const reqCtx = makeRequestContext("Will be canceled");
+    const executing = adapter.execute(reqCtx, eventBus);
+
+    // Give execute() a tick to subscribe before we cancel
+    await new Promise(r => setTimeout(r, 10));
+    await adapter.cancelTask(reqCtx.taskId, eventBus);
+    await executing;
+
+    const canceledEvt = collected.find(
+      e => e.kind === "status-update" && "status" in e && (e as { status: { state: string } }).status.state === "canceled",
+    );
+    expect(canceledEvt).toBeDefined();
+  });
+});

--- a/src/api/__tests__/agent-card.test.ts
+++ b/src/api/__tests__/agent-card.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Phase 7 — agent card endpoint exposes workstacean's registered skills.
+ *
+ * These tests exercise the /.well-known/agent-card.json handler directly,
+ * bypassing Bun.serve. They lock down:
+ *   - Skills deduplication when multiple agents register the same skill
+ *   - The agent-card.json → agent.json legacy alias
+ *   - WORKSTACEAN_BASE_URL is honored when building the card's url
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { ExecutorRegistry } from "../../executor/executor-registry.ts";
+import { createRoutes, buildAgentCard } from "../agent-card.ts";
+import type { ApiContext } from "../types.ts";
+import type { IExecutor, SkillResult } from "../../executor/types.ts";
+
+function fakeExecutor(type = "a2a"): IExecutor {
+  return {
+    type,
+    async execute(): Promise<SkillResult> {
+      return { text: "", isError: false, correlationId: "" };
+    },
+  };
+}
+
+describe("GET /.well-known/agent-card.json", () => {
+  let registry: ExecutorRegistry;
+  let ctx: ApiContext;
+  let origBaseUrl: string | undefined;
+
+  beforeEach(() => {
+    origBaseUrl = process.env.WORKSTACEAN_BASE_URL;
+    process.env.WORKSTACEAN_BASE_URL = "https://workstacean.example.com";
+    registry = new ExecutorRegistry();
+    ctx = {
+      workspaceDir: "/tmp",
+      bus: new InMemoryEventBus(),
+      plugins: [],
+      executorRegistry: registry,
+    };
+  });
+
+  afterEach(() => {
+    if (origBaseUrl === undefined) delete process.env.WORKSTACEAN_BASE_URL;
+    else process.env.WORKSTACEAN_BASE_URL = origBaseUrl;
+  });
+
+  test("emits two routes (agent-card.json + legacy agent.json)", () => {
+    const routes = createRoutes(ctx);
+    expect(routes).toHaveLength(2);
+    expect(routes.map(r => r.path)).toEqual([
+      "/.well-known/agent-card.json",
+      "/.well-known/agent.json",
+    ]);
+    expect(routes.every(r => r.method === "GET")).toBe(true);
+  });
+
+  test("includes every registered skill with agentName as tag", () => {
+    registry.register("plan", fakeExecutor(), { agentName: "ava" });
+    registry.register("sitrep", fakeExecutor(), { agentName: "ava" });
+    registry.register("bug_triage", fakeExecutor(), { agentName: "quinn" });
+
+    const card = buildAgentCard(ctx);
+    const skillIds = card.skills.map(s => s.id).sort();
+    expect(skillIds).toEqual(["bug_triage", "plan", "sitrep"]);
+
+    const quinnSkill = card.skills.find(s => s.id === "bug_triage");
+    expect(quinnSkill?.tags).toContain("quinn");
+  });
+
+  test("dedupes skills registered by multiple agents", () => {
+    registry.register("chat", fakeExecutor(), { agentName: "ava" });
+    registry.register("chat", fakeExecutor(), { agentName: "quinn" });
+    registry.register("chat", fakeExecutor(), { agentName: "frank" });
+
+    const card = buildAgentCard(ctx);
+    const chatSkills = card.skills.filter(s => s.id === "chat");
+    expect(chatSkills).toHaveLength(1);
+  });
+
+  test("honors WORKSTACEAN_BASE_URL for the card's url", () => {
+    const card = buildAgentCard(ctx);
+    expect(card.url).toBe("https://workstacean.example.com/a2a");
+    expect(card.preferredTransport).toBe("JSONRPC");
+  });
+
+  test("declares streaming + push notification capabilities", () => {
+    const card = buildAgentCard(ctx);
+    expect(card.capabilities.streaming).toBe(true);
+    expect(card.capabilities.pushNotifications).toBe(true);
+  });
+
+  test("route handler returns cache-control + JSON body", async () => {
+    registry.register("plan", fakeExecutor(), { agentName: "ava" });
+    const [route] = createRoutes(ctx);
+    const resp = route.handler(new Request("http://x/.well-known/agent-card.json"), {});
+    const realResp = resp instanceof Promise ? await resp : resp;
+    expect(realResp.status).toBe(200);
+    expect(realResp.headers.get("cache-control")).toContain("max-age=");
+    const body = await realResp.json() as { name: string; skills: Array<{ id: string }> };
+    expect(body.name).toBe("workstacean");
+    expect(body.skills.map(s => s.id)).toContain("plan");
+  });
+});

--- a/src/api/a2a-server.ts
+++ b/src/api/a2a-server.ts
@@ -1,0 +1,296 @@
+/**
+ * A2A server — exposes workstacean as an A2A-compliant agent.
+ *
+ * Routes external JSON-RPC calls into the existing bus/executor pipeline:
+ *
+ *   external agent --(POST /a2a, message/send)--> JsonRpcTransportHandler
+ *     --> DefaultRequestHandler --> BusAgentExecutor.execute()
+ *       --> bus.publish("agent.skill.request", ...)  [same as internal HTTP API]
+ *         --> SkillDispatcherPlugin resolves executor, runs skill
+ *           --> bus.publish("agent.skill.response.{correlationId}")
+ *             --> BusAgentExecutor translates to Task / Message events
+ *               --> ExecutionEventBus --> JsonRpcTransportHandler --> HTTP response
+ *
+ * The BusAgentExecutor is the adapter — it bridges the A2A task lifecycle
+ * to our bus contract. Task state progression:
+ *   submitted → working → (optionally input-required → working) → completed/failed
+ *
+ * Streaming (message/stream) works end-to-end: each status update from the
+ * internal executor becomes a TaskStatusUpdateEvent on the A2A stream.
+ *
+ * Auth: gated by WORKSTACEAN_API_KEY when set. Callers pass it via
+ * Authorization: Bearer <key> or X-API-Key. No key set → open access (dev mode).
+ */
+
+import {
+  DefaultRequestHandler,
+  InMemoryTaskStore,
+  InMemoryPushNotificationStore,
+  DefaultPushNotificationSender,
+  JsonRpcTransportHandler,
+  type AgentExecutor,
+  type ExecutionEventBus,
+  type RequestContext,
+} from "@a2a-js/sdk/server";
+import type { Message, Task } from "@a2a-js/sdk";
+import type { Route, ApiContext } from "./types.ts";
+import type { BusMessage } from "../../lib/types.ts";
+import { buildAgentCard } from "./agent-card.ts";
+
+/**
+ * Bridges A2A RequestContext → agent.skill.request bus message and back.
+ *
+ * Skill resolution:
+ *   1. params.metadata.skillHint (explicit)
+ *   2. Falls through to dispatcher's default executor if skillHint missing
+ *
+ * The executor emits events in this order:
+ *   1. Task (submitted) — initial acknowledgement
+ *   2. TaskStatusUpdateEvent (working) — optional, when we see progress
+ *   3. TaskStatusUpdateEvent (completed/failed, final=true) — terminal
+ *
+ * We don't produce partial Message events — all content comes back via the
+ * terminal status event's message.parts.
+ */
+class BusAgentExecutor implements AgentExecutor {
+  private readonly activeCancels = new Map<string, () => void>();
+
+  constructor(private readonly ctx: ApiContext) {}
+
+  async execute(requestContext: RequestContext, eventBus: ExecutionEventBus): Promise<void> {
+    const { userMessage, taskId, contextId } = requestContext;
+    const correlationId = taskId;
+
+    // Extract text from the incoming message parts
+    const text = (userMessage.parts ?? [])
+      .filter((p): p is { kind: "text"; text: string } =>
+        "kind" in p && p.kind === "text" && typeof (p as { text?: unknown }).text === "string",
+      )
+      .map(p => p.text)
+      .join("\n");
+
+    // Skill hint — from metadata or fallback to "chat"
+    const metadata = (userMessage.metadata ?? {}) as Record<string, unknown>;
+    const skill = (typeof metadata.skillHint === "string" && metadata.skillHint)
+      || (typeof metadata.skill === "string" && metadata.skill)
+      || "chat";
+    const targets = Array.isArray(metadata.targets)
+      ? (metadata.targets as unknown[]).filter((v): v is string => typeof v === "string")
+      : [];
+
+    // Emit initial Task event so the caller gets a taskId immediately
+    eventBus.publish({
+      kind: "task",
+      id: taskId,
+      contextId,
+      status: {
+        state: "submitted",
+        timestamp: new Date().toISOString(),
+      },
+      history: [userMessage],
+      artifacts: [],
+    });
+
+    const replyTopic = `agent.skill.response.${correlationId}`;
+    let settled = false;
+    let cancelled = false;
+    const done = new Promise<void>(resolve => {
+      const subId = this.ctx.bus.subscribe(replyTopic, "a2a-server", (msg: BusMessage) => {
+        if (settled) return;
+        settled = true;
+        this.ctx.bus.unsubscribe(subId);
+        this.activeCancels.delete(taskId);
+
+        const payload = (msg.payload ?? {}) as { content?: string; error?: string };
+        const errorText = typeof payload.error === "string" ? payload.error : undefined;
+        const contentText = typeof payload.content === "string" ? payload.content : "";
+
+        const finalState = errorText ? "failed" : "completed";
+        const finalText = errorText || contentText || "";
+
+        eventBus.publish({
+          kind: "status-update",
+          taskId,
+          contextId,
+          status: {
+            state: finalState,
+            timestamp: new Date().toISOString(),
+            message: {
+              kind: "message",
+              messageId: crypto.randomUUID(),
+              role: "agent",
+              taskId,
+              contextId,
+              parts: [{ kind: "text", text: finalText }],
+            },
+          },
+          final: true,
+        });
+        eventBus.finished();
+        resolve();
+      });
+
+      // Cancel hook — TaskStore calls cancelTask() which invokes this to break
+      // the await and publish a canceled status.
+      this.activeCancels.set(taskId, () => {
+        if (settled) return;
+        settled = true;
+        cancelled = true;
+        this.ctx.bus.unsubscribe(subId);
+        this.activeCancels.delete(taskId);
+        eventBus.publish({
+          kind: "status-update",
+          taskId,
+          contextId,
+          status: {
+            state: "canceled",
+            timestamp: new Date().toISOString(),
+          },
+          final: true,
+        });
+        eventBus.finished();
+        resolve();
+      });
+    });
+
+    // Transition to working before dispatching so the caller sees motion.
+    eventBus.publish({
+      kind: "status-update",
+      taskId,
+      contextId,
+      status: {
+        state: "working",
+        timestamp: new Date().toISOString(),
+      },
+      final: false,
+    });
+
+    // Dispatch to the bus. SkillDispatcherPlugin handles the rest.
+    this.ctx.bus.publish("agent.skill.request", {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic: "agent.skill.request",
+      timestamp: Date.now(),
+      payload: {
+        skill,
+        content: text,
+        targets,
+        // Pass through metadata for downstream consumers
+        meta: { ...metadata, via: "a2a-server" },
+      },
+      reply: { topic: replyTopic },
+      source: { interface: "a2a" },
+    });
+
+    await done;
+    if (cancelled) {
+      console.log(`[a2a-server] Task ${taskId.slice(0, 8)}… canceled`);
+    }
+  }
+
+  async cancelTask(taskId: string, _eventBus: ExecutionEventBus): Promise<void> {
+    const cancel = this.activeCancels.get(taskId);
+    if (cancel) cancel();
+  }
+}
+
+export function createRoutes(ctx: ApiContext): Route[] {
+  // Build request handler once per process — it's stateful (task store) but
+  // stores are in-memory and all requests go through the same bus pipeline.
+  const agentCard = buildAgentCard(ctx);
+  const taskStore = new InMemoryTaskStore();
+  const pushStore = new InMemoryPushNotificationStore();
+  const pushSender = new DefaultPushNotificationSender(pushStore);
+  const agentExecutor = new BusAgentExecutor(ctx);
+  const requestHandler = new DefaultRequestHandler(
+    agentCard,
+    taskStore,
+    agentExecutor,
+    undefined, // default event bus manager
+    pushStore,
+    pushSender,
+  );
+  const transport = new JsonRpcTransportHandler(requestHandler);
+
+  const authorize = (req: Request): boolean => {
+    if (!ctx.apiKey) return true;
+    const apiKeyHeader = req.headers.get("x-api-key");
+    if (apiKeyHeader === ctx.apiKey) return true;
+    const auth = req.headers.get("authorization") ?? "";
+    if (auth === `Bearer ${ctx.apiKey}`) return true;
+    return false;
+  };
+
+  return [
+    {
+      method: "POST",
+      path: "/a2a",
+      handler: async (req) => {
+        if (!authorize(req)) {
+          return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+        }
+
+        let body: unknown;
+        try {
+          body = await req.json();
+        } catch {
+          return Response.json(
+            { jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } },
+            { status: 400 },
+          );
+        }
+
+        try {
+          const result = await transport.handle(body);
+
+          // Streaming: result is an AsyncGenerator of JSONRPCResponse. Pipe
+          // each frame as a text/event-stream chunk so SSE clients see it.
+          if (result && typeof (result as AsyncGenerator).next === "function") {
+            const gen = result as AsyncGenerator<unknown, void, undefined>;
+            const stream = new ReadableStream({
+              async start(controller) {
+                const encoder = new TextEncoder();
+                try {
+                  for await (const event of gen) {
+                    const chunk = `data: ${JSON.stringify(event)}\n\n`;
+                    controller.enqueue(encoder.encode(chunk));
+                  }
+                } catch (err) {
+                  const errMsg = err instanceof Error ? err.message : String(err);
+                  controller.enqueue(encoder.encode(`data: ${JSON.stringify({ error: errMsg })}\n\n`));
+                } finally {
+                  controller.close();
+                }
+              },
+            });
+            return new Response(stream, {
+              headers: {
+                "content-type": "text/event-stream",
+                "cache-control": "no-cache",
+                connection: "keep-alive",
+              },
+            });
+          }
+
+          // Non-streaming: single JSON-RPC response
+          return Response.json(result as unknown as Record<string, unknown>);
+        } catch (err) {
+          return Response.json(
+            {
+              jsonrpc: "2.0",
+              id: null,
+              error: {
+                code: -32603,
+                message: err instanceof Error ? err.message : "Internal error",
+              },
+            },
+            { status: 500 },
+          );
+        }
+      },
+    },
+  ];
+}
+
+/** Expose the adapter class so tests can drive it directly without HTTP. */
+export { BusAgentExecutor };

--- a/src/api/agent-card.ts
+++ b/src/api/agent-card.ts
@@ -1,0 +1,84 @@
+/**
+ * Agent Card endpoint — serves GET /.well-known/agent-card.json (with a
+ * legacy /.well-known/agent.json alias).
+ *
+ * Exposes workstacean as an A2A-compliant agent gateway. The card aggregates
+ * every skill currently registered in the ExecutorRegistry so external agents
+ * can discover what workstacean can route to. Re-reads the registry on each
+ * request so newly discovered A2A skills (Phase 4 periodic refresh) show up
+ * without a restart.
+ *
+ * Skills list the id + name only. Tags default to ["routed"] — the caller
+ * doesn't need to know what machinery is behind a skill, just that they can
+ * dispatch it by name.
+ *
+ * Transport: JSON-RPC (mounted at POST /a2a by a2a-server.ts). Agents send
+ * messages to that URL; the AgentCard.url field is derived from
+ * WORKSTACEAN_BASE_URL so external agents get an absolute URL.
+ */
+
+import type { Route, ApiContext } from "./types.ts";
+import type { AgentCard, AgentSkill } from "@a2a-js/sdk";
+
+const DEFAULT_VERSION = "1.0.0";
+const PROTOCOL_VERSION = "0.3.0";
+
+export function createRoutes(ctx: ApiContext): Route[] {
+  const handler = () => {
+    const card = buildAgentCard(ctx);
+    return Response.json(card, {
+      headers: { "cache-control": "public, max-age=60" },
+    });
+  };
+
+  return [
+    { method: "GET", path: "/.well-known/agent-card.json", handler },
+    // Legacy path — keep for agents that still resolve /.well-known/agent.json
+    { method: "GET", path: "/.well-known/agent.json", handler },
+  ];
+}
+
+export function buildAgentCard(ctx: ApiContext): AgentCard {
+  const baseUrl = (process.env.WORKSTACEAN_BASE_URL ?? "").replace(/\/$/, "")
+    || `http://localhost:${process.env.WORKSTACEAN_HTTP_PORT ?? "3000"}`;
+
+  const registrations = ctx.executorRegistry.list();
+  // Dedupe by skill — multiple agents may register the same skill; external
+  // callers only need to see the skill once, and workstacean handles target
+  // selection via ExecutorRegistry.resolve().
+  const seen = new Set<string>();
+  const skills: AgentSkill[] = [];
+  for (const reg of registrations) {
+    if (!reg.skill || seen.has(reg.skill)) continue;
+    seen.add(reg.skill);
+    skills.push({
+      id: reg.skill,
+      name: reg.skill,
+      description: `Skill routed by workstacean to ${reg.agentName ?? "default executor"}`,
+      tags: ["routed", reg.agentName ?? "default"].filter(Boolean),
+    });
+  }
+
+  return {
+    name: "workstacean",
+    description:
+      "protoLabs Studio operational gateway. Routes skill requests across the " +
+      "agent fleet (Ava, Quinn, Frank, Jon, Cindi, Researcher, protopen, etc).",
+    protocolVersion: PROTOCOL_VERSION,
+    version: DEFAULT_VERSION,
+    url: `${baseUrl}/a2a`,
+    preferredTransport: "JSONRPC",
+    provider: {
+      organization: "protoLabs AI",
+      url: "https://protolabs.ai",
+    },
+    defaultInputModes: ["text/plain"],
+    defaultOutputModes: ["text/plain"],
+    capabilities: {
+      streaming: true,
+      pushNotifications: true,
+      stateTransitionHistory: false,
+    },
+    skills,
+  };
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -17,6 +17,8 @@ import { createRoutes as boardRoutes } from "./board.ts";
 import { createRoutes as mailboxRoutes } from "./mailbox.ts";
 import { createRoutes as discordRoutes } from "./discord.ts";
 import { createRoutes as a2aCallbackRoutes } from "./a2a-callback.ts";
+import { createRoutes as a2aServerRoutes } from "./a2a-server.ts";
+import { createRoutes as agentCardRoutes } from "./agent-card.ts";
 
 export { matchPath } from "./types.ts";
 export type { Route, ApiContext } from "./types.ts";
@@ -33,5 +35,7 @@ export function createAllRoutes(ctx: ApiContext): Route[] {
     ...(ctx.mailbox ? mailboxRoutes(ctx.mailbox, ctx) : []),
     ...discordRoutes(ctx),
     ...(ctx.taskTracker ? a2aCallbackRoutes(ctx.taskTracker, ctx) : []),
+    ...agentCardRoutes(ctx),
+    ...a2aServerRoutes(ctx),
   ];
 }

--- a/src/executor/__tests__/extension-registry.test.ts
+++ b/src/executor/__tests__/extension-registry.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Phase 8 — ExtensionRegistry foundation.
+ *
+ * These tests cover the registry's core matching + header generation logic.
+ * They don't cover any specific extension behavior (none shipped yet) — that
+ * comes in future phases when we implement cost/consent/etc.
+ */
+
+import { describe, test, expect } from "bun:test";
+import type { AgentCard } from "@a2a-js/sdk";
+import { ExtensionRegistry, type ExtensionInterceptor } from "../extension-registry.ts";
+
+function cardWithExtensions(uris: string[]): AgentCard {
+  return {
+    name: "fake",
+    description: "test",
+    protocolVersion: "0.3.0",
+    version: "1.0.0",
+    url: "http://localhost/a2a",
+    preferredTransport: "JSONRPC",
+    defaultInputModes: ["text/plain"],
+    defaultOutputModes: ["text/plain"],
+    capabilities: { extensions: uris.map(uri => ({ uri })) },
+    skills: [],
+  };
+}
+
+describe("ExtensionRegistry", () => {
+  test("matchAgent returns empty when agent has no extensions", () => {
+    const reg = new ExtensionRegistry();
+    reg.register({ uri: "https://example.com/ext/x" });
+    const card = cardWithExtensions([]);
+    expect(reg.matchAgent(card)).toEqual([]);
+  });
+
+  test("matchAgent returns only registered extensions advertised by agent", () => {
+    const reg = new ExtensionRegistry();
+    reg.register({ uri: "https://example.com/ext/cost" });
+    reg.register({ uri: "https://example.com/ext/consent" });
+    const card = cardWithExtensions([
+      "https://example.com/ext/cost",
+      "https://example.com/ext/unknown", // not registered — must be ignored
+    ]);
+    const matches = reg.matchAgent(card);
+    expect(matches.map(m => m.uri)).toEqual(["https://example.com/ext/cost"]);
+  });
+
+  test("headersFor emits comma-separated a2a-extensions opt-in list", () => {
+    const reg = new ExtensionRegistry();
+    reg.register({ uri: "https://example.com/ext/cost" });
+    reg.register({ uri: "https://example.com/ext/consent" });
+    const card = cardWithExtensions([
+      "https://example.com/ext/cost",
+      "https://example.com/ext/consent",
+    ]);
+    const headers = reg.headersFor(card);
+    expect(headers).toEqual({
+      "a2a-extensions": "https://example.com/ext/cost, https://example.com/ext/consent",
+    });
+  });
+
+  test("headersFor returns empty object when no matches", () => {
+    const reg = new ExtensionRegistry();
+    reg.register({ uri: "https://example.com/ext/cost" });
+    const card = cardWithExtensions([]);
+    expect(reg.headersFor(card)).toEqual({});
+  });
+
+  test("interceptorsFor filters only extensions with interceptors", () => {
+    const reg = new ExtensionRegistry();
+    const costInterceptor: ExtensionInterceptor = { before: async () => {} };
+    reg.register({ uri: "https://example.com/ext/cost", interceptor: costInterceptor });
+    reg.register({ uri: "https://example.com/ext/plain" }); // no interceptor
+    const card = cardWithExtensions([
+      "https://example.com/ext/cost",
+      "https://example.com/ext/plain",
+    ]);
+    const interceptors = reg.interceptorsFor(card);
+    expect(interceptors).toHaveLength(1);
+    expect(interceptors[0]).toBe(costInterceptor);
+  });
+
+  test("null/undefined card is safe", () => {
+    const reg = new ExtensionRegistry();
+    reg.register({ uri: "https://example.com/ext/cost" });
+    expect(reg.matchAgent(undefined)).toEqual([]);
+    expect(reg.matchAgent(null)).toEqual([]);
+    expect(reg.headersFor(undefined)).toEqual({});
+  });
+});

--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -20,13 +20,36 @@ import type {
 } from "@a2a-js/sdk";
 import type { IExecutor, SkillRequest, SkillResult } from "../types.ts";
 
+/**
+ * Auth scheme the executor applies on outbound requests.
+ *
+ *   "apiKey" — sends X-API-Key: <value>    (default — same as legacy behavior)
+ *   "bearer" — sends Authorization: Bearer <value>
+ *   "hmac"   — reserved for future HMAC-signed requests (extension hook only)
+ *
+ * `value` resolution: if `valueEnv` is set, we read process.env[valueEnv];
+ * otherwise we fall back to the agent-level `apiKeyEnv` for backward compat.
+ * Unset → no auth header stamped.
+ */
+export type A2AAuthScheme = "apiKey" | "bearer" | "hmac";
+
+export interface A2AAuthConfig {
+  scheme: A2AAuthScheme;
+  /** Environment variable holding the credential value. */
+  credentialsEnv?: string;
+}
+
 export interface A2AAgentConfig {
   /** Agent name (for logging). */
   name: string;
   /** Full A2A endpoint URL (to agent root — card is fetched at /.well-known/agent-card.json). */
   url: string;
-  /** Environment variable name holding the API key. Optional. */
+  /** Environment variable name holding the API key. Optional. Legacy alias for auth.apiKey. */
   apiKeyEnv?: string;
+  /** Structured auth config — preferred over apiKeyEnv when set. */
+  auth?: A2AAuthConfig;
+  /** Extra request headers (e.g. opt-in A2A extensions). Merged per-call. */
+  extraHeaders?: Record<string, string>;
   /** Request timeout in ms. Default: 300_000 (5 min). */
   timeoutMs?: number;
   /** Whether the remote agent supports SSE streaming (from agent card). */
@@ -51,7 +74,7 @@ export interface ExecuteOptions {
 }
 
 /**
- * Build a fetch wrapper that stamps API key + per-request trace headers.
+ * Build a fetch wrapper that stamps auth + per-request trace headers.
  * A new wrapper is built per executor.execute() call so each client sees
  * the right correlationId without requiring a separate cached client per trace.
  *
@@ -59,14 +82,33 @@ export interface ExecuteOptions {
  * `preconnect` (a browser-only signature) that Node/Bun's fetch doesn't expose.
  */
 function buildFetch(
-  apiKey: string,
+  auth: { scheme: A2AAuthScheme; value: string } | undefined,
+  extraHeaders: Record<string, string> | undefined,
   timeoutMs: number,
   correlationId: string,
   parentId?: string,
 ): typeof fetch {
   const wrapped = async (input: string | URL | Request, init?: RequestInit) => {
     const headers = new Headers(init?.headers);
-    if (apiKey) headers.set("X-API-Key", apiKey);
+
+    // Auth header selection — scheme drives the header name.
+    if (auth && auth.value) {
+      if (auth.scheme === "bearer") {
+        headers.set("Authorization", `Bearer ${auth.value}`);
+      } else if (auth.scheme === "apiKey") {
+        headers.set("X-API-Key", auth.value);
+      }
+      // "hmac" is handled by an extension interceptor, not here.
+    }
+
+    // Static extra headers (e.g. a2a-extensions opt-in list). Don't overwrite
+    // anything the SDK already set — extras are for our metadata only.
+    if (extraHeaders) {
+      for (const [k, v] of Object.entries(extraHeaders)) {
+        if (!headers.has(k)) headers.set(k, v);
+      }
+    }
+
     headers.set("X-Correlation-Id", correlationId);
     if (parentId) headers.set("X-Parent-Id", parentId);
 
@@ -120,6 +162,30 @@ export class A2AExecutor implements IExecutor {
         correlationId: req.correlationId,
       };
     }
+  }
+
+  /**
+   * Resume a task that's in input-required state by sending a new message
+   * with the same taskId. Used by TaskTracker when a HITL response arrives.
+   */
+  async resumeTask(
+    taskId: string,
+    contextId: string,
+    text: string,
+    correlationId: string,
+    parentId?: string,
+  ): Promise<void> {
+    const client = await this._buildClient(correlationId, parentId);
+    await client.sendMessage({
+      message: {
+        kind: "message",
+        messageId: crypto.randomUUID(),
+        role: "user",
+        parts: [{ kind: "text", text }],
+        taskId,
+        contextId,
+      },
+    });
   }
 
   /**
@@ -271,15 +337,21 @@ export class A2AExecutor implements IExecutor {
     params: Parameters<Client["sendMessageStream"]>[0],
     req: SkillRequest,
   ): Promise<SkillResult> {
-    let resultText = "";
     let taskId: string | undefined;
     let contextId: string | undefined;
     let taskState = "working";
+    let terminalMessage = "";
+
+    // Artifact buffering — honors append + lastChunk per A2A spec.
+    // - append: false (or undefined) → replace the artifact's parts
+    // - append: true → concatenate incoming parts to existing buffer
+    // - lastChunk: true → signal artifact is complete (we emit artifact_complete)
+    const artifactBuffers = new Map<string, Array<{ kind: string; text?: string }>>();
 
     for await (const event of client.sendMessageStream(params)) {
       if (event.kind === "message") {
         // Terminal message — stream ends
-        resultText = this._textFromParts(event.parts);
+        terminalMessage = this._textFromParts(event.parts);
         taskState = "completed";
         break;
       }
@@ -287,6 +359,10 @@ export class A2AExecutor implements IExecutor {
         taskId = event.id;
         contextId = event.contextId;
         taskState = event.status.state;
+        // Seed artifact buffers from task snapshot if present
+        for (const artifact of event.artifacts ?? []) {
+          artifactBuffers.set(artifact.artifactId, [...artifact.parts]);
+        }
         continue;
       }
       if (event.kind === "status-update") {
@@ -303,13 +379,41 @@ export class A2AExecutor implements IExecutor {
       if (event.kind === "artifact-update") {
         taskId = event.taskId;
         contextId = event.contextId;
-        const artifactText = this._textFromParts(event.artifact.parts);
-        if (artifactText) {
-          resultText += (resultText ? "\n" : "") + artifactText;
-          this.config.onStreamUpdate?.({ type: "artifact", text: artifactText });
+        const aid = event.artifact.artifactId;
+        const incomingParts = event.artifact.parts;
+        const incomingText = this._textFromParts(incomingParts);
+
+        if (event.append) {
+          const existing = artifactBuffers.get(aid) ?? [];
+          artifactBuffers.set(aid, [...existing, ...incomingParts]);
+        } else {
+          // New artifact or replacement
+          artifactBuffers.set(aid, [...incomingParts]);
+        }
+
+        // Emit chunk event — consumers see progressive updates in real time
+        if (incomingText) {
+          this.config.onStreamUpdate?.({
+            type: event.append ? "artifact_chunk" : "artifact",
+            text: incomingText,
+          });
+        }
+        if (event.lastChunk) {
+          const finalText = this._textFromParts(artifactBuffers.get(aid) ?? []);
+          this.config.onStreamUpdate?.({
+            type: "artifact_complete",
+            text: finalText,
+          });
         }
       }
     }
+
+    // Final resultText = terminal message if we got one, otherwise concat of all artifact buffers
+    const artifactText = Array.from(artifactBuffers.values())
+      .map(parts => this._textFromParts(parts))
+      .filter(Boolean)
+      .join("\n");
+    const resultText = terminalMessage || artifactText;
 
     return {
       text: resultText || `Skill "${req.skill}" completed by ${this.config.name}`,
@@ -335,10 +439,22 @@ export class A2AExecutor implements IExecutor {
    */
   private async _buildClient(correlationId: string, parentId?: string): Promise<Client> {
     const baseUrl = this.config.url.replace(/\/a2a\/?$/, "");
-    const apiKey = this.config.apiKeyEnv ? (process.env[this.config.apiKeyEnv] ?? "") : "";
     const timeoutMs = this.config.timeoutMs ?? 300_000;
 
-    const customFetch = buildFetch(apiKey, timeoutMs, correlationId, parentId);
+    // Auth resolution — prefer structured auth.credentialsEnv; fall back to
+    // the legacy apiKeyEnv so existing agents.yaml keeps working.
+    const scheme: A2AAuthScheme = this.config.auth?.scheme ?? "apiKey";
+    const credEnv = this.config.auth?.credentialsEnv ?? this.config.apiKeyEnv;
+    const credValue = credEnv ? (process.env[credEnv] ?? "") : "";
+    const authOpts = credValue ? { scheme, value: credValue } : undefined;
+
+    const customFetch = buildFetch(
+      authOpts,
+      this.config.extraHeaders,
+      timeoutMs,
+      correlationId,
+      parentId,
+    );
     const factory = new ClientFactory({
       transports: [new JsonRpcTransportFactory({ fetchImpl: customFetch })],
     });

--- a/src/executor/extension-registry.ts
+++ b/src/executor/extension-registry.ts
@@ -1,0 +1,99 @@
+/**
+ * ExtensionRegistry — lightweight map of known A2A protocol extensions and
+ * the interceptors we want to apply when an agent declares support for them
+ * in its agent card's `capabilities.extensions` list.
+ *
+ * The A2A spec models extensions as URIs (e.g. `https://a2a-protocol.org/ext/cost-v1`)
+ * plus optional `params`. Agents advertise them in their card; clients can
+ * opt-in per-request via the `a2a-extensions` header (comma-separated URIs).
+ *
+ * This phase is foundation only — we wire the registry, the header stamping,
+ * and the interceptor hook points, but don't ship specific extension
+ * implementations yet. Adding "cost tracking" or "consent negotiation" later
+ * means registering an interceptor here; no other code needs to change.
+ *
+ * Usage:
+ *   const ext = new ExtensionRegistry();
+ *   ext.register({ uri: "https://a2a-protocol.org/ext/cost-v1", interceptor: costInterceptor });
+ *   const headers = ext.headersFor(agentCard); // { "a2a-extensions": "https://..." }
+ *   for (const i of ext.interceptorsFor(agentCard)) await i.before?.(request);
+ */
+
+import type { AgentCard } from "@a2a-js/sdk";
+
+export interface ExtensionInterceptor {
+  /** Called before a skill request is dispatched. May mutate metadata. */
+  before?: (ctx: ExtensionContext) => Promise<void> | void;
+  /** Called after a response is received. May attach data to the result. */
+  after?: (ctx: ExtensionContext, result: { text: string; data?: Record<string, unknown> }) => Promise<void> | void;
+}
+
+export interface ExtensionContext {
+  agentName: string;
+  skill: string;
+  correlationId: string;
+  /** Mutable metadata bag — interceptors can stamp keys here. */
+  metadata: Record<string, unknown>;
+}
+
+export interface ExtensionDefinition {
+  /** Canonical URI from the agent card (e.g. "https://a2a-protocol.org/ext/cost-v1"). */
+  uri: string;
+  /** Optional interceptor applied when an agent declares this extension. */
+  interceptor?: ExtensionInterceptor;
+  /** Human-readable description for diagnostics. */
+  description?: string;
+}
+
+export class ExtensionRegistry {
+  private readonly extensions = new Map<string, ExtensionDefinition>();
+
+  register(def: ExtensionDefinition): void {
+    this.extensions.set(def.uri, def);
+  }
+
+  /** List every registered extension URI — useful for diagnostics. */
+  list(): ExtensionDefinition[] {
+    return Array.from(this.extensions.values());
+  }
+
+  /**
+   * Return the subset of our registered extensions that the given agent card
+   * declares support for. Filters by exact URI match; agents must advertise
+   * each URI they actually implement.
+   */
+  matchAgent(card: AgentCard | undefined | null): ExtensionDefinition[] {
+    if (!card?.capabilities?.extensions) return [];
+    const advertised = new Set(card.capabilities.extensions.map(e => e.uri));
+    return Array.from(this.extensions.values()).filter(def => advertised.has(def.uri));
+  }
+
+  /**
+   * Build the `a2a-extensions` request header for an agent — a comma-
+   * separated list of URIs the client wants to opt into on this call.
+   * Returns an empty record when no matches exist so callers can just
+   * spread the result without null-checking.
+   */
+  headersFor(card: AgentCard | undefined | null): Record<string, string> {
+    const matches = this.matchAgent(card);
+    if (matches.length === 0) return {};
+    return { "a2a-extensions": matches.map(m => m.uri).join(", ") };
+  }
+
+  /** Interceptors for the subset of extensions an agent supports. */
+  interceptorsFor(card: AgentCard | undefined | null): ExtensionInterceptor[] {
+    return this.matchAgent(card)
+      .map(d => d.interceptor)
+      .filter((i): i is ExtensionInterceptor => !!i);
+  }
+
+  get size(): number {
+    return this.extensions.size;
+  }
+}
+
+/**
+ * Singleton used by the skill broker / A2A executor. Test code can construct
+ * its own ExtensionRegistry to avoid cross-test pollution.
+ */
+export const defaultExtensionRegistry = new ExtensionRegistry();

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -316,6 +316,9 @@ export class SkillDispatcherPlugin implements Plugin {
           executor: a2aExecutor,
           parentId,
           callbackToken,
+          sourceInterface: sourcePlatform,
+          sourceChannelId: sourceChannelId,
+          sourceUserId: sourceUserId,
         });
 
         // Try to register a push-notification webhook so the agent can POST

--- a/src/executor/task-tracker.ts
+++ b/src/executor/task-tracker.ts
@@ -12,11 +12,12 @@
  * response on the reply topic, just later.
  */
 
-import type { EventBus } from "../../lib/types.ts";
+import type { EventBus, BusMessage, HITLRequest, HITLResponse } from "../../lib/types.ts";
 import type { A2AExecutor } from "./executors/a2a-executor.ts";
 import type { AgentSkillResponsePayload } from "../event-bus/payloads.ts";
 
 const TERMINAL_STATES = new Set(["completed", "failed", "canceled", "rejected"]);
+const HITL_TTL_MS = 30 * 60_000; // 30 min default input-required window
 
 export interface TrackedTask {
   correlationId: string;
@@ -30,6 +31,14 @@ export interface TrackedTask {
   pollIntervalMs: number;
   /** Per-task secret for authenticating push-notification callbacks. */
   callbackToken?: string;
+  /** Set when the task has asked for human input — suppresses polling until resumed. */
+  awaitingHuman?: boolean;
+  /** The Discord/etc interface that originated the request — reused for HITL routing. */
+  sourceInterface?: string;
+  /** Source channel ID for HITL rendering. */
+  sourceChannelId?: string;
+  /** User ID for HITL rendering. */
+  sourceUserId?: string;
 }
 
 export interface TaskTrackerOptions {
@@ -58,6 +67,14 @@ export class TaskTracker {
     this.maxTrackingMs = opts.maxTrackingMs ?? 60 * 60_000;
     this.sweepTimer = setInterval(() => { void this._sweep(); }, this.sweepIntervalMs);
     this.sweepTimer.unref?.();
+
+    // Subscribe to HITL responses — when a tracked task was awaiting input
+    // and a human responds, resume the task via sendMessage(taskId, decisionText).
+    this.bus.subscribe("hitl.response.#", "task-tracker", (msg: BusMessage) => {
+      const resp = msg.payload as HITLResponse | undefined;
+      if (!resp || resp.type !== "hitl_response") return;
+      void this._resumeFromHitl(resp);
+    });
   }
 
   /** Register a task for tracking. Dispatcher calls this after executor returns working. */
@@ -71,6 +88,10 @@ export class TaskTracker {
     pollIntervalMs?: number;
     /** Per-task token for authenticating push callbacks. Generated if omitted. */
     callbackToken?: string;
+    /** Source interface/channel/user — reused to route input-required HITL requests. */
+    sourceInterface?: string;
+    sourceChannelId?: string;
+    sourceUserId?: string;
   }): void {
     const now = Date.now();
     this.tasks.set(params.correlationId, {
@@ -84,6 +105,9 @@ export class TaskTracker {
       lastPolledAt: now,
       pollIntervalMs: params.pollIntervalMs ?? this.defaultPollIntervalMs,
       callbackToken: params.callbackToken ?? crypto.randomUUID(),
+      sourceInterface: params.sourceInterface,
+      sourceChannelId: params.sourceChannelId,
+      sourceUserId: params.sourceUserId,
     });
     console.log(
       `[task-tracker] Tracking ${params.agentName} task ${params.taskId.slice(0, 8)}… (correlationId: ${params.correlationId.slice(0, 8)}…)`,
@@ -108,6 +132,14 @@ export class TaskTracker {
     const state = typeof status.state === "string" ? status.state : undefined;
 
     task.lastPolledAt = Date.now();
+
+    if (state === "input-required") {
+      const statusText = status.message?.parts
+        ? status.message.parts.filter(p => p.kind === "text").map(p => p.text ?? "").join("")
+        : "";
+      this._raiseHitl(task, statusText);
+      return;
+    }
 
     if (!state || !TERMINAL_STATES.has(state)) {
       // Non-terminal update — just refresh the polled timestamp
@@ -169,6 +201,9 @@ export class TaskTracker {
         continue;
       }
 
+      // Awaiting human input — don't poll, just wait for hitl.response.*
+      if (task.awaitingHuman) continue;
+
       // Not yet due
       if (now - task.lastPolledAt < task.pollIntervalMs) continue;
 
@@ -177,6 +212,11 @@ export class TaskTracker {
       try {
         const result = await task.executor.pollTask(task.taskId, task.correlationId, task.parentId);
         const state = result.data?.taskState;
+
+        if (state === "input-required") {
+          this._raiseHitl(task, result.text);
+          continue;
+        }
 
         if (state && TERMINAL_STATES.has(state)) {
           this._publishResponse(task, result.text, result.isError ? result.text : undefined);
@@ -191,6 +231,81 @@ export class TaskTracker {
           err instanceof Error ? err.message : String(err),
         );
       }
+    }
+  }
+
+  /**
+   * Emit a HITL request for a task that hit input-required. HITLPlugin will
+   * route to the registered renderer (Discord approval buttons, etc). The
+   * response flows back via hitl.response.# which we subscribe to.
+   */
+  private _raiseHitl(task: TrackedTask, question: string | undefined): void {
+    if (task.awaitingHuman) return; // already raised, avoid duplicate
+    task.awaitingHuman = true;
+
+    const req: HITLRequest = {
+      type: "hitl_request",
+      correlationId: task.correlationId,
+      title: `Input needed from ${task.agentName}`,
+      summary: question || "The agent is requesting input to continue.",
+      options: ["approve", "reject"],
+      expiresAt: new Date(Date.now() + HITL_TTL_MS).toISOString(),
+      replyTopic: `hitl.response.${task.correlationId}`,
+      sourceMeta: {
+        interface: task.sourceInterface ?? "discord",
+        channelId: task.sourceChannelId,
+        userId: task.sourceUserId,
+      },
+    };
+
+    this.bus.publish(`hitl.request.${task.correlationId}`, {
+      id: crypto.randomUUID(),
+      correlationId: task.correlationId,
+      topic: `hitl.request.${task.correlationId}`,
+      timestamp: Date.now(),
+      payload: req,
+    });
+
+    console.log(
+      `[task-tracker] input-required from ${task.agentName} — raised HITL request (correlationId: ${task.correlationId.slice(0, 8)}…)`,
+    );
+  }
+
+  /**
+   * When a HITL response arrives for a tracked task, resume the agent by
+   * sending a new message in the same taskId. Uses executor.execute() with
+   * the original skill context so memory enrichment still applies.
+   */
+  private async _resumeFromHitl(resp: HITLResponse): Promise<void> {
+    const task = this.tasks.get(resp.correlationId);
+    if (!task || !task.awaitingHuman) return;
+
+    const decisionText = [
+      `Human decision: ${resp.decision}`,
+      resp.feedback ? `Feedback: ${resp.feedback}` : "",
+      `Decided by: ${resp.decidedBy}`,
+    ].filter(Boolean).join("\n");
+
+    try {
+      await task.executor.resumeTask(
+        task.taskId,
+        task.correlationId,
+        decisionText,
+        task.correlationId,
+        task.parentId,
+      );
+      task.awaitingHuman = false;
+      task.lastPolledAt = Date.now();
+      console.log(
+        `[task-tracker] Resumed ${task.taskId.slice(0, 8)}… with decision "${resp.decision}" — polling resumes`,
+      );
+    } catch (err) {
+      console.error(
+        `[task-tracker] Failed to resume ${task.taskId.slice(0, 8)}…:`,
+        err instanceof Error ? err.message : String(err),
+      );
+      this._publishResponse(task, undefined, `Resume failed: ${err instanceof Error ? err.message : String(err)}`);
+      this.tasks.delete(task.correlationId);
     }
   }
 

--- a/src/plugins/skill-broker-plugin.ts
+++ b/src/plugins/skill-broker-plugin.ts
@@ -1,18 +1,27 @@
 /**
  * SkillBrokerPlugin — registers A2AExecutor instances with ExecutorRegistry.
  *
- * Reads workspace/agents.yaml on install, creates one A2AExecutor per agent
- * definition, and registers each skill declared for that agent.
+ * Reads workspace/agents.yaml on install, creates one A2AExecutor per agent,
+ * then auto-discovers skills from each agent's /.well-known/agent-card.json.
  *
- * This plugin is a registrar only — it does NOT subscribe to agent.skill.request.
- * SkillDispatcherPlugin is the sole subscriber and delegates to the registry.
+ * Skill sources (in order of priority):
+ *   1. agents.yaml `skills:` block (if present) — explicit overrides
+ *   2. Agent card `skills` field — auto-discovered on install + refreshed every 10 min
  *
- * Config: workspace/agents.yaml (A2A URLs and skill registrations)
+ * If agents.yaml omits `skills:` entirely, the card is the only source.
+ * If it lists skills, those take precedence and the card is used as a backup/diff.
+ *
+ * This plugin is a registrar only — SkillDispatcherPlugin is the sole
+ * subscriber to agent.skill.request.
+ *
+ * Config: workspace/agents.yaml (A2A URLs and optional skill overrides)
  */
 
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
+import { ClientFactory, JsonRpcTransportFactory } from "@a2a-js/sdk/client";
+import type { AgentCard } from "@a2a-js/sdk";
 import type { Plugin, EventBus } from "../../lib/types.ts";
 import type { ExecutorRegistry } from "../executor/executor-registry.ts";
 import { A2AExecutor } from "../executor/executors/a2a-executor.ts";
@@ -23,21 +32,36 @@ interface AgentSkill {
   description?: string;
 }
 
+interface AgentAuthDef {
+  /** One of: apiKey, bearer, hmac */
+  scheme: "apiKey" | "bearer" | "hmac";
+  credentialsEnv?: string;
+}
+
 interface AgentDef {
   name: string;
   url: string;
   apiKeyEnv?: string;
+  /** Structured auth (Phase 8) — preferred over apiKeyEnv when set. */
+  auth?: AgentAuthDef;
+  /** Extra static request headers — e.g. extension opt-in. */
+  headers?: Record<string, string>;
   streaming?: boolean;
   skills?: Array<AgentSkill | string>;
 }
 
+const CARD_REFRESH_INTERVAL_MS = 10 * 60_000; // 10 min
+
 export class SkillBrokerPlugin implements Plugin {
   readonly name = "skill-broker";
-  readonly description = "Registers A2AExecutors with ExecutorRegistry from workspace/agents.yaml";
+  readonly description = "Registers A2AExecutors with ExecutorRegistry from agents.yaml + auto-discovered agent cards";
   readonly capabilities = ["executor-registrar", "a2a-routing"];
 
   private readonly workspaceDir: string;
   private readonly executorRegistry: ExecutorRegistry;
+  private refreshTimer?: ReturnType<typeof setInterval>;
+  /** Tracks skills we registered per agent so we can cleanly re-register on refresh. */
+  private registeredSkills = new Map<string, Set<string>>();
 
   constructor(workspaceDir: string, executorRegistry: ExecutorRegistry) {
     this.workspaceDir = workspaceDir;
@@ -49,10 +73,13 @@ export class SkillBrokerPlugin implements Plugin {
     const opsChannel = process.env.DISCORD_AGENT_OPS_CHANNEL ?? "";
 
     for (const agent of agents) {
+      const resolvedUrl = resolveEnvVars(agent.url, "skill-broker");
       const executor = new A2AExecutor({
         name: agent.name,
-        url: resolveEnvVars(agent.url, "skill-broker"),
+        url: resolvedUrl,
         apiKeyEnv: agent.apiKeyEnv,
+        auth: agent.auth,
+        extraHeaders: agent.headers,
         streaming: agent.streaming ?? false,
         onStreamUpdate: opsChannel
           ? (update) => {
@@ -69,19 +96,91 @@ export class SkillBrokerPlugin implements Plugin {
           : undefined,
       });
 
+      // Register yaml-declared skills synchronously (explicit overrides)
+      const explicitSkills = new Set<string>();
       for (const s of agent.skills ?? []) {
         const skillName = typeof s === "string" ? s : s.name;
         this.executorRegistry.register(skillName, executor, {
           agentName: agent.name,
           priority: 5,
         });
+        explicitSkills.add(skillName);
       }
+      this.registeredSkills.set(agent.name, explicitSkills);
+
+      // Kick off async card discovery for any skills not in yaml
+      void this._discoverSkills(agent, executor, resolvedUrl);
     }
 
-    console.log(`[skill-broker] Registered ${agents.length} A2A agent(s)`);
+    console.log(`[skill-broker] Registered ${agents.length} A2A agent(s) (skills from yaml; discovery in progress)`);
+
+    // Periodic refresh — picks up new skills without a restart
+    this.refreshTimer = setInterval(() => {
+      for (const agent of agents) {
+        const executor = this.executorRegistry.list().find(r => r.agentName === agent.name)?.executor;
+        if (executor && executor.type === "a2a") {
+          void this._discoverSkills(agent, executor as A2AExecutor, resolveEnvVars(agent.url, "skill-broker"));
+        }
+      }
+    }, CARD_REFRESH_INTERVAL_MS);
+    this.refreshTimer.unref?.();
   }
 
-  uninstall(): void {}
+  uninstall(): void {
+    if (this.refreshTimer) clearInterval(this.refreshTimer);
+  }
+
+  /**
+   * Fetch the agent card and register any skills not already in yaml.
+   * Silent failure — card fetch errors are logged but don't break the broker.
+   */
+  private async _discoverSkills(agent: AgentDef, executor: A2AExecutor, url: string): Promise<void> {
+    try {
+      const card = await this._fetchCard(url);
+      if (!card) return;
+
+      const registered = this.registeredSkills.get(agent.name) ?? new Set();
+      let added = 0;
+
+      for (const cardSkill of card.skills ?? []) {
+        const skillName = cardSkill.id;
+        if (!skillName || registered.has(skillName)) continue;
+
+        this.executorRegistry.register(skillName, executor, {
+          agentName: agent.name,
+          priority: 5,
+        });
+        registered.add(skillName);
+        added++;
+      }
+
+      this.registeredSkills.set(agent.name, registered);
+      if (added > 0) {
+        console.log(`[skill-broker] ${agent.name}: discovered ${added} new skill(s) from agent card (${Array.from(registered).join(", ")})`);
+      }
+    } catch (err) {
+      console.debug(`[skill-broker] ${agent.name}: card discovery skipped:`, err instanceof Error ? err.message : err);
+    }
+  }
+
+  private async _fetchCard(url: string): Promise<AgentCard | null> {
+    const baseUrl = url.replace(/\/a2a\/?$/, "");
+    const factory = new ClientFactory({
+      transports: [new JsonRpcTransportFactory()],
+    });
+    try {
+      const client = await factory.createFromUrl(baseUrl);
+      return await client.getAgentCard();
+    } catch {
+      // Try legacy path
+      try {
+        const client = await factory.createFromUrl(baseUrl, "/.well-known/agent.json");
+        return await client.getAgentCard();
+      } catch {
+        return null;
+      }
+    }
+  }
 
   private _loadAgents(): AgentDef[] {
     const agentsPath = join(this.workspaceDir, "agents.yaml");

--- a/src/router/__tests__/router-plugin.test.ts
+++ b/src/router/__tests__/router-plugin.test.ts
@@ -356,14 +356,14 @@ describe("RouterPlugin", () => {
       } finally { cleanup(); }
     });
 
-    test("skips plan, plan_resume, deep_research", async () => {
+    test("skips plan, deep_research", async () => {
       const { workspaceDir, cleanup } = makeWorkspace({ agents: { "ava.yaml": onboardingAgent } });
       try {
         const bus = new InMemoryEventBus();
         const plugin = new RouterPlugin({ workspaceDir });
         plugin.install(bus);
 
-        for (const skill of ["plan", "plan_resume", "deep_research"]) {
+        for (const skill of ["plan", "deep_research"]) {
           const req = waitForSkillRequest(bus, 80);
           bus.publish(
             "message.inbound.discord.faf",

--- a/src/router/faf-skills.ts
+++ b/src/router/faf-skills.ts
@@ -22,6 +22,5 @@
 export const FIRE_AND_FORGET_SKILLS: ReadonlySet<string> = new Set([
   "onboard_project",
   "plan",
-  "plan_resume",
   "deep_research",
 ]);

--- a/workspace/agents.yaml.example
+++ b/workspace/agents.yaml.example
@@ -1,7 +1,14 @@
 # protoLabs A2A Agent Registry
 # Authoritative source for the agent fleet.
-# Skills are refreshed live from /.well-known/agent.json on startup.
-# apiKeyEnv: name of env var holding the API key for this agent's /a2a endpoint.
+# Skills are refreshed live from /.well-known/agent-card.json on startup
+# (with a fallback to /.well-known/agent.json for legacy agents).
+#
+# Auth options (Phase 8):
+#   apiKeyEnv: env var holding a value sent as X-API-Key (legacy shorthand)
+#   auth:      structured auth block — preferred. Fields:
+#                scheme:          "apiKey" | "bearer" | "hmac"
+#                credentialsEnv:  env var holding the credential value
+#   headers:   static request headers (e.g. a2a-extensions opt-in)
 
 agents:
   - name: ava
@@ -19,7 +26,11 @@ agents:
 
   - name: quinn
     url: http://your-quinn-host:7870/a2a
-    apiKeyEnv: QUINN_API_KEY
+    # Structured auth (Phase 8). Same behavior as apiKeyEnv: QUINN_API_KEY
+    # but makes the scheme explicit and leaves room for bearer/hmac.
+    auth:
+      scheme: apiKey
+      credentialsEnv: QUINN_API_KEY
     discordBotTokenEnvKey: DISCORD_BOT_TOKEN_QUINN
     skills:
       - name: bug_triage
@@ -29,3 +40,12 @@ agents:
     subscribesTo:
       - message.inbound.discord.#
       - message.inbound.github.#
+
+  # Example — an external agent served over bearer auth:
+  # - name: external_partner
+  #   url: https://partner.example.com/a2a
+  #   auth:
+  #     scheme: bearer
+  #     credentialsEnv: PARTNER_API_TOKEN
+  #   headers:
+  #     a2a-extensions: "https://a2a-protocol.org/ext/cost-v1"

--- a/workspace/agents/ava.yaml.example
+++ b/workspace/agents/ava.yaml.example
@@ -66,9 +66,6 @@ skills:
   - name: plan
     description: Build a feature plan from a PRD (requires HITL approval)
     keywords: [plan, idea, build, proposal, project idea, /plan, i want to, let's build]
-  - name: plan_resume
-    description: Resume plan execution after HITL approval
-    # no keywords — dispatched programmatically via HITLPlugin
   - name: triage
     description: Triage an incoming message and decide next action
     keywords: [help, question, not sure, what should, /triage]

--- a/workspace/plugins/a2a.ts
+++ b/workspace/plugins/a2a.ts
@@ -191,7 +191,6 @@ const SKILL_KEYWORDS: Record<string, string[]> = {
   pr_review:    ["pr", "pull request", "review", "merge", "ci", "/review"],
   // Ava
   plan:           ["build", "create feature", "new feature", "idea:", "let's build", "plan:", "i want to"],
-  plan_resume:    ["approve", "reject", "modify"],
   sitrep:         ["status", "sitrep", "situation", "what's up", "summary", "/status", "/sitrep"],
   manage_feature: ["unblock", "assign", "move to", "add to board"],
   board_health:   ["blocked", "stalled", "stuck", "health", "unhealthy"],


### PR DESCRIPTION
## Summary
Completes the A2A protocol adoption started in PRs #169, #170, #171.

- **Phase 4** — agent card auto-discovery (`/.well-known/agent-card.json` with 10-min refresh)
- **Phase 5** — artifact chunking (honors `append`/`lastChunk`, progressive `onStreamUpdate` events)
- **Phase 6** — native `input-required` HITL (strips `plan_resume` per greenfield policy)
- **Phase 7** — workstacean as an A2A server (`POST /a2a` JSON-RPC + agent card)
- **Phase 8** — auth + extensions foundation (structured `auth:` block in agents.yaml, `ExtensionRegistry` scaffolding)

26 files changed, +1422/-185. 8 new tests across card + server + extension registry.

## Test plan
- [x] `bun test` — 731 pass / 0 fail
- [x] `bunx tsc --noEmit` — clean
- [ ] Post-merge: roll-call smoke test against all agents (Ava, Quinn, Frank, Researcher, protopen)
- [ ] Post-merge: external A2A call via new `POST /a2a` endpoint

## Docs
- README A2A section, `http-api` reference, `add-an-agent` guide, HITL guide, Plane integration, agent.yaml example — all updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added A2A protocol support with `/.well-known/agent-card.json` endpoint for agent discovery.
  * Introduced streaming tasks via Server-Sent Events with artifact chunking.
  * Added long-running task handling with polling and push-notification callbacks.
  * Enhanced external agent authentication with structured `auth` schemes (apiKey, bearer, hmac).
  * Integrated Human-in-the-Loop with A2A task states for approval workflows.

* **Improvements**
  * Agent card auto-discovery now refreshes every 10 minutes; YAML skills override card skills.
  * Added optional static request headers for external agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->