### PR TITLE
docs(a2a): post-ship follow-up — env vars, reachability, auth block

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -35,3 +35,21 @@ GRAPHITI_EMBEDDING_MODEL=text-embedding-3-small
 
 # Model configuration is in models.json (in repo root)
 # Pi SDK uses in-memory auth configured via models.json and OPENAI_API_KEY
+
+# ── HTTP API + A2A server ──────────────────────────────────────────────────────
+# Port the internal HTTP server listens on. Exposes:
+#   GET  /.well-known/agent-card.json   (A2A discovery)
+#   POST /a2a                           (A2A JSON-RPC endpoint)
+#   POST /api/a2a/callback/:taskId      (push-notification webhooks)
+#   POST /publish, /api/*               (internal API)
+WORKSTACEAN_HTTP_PORT=3000
+
+# API key required for authenticated endpoints. Gates /publish + POST /a2a.
+# Unset → auth skipped (dev mode).
+WORKSTACEAN_API_KEY=
+
+# Public base URL of this workstacean instance. Used to build the agent
+# card `url` field and to register push-notification callback URLs with
+# external A2A agents. Falls back to http://localhost:$WORKSTACEAN_HTTP_PORT.
+# Example: https://workstacean.example.com  or  http://workstacean:3000 (Docker net)
+WORKSTACEAN_BASE_URL=

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ bun run src/index.ts
 | `AVA_BASE_URL` | For domain polling | Base URL of the protoMaker team server (env var name kept for historical reasons; e.g. `http://localhost:3008`) |
 | `AVA_API_KEY` | For domain polling | protoMaker team API key (`X-API-Key`) |
 | `WORKSTACEAN_HTTP_PORT` | No | HTTP API port (default: `3000`) |
-| `WORKSTACEAN_API_KEY` | No | API key for `/publish` endpoint |
+| `WORKSTACEAN_API_KEY` | No | API key for `/publish` + `POST /a2a` endpoints |
+| `WORKSTACEAN_BASE_URL` | For A2A server/webhooks | Public base URL — populates the agent card `url` and webhook callback URLs |
 | `ANTHROPIC_API_KEY` | For in-process agents | Claude API key |
 
 Full list: see `.env.dist`.
@@ -67,8 +68,9 @@ Plugins are loaded in `src/index.ts`. Each implements `install(bus) / uninstall(
 |---|---|---|
 | `RouterPlugin` | always | Translates inbound messages + cron events → `agent.skill.request` |
 | `AgentRuntimePlugin` | always | Registers `ProtoSdkExecutor` per `workspace/agents/*.yaml` into `ExecutorRegistry` |
-| `SkillBrokerPlugin` | always | Registers `A2AExecutor` per `workspace/agents.yaml` into `ExecutorRegistry` |
-| `SkillDispatcherPlugin` | always | Sole `agent.skill.request` subscriber; dispatches via `ExecutorRegistry` |
+| `SkillBrokerPlugin` | always | Registers `A2AExecutor` per `workspace/agents.yaml` + auto-discovers skills from each agent's card (10-min refresh) |
+| `SkillDispatcherPlugin` | always | Sole `agent.skill.request` subscriber; dispatches via `ExecutorRegistry`. Hands long-running A2A tasks off to `TaskTracker`. |
+| `TaskTracker` | always | In-process tracker for long-running A2A tasks — polls `tasks/get` (or uses `tasks/resubscribe`) until terminal, raises HITL on `input-required`, publishes the final response. |
 | `WorldStateEngine` | always | Generic domain poller; domains registered via `discoverAndRegister()` at startup |
 | `GoalEvaluatorPlugin` | always | Evaluates `workspace/goals.yaml` against world state |
 | `PlannerPluginL0` | always | Maps violated goals → actions from `ActionRegistry` |

--- a/README.md
+++ b/README.md
@@ -166,12 +166,30 @@ Copy `*.example` counterparts to bootstrap a new deployment.
 | `GET` | `/api/incidents` | Security incident list |
 | `POST` | `/api/incidents` | Report a new incident |
 | `POST` | `/api/incidents/:id/resolve` | Resolve an incident |
+| `GET` | `/.well-known/agent-card.json` | A2A agent card — discovery for external agents |
+| `POST` | `/a2a` | A2A JSON-RPC 2.0 endpoint (message/send, message/stream, tasks/*) |
+| `POST` | `/api/a2a/callback/:taskId` | Push-notification webhook for long-running A2A tasks |
+
+Full reference: [`docs/reference/http-api.md`](docs/reference/http-api.md).
+
+---
+
+## A2A protocol support
+
+protoWorkstacean is a first-class [A2A](https://a2a-protocol.org) client **and** server, built on [`@a2a-js/sdk`](https://www.npmjs.com/package/@a2a-js/sdk):
+
+- **Client** — `A2AExecutor` speaks the full A2A v0.3 protocol: `message/send`, `message/stream`, `tasks/get`, `tasks/cancel`, `tasks/resubscribe`, push notifications, artifact chunking, and native `input-required` HITL.
+- **Server** — workstacean exposes `/.well-known/agent-card.json` + `POST /a2a` so external agents can call it. Incoming calls bridge through the bus and back via `BusAgentExecutor`.
+- **Auth** — per-agent structured auth config in `workspace/agents.yaml` (apiKey / bearer / hmac schemes).
+- **Extensions** — `ExtensionRegistry` scaffolding for opt-in A2A extensions; no extensions shipped by default.
+
+See [`docs/guides/add-an-agent.md`](docs/guides/add-an-agent.md) for the full agent-onboarding flow.
 
 ---
 
 ## Testing
 
 ```bash
-bun test              # all 577 tests
+bun test              # all tests
 bun test --watch      # watch mode
 ```

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "workstacean",
       "dependencies": {
+        "@a2a-js/sdk": "^0.3.13",
         "@langchain/core": "^1.1.39",
         "@langchain/langgraph": "^1.2.8",
         "@langchain/openai": "^1.4.4",
@@ -31,6 +32,8 @@
     "@biomejs/biome",
   ],
   "packages": {
+    "@a2a-js/sdk": ["@a2a-js/sdk@0.3.13", "", { "dependencies": { "uuid": "^11.1.0" }, "peerDependencies": { "@bufbuild/protobuf": "^2.10.2", "@grpc/grpc-js": "^1.11.0", "express": "^4.21.2 || ^5.1.0" }, "optionalPeers": ["@bufbuild/protobuf", "@grpc/grpc-js", "express"] }, "sha512-BZr0f9JVNQs3GKOM9xINWCh6OKIJWZFPyqqVqTym5mxO2Eemc6I/0zL7zWnljHzGdaf5aZQyQN5xa6PSH62q+A=="],
+
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.73.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw=="],
 
     "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],

--- a/docs/explanation/agent-identity.md
+++ b/docs/explanation/agent-identity.md
@@ -121,7 +121,7 @@ The split is conceptual:
 
 All per-agent secrets live in Infisical (AI project `11e172e0`). The workstacean container receives them via `infisical run` at deploy time. The homelab-iac `docker-compose.yml` is the canonical reference for which secrets map to which services.
 
-No secrets are stored in this repository. `workspace/agents.yaml` uses `apiKeyEnv` to reference the env var name (e.g., `AVA_API_KEY`), not the key value itself.
+No secrets are stored in this repository. `workspace/agents.yaml` references env var names — either via the legacy `apiKeyEnv: AVA_API_KEY` shorthand or the structured `auth: { scheme, credentialsEnv }` form (Phase 8). The env var name is the reference; the value lives only in Infisical.
 
 ---
 
@@ -129,12 +129,12 @@ No secrets are stored in this repository. `workspace/agents.yaml` uses `apiKeyEn
 
 ### External (A2A) agent
 
-1. Create the agent runtime in its own repo with a JSON-RPC `/a2a` endpoint
+1. Create the agent runtime in its own repo with a JSON-RPC `/a2a` endpoint + `/.well-known/agent-card.json`
 2. (Optional) Create a GitHub App for bot attribution; generate and store the private key in Infisical
-3. Add `APP_ID`, `APP_PRIVATE_KEY`, and any `API_KEY` env vars to `homelab-iac/stacks/ai/docker-compose.yml`
-4. Add an entry to `workspace/agents.yaml` with `name`, `url`, `apiKeyEnv`, and declared `skills`
+3. Add `APP_ID`, `APP_PRIVATE_KEY`, and any auth env vars (API key / bearer token / HMAC secret) to `homelab-iac/stacks/ai/docker-compose.yml`
+4. Add an entry to `workspace/agents.yaml` with `name`, `url`, auth config (`apiKeyEnv` or `auth.credentialsEnv`). Skills are optional — if omitted, the broker auto-discovers them from the agent card
 5. (Optional) If the agent should have its own Discord bot, add `discordBotTokenEnvKey` pointing at a new `DISCORD_BOT_TOKEN_*` env var
-6. Restart workstacean — `[skill-broker] Registered N A2A agent(s)` in logs should increment
+6. Restart workstacean — `[skill-broker] Registered N A2A agent(s) (skills from yaml; discovery in progress)` in logs should increment
 
 ### In-process agent
 

--- a/docs/guides/a2a-streaming.md
+++ b/docs/guides/a2a-streaming.md
@@ -8,7 +8,7 @@ How to add Server-Sent Events (SSE) streaming to an A2A agent so consumers (like
 
 By default, A2A agents handle `message/send` — the client blocks until the agent finishes. For long-running skills (deep research, multi-step triage), this creates dead air. SSE streaming solves this:
 
-1. Client sends `message/sendStream` instead of `message/send`
+1. Client sends `message/stream` instead of `message/send`
 2. Agent returns `text/event-stream` with intermediate updates
 3. Client reads events as they arrive, publishes them to Discord for o11y
 4. Agent sends final artifact + `[DONE]` to close the stream
@@ -25,9 +25,9 @@ AGENT_CARD = {
 }
 ```
 
-### 2. Handle `message/sendStream` in your `/a2a` endpoint
+### 2. Handle `message/stream` in your `/a2a` endpoint
 
-Accept both `message/send` (blocking) and `message/sendStream` (SSE):
+Accept both `message/send` (blocking) and `message/stream` (SSE):
 
 ```python
 from fastapi.responses import StreamingResponse
@@ -37,7 +37,7 @@ import json, asyncio, queue
 async def a2a_handler(req: dict):
     method = req.get("method", "")
     
-    if method == "message/sendStream":
+    if method == "message/stream":
         return StreamingResponse(
             sse_generator(req),
             media_type="text/event-stream",
@@ -128,7 +128,7 @@ Ava calls chat_with_agent(agent="researcher", ...)
     ↓
 ava-tools.ts POST /api/a2a/chat → ExecutorRegistry → A2AExecutor
     ↓
-A2AExecutor sees streaming:true → sends message/sendStream
+A2AExecutor sees streaming:true → sends message/stream
     ↓
 protoResearcher returns text/event-stream:
     data: {"status":{"state":"working","message":"Scanning HuggingFace..."}}
@@ -155,3 +155,19 @@ Final artifact → returned as chat_with_agent response to Ava
 If the agent doesn't support streaming (card says `streaming: false` or omits it), A2AExecutor falls back to blocking `message/send`. No code changes needed on the client side.
 
 If the agent supports streaming but the SSE connection fails, the executor catches the error and falls back to `message/send` automatically.
+
+## Artifact chunking
+
+Agents can progressively stream a long artifact in multiple frames using `append` + `lastChunk` on `TaskArtifactUpdateEvent`:
+
+- `append: false` (or omitted) → the incoming `parts` **replace** the buffer for that `artifactId`
+- `append: true` → the incoming `parts` are **concatenated** to the existing buffer
+- `lastChunk: true` → finalize the artifact; A2AExecutor fires `onStreamUpdate({ type: "artifact_complete", ... })`
+
+This lets a researcher stream a 2000-word report as 20 × 100-word chunks. Each chunk surfaces live via `onStreamUpdate({ type: "artifact_chunk", ... })` to Discord, the dashboard, etc. The final concatenated text is what lands in the `SkillResult.text`.
+
+## Long-running tasks + input-required
+
+If your agent returns a non-terminal task (`working`, `submitted`, `input-required`) rather than a final result, workstacean's `TaskTracker` polls `tasks/get` (or uses `tasks/resubscribe` for streaming agents) and publishes the response on the original reply topic once terminal. No caller-side timeout tuning needed.
+
+For `input-required`, the tracker raises a HITL request automatically and resumes the task via `message/send` with the same `taskId` once a human decides. See [HITL guide](./hitl.md) for the full flow.

--- a/docs/guides/add-an-agent.md
+++ b/docs/guides/add-an-agent.md
@@ -125,9 +125,17 @@ agents:
   - name: my-service
     # Full URL of the agent's /a2a endpoint (JSON-RPC 2.0).
     url: http://my-service:8080/a2a
-    # Environment variable holding the API key. Optional.
-    apiKeyEnv: MY_SERVICE_API_KEY
-    # Skills this agent handles.
+    # Auth — either the legacy apiKeyEnv shorthand OR a structured auth block.
+    apiKeyEnv: MY_SERVICE_API_KEY   # legacy: X-API-Key: <env>
+    # auth:                          # preferred (Phase 8):
+    #   scheme: bearer               # "apiKey" | "bearer" | "hmac"
+    #   credentialsEnv: MY_SERVICE_TOKEN
+    # Optional: stamp static headers (e.g. opt in to A2A extensions).
+    # headers:
+    #   a2a-extensions: "https://a2a-protocol.org/ext/cost-v1"
+    # Whether the agent supports SSE streaming (card-derived fallback).
+    streaming: false
+    # Skills this agent handles. Omit to auto-discover from the agent card.
     skills:
       - name: analyze_data
         description: Analyze a dataset and return a summary
@@ -138,7 +146,13 @@ agents:
       - message.inbound.#
 ```
 
-The `apiKeyEnv` value is the **name** of the environment variable (not the key itself). At request time, `A2AExecutor` reads `process.env[apiKeyEnv]` and sends it as `X-API-Key`.
+Auth resolution:
+- `apiKeyEnv: X` → sends `X-API-Key: $X` on every request (legacy shorthand).
+- `auth.scheme: apiKey` + `credentialsEnv: X` → same header, explicit scheme.
+- `auth.scheme: bearer` + `credentialsEnv: X` → sends `Authorization: Bearer $X`.
+- `auth.scheme: hmac` → reserved for future HMAC-signing extension.
+
+At request time, `A2AExecutor` reads `process.env[credentialsEnv]` (or `apiKeyEnv` as fallback) and stamps the right header based on scheme.
 
 ### How the A2A call is made
 
@@ -174,9 +188,30 @@ X-API-Key: <resolved key>
 
 The receiving service should propagate `contextId` / `X-Correlation-Id` through its own spans.
 
-### Skills refreshed from /.well-known/agent.json
+### Skills refreshed from the agent card
 
-You can omit `skills` from `agents.yaml` if your service exposes a `/.well-known/agent.json` discovery endpoint. `SkillBrokerPlugin` will fetch it at startup and register the declared skills automatically.
+You can omit `skills` from `agents.yaml` if your service exposes a `/.well-known/agent-card.json` (or legacy `/.well-known/agent.json`) discovery endpoint. `SkillBrokerPlugin` fetches it at startup and registers declared skills automatically, then re-fetches every 10 min so new skills land without a restart. When both yaml skills and card skills are present, the yaml entries take precedence as explicit overrides.
+
+### Long-running tasks
+
+If your agent returns a non-terminal `Task` (state: `submitted` or `working`) instead of an immediate reply, `SkillDispatcherPlugin` hands the task to `TaskTracker` which polls `tasks/get` every 30s (or uses `tasks/resubscribe` for streaming agents). When the task reaches a terminal state, the tracker publishes the response on the original reply topic — the caller sees exactly one response, just later.
+
+For agents that support push notifications (`capabilities.pushNotifications: true` in the card), workstacean registers `PushNotificationConfig` with a per-task HMAC token pointing at `${WORKSTACEAN_BASE_URL}/api/a2a/callback/:taskId`. The agent POSTs Task snapshots to that URL when the state changes, which is faster and cheaper than polling.
+
+### input-required → HITL
+
+When your agent returns `Task.status.state == "input-required"`, the tracker automatically raises a HITL request (Discord approval UI by default). Once a human responds, the tracker resumes the task with `message/send` on the same `taskId` carrying the decision text. No custom `plan_resume` skill is needed — this is the native A2A state machine.
+
+---
+
+## Workstacean as an A2A server
+
+Workstacean itself is an A2A agent too. It exposes:
+
+- `GET /.well-known/agent-card.json` — lists every skill registered in `ExecutorRegistry`
+- `POST /a2a` — JSON-RPC 2.0 endpoint (supports `message/send`, `message/stream`, `tasks/*`)
+
+External agents can call workstacean by resolving the card and dispatching skills with a `skillHint` in the message metadata. Auth is the same `WORKSTACEAN_API_KEY` via `Authorization: Bearer <key>` or `X-API-Key`. See [HTTP API reference — POST /a2a](../../reference/http-api#post-a2a) for full details.
 
 ---
 

--- a/docs/guides/hitl.md
+++ b/docs/guides/hitl.md
@@ -10,16 +10,16 @@ HITL is the approval gate that sits between an autonomous decision and its perma
 
 ## Overview
 
-When any system component needs a human decision, it publishes an `HITLRequest` to the bus. `HITLPlugin` routes it to the registered renderer for the originating interface (Discord, Plane, Signal, API). A human responds. The interface plugin publishes an `HITLResponse`. `HITLPlugin` routes the response back to the requester via `replyTopic` (bus) and, if configured, calls the plan_resume agent via A2A.
+When any system component needs a human decision, it publishes an `HITLRequest` to the bus. `HITLPlugin` routes it to the registered renderer for the originating interface (Discord, Plane, Signal, API). A human responds. The interface plugin publishes an `HITLResponse`. The bus delivers it to whichever plugin subscribed to the `replyTopic`.
 
 Two types of HITL flow coexist on the same infrastructure:
 
 | Flow | Publisher | Callback path | Example |
 |---|---|---|---|
-| **Plan gate** | Ava | plan_resume A2A → Ava resumes feature creation | New project plan after SPARC PRD |
+| **Plan gate** | A2A agent returns `input-required` | `TaskTracker` sends `message/send` with same `taskId` | Ava asks for approval mid-task |
 | **Operational gate** | Any plugin | `replyTopic` on the bus | Budget L3 escalation, goal violation, queue saturation |
 
-Both use the same `HITLRequest`/`HITLResponse` shapes, the same topic conventions, and the same renderer interface.
+Both use the same `HITLRequest`/`HITLResponse` shapes, the same topic conventions, and the same renderer interface. The plan-gate path uses the native A2A `input-required` state machine — no custom `plan_resume` skill is required.
 
 ---
 
@@ -93,9 +93,9 @@ When a renderer publishes an `HITLResponse` to `request.replyTopic` (a `hitl.res
 
 1. **Bus delivery** — the message lands on `request.replyTopic`. Any plugin that subscribed to that topic receives it automatically through pub/sub. No re-routing by HITLPlugin is needed — the bus handles it.
 
-2. **A2A plan_resume** — HITLPlugin subscribes to `hitl.response.#` and intercepts every response. If `workspace/agents.yaml` contains an agent with the `plan_resume` skill (Ava), HITLPlugin calls that agent via JSON-RPC 2.0. This is Ava's plan gate path — Ava is an external service that doesn't subscribe to the bus directly.
+2. **A2A task resume** — `TaskTracker` subscribes to `hitl.response.#`. If the response correlates to a tracked task that entered `input-required`, the tracker calls `executor.resumeTask(taskId, ...)` with the decision text. The agent picks up in the same task/context — no custom skill is invoked.
 
-Both paths are triggered by the single publish from the renderer. The A2A call is a no-op if no plan_resume agent is configured.
+Both paths are triggered by the single publish from the renderer. The A2A resume is a no-op if no task is awaiting input for that `correlationId`.
 
 > **Convention:** `request.replyTopic` is always in the `hitl.response.#` namespace so HITLPlugin can intercept it. Renderers should publish to `request.replyTopic` directly rather than constructing the topic themselves.
 
@@ -283,27 +283,28 @@ The plan gate is one specific use of HITL, triggered after Ava generates a SPARC
 2. Ava generates SPARC PRD + antagonistic review
    - Ava verdict: operational feasibility, risk score
    - Jon verdict: strategic value, ROI score
-3. Ava checkpoints plan to PlanStore (SQLite, keyed by correlationId, 7-day TTL)
-4. Ava publishes hitl.request.plan.{correlationId} with replyTopic
-5. HITLPlugin routes to registered renderer (Discord embed shows PRD summary + verdicts)
+3. Ava returns Task { status: { state: "input-required", message: <PRD summary> } }
+4. TaskTracker detects input-required → raises HITLRequest
+5. HITLPlugin routes to the registered renderer (Discord embed)
 6. Human approves/rejects/modifies
-7. Renderer publishes hitl.response.plan.{correlationId}
-8. HITLPlugin:
-   a. Publishes response to replyTopic (bus)
-   b. Calls plan_resume via A2A → Ava restores checkpoint, executes decision
+7. Renderer publishes HITLResponse on hitl.response.{correlationId}
+8. TaskTracker intercepts the response → sends message/send with same taskId
+   carrying the decision text; Ava resumes the task natively
 ```
 
-### plan_resume decisions
+### plan decisions (resume payload)
+
+The decision is relayed verbatim as the resume message text. Ava parses it and takes the branch:
 
 | Decision | What happens |
 |---|---|
 | `approve` | Board features created, Plane issue → "In Progress", summary comment posted |
-| `reject` | Plan archived in PlanStore, rejection notice sent to originating channel |
-| `modify` | PRD re-drafted with `feedback` applied, antagonistic review re-run, new `HITLRequest` emitted with same `correlationId` |
+| `reject` | Plan archived, rejection notice sent to originating channel |
+| `modify` | PRD re-drafted with `feedback` applied, antagonistic review re-run, new `input-required` emitted |
 
 ### Auto-approve
 
-Plane issues with the `auto` label skip the gate entirely. `PlanePlugin` sets `autoApprove: true` in the bus message. Ava internally generates `HITLResponse { decision: "approve", decidedBy: "auto" }` and calls `plan_resume` directly.
+Plane issues with the `auto` label skip the gate entirely. `PlanePlugin` sets `autoApprove: true` in the bus message, and the agent either never enters `input-required` or short-circuits itself.
 
 ---
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -8,7 +8,9 @@ Task-oriented guides for common operations in protoWorkstacean.
 
 | Guide | Description |
 |-------|-------------|
-| [Add an agent](./add-an-agent) | Register an in-process agent (YAML + ProtoSdkExecutor) or an external A2A agent |
+| [Add an agent](./add-an-agent) | Register an in-process agent (YAML + ProtoSdkExecutor) or an external A2A agent (with auth schemes + card auto-discovery) |
+| [A2A streaming](./a2a-streaming) | Enable SSE streaming, artifact chunking, long-running tasks, and native `input-required` HITL |
+| [HITL](./hitl) | Human-in-the-loop approval gates (plan gate + operational gate, both built on the A2A `input-required` state) |
 | [Add a domain](./add-a-domain) | Poll a custom HTTP endpoint and expose it as a world-state domain |
 | [Add goals and actions](./add-goals-and-actions) | Write goal definitions (Invariant, Threshold, Distribution) and matching actions with preconditions and effects |
 | [Create a ceremony](./create-a-ceremony) | Schedule a recurring fleet ritual — a skill dispatched on a cron expression |

--- a/docs/guides/integrate-external-app.md
+++ b/docs/guides/integrate-external-app.md
@@ -148,8 +148,14 @@ If the app has an A2A endpoint, create or append to `workspace/agents.yaml`:
 agents:
   - name: myapp
     url: "${MYAPP_BASE_URL}/a2a"
+    # Legacy apiKey shorthand:
     apiKeyEnv: MYAPP_API_KEY
-    skills:
+    # ...or structured auth (Phase 8):
+    # auth:
+    #   scheme: bearer
+    #   credentialsEnv: MYAPP_TOKEN
+    streaming: false            # set true if the agent's card declares it
+    skills:                     # omit to auto-discover from /.well-known/agent-card.json
       - name: diagnose
         description: Run diagnostics and attempt self-healing
       - name: status
@@ -157,8 +163,9 @@ agents:
 ```
 
 - `url` supports `${ENV_VAR}` interpolation
-- `apiKeyEnv` is the **name** of the env var (not the value)
+- `apiKeyEnv` / `auth.credentialsEnv` is the **name** of the env var (not the value)
 - Skills are registered with the `ExecutorRegistry` and become routable via `agent.skill.request`
+- Agent card is re-fetched every 10 min so new skills land without a restart
 
 See [Add an agent](./add-an-agent) for the full A2A schema.
 

--- a/docs/integrations/plane.md
+++ b/docs/integrations/plane.md
@@ -80,10 +80,10 @@ Only `issue` events (create/update/delete) are subscribed. Project/cycle/module 
    f. Store {planeIssueId, planeProjectId} in pendingIssues Map keyed by correlationId
 4. RouterPlugin routes to Ava (skillHint "plan" → plan skill)
 5. Ava runs SPARC PRD + antagonistic review (Ava operational lens + Jon strategic lens)
-6. HITL gate:
-   - "auto" label → skip gate, emit HITLResponse(approve) internally
-   - "plan" label → emit HITLRequest to plane.reply.{correlationId}
-7. On approval: Ava's plan_resume creates board features, stamps correlationId
+6. HITL gate (native A2A):
+   - "auto" label → Ava short-circuits and returns a completed Task directly
+   - "plan" label → Ava returns Task with state "input-required" → TaskTracker raises HITLRequest on plane.reply.{correlationId}
+7. On approval: TaskTracker sends message/send with the same taskId, Ava resumes in-context and creates board features (same correlationId throughout)
 8. PlanePlugin outbound handler picks up plane.reply.# events → syncs back to Plane
 ```
 

--- a/docs/integrations/runtimes/a2a.md
+++ b/docs/integrations/runtimes/a2a.md
@@ -98,7 +98,7 @@ Accept: text/event-stream       (if streaming enabled)
 
 ## SSE streaming
 
-When the agent card declares `capabilities.streaming: true`, the executor sends `message/sendStream` and reads Server-Sent Events:
+When the agent card declares `capabilities.streaming: true`, the executor sends `message/stream` and reads Server-Sent Events:
 
 - **TaskStatusUpdateEvent** — intermediate status changes with optional message
 - **TaskArtifactUpdateEvent** — progressive artifact chunks
@@ -124,7 +124,7 @@ The executor resolves the API key from the environment variable named in `apiKey
 
 ## Agent card discovery
 
-On startup, `SkillBrokerPlugin` fetches `GET /.well-known/agent.json` from each agent's base URL (5s timeout). The card's `skills` array is merged into the executor registry, allowing runtime skill discovery.
+On startup, `SkillBrokerPlugin` fetches `GET /.well-known/agent-card.json` (with a fallback to the legacy `/.well-known/agent.json`) from each agent's base URL. The card's `skills` array is merged into the executor registry, allowing runtime skill discovery. The card is re-fetched every 10 min so new skills land without a restart; when the yaml lists skills too, the yaml entries take precedence as explicit overrides.
 
 ## Agent YAML entry
 

--- a/docs/reference/agent-skills.md
+++ b/docs/reference/agent-skills.md
@@ -76,14 +76,19 @@ Available tools: `publish_event`, `get_world_state`, `get_incidents`, `report_in
 agents:
   - name: my-agent
     url: http://my-agent:PORT/a2a
+    # Either the legacy shorthand...
     apiKeyEnv: MY_AGENT_API_KEY
+    # ...or the structured form (Phase 8):
+    # auth: { scheme: bearer, credentialsEnv: MY_AGENT_TOKEN }
     skills:
       - my_skill
+    # skills can be omitted — SkillBrokerPlugin discovers them from
+    # /.well-known/agent-card.json (10-min refresh).
 ```
 
 2. Restart: `docker restart workstacean`
 
-`SkillBrokerPlugin` dispatches via JSON-RPC 2.0. In-process agents take priority for any skill they declare — external A2A is the fallback.
+`SkillBrokerPlugin` dispatches via the `@a2a-js/sdk` client (JSON-RPC 2.0 + SSE). In-process agents take priority for any skill they declare — external A2A is the fallback.
 
 ---
 

--- a/docs/reference/config-files.md
+++ b/docs/reference/config-files.md
@@ -164,7 +164,6 @@ agents:
       - board_health
       - onboard_project
       - plan
-      - plan_resume
 
   - name: quinn
     team: dev

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -9,8 +9,9 @@ All environment variables recognised by protoWorkstacean, their defaults, and wh
 | Variable | Default | Plugin | Description |
 |----------|---------|--------|-------------|
 | `WORKSTACEAN_HTTP_PORT` | `3000` | HTTP server | Port the HTTP API listens on |
-| `WORKSTACEAN_API_KEY` | _(none)_ | HTTP server | API key required for authenticated endpoints. If unset, auth is skipped. |
-| `WORKSTACEAN_PUBLIC_URL` | _(none)_ | HTTP server | Public base URL (used for webhook registration and self-links) |
+| `WORKSTACEAN_API_KEY` | _(none)_ | HTTP server | API key required for authenticated endpoints. If unset, auth is skipped. Also gates `POST /a2a` (accepts `Authorization: Bearer <key>` or `X-API-Key`). |
+| `WORKSTACEAN_BASE_URL` | _(none)_ | A2AExecutor, agent-card | Public base URL of this workstacean instance (e.g. `https://workstacean.example.com`). Used to (a) register push-notification webhook URLs with external agents, (b) populate the `url` field of `/.well-known/agent-card.json`. Falls back to `http://localhost:$WORKSTACEAN_HTTP_PORT` when unset. |
+| `WORKSTACEAN_PUBLIC_URL` | _(none)_ | HTTP server | Legacy public base URL (used for webhook registration). Prefer `WORKSTACEAN_BASE_URL` for new deployments. |
 | `WORKSPACE_DIR` | `./workspace` | All loaders | Path to the workspace directory containing agent, goal, action, ceremony, and domain YAML files |
 | `DATA_DIR` | `./data` | LoggerPlugin, SQLite | Directory for the SQLite event log (`events.db`) |
 | `TZ` | system default | SchedulerPlugin | Timezone for cron schedule evaluation |

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -745,6 +745,70 @@ Fire-and-forget task dispatch to a remote agent. Publishes to `agent.skill.reque
 
 ---
 
+## GET /.well-known/agent-card.json
+
+Served by `src/api/agent-card.ts`. Exposes workstacean as an A2A-compliant agent — external agents fetch this URL to discover what skills they can dispatch. Skills are aggregated from the `ExecutorRegistry`, so any skill registered (yaml-declared + auto-discovered Phase 4 skills) shows up without a restart.
+
+A legacy alias at `GET /.well-known/agent.json` returns the same body for clients that resolve the older path.
+
+**Auth**: None (discovery is always public)
+
+**Response** (`200`) — an [AgentCard](https://a2a-protocol.org/latest/specification/#agent-card):
+```json
+{
+  "name": "workstacean",
+  "description": "protoLabs Studio operational gateway...",
+  "protocolVersion": "0.3.0",
+  "version": "1.0.0",
+  "url": "https://workstacean.example.com/a2a",
+  "preferredTransport": "JSONRPC",
+  "capabilities": { "streaming": true, "pushNotifications": true },
+  "skills": [
+    { "id": "plan", "name": "plan", "description": "...", "tags": ["routed", "ava"] },
+    { "id": "bug_triage", "name": "bug_triage", "description": "...", "tags": ["routed", "quinn"] }
+  ]
+}
+```
+
+`url` is derived from `WORKSTACEAN_BASE_URL` (falling back to `http://localhost:$WORKSTACEAN_HTTP_PORT` when unset).
+
+---
+
+## POST /a2a
+
+A2A JSON-RPC 2.0 endpoint. Accepts every method in the A2A protocol (`message/send`, `message/stream`, `tasks/get`, `tasks/cancel`, `tasks/resubscribe`, `tasks/pushNotificationConfig/*`) and bridges them into the internal bus pipeline via `BusAgentExecutor` (`src/api/a2a-server.ts`).
+
+**Auth**: When `WORKSTACEAN_API_KEY` is set, callers must supply it as `Authorization: Bearer <key>` or `X-API-Key: <key>`. Unset → open access (dev mode).
+
+**Flow for `message/send`**:
+1. SDK `JsonRpcTransportHandler` receives the request
+2. `BusAgentExecutor.execute()` emits an initial `submitted` Task event, transitions to `working`, publishes to `agent.skill.request` on the bus
+3. `SkillDispatcherPlugin` resolves an executor via `ExecutorRegistry` and runs the skill
+4. Response lands on `agent.skill.response.{taskId}` → adapter emits a terminal `completed`/`failed` status update with the text in `status.message.parts`
+5. Response returns as `{ jsonrpc: "2.0", id, result: <Task> }`
+
+`message/stream` uses the same pipeline but returns a `text/event-stream` where each `data:` frame is a JSON-RPC response wrapping one A2A event.
+
+Skill routing: metadata fields control which skill is invoked.
+- `metadata.skillHint` or `metadata.skill` — skill name, defaults to `"chat"`
+- `metadata.targets` — array of agent names, passed through to `ExecutorRegistry.resolve()`
+
+---
+
+## POST /api/a2a/callback/:taskId
+
+Push-notification webhook for long-running A2A tasks (Phase 3). External agents POST Task snapshots here when they reach terminal state (or at configurable checkpoints) so workstacean doesn't need to hold an HTTP connection open for minutes.
+
+**Auth**: Per-task token passed as `Authorization: Bearer <token>` or `X-A2A-Notification-Token: <token>`. The token is generated per-task and registered with the agent when the skill is dispatched; workstacean looks it up by `taskId` in `TaskTracker`.
+
+**Request body**: Full A2A `Task` object (not a delta).
+
+**Response** (`200`): `{ "success": true }`
+
+Non-terminal states just refresh `lastPolledAt`. `input-required` states raise a HITL request. Terminal states publish the response and untrack the task.
+
+---
+
 ## POST /api/github/issues
 
 File an issue on a managed GitHub repository. Only repos listed in `projects.yaml` are allowed.

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -751,6 +751,8 @@ Served by `src/api/agent-card.ts`. Exposes workstacean as an A2A-compliant agent
 
 A legacy alias at `GET /.well-known/agent.json` returns the same body for clients that resolve the older path.
 
+> **Reachability**: this endpoint is served by the main HTTP server on `WORKSTACEAN_HTTP_PORT` (default `3000`, **not** the `8080` dashboard/event-viewer port which only proxies `/api/*`). Inside the Docker network, agents call `http://workstacean:3000/...` directly. To expose it to external networks, add a proxy rule (Caddy / Cloudflare tunnel) forwarding `/a2a` and `/.well-known/agent-card.json` to port 3000.
+
 **Auth**: None (discovery is always public)
 
 **Response** (`200`) — an [AgentCard](https://a2a-protocol.org/latest/specification/#agent-card):
@@ -930,3 +932,5 @@ Update an existing feature on the protoMaker board.
 ## Dashboard proxy
 
 The event-viewer plugin (port `8080`, disabled by `DISABLE_EVENT_VIEWER`) serves the Astro dashboard from `dashboard/dist/` and proxies unmatched `/api/*` requests plus the `/ws` WebSocket to the main HTTP server on `WORKSTACEAN_HTTP_PORT`. The dashboard's client-side API client talks only to the event-viewer port, so CORS is never an issue. See [Dashboard](./dashboard) for details.
+
+> **A2A endpoints bypass the dashboard proxy.** `/a2a`, `/.well-known/agent-card.json`, and `/api/a2a/callback/:taskId` are all served directly by the main HTTP server on port `3000`. External agents calling workstacean over A2A must hit that port (inside the Docker network via `http://workstacean:3000`, or externally via a Caddy/Cloudflare rule forwarding those paths).

--- a/docs/reference/workspace-files.md
+++ b/docs/reference/workspace-files.md
@@ -14,11 +14,18 @@ External A2A agent registry. Read by `SkillBrokerPlugin`.
 agents:
   - name: string                    # Unique agent name
     url: string                     # Full A2A endpoint URL
-    apiKeyEnv?: string              # Env var name holding the API key
+    apiKeyEnv?: string              # Legacy shorthand — env var holding a value sent as X-API-Key
+    auth?:                          # Structured auth (Phase 8). Preferred over apiKeyEnv.
+      scheme: "apiKey" | "bearer" | "hmac"
+      credentialsEnv: string        # Env var holding the credential value
+    headers?: Record<string, string> # Static extra request headers (e.g. a2a-extensions opt-in)
+    streaming?: boolean             # Whether the agent supports SSE streaming
     discordBotTokenEnvKey?: string  # Optional Discord bot token env var — when set,
                                     # DiscordPlugin's agent pool spins up a dedicated
                                     # Client() for this agent so users can DM it directly
-    skills?:                        # Skills to register. Omit to use /.well-known/agent.json discovery.
+    skills?:                        # Skills to register. Omit to auto-discover from
+                                    # /.well-known/agent-card.json (falls back to agent.json).
+                                    # Yaml entries take precedence as explicit overrides.
       - name: string
         description?: string
     subscribesTo?:                  # Informational — bus topics this agent watches (not enforced)

--- a/lib/plugins/hitl.ts
+++ b/lib/plugins/hitl.ts
@@ -1,10 +1,11 @@
 /**
  * HITLPlugin — Human-in-the-Loop gate for the Workstacean bus.
  *
- * Dispatches HITLRequest messages to registered HITLRenderer instances (one per
- * interface), and routes HITLResponse messages back to requesters via two paths:
- *   1. Bus callback — publishes to request.replyTopic (operational callers)
- *   2. A2A plan_resume — calls Ava to resume a checkpointed plan
+ * Pure routing layer between HITL requests and registered renderers.
+ * TaskTracker owns the A2A native `input-required` resume path — when a
+ * response arrives for a tracked A2A task, the tracker re-sends via
+ * sendMessage(taskId, decisionText). This plugin just orchestrates the
+ * request/renderer/response bus plumbing.
  *
  * Interface plugins register a renderer during install():
  *   hitlPlugin.registerRenderer("discord", renderer)
@@ -16,27 +17,9 @@
  * Pending requests are tracked in-memory with expiry. On a 60s interval,
  * expired entries are removed, hitl.expired.{correlationId} is published,
  * and the renderer's onExpired() is called.
- *
- * Config: workspace/agents.yaml (to find Ava's A2A endpoint for plan_resume)
  */
 
-import { readFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
-import { parse as parseYaml } from "yaml";
 import type { EventBus, BusMessage, Plugin, HITLRequest, HITLResponse, HITLRenderer } from "../types.ts";
-
-// ── Agent registry (minimal — just enough to find Ava) ──────────────────────
-
-interface AgentDef {
-  name: string;
-  url: string;
-  apiKeyEnv?: string;
-  skills: string[];
-}
-
-interface AgentsYaml {
-  agents: AgentDef[];
-}
 
 // ── Renderer registry ─────────────────────────────────────────────────────────
 // Maps interface name → HITLRenderer.
@@ -56,58 +39,19 @@ const pendingRequests = new Map<string, HITLRequest>();
  */
 const unrenderedCorrelationIds = new Set<string>();
 
-// ── A2A call to Ava for plan_resume ──────────────────────────────────────────
-
-async function callPlanResume(agent: AgentDef, response: HITLResponse): Promise<void> {
-  const apiKey = agent.apiKeyEnv ? (process.env[agent.apiKeyEnv] ?? "") : "";
-  const headers: Record<string, string> = { "Content-Type": "application/json" };
-  if (apiKey) headers["X-API-Key"] = apiKey;
-
-  const content = [
-    `HITL Decision: ${response.decision}`,
-    response.feedback ? `Feedback: ${response.feedback}` : "",
-    `Decided by: ${response.decidedBy}`,
-  ].filter(Boolean).join("\n");
-
-  const resp = await fetch(agent.url, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: crypto.randomUUID(),
-      method: "message/send",
-      params: {
-        message: { role: "user", parts: [{ kind: "text", text: content }] },
-        contextId: response.correlationId,
-        metadata: { skillHint: "plan_resume", hitlResponse: response },
-      },
-    }),
-    signal: AbortSignal.timeout(120_000),
-  });
-
-  if (!resp.ok) {
-    const errText = await resp.text();
-    throw new Error(`plan_resume A2A call failed (${resp.status}): ${errText}`);
-  }
-
-  const data = (await resp.json()) as { error?: { message: string } };
-  if (data.error) throw new Error(data.error.message);
-}
-
 // ── Plugin ───────────────────────────────────────────────────────────────────
 
 export class HITLPlugin implements Plugin {
   readonly name = "hitl";
-  readonly description = "Human-in-the-Loop gate — routes approval requests to interface plugins and responses back to callers";
+  readonly description = "Human-in-the-Loop gate — routes approval requests to interface plugins";
   readonly capabilities = ["hitl-routing"];
 
-  private workspaceDir: string;
-  private agents: AgentDef[] = [];
   private expiryTimer: ReturnType<typeof setInterval> | null = null;
   private busRef: EventBus | null = null;
 
-  constructor(workspaceDir: string) {
-    this.workspaceDir = workspaceDir;
+  constructor(_workspaceDir: string) {
+    // workspaceDir retained for API compat with existing plugin constructors,
+    // but not used — HITL is pure bus routing now.
   }
 
   /** All currently pending (unexpired, undecided) HITL requests. */
@@ -138,8 +82,6 @@ export class HITLPlugin implements Plugin {
 
   install(bus: EventBus): void {
     this.busRef = bus;
-    this.agents = this._loadAgents();
-    console.log(`[hitl] Loaded ${this.agents.length} agent(s) for plan_resume routing`);
 
     // ── Expiry sweep: every 60s, remove expired pending requests ─────────
     this.expiryTimer = setInterval(() => {
@@ -212,40 +154,16 @@ export class HITLPlugin implements Plugin {
       );
     });
 
-    // ── Route HITLResponse back to Ava ───────────────────────────────────
-    bus.subscribe("hitl.response.#", this.name, async (msg: BusMessage) => {
+    // ── Clean up pending map when a response arrives ─────────────────────
+    // Bus delivery of the response is automatic — renderers published to
+    // request.replyTopic (a hitl.response.* topic) and callers subscribed
+    // directly. TaskTracker subscribes to hitl.response.# for A2A tasks
+    // and resumes via sendMessage(taskId, decisionText).
+    bus.subscribe("hitl.response.#", this.name, (msg: BusMessage) => {
       const resp = msg.payload as HITLResponse;
       if (resp?.type !== "hitl_response") return;
-
-      // Remove from pending map
-      const pending = pendingRequests.get(resp.correlationId);
-      if (pending) {
-        pendingRequests.delete(resp.correlationId);
-        unrenderedCorrelationIds.delete(resp.correlationId);
-      } else {
-        console.warn(`[hitl] No pending request for correlationId ${resp.correlationId} — processing anyway`);
-      }
-
-      // ── Bus delivery is automatic via pub/sub ────────────────────────────
-      // The renderer published to request.replyTopic (a hitl.response.* topic).
-      // Operational callers subscribed directly to that topic — they already
-      // received the message. No re-publish needed from HITLPlugin.
-
-      // Find agent with plan_resume skill (should be Ava)
-      const planAgent = this.agents.find(a => a.skills.includes("plan_resume"));
-      if (!planAgent) {
-        console.error("[hitl] No agent with plan_resume skill found — cannot route HITLResponse");
-        return;
-      }
-
-      console.log(`[hitl] Routing HITLResponse (${resp.correlationId}, decision: ${resp.decision}) → ${planAgent.name}`);
-
-      try {
-        await callPlanResume(planAgent, resp);
-        console.log(`[hitl] plan_resume call to ${planAgent.name} succeeded`);
-      } catch (err) {
-        console.error(`[hitl] plan_resume call to ${planAgent.name} failed:`, err);
-      }
+      pendingRequests.delete(resp.correlationId);
+      unrenderedCorrelationIds.delete(resp.correlationId);
     });
   }
 
@@ -255,22 +173,5 @@ export class HITLPlugin implements Plugin {
       this.expiryTimer = null;
     }
     this.busRef = null;
-  }
-
-  private _loadAgents(): AgentDef[] {
-    const agentsPath = join(this.workspaceDir, "agents.yaml");
-    if (!existsSync(agentsPath)) {
-      console.warn("[hitl] agents.yaml not found — HITL response routing will be unavailable");
-      return [];
-    }
-
-    try {
-      const raw = readFileSync(agentsPath, "utf8");
-      const parsed = parseYaml(raw) as AgentsYaml;
-      return parsed.agents ?? [];
-    } catch (err) {
-      console.error("[hitl] Failed to parse agents.yaml:", err);
-      return [];
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@a2a-js/sdk": "^0.3.13",
     "@langchain/core": "^1.1.39",
     "@langchain/langgraph": "^1.2.8",
     "@langchain/openai": "^1.4.4",

--- a/src/api/__tests__/a2a-callback.test.ts
+++ b/src/api/__tests__/a2a-callback.test.ts
@@ -1,0 +1,158 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { TaskTracker } from "../../executor/task-tracker.ts";
+import type { A2AExecutor } from "../../executor/executors/a2a-executor.ts";
+import { createRoutes } from "../a2a-callback.ts";
+import type { ApiContext } from "../types.ts";
+
+function fakeExecutor(): A2AExecutor {
+  return {
+    type: "a2a",
+    execute: async () => ({ text: "", isError: false, correlationId: "" }),
+    pollTask: async () => ({ text: "", isError: false, correlationId: "", data: { taskState: "working" } }),
+    cancelTask: async () => ({ text: "", isError: false, correlationId: "" }),
+    resubscribeTask: async () => { throw new Error("not used"); },
+    registerPushNotification: async () => false,
+  } as unknown as A2AExecutor;
+}
+
+describe("/api/a2a/callback/:taskId", () => {
+  let bus: InMemoryEventBus;
+  let tracker: TaskTracker;
+  let handler: (req: Request, params: Record<string, string>) => Promise<Response> | Response;
+  let received: Array<{ topic: string; payload: unknown }>;
+  const ctx = { taskTracker: undefined } as unknown as ApiContext;
+
+  beforeEach(() => {
+    bus = new InMemoryEventBus();
+    received = [];
+    bus.subscribe("agent.skill.response.#", "test", (msg) => {
+      received.push({ topic: msg.topic, payload: msg.payload });
+    });
+    tracker = new TaskTracker({ bus, sweepIntervalMs: 60_000, defaultPollIntervalMs: 60_000 });
+    const routes = createRoutes(tracker, ctx);
+    const route = routes[0];
+    handler = route.handler;
+  });
+
+  afterEach(() => {
+    tracker.destroy();
+  });
+
+  test("404 for unknown taskId", async () => {
+    const req = new Request("http://x/api/a2a/callback/unknown", { method: "POST", body: "{}" });
+    const resp = await handler(req, { taskId: "unknown" });
+    expect(resp.status).toBe(404);
+  });
+
+  test("401 when token missing or wrong", async () => {
+    tracker.track({
+      correlationId: "c1", taskId: "t1", agentName: "quinn",
+      replyTopic: "agent.skill.response.c1", executor: fakeExecutor(), callbackToken: "secret",
+    });
+
+    // No token
+    const r1 = await handler(
+      new Request("http://x/api/a2a/callback/t1", { method: "POST", body: JSON.stringify({}) }),
+      { taskId: "t1" },
+    );
+    expect(r1.status).toBe(401);
+
+    // Wrong token
+    const r2 = await handler(
+      new Request("http://x/api/a2a/callback/t1", {
+        method: "POST",
+        headers: { "x-a2a-notification-token": "wrong" },
+        body: JSON.stringify({}),
+      }),
+      { taskId: "t1" },
+    );
+    expect(r2.status).toBe(401);
+  });
+
+  test("200 + publishes response on terminal Task callback (via X-A2A-Notification-Token)", async () => {
+    tracker.track({
+      correlationId: "c1", taskId: "t1", agentName: "quinn",
+      replyTopic: "agent.skill.response.c1", executor: fakeExecutor(), callbackToken: "secret",
+    });
+
+    const body = {
+      id: "t1",
+      kind: "task",
+      status: { state: "completed" },
+      artifacts: [{ artifactId: "a1", parts: [{ kind: "text", text: "all good" }] }],
+    };
+    const resp = await handler(
+      new Request("http://x/api/a2a/callback/t1", {
+        method: "POST",
+        headers: { "x-a2a-notification-token": "secret", "content-type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+      { taskId: "t1" },
+    );
+    expect(resp.status).toBe(200);
+    expect(received).toHaveLength(1);
+    expect((received[0].payload as { content: string }).content).toBe("all good");
+    expect(tracker.size).toBe(0);
+  });
+
+  test("accepts Bearer token as alternative", async () => {
+    tracker.track({
+      correlationId: "c1", taskId: "t1", agentName: "quinn",
+      replyTopic: "agent.skill.response.c1", executor: fakeExecutor(), callbackToken: "secret",
+    });
+
+    const body = { id: "t1", kind: "task", status: { state: "completed" } };
+    const resp = await handler(
+      new Request("http://x/api/a2a/callback/t1", {
+        method: "POST",
+        headers: { authorization: "Bearer secret", "content-type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+      { taskId: "t1" },
+    );
+    expect(resp.status).toBe(200);
+  });
+
+  test("non-terminal callback just updates lastPolledAt, no publish", async () => {
+    tracker.track({
+      correlationId: "c1", taskId: "t1", agentName: "quinn",
+      replyTopic: "agent.skill.response.c1", executor: fakeExecutor(), callbackToken: "secret",
+    });
+
+    const body = { id: "t1", kind: "task", status: { state: "working" } };
+    const resp = await handler(
+      new Request("http://x/api/a2a/callback/t1", {
+        method: "POST",
+        headers: { "x-a2a-notification-token": "secret" },
+        body: JSON.stringify(body),
+      }),
+      { taskId: "t1" },
+    );
+    expect(resp.status).toBe(200);
+    expect(received).toHaveLength(0);
+    expect(tracker.size).toBe(1);
+  });
+
+  test("failed state surfaces as error in published response", async () => {
+    tracker.track({
+      correlationId: "c1", taskId: "t1", agentName: "quinn",
+      replyTopic: "agent.skill.response.c1", executor: fakeExecutor(), callbackToken: "secret",
+    });
+
+    const body = {
+      id: "t1", kind: "task",
+      status: { state: "failed", message: { parts: [{ kind: "text", text: "kaboom" }] } },
+    };
+    await handler(
+      new Request("http://x/api/a2a/callback/t1", {
+        method: "POST",
+        headers: { "x-a2a-notification-token": "secret" },
+        body: JSON.stringify(body),
+      }),
+      { taskId: "t1" },
+    );
+    expect(received).toHaveLength(1);
+    expect((received[0].payload as { error: string }).error).toBe("kaboom");
+  });
+});

--- a/src/api/__tests__/a2a-server.test.ts
+++ b/src/api/__tests__/a2a-server.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Phase 7 — A2A server adapter round-trips external JSON-RPC calls through
+ * the bus and back.
+ *
+ * Drive the BusAgentExecutor directly (no HTTP layer) so we can inspect the
+ * events it publishes to the SDK's ExecutionEventBus. The bus subscribes to
+ * agent.skill.request and publishes a response on the correlated reply topic
+ * — that's exactly the internal contract SkillDispatcherPlugin satisfies.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { DefaultExecutionEventBus } from "@a2a-js/sdk/server";
+import type { AgentExecutionEvent, RequestContext } from "@a2a-js/sdk/server";
+import type { Message } from "@a2a-js/sdk";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { ExecutorRegistry } from "../../executor/executor-registry.ts";
+import { BusAgentExecutor } from "../a2a-server.ts";
+import type { ApiContext } from "../types.ts";
+
+function makeUserMessage(text: string, metadata: Record<string, unknown> = {}): Message {
+  return {
+    kind: "message",
+    messageId: crypto.randomUUID(),
+    role: "user",
+    parts: [{ kind: "text", text }],
+    metadata,
+  };
+}
+
+function makeRequestContext(text: string, metadata: Record<string, unknown> = {}): RequestContext {
+  const userMessage = makeUserMessage(text, metadata);
+  const taskId = crypto.randomUUID();
+  const contextId = crypto.randomUUID();
+  return {
+    userMessage,
+    taskId,
+    contextId,
+  } as RequestContext;
+}
+
+describe("BusAgentExecutor (Phase 7)", () => {
+  test("publishes agent.skill.request and resolves with the reply content", async () => {
+    const bus = new InMemoryEventBus();
+    const ctx: ApiContext = {
+      workspaceDir: "/tmp",
+      bus,
+      plugins: [],
+      executorRegistry: new ExecutorRegistry(),
+    };
+
+    let requestPayload: Record<string, unknown> | undefined;
+    let replyTopic: string | undefined;
+    bus.subscribe("agent.skill.request", "test", (msg) => {
+      requestPayload = msg.payload as Record<string, unknown>;
+      replyTopic = msg.reply?.topic;
+      // Mimic SkillDispatcherPlugin: publish a response on the replyTopic
+      setTimeout(() => {
+        bus.publish(msg.reply!.topic!, {
+          id: crypto.randomUUID(),
+          correlationId: msg.correlationId,
+          topic: msg.reply!.topic!,
+          timestamp: Date.now(),
+          payload: { content: "42", correlationId: msg.correlationId },
+        });
+      }, 0);
+    });
+
+    const adapter = new BusAgentExecutor(ctx);
+    const eventBus = new DefaultExecutionEventBus();
+    const collected: AgentExecutionEvent[] = [];
+    eventBus.on("event", (e) => collected.push(e));
+    const done = new Promise<void>(resolve => eventBus.on("finished", () => resolve()));
+
+    const reqCtx = makeRequestContext("What is the answer?", { skillHint: "plan", targets: ["ava"] });
+
+    await adapter.execute(reqCtx, eventBus);
+    await done;
+
+    expect(requestPayload).toBeDefined();
+    expect((requestPayload as { skill: string }).skill).toBe("plan");
+    expect((requestPayload as { targets: string[] }).targets).toEqual(["ava"]);
+    expect((requestPayload as { content: string }).content).toBe("What is the answer?");
+    expect(replyTopic).toBe(`agent.skill.response.${reqCtx.taskId}`);
+
+    // Events in order: submitted task, working status, completed status (final)
+    const taskEvt = collected.find(e => e.kind === "task");
+    const workingEvt = collected.find(e => e.kind === "status-update" && "status" in e && (e as { status: { state: string } }).status.state === "working");
+    const completedEvt = collected.find(e => e.kind === "status-update" && "status" in e && (e as { status: { state: string } }).status.state === "completed");
+    expect(taskEvt).toBeDefined();
+    expect(workingEvt).toBeDefined();
+    expect(completedEvt).toBeDefined();
+
+    // Terminal event should carry the reply content + final: true
+    const finalEvt = completedEvt as { final: boolean; status: { message?: { parts: Array<{ text?: string }> } } };
+    expect(finalEvt.final).toBe(true);
+    const terminalText = finalEvt.status.message?.parts?.map(p => p.text ?? "").join("") ?? "";
+    expect(terminalText).toBe("42");
+  });
+
+  test("error response maps to failed status-update", async () => {
+    const bus = new InMemoryEventBus();
+    const ctx: ApiContext = {
+      workspaceDir: "/tmp",
+      bus,
+      plugins: [],
+      executorRegistry: new ExecutorRegistry(),
+    };
+
+    bus.subscribe("agent.skill.request", "test", (msg) => {
+      setTimeout(() => {
+        bus.publish(msg.reply!.topic!, {
+          id: crypto.randomUUID(),
+          correlationId: msg.correlationId,
+          topic: msg.reply!.topic!,
+          timestamp: Date.now(),
+          payload: { error: "boom", correlationId: msg.correlationId },
+        });
+      }, 0);
+    });
+
+    const adapter = new BusAgentExecutor(ctx);
+    const eventBus = new DefaultExecutionEventBus();
+    const collected: AgentExecutionEvent[] = [];
+    eventBus.on("event", (e) => collected.push(e));
+    const done = new Promise<void>(resolve => eventBus.on("finished", () => resolve()));
+
+    const reqCtx = makeRequestContext("Broken request", { skillHint: "chat" });
+    await adapter.execute(reqCtx, eventBus);
+    await done;
+
+    const failedEvt = collected.find(
+      e => e.kind === "status-update" && "status" in e && (e as { status: { state: string } }).status.state === "failed",
+    ) as { final: boolean; status: { message?: { parts: Array<{ text?: string }> } } } | undefined;
+    expect(failedEvt).toBeDefined();
+    expect(failedEvt!.final).toBe(true);
+    const text = failedEvt!.status.message?.parts?.map(p => p.text ?? "").join("") ?? "";
+    expect(text).toBe("boom");
+  });
+
+  test("cancelTask yields canceled status and unblocks execute()", async () => {
+    const bus = new InMemoryEventBus();
+    const ctx: ApiContext = {
+      workspaceDir: "/tmp",
+      bus,
+      plugins: [],
+      executorRegistry: new ExecutorRegistry(),
+    };
+
+    // Never respond — we'll cancel before a reply arrives
+    bus.subscribe("agent.skill.request", "test", () => {});
+
+    const adapter = new BusAgentExecutor(ctx);
+    const eventBus = new DefaultExecutionEventBus();
+    const collected: AgentExecutionEvent[] = [];
+    eventBus.on("event", (e) => collected.push(e));
+
+    const reqCtx = makeRequestContext("Will be canceled");
+    const executing = adapter.execute(reqCtx, eventBus);
+
+    // Give execute() a tick to subscribe before we cancel
+    await new Promise(r => setTimeout(r, 10));
+    await adapter.cancelTask(reqCtx.taskId, eventBus);
+    await executing;
+
+    const canceledEvt = collected.find(
+      e => e.kind === "status-update" && "status" in e && (e as { status: { state: string } }).status.state === "canceled",
+    );
+    expect(canceledEvt).toBeDefined();
+  });
+});

--- a/src/api/__tests__/agent-card.test.ts
+++ b/src/api/__tests__/agent-card.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Phase 7 — agent card endpoint exposes workstacean's registered skills.
+ *
+ * These tests exercise the /.well-known/agent-card.json handler directly,
+ * bypassing Bun.serve. They lock down:
+ *   - Skills deduplication when multiple agents register the same skill
+ *   - The agent-card.json → agent.json legacy alias
+ *   - WORKSTACEAN_BASE_URL is honored when building the card's url
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { ExecutorRegistry } from "../../executor/executor-registry.ts";
+import { createRoutes, buildAgentCard } from "../agent-card.ts";
+import type { ApiContext } from "../types.ts";
+import type { IExecutor, SkillResult } from "../../executor/types.ts";
+
+function fakeExecutor(type = "a2a"): IExecutor {
+  return {
+    type,
+    async execute(): Promise<SkillResult> {
+      return { text: "", isError: false, correlationId: "" };
+    },
+  };
+}
+
+describe("GET /.well-known/agent-card.json", () => {
+  let registry: ExecutorRegistry;
+  let ctx: ApiContext;
+  let origBaseUrl: string | undefined;
+
+  beforeEach(() => {
+    origBaseUrl = process.env.WORKSTACEAN_BASE_URL;
+    process.env.WORKSTACEAN_BASE_URL = "https://workstacean.example.com";
+    registry = new ExecutorRegistry();
+    ctx = {
+      workspaceDir: "/tmp",
+      bus: new InMemoryEventBus(),
+      plugins: [],
+      executorRegistry: registry,
+    };
+  });
+
+  afterEach(() => {
+    if (origBaseUrl === undefined) delete process.env.WORKSTACEAN_BASE_URL;
+    else process.env.WORKSTACEAN_BASE_URL = origBaseUrl;
+  });
+
+  test("emits two routes (agent-card.json + legacy agent.json)", () => {
+    const routes = createRoutes(ctx);
+    expect(routes).toHaveLength(2);
+    expect(routes.map(r => r.path)).toEqual([
+      "/.well-known/agent-card.json",
+      "/.well-known/agent.json",
+    ]);
+    expect(routes.every(r => r.method === "GET")).toBe(true);
+  });
+
+  test("includes every registered skill with agentName as tag", () => {
+    registry.register("plan", fakeExecutor(), { agentName: "ava" });
+    registry.register("sitrep", fakeExecutor(), { agentName: "ava" });
+    registry.register("bug_triage", fakeExecutor(), { agentName: "quinn" });
+
+    const card = buildAgentCard(ctx);
+    const skillIds = card.skills.map(s => s.id).sort();
+    expect(skillIds).toEqual(["bug_triage", "plan", "sitrep"]);
+
+    const quinnSkill = card.skills.find(s => s.id === "bug_triage");
+    expect(quinnSkill?.tags).toContain("quinn");
+  });
+
+  test("dedupes skills registered by multiple agents", () => {
+    registry.register("chat", fakeExecutor(), { agentName: "ava" });
+    registry.register("chat", fakeExecutor(), { agentName: "quinn" });
+    registry.register("chat", fakeExecutor(), { agentName: "frank" });
+
+    const card = buildAgentCard(ctx);
+    const chatSkills = card.skills.filter(s => s.id === "chat");
+    expect(chatSkills).toHaveLength(1);
+  });
+
+  test("honors WORKSTACEAN_BASE_URL for the card's url", () => {
+    const card = buildAgentCard(ctx);
+    expect(card.url).toBe("https://workstacean.example.com/a2a");
+    expect(card.preferredTransport).toBe("JSONRPC");
+  });
+
+  test("declares streaming + push notification capabilities", () => {
+    const card = buildAgentCard(ctx);
+    expect(card.capabilities.streaming).toBe(true);
+    expect(card.capabilities.pushNotifications).toBe(true);
+  });
+
+  test("route handler returns cache-control + JSON body", async () => {
+    registry.register("plan", fakeExecutor(), { agentName: "ava" });
+    const [route] = createRoutes(ctx);
+    const resp = route.handler(new Request("http://x/.well-known/agent-card.json"), {});
+    const realResp = resp instanceof Promise ? await resp : resp;
+    expect(realResp.status).toBe(200);
+    expect(realResp.headers.get("cache-control")).toContain("max-age=");
+    const body = await realResp.json() as { name: string; skills: Array<{ id: string }> };
+    expect(body.name).toBe("workstacean");
+    expect(body.skills.map(s => s.id)).toContain("plan");
+  });
+});

--- a/src/api/a2a-callback.ts
+++ b/src/api/a2a-callback.ts
@@ -1,0 +1,68 @@
+/**
+ * A2A push notification callback — webhook endpoint for long-running tasks.
+ *
+ * External agents POST Task snapshots here when they reach terminal state
+ * (or at configurable checkpoints). This closes the loop without requiring
+ * workstacean to hold an HTTP connection open for minutes.
+ *
+ * Flow:
+ *   1. A2AExecutor registers a PushNotificationConfig with the agent when
+ *      dispatching a task: { url: WORKSTACEAN_BASE_URL/api/a2a/callback/{taskId},
+ *      token: random-per-task-secret }
+ *   2. Agent POSTs Task JSON here with Bearer token
+ *   3. We verify token, look up task in TaskTracker, publish response to
+ *      original replyTopic
+ *
+ * Security: token is a per-task HMAC-unguessable shared secret. Without the
+ * right token the request is dropped. Broken callbacks don't surface to agents
+ * (they're not expected to retry here).
+ */
+
+import type { Route, ApiContext } from "./types.ts";
+import type { TaskTracker } from "../executor/task-tracker.ts";
+
+export function createRoutes(tracker: TaskTracker, _ctx: ApiContext): Route[] {
+  return [
+    {
+      method: "POST",
+      path: "/api/a2a/callback/:taskId",
+      handler: async (req, params) => {
+        const taskId = params.taskId;
+        if (!taskId) {
+          return Response.json({ success: false, error: "taskId required" }, { status: 400 });
+        }
+
+        // Token from Authorization: Bearer <token> OR X-A2A-Notification-Token header.
+        // A2A spec uses X-A2A-Notification-Token for the unauthenticated case.
+        const authHeader = req.headers.get("authorization") ?? "";
+        const bearer = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+        const notifToken = req.headers.get("x-a2a-notification-token") ?? "";
+        const providedToken = bearer || notifToken;
+
+        const tracked = tracker.getAll().find(t => t.taskId === taskId);
+        if (!tracked) {
+          return Response.json({ success: false, error: "Unknown taskId" }, { status: 404 });
+        }
+
+        const expectedToken = tracker.getCallbackToken(tracked.correlationId);
+        if (!expectedToken || providedToken !== expectedToken) {
+          return Response.json({ success: false, error: "Invalid notification token" }, { status: 401 });
+        }
+
+        let body: Record<string, unknown>;
+        try {
+          body = (await req.json()) as Record<string, unknown>;
+        } catch {
+          return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 });
+        }
+
+        // The A2A spec says the webhook receives the full Task object (not a delta).
+        // We route it through the tracker so terminal-state handling is identical
+        // to the polling path.
+        tracker.handleCallback(tracked.correlationId, body);
+
+        return Response.json({ success: true });
+      },
+    },
+  ];
+}

--- a/src/api/a2a-server.ts
+++ b/src/api/a2a-server.ts
@@ -1,0 +1,296 @@
+/**
+ * A2A server — exposes workstacean as an A2A-compliant agent.
+ *
+ * Routes external JSON-RPC calls into the existing bus/executor pipeline:
+ *
+ *   external agent --(POST /a2a, message/send)--> JsonRpcTransportHandler
+ *     --> DefaultRequestHandler --> BusAgentExecutor.execute()
+ *       --> bus.publish("agent.skill.request", ...)  [same as internal HTTP API]
+ *         --> SkillDispatcherPlugin resolves executor, runs skill
+ *           --> bus.publish("agent.skill.response.{correlationId}")
+ *             --> BusAgentExecutor translates to Task / Message events
+ *               --> ExecutionEventBus --> JsonRpcTransportHandler --> HTTP response
+ *
+ * The BusAgentExecutor is the adapter — it bridges the A2A task lifecycle
+ * to our bus contract. Task state progression:
+ *   submitted → working → (optionally input-required → working) → completed/failed
+ *
+ * Streaming (message/stream) works end-to-end: each status update from the
+ * internal executor becomes a TaskStatusUpdateEvent on the A2A stream.
+ *
+ * Auth: gated by WORKSTACEAN_API_KEY when set. Callers pass it via
+ * Authorization: Bearer <key> or X-API-Key. No key set → open access (dev mode).
+ */
+
+import {
+  DefaultRequestHandler,
+  InMemoryTaskStore,
+  InMemoryPushNotificationStore,
+  DefaultPushNotificationSender,
+  JsonRpcTransportHandler,
+  type AgentExecutor,
+  type ExecutionEventBus,
+  type RequestContext,
+} from "@a2a-js/sdk/server";
+import type { Message, Task } from "@a2a-js/sdk";
+import type { Route, ApiContext } from "./types.ts";
+import type { BusMessage } from "../../lib/types.ts";
+import { buildAgentCard } from "./agent-card.ts";
+
+/**
+ * Bridges A2A RequestContext → agent.skill.request bus message and back.
+ *
+ * Skill resolution:
+ *   1. params.metadata.skillHint (explicit)
+ *   2. Falls through to dispatcher's default executor if skillHint missing
+ *
+ * The executor emits events in this order:
+ *   1. Task (submitted) — initial acknowledgement
+ *   2. TaskStatusUpdateEvent (working) — optional, when we see progress
+ *   3. TaskStatusUpdateEvent (completed/failed, final=true) — terminal
+ *
+ * We don't produce partial Message events — all content comes back via the
+ * terminal status event's message.parts.
+ */
+class BusAgentExecutor implements AgentExecutor {
+  private readonly activeCancels = new Map<string, () => void>();
+
+  constructor(private readonly ctx: ApiContext) {}
+
+  async execute(requestContext: RequestContext, eventBus: ExecutionEventBus): Promise<void> {
+    const { userMessage, taskId, contextId } = requestContext;
+    const correlationId = taskId;
+
+    // Extract text from the incoming message parts
+    const text = (userMessage.parts ?? [])
+      .filter((p): p is { kind: "text"; text: string } =>
+        "kind" in p && p.kind === "text" && typeof (p as { text?: unknown }).text === "string",
+      )
+      .map(p => p.text)
+      .join("\n");
+
+    // Skill hint — from metadata or fallback to "chat"
+    const metadata = (userMessage.metadata ?? {}) as Record<string, unknown>;
+    const skill = (typeof metadata.skillHint === "string" && metadata.skillHint)
+      || (typeof metadata.skill === "string" && metadata.skill)
+      || "chat";
+    const targets = Array.isArray(metadata.targets)
+      ? (metadata.targets as unknown[]).filter((v): v is string => typeof v === "string")
+      : [];
+
+    // Emit initial Task event so the caller gets a taskId immediately
+    eventBus.publish({
+      kind: "task",
+      id: taskId,
+      contextId,
+      status: {
+        state: "submitted",
+        timestamp: new Date().toISOString(),
+      },
+      history: [userMessage],
+      artifacts: [],
+    });
+
+    const replyTopic = `agent.skill.response.${correlationId}`;
+    let settled = false;
+    let cancelled = false;
+    const done = new Promise<void>(resolve => {
+      const subId = this.ctx.bus.subscribe(replyTopic, "a2a-server", (msg: BusMessage) => {
+        if (settled) return;
+        settled = true;
+        this.ctx.bus.unsubscribe(subId);
+        this.activeCancels.delete(taskId);
+
+        const payload = (msg.payload ?? {}) as { content?: string; error?: string };
+        const errorText = typeof payload.error === "string" ? payload.error : undefined;
+        const contentText = typeof payload.content === "string" ? payload.content : "";
+
+        const finalState = errorText ? "failed" : "completed";
+        const finalText = errorText || contentText || "";
+
+        eventBus.publish({
+          kind: "status-update",
+          taskId,
+          contextId,
+          status: {
+            state: finalState,
+            timestamp: new Date().toISOString(),
+            message: {
+              kind: "message",
+              messageId: crypto.randomUUID(),
+              role: "agent",
+              taskId,
+              contextId,
+              parts: [{ kind: "text", text: finalText }],
+            },
+          },
+          final: true,
+        });
+        eventBus.finished();
+        resolve();
+      });
+
+      // Cancel hook — TaskStore calls cancelTask() which invokes this to break
+      // the await and publish a canceled status.
+      this.activeCancels.set(taskId, () => {
+        if (settled) return;
+        settled = true;
+        cancelled = true;
+        this.ctx.bus.unsubscribe(subId);
+        this.activeCancels.delete(taskId);
+        eventBus.publish({
+          kind: "status-update",
+          taskId,
+          contextId,
+          status: {
+            state: "canceled",
+            timestamp: new Date().toISOString(),
+          },
+          final: true,
+        });
+        eventBus.finished();
+        resolve();
+      });
+    });
+
+    // Transition to working before dispatching so the caller sees motion.
+    eventBus.publish({
+      kind: "status-update",
+      taskId,
+      contextId,
+      status: {
+        state: "working",
+        timestamp: new Date().toISOString(),
+      },
+      final: false,
+    });
+
+    // Dispatch to the bus. SkillDispatcherPlugin handles the rest.
+    this.ctx.bus.publish("agent.skill.request", {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic: "agent.skill.request",
+      timestamp: Date.now(),
+      payload: {
+        skill,
+        content: text,
+        targets,
+        // Pass through metadata for downstream consumers
+        meta: { ...metadata, via: "a2a-server" },
+      },
+      reply: { topic: replyTopic },
+      source: { interface: "a2a" },
+    });
+
+    await done;
+    if (cancelled) {
+      console.log(`[a2a-server] Task ${taskId.slice(0, 8)}… canceled`);
+    }
+  }
+
+  async cancelTask(taskId: string, _eventBus: ExecutionEventBus): Promise<void> {
+    const cancel = this.activeCancels.get(taskId);
+    if (cancel) cancel();
+  }
+}
+
+export function createRoutes(ctx: ApiContext): Route[] {
+  // Build request handler once per process — it's stateful (task store) but
+  // stores are in-memory and all requests go through the same bus pipeline.
+  const agentCard = buildAgentCard(ctx);
+  const taskStore = new InMemoryTaskStore();
+  const pushStore = new InMemoryPushNotificationStore();
+  const pushSender = new DefaultPushNotificationSender(pushStore);
+  const agentExecutor = new BusAgentExecutor(ctx);
+  const requestHandler = new DefaultRequestHandler(
+    agentCard,
+    taskStore,
+    agentExecutor,
+    undefined, // default event bus manager
+    pushStore,
+    pushSender,
+  );
+  const transport = new JsonRpcTransportHandler(requestHandler);
+
+  const authorize = (req: Request): boolean => {
+    if (!ctx.apiKey) return true;
+    const apiKeyHeader = req.headers.get("x-api-key");
+    if (apiKeyHeader === ctx.apiKey) return true;
+    const auth = req.headers.get("authorization") ?? "";
+    if (auth === `Bearer ${ctx.apiKey}`) return true;
+    return false;
+  };
+
+  return [
+    {
+      method: "POST",
+      path: "/a2a",
+      handler: async (req) => {
+        if (!authorize(req)) {
+          return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+        }
+
+        let body: unknown;
+        try {
+          body = await req.json();
+        } catch {
+          return Response.json(
+            { jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } },
+            { status: 400 },
+          );
+        }
+
+        try {
+          const result = await transport.handle(body);
+
+          // Streaming: result is an AsyncGenerator of JSONRPCResponse. Pipe
+          // each frame as a text/event-stream chunk so SSE clients see it.
+          if (result && typeof (result as AsyncGenerator).next === "function") {
+            const gen = result as AsyncGenerator<unknown, void, undefined>;
+            const stream = new ReadableStream({
+              async start(controller) {
+                const encoder = new TextEncoder();
+                try {
+                  for await (const event of gen) {
+                    const chunk = `data: ${JSON.stringify(event)}\n\n`;
+                    controller.enqueue(encoder.encode(chunk));
+                  }
+                } catch (err) {
+                  const errMsg = err instanceof Error ? err.message : String(err);
+                  controller.enqueue(encoder.encode(`data: ${JSON.stringify({ error: errMsg })}\n\n`));
+                } finally {
+                  controller.close();
+                }
+              },
+            });
+            return new Response(stream, {
+              headers: {
+                "content-type": "text/event-stream",
+                "cache-control": "no-cache",
+                connection: "keep-alive",
+              },
+            });
+          }
+
+          // Non-streaming: single JSON-RPC response
+          return Response.json(result as unknown as Record<string, unknown>);
+        } catch (err) {
+          return Response.json(
+            {
+              jsonrpc: "2.0",
+              id: null,
+              error: {
+                code: -32603,
+                message: err instanceof Error ? err.message : "Internal error",
+              },
+            },
+            { status: 500 },
+          );
+        }
+      },
+    },
+  ];
+}
+
+/** Expose the adapter class so tests can drive it directly without HTTP. */
+export { BusAgentExecutor };

--- a/src/api/agent-card.ts
+++ b/src/api/agent-card.ts
@@ -1,0 +1,84 @@
+/**
+ * Agent Card endpoint — serves GET /.well-known/agent-card.json (with a
+ * legacy /.well-known/agent.json alias).
+ *
+ * Exposes workstacean as an A2A-compliant agent gateway. The card aggregates
+ * every skill currently registered in the ExecutorRegistry so external agents
+ * can discover what workstacean can route to. Re-reads the registry on each
+ * request so newly discovered A2A skills (Phase 4 periodic refresh) show up
+ * without a restart.
+ *
+ * Skills list the id + name only. Tags default to ["routed"] — the caller
+ * doesn't need to know what machinery is behind a skill, just that they can
+ * dispatch it by name.
+ *
+ * Transport: JSON-RPC (mounted at POST /a2a by a2a-server.ts). Agents send
+ * messages to that URL; the AgentCard.url field is derived from
+ * WORKSTACEAN_BASE_URL so external agents get an absolute URL.
+ */
+
+import type { Route, ApiContext } from "./types.ts";
+import type { AgentCard, AgentSkill } from "@a2a-js/sdk";
+
+const DEFAULT_VERSION = "1.0.0";
+const PROTOCOL_VERSION = "0.3.0";
+
+export function createRoutes(ctx: ApiContext): Route[] {
+  const handler = () => {
+    const card = buildAgentCard(ctx);
+    return Response.json(card, {
+      headers: { "cache-control": "public, max-age=60" },
+    });
+  };
+
+  return [
+    { method: "GET", path: "/.well-known/agent-card.json", handler },
+    // Legacy path — keep for agents that still resolve /.well-known/agent.json
+    { method: "GET", path: "/.well-known/agent.json", handler },
+  ];
+}
+
+export function buildAgentCard(ctx: ApiContext): AgentCard {
+  const baseUrl = (process.env.WORKSTACEAN_BASE_URL ?? "").replace(/\/$/, "")
+    || `http://localhost:${process.env.WORKSTACEAN_HTTP_PORT ?? "3000"}`;
+
+  const registrations = ctx.executorRegistry.list();
+  // Dedupe by skill — multiple agents may register the same skill; external
+  // callers only need to see the skill once, and workstacean handles target
+  // selection via ExecutorRegistry.resolve().
+  const seen = new Set<string>();
+  const skills: AgentSkill[] = [];
+  for (const reg of registrations) {
+    if (!reg.skill || seen.has(reg.skill)) continue;
+    seen.add(reg.skill);
+    skills.push({
+      id: reg.skill,
+      name: reg.skill,
+      description: `Skill routed by workstacean to ${reg.agentName ?? "default executor"}`,
+      tags: ["routed", reg.agentName ?? "default"].filter(Boolean),
+    });
+  }
+
+  return {
+    name: "workstacean",
+    description:
+      "protoLabs Studio operational gateway. Routes skill requests across the " +
+      "agent fleet (Ava, Quinn, Frank, Jon, Cindi, Researcher, protopen, etc).",
+    protocolVersion: PROTOCOL_VERSION,
+    version: DEFAULT_VERSION,
+    url: `${baseUrl}/a2a`,
+    preferredTransport: "JSONRPC",
+    provider: {
+      organization: "protoLabs AI",
+      url: "https://protolabs.ai",
+    },
+    defaultInputModes: ["text/plain"],
+    defaultOutputModes: ["text/plain"],
+    capabilities: {
+      streaming: true,
+      pushNotifications: true,
+      stateTransitionHistory: false,
+    },
+    skills,
+  };
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -16,6 +16,9 @@ import { createRoutes as avaToolRoutes } from "./ava-tools.ts";
 import { createRoutes as boardRoutes } from "./board.ts";
 import { createRoutes as mailboxRoutes } from "./mailbox.ts";
 import { createRoutes as discordRoutes } from "./discord.ts";
+import { createRoutes as a2aCallbackRoutes } from "./a2a-callback.ts";
+import { createRoutes as a2aServerRoutes } from "./a2a-server.ts";
+import { createRoutes as agentCardRoutes } from "./agent-card.ts";
 
 export { matchPath } from "./types.ts";
 export type { Route, ApiContext } from "./types.ts";
@@ -31,5 +34,8 @@ export function createAllRoutes(ctx: ApiContext): Route[] {
     ...boardRoutes(ctx),
     ...(ctx.mailbox ? mailboxRoutes(ctx.mailbox, ctx) : []),
     ...discordRoutes(ctx),
+    ...(ctx.taskTracker ? a2aCallbackRoutes(ctx.taskTracker, ctx) : []),
+    ...agentCardRoutes(ctx),
+    ...a2aServerRoutes(ctx),
   ];
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -12,6 +12,7 @@ import type { Plugin, EventBus } from "../../lib/types.ts";
 import type { ExecutorRegistry } from "../executor/executor-registry.ts";
 import type { TelemetryService } from "../telemetry/telemetry-service.ts";
 import type { ContextMailbox } from "../../lib/dm/context-mailbox.ts";
+import type { TaskTracker } from "../executor/task-tracker.ts";
 
 export type Params = Record<string, string>;
 export type RouteHandler = (req: Request, params: Params) => Response | Promise<Response>;
@@ -34,6 +35,7 @@ export interface ApiContext {
   telemetry?: TelemetryService;
   apiKey?: string;
   mailbox?: ContextMailbox;
+  taskTracker?: TaskTracker;
 }
 
 /** Match a path against a pattern like "/api/foo/:id/run". Returns params or null. */

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -62,6 +62,8 @@ export const EnvSchema = z
     DM_DEBOUNCE_MS:               z.string().optional(),
     /** TTL (ms) for pending mailbox messages before they're swept (default: 10 min). */
     MAILBOX_TTL_MS:               z.string().optional(),
+    /** Public URL of workstacean API — used by A2A push-notification webhooks (e.g. http://workstacean:3000). */
+    WORKSTACEAN_BASE_URL:         z.string().optional(),
 
     // GitHub
     GITHUB_TOKEN:          z.string().optional(),

--- a/src/executor/__tests__/extension-registry.test.ts
+++ b/src/executor/__tests__/extension-registry.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Phase 8 — ExtensionRegistry foundation.
+ *
+ * These tests cover the registry's core matching + header generation logic.
+ * They don't cover any specific extension behavior (none shipped yet) — that
+ * comes in future phases when we implement cost/consent/etc.
+ */
+
+import { describe, test, expect } from "bun:test";
+import type { AgentCard } from "@a2a-js/sdk";
+import { ExtensionRegistry, type ExtensionInterceptor } from "../extension-registry.ts";
+
+function cardWithExtensions(uris: string[]): AgentCard {
+  return {
+    name: "fake",
+    description: "test",
+    protocolVersion: "0.3.0",
+    version: "1.0.0",
+    url: "http://localhost/a2a",
+    preferredTransport: "JSONRPC",
+    defaultInputModes: ["text/plain"],
+    defaultOutputModes: ["text/plain"],
+    capabilities: { extensions: uris.map(uri => ({ uri })) },
+    skills: [],
+  };
+}
+
+describe("ExtensionRegistry", () => {
+  test("matchAgent returns empty when agent has no extensions", () => {
+    const reg = new ExtensionRegistry();
+    reg.register({ uri: "https://example.com/ext/x" });
+    const card = cardWithExtensions([]);
+    expect(reg.matchAgent(card)).toEqual([]);
+  });
+
+  test("matchAgent returns only registered extensions advertised by agent", () => {
+    const reg = new ExtensionRegistry();
+    reg.register({ uri: "https://example.com/ext/cost" });
+    reg.register({ uri: "https://example.com/ext/consent" });
+    const card = cardWithExtensions([
+      "https://example.com/ext/cost",
+      "https://example.com/ext/unknown", // not registered — must be ignored
+    ]);
+    const matches = reg.matchAgent(card);
+    expect(matches.map(m => m.uri)).toEqual(["https://example.com/ext/cost"]);
+  });
+
+  test("headersFor emits comma-separated a2a-extensions opt-in list", () => {
+    const reg = new ExtensionRegistry();
+    reg.register({ uri: "https://example.com/ext/cost" });
+    reg.register({ uri: "https://example.com/ext/consent" });
+    const card = cardWithExtensions([
+      "https://example.com/ext/cost",
+      "https://example.com/ext/consent",
+    ]);
+    const headers = reg.headersFor(card);
+    expect(headers).toEqual({
+      "a2a-extensions": "https://example.com/ext/cost, https://example.com/ext/consent",
+    });
+  });
+
+  test("headersFor returns empty object when no matches", () => {
+    const reg = new ExtensionRegistry();
+    reg.register({ uri: "https://example.com/ext/cost" });
+    const card = cardWithExtensions([]);
+    expect(reg.headersFor(card)).toEqual({});
+  });
+
+  test("interceptorsFor filters only extensions with interceptors", () => {
+    const reg = new ExtensionRegistry();
+    const costInterceptor: ExtensionInterceptor = { before: async () => {} };
+    reg.register({ uri: "https://example.com/ext/cost", interceptor: costInterceptor });
+    reg.register({ uri: "https://example.com/ext/plain" }); // no interceptor
+    const card = cardWithExtensions([
+      "https://example.com/ext/cost",
+      "https://example.com/ext/plain",
+    ]);
+    const interceptors = reg.interceptorsFor(card);
+    expect(interceptors).toHaveLength(1);
+    expect(interceptors[0]).toBe(costInterceptor);
+  });
+
+  test("null/undefined card is safe", () => {
+    const reg = new ExtensionRegistry();
+    reg.register({ uri: "https://example.com/ext/cost" });
+    expect(reg.matchAgent(undefined)).toEqual([]);
+    expect(reg.matchAgent(null)).toEqual([]);
+    expect(reg.headersFor(undefined)).toEqual({});
+  });
+});

--- a/src/executor/__tests__/task-tracker.test.ts
+++ b/src/executor/__tests__/task-tracker.test.ts
@@ -1,0 +1,180 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { TaskTracker } from "../task-tracker.ts";
+import type { A2AExecutor } from "../executors/a2a-executor.ts";
+import type { SkillResult } from "../types.ts";
+
+/** Minimal fake executor that lets tests drive pollTask responses. */
+function makeFakeExecutor(responses: SkillResult[] | (() => SkillResult)): A2AExecutor {
+  let idx = 0;
+  const nextResult = typeof responses === "function"
+    ? responses
+    : () => responses[Math.min(idx++, responses.length - 1)];
+  const fake = {
+    type: "a2a" as const,
+    execute: async () => ({ text: "", isError: false, correlationId: "" }),
+    pollTask: async () => nextResult(),
+    cancelTask: async () => ({ text: "canceled", isError: false, correlationId: "" }),
+    resubscribeTask: async () => { throw new Error("not used in tests"); },
+  };
+  // Cast — the tracker only needs pollTask, and A2AExecutor's private fields
+  // aren't part of the behavior being tested here.
+  return fake as unknown as A2AExecutor;
+}
+
+describe("TaskTracker", () => {
+  let bus: InMemoryEventBus;
+  let tracker: TaskTracker;
+  let received: Array<{ topic: string; payload: unknown }>;
+
+  beforeEach(() => {
+    bus = new InMemoryEventBus();
+    received = [];
+    bus.subscribe("agent.skill.response.#", "test-listener", (msg) => {
+      received.push({ topic: msg.topic, payload: msg.payload });
+    });
+  });
+
+  afterEach(() => {
+    tracker?.destroy();
+  });
+
+  test("publishes response when task reaches terminal state", async () => {
+    const executor = makeFakeExecutor([
+      { text: "still working", isError: false, correlationId: "c1", data: { taskState: "working", taskId: "t1", contextId: "ctx1" } },
+      { text: "all done", isError: false, correlationId: "c1", data: { taskState: "completed", taskId: "t1", contextId: "ctx1" } },
+    ]);
+
+    tracker = new TaskTracker({ bus, sweepIntervalMs: 30, defaultPollIntervalMs: 20 });
+    tracker.track({
+      correlationId: "c1",
+      taskId: "t1",
+      agentName: "quinn",
+      replyTopic: "agent.skill.response.c1",
+      executor,
+    });
+
+    // First sweep sees "working"; second sees "completed"
+    await new Promise(r => setTimeout(r, 90));
+
+    expect(received).toHaveLength(1);
+    expect(received[0].topic).toBe("agent.skill.response.c1");
+    expect((received[0].payload as { content: string }).content).toBe("all done");
+    expect(tracker.size).toBe(0);
+  });
+
+  test("surfaces failed state as error response", async () => {
+    const executor = makeFakeExecutor([
+      { text: "kaboom", isError: true, correlationId: "c1", data: { taskState: "failed", taskId: "t1" } },
+    ]);
+
+    tracker = new TaskTracker({ bus, sweepIntervalMs: 20, defaultPollIntervalMs: 10 });
+    tracker.track({
+      correlationId: "c1", taskId: "t1", agentName: "quinn",
+      replyTopic: "agent.skill.response.c1", executor,
+    });
+
+    await new Promise(r => setTimeout(r, 60));
+    expect(received).toHaveLength(1);
+    expect((received[0].payload as { error: string }).error).toBe("kaboom");
+    expect(tracker.size).toBe(0);
+  });
+
+  test("respects pollIntervalMs — doesn't poll on every sweep", async () => {
+    let polls = 0;
+    const executor = makeFakeExecutor(() => {
+      polls++;
+      return { text: "still going", isError: false, correlationId: "c1", data: { taskState: "working", taskId: "t1" } };
+    });
+
+    tracker = new TaskTracker({ bus, sweepIntervalMs: 20, defaultPollIntervalMs: 200 });
+    tracker.track({
+      correlationId: "c1", taskId: "t1", agentName: "quinn",
+      replyTopic: "agent.skill.response.c1", executor,
+    });
+
+    // 100ms: sweeps run 5 times (20ms each) but poll only fires once (200ms interval)
+    await new Promise(r => setTimeout(r, 100));
+    expect(polls).toBeLessThanOrEqual(2);
+  });
+
+  test("ages out tasks past maxTrackingMs with timeout error", async () => {
+    const executor = makeFakeExecutor([
+      { text: "still going", isError: false, correlationId: "c1", data: { taskState: "working", taskId: "t1" } },
+    ]);
+
+    tracker = new TaskTracker({ bus, sweepIntervalMs: 20, defaultPollIntervalMs: 10, maxTrackingMs: 50 });
+    tracker.track({
+      correlationId: "c1", taskId: "t1", agentName: "quinn",
+      replyTopic: "agent.skill.response.c1", executor,
+    });
+
+    await new Promise(r => setTimeout(r, 120));
+    expect(received).toHaveLength(1);
+    expect((received[0].payload as { error: string }).error).toMatch(/timeout/i);
+    expect(tracker.size).toBe(0);
+  });
+
+  test("untrack removes task without publishing", async () => {
+    const executor = makeFakeExecutor([
+      { text: "completed", isError: false, correlationId: "c1", data: { taskState: "completed", taskId: "t1" } },
+    ]);
+
+    tracker = new TaskTracker({ bus, sweepIntervalMs: 50, defaultPollIntervalMs: 30 });
+    tracker.track({
+      correlationId: "c1", taskId: "t1", agentName: "quinn",
+      replyTopic: "agent.skill.response.c1", executor,
+    });
+    tracker.untrack("c1");
+
+    await new Promise(r => setTimeout(r, 80));
+    expect(received).toHaveLength(0);
+    expect(tracker.size).toBe(0);
+  });
+
+  test("concurrent tasks stay isolated", async () => {
+    const executor = makeFakeExecutor(() => ({
+      text: "done", isError: false, correlationId: "", data: { taskState: "completed", taskId: "t" },
+    }));
+
+    tracker = new TaskTracker({ bus, sweepIntervalMs: 20, defaultPollIntervalMs: 10 });
+    for (let i = 0; i < 5; i++) {
+      tracker.track({
+        correlationId: `c${i}`, taskId: `t${i}`, agentName: "quinn",
+        replyTopic: `agent.skill.response.c${i}`, executor,
+      });
+    }
+
+    await new Promise(r => setTimeout(r, 80));
+    expect(received).toHaveLength(5);
+    const topics = received.map(r => r.topic).sort();
+    expect(topics).toEqual([
+      "agent.skill.response.c0",
+      "agent.skill.response.c1",
+      "agent.skill.response.c2",
+      "agent.skill.response.c3",
+      "agent.skill.response.c4",
+    ]);
+  });
+
+  test("poll failures don't crash the sweep", async () => {
+    const executor = {
+      type: "a2a" as const,
+      execute: async () => ({ text: "", isError: false, correlationId: "" }),
+      pollTask: async () => { throw new Error("network blip"); },
+      cancelTask: async () => ({ text: "", isError: false, correlationId: "" }),
+      resubscribeTask: async () => { throw new Error("not used"); },
+    } as unknown as A2AExecutor;
+
+    tracker = new TaskTracker({ bus, sweepIntervalMs: 20, defaultPollIntervalMs: 10 });
+    tracker.track({
+      correlationId: "c1", taskId: "t1", agentName: "quinn",
+      replyTopic: "agent.skill.response.c1", executor,
+    });
+
+    await new Promise(r => setTimeout(r, 80));
+    // Task still tracked (no terminal state seen); no response published
+    expect(received).toHaveLength(0);
+    expect(tracker.size).toBe(1);
+  });
+});

--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -1,244 +1,475 @@
 /**
- * A2AExecutor — dispatches a skill to an external agent via A2A JSON-RPC (HTTP).
+ * A2AExecutor — dispatches a skill to an external agent via @a2a-js/sdk.
  *
- * Passes correlationId and parentId as HTTP headers (X-Correlation-Id, X-Parent-Id)
- * so the receiving service can propagate the distributed trace.
+ * Uses the new ClientFactory / Client API (JSON-RPC transport). The SDK handles:
+ *   - JSON-RPC request/response shape and error envelope unwrapping
+ *   - SSE streaming (sendMessageStream) with automatic fallback to sendMessage
+ *     when the agent card says capabilities.streaming !== true
+ *   - Agent card resolution (DefaultAgentCardResolver)
+ *   - Auth-handler pattern (wired per-instance via createAuthenticatingFetchWithRetry)
  *
  * Registered by SkillBrokerPlugin during install().
  */
 
+import { ClientFactory, JsonRpcTransportFactory, type Client } from "@a2a-js/sdk/client";
+import type {
+  Message,
+  Task,
+  TaskArtifactUpdateEvent,
+  TaskStatusUpdateEvent,
+} from "@a2a-js/sdk";
 import type { IExecutor, SkillRequest, SkillResult } from "../types.ts";
-import { HttpClient } from "../../services/http-client.ts";
+
+/**
+ * Auth scheme the executor applies on outbound requests.
+ *
+ *   "apiKey" — sends X-API-Key: <value>    (default — same as legacy behavior)
+ *   "bearer" — sends Authorization: Bearer <value>
+ *   "hmac"   — reserved for future HMAC-signed requests (extension hook only)
+ *
+ * `value` resolution: if `valueEnv` is set, we read process.env[valueEnv];
+ * otherwise we fall back to the agent-level `apiKeyEnv` for backward compat.
+ * Unset → no auth header stamped.
+ */
+export type A2AAuthScheme = "apiKey" | "bearer" | "hmac";
+
+export interface A2AAuthConfig {
+  scheme: A2AAuthScheme;
+  /** Environment variable holding the credential value. */
+  credentialsEnv?: string;
+}
 
 export interface A2AAgentConfig {
   /** Agent name (for logging). */
   name: string;
-  /** Full A2A endpoint URL. */
+  /** Full A2A endpoint URL (to agent root — card is fetched at /.well-known/agent-card.json). */
   url: string;
-  /** Environment variable name holding the API key. Optional. */
+  /** Environment variable name holding the API key. Optional. Legacy alias for auth.apiKey. */
   apiKeyEnv?: string;
-  /** Request timeout in ms. Default: 300_000 (5 min — agent-driven chats with
-   * multiple tool calls routinely exceed 2 min). */
+  /** Structured auth config — preferred over apiKeyEnv when set. */
+  auth?: A2AAuthConfig;
+  /** Extra request headers (e.g. opt-in A2A extensions). Merged per-call. */
+  extraHeaders?: Record<string, string>;
+  /** Request timeout in ms. Default: 300_000 (5 min). */
   timeoutMs?: number;
   /** Whether the remote agent supports SSE streaming (from agent card). */
   streaming?: boolean;
   /** Callback for intermediate streaming updates (e.g. publish to bus). */
   onStreamUpdate?: (update: { type: string; text?: string; state?: string }) => void;
+  /**
+   * Public base URL of the workstacean API server (e.g. http://workstacean:3000
+   * on the docker network). Required to register push notification webhooks.
+   * If unset, push notifications are skipped and we fall back to polling.
+   */
+  callbackBaseUrl?: string;
+}
+
+export interface ExecuteOptions {
+  /**
+   * If provided and the agent supports push notifications, the executor
+   * registers a push-notification config pointing at this taskId + token
+   * so the agent can POST task updates back via /api/a2a/callback/:taskId.
+   */
+  callback?: { taskId: string; token: string };
+}
+
+/**
+ * Build a fetch wrapper that stamps auth + per-request trace headers.
+ * A new wrapper is built per executor.execute() call so each client sees
+ * the right correlationId without requiring a separate cached client per trace.
+ *
+ * The `as typeof fetch` cast is because TS types `typeof fetch` includes
+ * `preconnect` (a browser-only signature) that Node/Bun's fetch doesn't expose.
+ */
+function buildFetch(
+  auth: { scheme: A2AAuthScheme; value: string } | undefined,
+  extraHeaders: Record<string, string> | undefined,
+  timeoutMs: number,
+  correlationId: string,
+  parentId?: string,
+): typeof fetch {
+  const wrapped = async (input: string | URL | Request, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+
+    // Auth header selection — scheme drives the header name.
+    if (auth && auth.value) {
+      if (auth.scheme === "bearer") {
+        headers.set("Authorization", `Bearer ${auth.value}`);
+      } else if (auth.scheme === "apiKey") {
+        headers.set("X-API-Key", auth.value);
+      }
+      // "hmac" is handled by an extension interceptor, not here.
+    }
+
+    // Static extra headers (e.g. a2a-extensions opt-in list). Don't overwrite
+    // anything the SDK already set — extras are for our metadata only.
+    if (extraHeaders) {
+      for (const [k, v] of Object.entries(extraHeaders)) {
+        if (!headers.has(k)) headers.set(k, v);
+      }
+    }
+
+    headers.set("X-Correlation-Id", correlationId);
+    if (parentId) headers.set("X-Parent-Id", parentId);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      return await fetch(input, { ...init, headers, signal: init?.signal ?? controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+  return wrapped as typeof fetch;
 }
 
 export class A2AExecutor implements IExecutor {
   readonly type = "a2a";
-  private readonly http: HttpClient;
 
-  constructor(private readonly config: A2AAgentConfig) {
-    this.http = new HttpClient({ timeoutMs: config.timeoutMs ?? 300_000 });
-  }
+  constructor(private readonly config: A2AAgentConfig) {}
 
   async execute(req: SkillRequest): Promise<SkillResult> {
-    const apiKey = this.config.apiKeyEnv
-      ? (process.env[this.config.apiKeyEnv] ?? "")
-      : "";
-
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-      // Distributed trace headers — received by ava's A2A handler
-      "X-Correlation-Id": req.correlationId,
-      ...(req.parentId ? { "X-Parent-Id": req.parentId } : {}),
-    };
-    if (apiKey) headers["X-API-Key"] = apiKey;
-
     const text = req.content ?? req.prompt ?? this._buildText(req);
 
-    const body = JSON.stringify({
-      jsonrpc: "2.0",
-      id: crypto.randomUUID(),
-      method: "message/send",
-      params: {
+    try {
+      // Per-request client so trace headers get stamped via the fetch wrapper.
+      const client = await this._buildClient(req.correlationId, req.parentId);
+
+      const params = {
         message: {
-          role: "user",
-          parts: [{ kind: "text", text }],
+          kind: "message" as const,
+          messageId: crypto.randomUUID(),
+          role: "user" as const,
+          parts: [{ kind: "text" as const, text }],
+          contextId: req.contextId ?? req.correlationId,
         },
-        // contextId carries conversation state; correlationId is the trace ID
-        contextId: req.contextId ?? req.correlationId,
         metadata: {
           skillHint: req.skill,
           correlationId: req.correlationId,
           parentId: req.parentId,
           ...req.payload,
         },
-      },
-    });
+      };
 
-    // If agent supports streaming, use SSE for intermediate updates
-    if (this.config.streaming) {
-      const streamBody = body.replace('"message/send"', '"message/sendStream"');
-      const streamHeaders = { ...headers, Accept: "text/event-stream" };
-      try {
-        const streamResult = await this._executeStream(streamHeaders, streamBody, req);
-        if (streamResult) return streamResult;
-      } catch {
-        // Fall through to blocking path
+      if (this.config.streaming) {
+        return await this._executeStream(client, params, req);
       }
-    }
-
-    const resp = await this.http.fetch(this.config.url, {
-      method: "POST",
-      headers,
-      body,
-    });
-
-    if (!resp.ok) {
-      const errText = await resp.text().catch(() => "(no body)");
+      return await this._executeBlocking(client, params, req);
+    } catch (err) {
       return {
-        text: "",
+        text: err instanceof Error ? err.message : String(err),
         isError: true,
         correlationId: req.correlationId,
       };
     }
+  }
 
-    // Google A2A protocol response shape:
-    //   result: {
-    //     id, contextId, status: { state: "completed" },
-    //     artifacts: [{ artifactId, parts: [{ kind: "text", text: "..." }] }]
-    //   }
-    //
-    // We flatten all text parts across all artifacts into a single string
-    // so callers (skill-dispatcher) get the actual agent reply, not a generic
-    // "accepted" stub. Fallback cascade: artifacts.parts.text → result.message
-    // (legacy shape) → generic placeholder. Also logs the parse path on debug
-    // so future regressions are visible.
-    const data = (await resp.json()) as {
-      error?: { message: string };
-      result?: {
-        id?: string;
-        contextId?: string;
-        status?: { state?: string } | string;
-        message?: string;
-        artifacts?: Array<{ parts?: Array<{ kind?: string; text?: string }> }>;
-        [key: string]: unknown;
+  /**
+   * Resume a task that's in input-required state by sending a new message
+   * with the same taskId. Used by TaskTracker when a HITL response arrives.
+   */
+  async resumeTask(
+    taskId: string,
+    contextId: string,
+    text: string,
+    correlationId: string,
+    parentId?: string,
+  ): Promise<void> {
+    const client = await this._buildClient(correlationId, parentId);
+    await client.sendMessage({
+      message: {
+        kind: "message",
+        messageId: crypto.randomUUID(),
+        role: "user",
+        parts: [{ kind: "text", text }],
+        taskId,
+        contextId,
+      },
+    });
+  }
+
+  /**
+   * Register a push-notification webhook for a task. Agent will POST Task
+   * snapshots to the URL with the given token in X-A2A-Notification-Token
+   * when the task state changes. Silently no-ops if the agent doesn't
+   * support push notifications (we fall back to polling).
+   */
+  async registerPushNotification(
+    taskId: string,
+    callbackUrl: string,
+    token: string,
+    correlationId: string,
+    parentId?: string,
+  ): Promise<boolean> {
+    try {
+      const client = await this._buildClient(correlationId, parentId);
+      await client.setTaskPushNotificationConfig({
+        taskId,
+        pushNotificationConfig: { url: callbackUrl, token },
+      });
+      return true;
+    } catch {
+      // Agent doesn't support push notifications — tracker falls back to polling
+      return false;
+    }
+  }
+
+  /**
+   * Poll a task for its current state. Used by TaskTracker to check progress
+   * on long-running tasks without blocking the executor loop.
+   */
+  async pollTask(taskId: string, correlationId: string, parentId?: string): Promise<SkillResult> {
+    try {
+      const client = await this._buildClient(correlationId, parentId);
+      const task = await client.getTask({ id: taskId });
+      const artifactText = (task.artifacts ?? [])
+        .flatMap(a => a.parts)
+        .filter((p): p is { kind: "text"; text: string } => p.kind === "text" && typeof p.text === "string")
+        .map(p => p.text)
+        .join("\n");
+      const statusText = task.status.message ? this._textFromParts(task.status.message.parts) : "";
+      return {
+        text: artifactText || statusText || "",
+        isError: task.status.state === "failed" || task.status.state === "rejected",
+        correlationId,
+        data: { taskId: task.id, contextId: task.contextId, taskState: task.status.state },
       };
-    };
+    } catch (err) {
+      return {
+        text: err instanceof Error ? err.message : String(err),
+        isError: true,
+        correlationId,
+      };
+    }
+  }
 
-    if (data.error) {
-      return { text: data.error.message, isError: true, correlationId: req.correlationId };
+  /**
+   * Cancel an in-flight task. Idempotent: already-terminal tasks throw
+   * TaskNotCancelableError which we surface as isError.
+   */
+  async cancelTask(taskId: string, correlationId: string, parentId?: string): Promise<SkillResult> {
+    try {
+      const client = await this._buildClient(correlationId, parentId);
+      const task = await client.cancelTask({ id: taskId });
+      return {
+        text: `Task ${taskId} canceled`,
+        isError: false,
+        correlationId,
+        data: { taskId: task.id, contextId: task.contextId, taskState: task.status.state },
+      };
+    } catch (err) {
+      return {
+        text: err instanceof Error ? err.message : String(err),
+        isError: true,
+        correlationId,
+      };
+    }
+  }
+
+  /**
+   * Resubscribe to a task's SSE stream after connection drops. Yields events
+   * just like sendMessageStream; TaskTracker can prefer this over polling
+   * when the agent card says capabilities.streaming: true.
+   */
+  async resubscribeTask(
+    taskId: string,
+    correlationId: string,
+    parentId?: string,
+  ): Promise<AsyncGenerator<Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent, void, undefined>> {
+    const client = await this._buildClient(correlationId, parentId);
+    return client.resubscribeTask({ id: taskId });
+  }
+
+  /**
+   * Non-streaming path: client.sendMessage returns Message | Task.
+   */
+  private async _executeBlocking(
+    client: Client,
+    params: Parameters<Client["sendMessage"]>[0],
+    req: SkillRequest,
+  ): Promise<SkillResult> {
+    const result = await client.sendMessage(params);
+
+    // Result can be a Message (immediate agent reply, no task) or a Task (may still be working).
+    if (result.kind === "message") {
+      const text = this._textFromParts(result.parts);
+      return {
+        text,
+        isError: false,
+        correlationId: req.correlationId,
+        data: { taskState: "completed" },
+      };
     }
 
-    const artifactTexts = (data.result?.artifacts ?? [])
-      .flatMap((a) => a.parts ?? [])
-      .filter((p) => p.kind === "text" && typeof p.text === "string")
-      .map((p) => p.text as string);
+    // Task — extract text from artifacts or status.message.parts
+    const task = result;
+    const artifactText = (task.artifacts ?? [])
+      .flatMap(a => a.parts)
+      .filter((p): p is { kind: "text"; text: string } => p.kind === "text" && typeof p.text === "string")
+      .map(p => p.text)
+      .join("\n");
 
-    const resultText =
-      artifactTexts.length > 0
-        ? artifactTexts.join("\n")
-        : data.result?.message ?? `Skill "${req.skill}" accepted by ${this.config.name}`;
+    const statusText = task.status.message
+      ? this._textFromParts(task.status.message.parts)
+      : "";
 
-    const statusObj = data.result?.status;
-    const taskState = typeof statusObj === "object" ? statusObj?.state : typeof statusObj === "string" ? statusObj : undefined;
+    const text = artifactText || statusText || `Skill "${req.skill}" accepted by ${this.config.name}`;
+    const taskState = task.status.state;
 
     return {
-      text: resultText,
-      isError: false,
+      text,
+      isError: taskState === "failed" || taskState === "rejected",
       correlationId: req.correlationId,
       data: {
-        ...(data.result?.data as Record<string, unknown> | undefined),
-        taskId: data.result?.id as string | undefined,
-        contextId: data.result?.contextId as string | undefined,
+        taskId: task.id,
+        contextId: task.contextId,
         taskState,
       },
     };
   }
 
   /**
-   * SSE streaming path — reads TaskStatusUpdateEvent / TaskArtifactUpdateEvent
-   * from the response stream. Returns null if the agent doesn't support streaming.
+   * Streaming path: iterates the SSE event stream, accumulates artifact text.
+   * Supports artifact chunking via append/lastChunk (Phase 5 honors this fully).
    */
   private async _executeStream(
-    headers: Record<string, string>,
-    body: string,
+    client: Client,
+    params: Parameters<Client["sendMessageStream"]>[0],
     req: SkillRequest,
-  ): Promise<SkillResult | null> {
-    const resp = await this.http.fetch(this.config.url, {
-      method: "POST",
-      headers,
-      body,
-    });
-
-    if (!resp.ok || !resp.body) return null;
-
-    const contentType = resp.headers.get("content-type") ?? "";
-    if (!contentType.includes("text/event-stream")) {
-      // Not SSE — let caller fall back to blocking path
-      return null;
-    }
-
-    let resultText = "";
+  ): Promise<SkillResult> {
     let taskId: string | undefined;
     let contextId: string | undefined;
     let taskState = "working";
+    let terminalMessage = "";
 
-    const reader = resp.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = "";
+    // Artifact buffering — honors append + lastChunk per A2A spec.
+    // - append: false (or undefined) → replace the artifact's parts
+    // - append: true → concatenate incoming parts to existing buffer
+    // - lastChunk: true → signal artifact is complete (we emit artifact_complete)
+    const artifactBuffers = new Map<string, Array<{ kind: string; text?: string }>>();
 
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
+    for await (const event of client.sendMessageStream(params)) {
+      if (event.kind === "message") {
+        // Terminal message — stream ends
+        terminalMessage = this._textFromParts(event.parts);
+        taskState = "completed";
+        break;
+      }
+      if (event.kind === "task") {
+        taskId = event.id;
+        contextId = event.contextId;
+        taskState = event.status.state;
+        // Seed artifact buffers from task snapshot if present
+        for (const artifact of event.artifacts ?? []) {
+          artifactBuffers.set(artifact.artifactId, [...artifact.parts]);
+        }
+        continue;
+      }
+      if (event.kind === "status-update") {
+        taskId = event.taskId;
+        contextId = event.contextId;
+        taskState = event.status.state;
+        const statusText = event.status.message ? this._textFromParts(event.status.message.parts) : "";
+        if (statusText) {
+          this.config.onStreamUpdate?.({ type: "status", text: statusText, state: taskState });
+        }
+        if (event.final) break;
+        continue;
+      }
+      if (event.kind === "artifact-update") {
+        taskId = event.taskId;
+        contextId = event.contextId;
+        const aid = event.artifact.artifactId;
+        const incomingParts = event.artifact.parts;
+        const incomingText = this._textFromParts(incomingParts);
 
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() ?? "";
+        if (event.append) {
+          const existing = artifactBuffers.get(aid) ?? [];
+          artifactBuffers.set(aid, [...existing, ...incomingParts]);
+        } else {
+          // New artifact or replacement
+          artifactBuffers.set(aid, [...incomingParts]);
+        }
 
-        for (const line of lines) {
-          if (!line.startsWith("data: ")) continue;
-          const raw = line.slice(6).trim();
-          if (!raw || raw === "[DONE]") continue;
-
-          try {
-            const event = JSON.parse(raw) as {
-              id?: string;
-              contextId?: string;
-              status?: { state?: string; message?: { parts?: Array<{ text?: string }> } };
-              artifact?: { parts?: Array<{ kind?: string; text?: string }> };
-            };
-
-            taskId = event.id ?? taskId;
-            contextId = event.contextId ?? contextId;
-
-            if (event.status?.state) {
-              taskState = event.status.state;
-              const statusText = event.status.message?.parts
-                ?.map(p => p.text).filter(Boolean).join("") ?? "";
-              if (statusText) {
-                this.config.onStreamUpdate?.({ type: "status", text: statusText, state: taskState });
-              }
-            }
-
-            if (event.artifact) {
-              const artifactText = (event.artifact.parts ?? [])
-                .filter(p => p.kind === "text" && p.text)
-                .map(p => p.text).join("");
-              if (artifactText) {
-                resultText += (resultText ? "\n" : "") + artifactText;
-                this.config.onStreamUpdate?.({ type: "artifact", text: artifactText });
-              }
-            }
-          } catch {
-            // Skip malformed SSE lines
-          }
+        // Emit chunk event — consumers see progressive updates in real time
+        if (incomingText) {
+          this.config.onStreamUpdate?.({
+            type: event.append ? "artifact_chunk" : "artifact",
+            text: incomingText,
+          });
+        }
+        if (event.lastChunk) {
+          const finalText = this._textFromParts(artifactBuffers.get(aid) ?? []);
+          this.config.onStreamUpdate?.({
+            type: "artifact_complete",
+            text: finalText,
+          });
         }
       }
-    } finally {
-      reader.releaseLock();
     }
+
+    // Final resultText = terminal message if we got one, otherwise concat of all artifact buffers
+    const artifactText = Array.from(artifactBuffers.values())
+      .map(parts => this._textFromParts(parts))
+      .filter(Boolean)
+      .join("\n");
+    const resultText = terminalMessage || artifactText;
 
     return {
       text: resultText || `Skill "${req.skill}" completed by ${this.config.name}`,
-      isError: taskState === "failed",
+      isError: taskState === "failed" || taskState === "rejected",
       correlationId: req.correlationId,
       data: { taskId, contextId, taskState },
     };
+  }
+
+  private _textFromParts(parts: Array<{ kind: string; text?: string }>): string {
+    return parts
+      .filter((p): p is { kind: "text"; text: string } => p.kind === "text" && typeof p.text === "string")
+      .map(p => p.text)
+      .join("");
+  }
+
+  /**
+   * Build a Client with per-request trace headers. A new client per-call is
+   * the simplest way to inject correlationId/parentId via the fetch layer —
+   * ClientFactory / ClientConfig don't expose a per-call header hook.
+   * The agent card fetch is the only cacheable cost; we accept the overhead
+   * today and can add card-level caching in Phase 4.
+   */
+  private async _buildClient(correlationId: string, parentId?: string): Promise<Client> {
+    const baseUrl = this.config.url.replace(/\/a2a\/?$/, "");
+    const timeoutMs = this.config.timeoutMs ?? 300_000;
+
+    // Auth resolution — prefer structured auth.credentialsEnv; fall back to
+    // the legacy apiKeyEnv so existing agents.yaml keeps working.
+    const scheme: A2AAuthScheme = this.config.auth?.scheme ?? "apiKey";
+    const credEnv = this.config.auth?.credentialsEnv ?? this.config.apiKeyEnv;
+    const credValue = credEnv ? (process.env[credEnv] ?? "") : "";
+    const authOpts = credValue ? { scheme, value: credValue } : undefined;
+
+    const customFetch = buildFetch(
+      authOpts,
+      this.config.extraHeaders,
+      timeoutMs,
+      correlationId,
+      parentId,
+    );
+    const factory = new ClientFactory({
+      transports: [new JsonRpcTransportFactory({ fetchImpl: customFetch })],
+    });
+
+    try {
+      return await factory.createFromUrl(baseUrl);
+    } catch (err) {
+      // Fallback to legacy path — some servers still serve /.well-known/agent.json
+      // instead of the newer /.well-known/agent-card.json
+      try {
+        return await factory.createFromUrl(baseUrl, "/.well-known/agent.json");
+      } catch {
+        throw err;
+      }
+    }
   }
 
   private _buildText(req: SkillRequest): string {

--- a/src/executor/extension-registry.ts
+++ b/src/executor/extension-registry.ts
@@ -1,0 +1,99 @@
+/**
+ * ExtensionRegistry — lightweight map of known A2A protocol extensions and
+ * the interceptors we want to apply when an agent declares support for them
+ * in its agent card's `capabilities.extensions` list.
+ *
+ * The A2A spec models extensions as URIs (e.g. `https://a2a-protocol.org/ext/cost-v1`)
+ * plus optional `params`. Agents advertise them in their card; clients can
+ * opt-in per-request via the `a2a-extensions` header (comma-separated URIs).
+ *
+ * This phase is foundation only — we wire the registry, the header stamping,
+ * and the interceptor hook points, but don't ship specific extension
+ * implementations yet. Adding "cost tracking" or "consent negotiation" later
+ * means registering an interceptor here; no other code needs to change.
+ *
+ * Usage:
+ *   const ext = new ExtensionRegistry();
+ *   ext.register({ uri: "https://a2a-protocol.org/ext/cost-v1", interceptor: costInterceptor });
+ *   const headers = ext.headersFor(agentCard); // { "a2a-extensions": "https://..." }
+ *   for (const i of ext.interceptorsFor(agentCard)) await i.before?.(request);
+ */
+
+import type { AgentCard } from "@a2a-js/sdk";
+
+export interface ExtensionInterceptor {
+  /** Called before a skill request is dispatched. May mutate metadata. */
+  before?: (ctx: ExtensionContext) => Promise<void> | void;
+  /** Called after a response is received. May attach data to the result. */
+  after?: (ctx: ExtensionContext, result: { text: string; data?: Record<string, unknown> }) => Promise<void> | void;
+}
+
+export interface ExtensionContext {
+  agentName: string;
+  skill: string;
+  correlationId: string;
+  /** Mutable metadata bag — interceptors can stamp keys here. */
+  metadata: Record<string, unknown>;
+}
+
+export interface ExtensionDefinition {
+  /** Canonical URI from the agent card (e.g. "https://a2a-protocol.org/ext/cost-v1"). */
+  uri: string;
+  /** Optional interceptor applied when an agent declares this extension. */
+  interceptor?: ExtensionInterceptor;
+  /** Human-readable description for diagnostics. */
+  description?: string;
+}
+
+export class ExtensionRegistry {
+  private readonly extensions = new Map<string, ExtensionDefinition>();
+
+  register(def: ExtensionDefinition): void {
+    this.extensions.set(def.uri, def);
+  }
+
+  /** List every registered extension URI — useful for diagnostics. */
+  list(): ExtensionDefinition[] {
+    return Array.from(this.extensions.values());
+  }
+
+  /**
+   * Return the subset of our registered extensions that the given agent card
+   * declares support for. Filters by exact URI match; agents must advertise
+   * each URI they actually implement.
+   */
+  matchAgent(card: AgentCard | undefined | null): ExtensionDefinition[] {
+    if (!card?.capabilities?.extensions) return [];
+    const advertised = new Set(card.capabilities.extensions.map(e => e.uri));
+    return Array.from(this.extensions.values()).filter(def => advertised.has(def.uri));
+  }
+
+  /**
+   * Build the `a2a-extensions` request header for an agent — a comma-
+   * separated list of URIs the client wants to opt into on this call.
+   * Returns an empty record when no matches exist so callers can just
+   * spread the result without null-checking.
+   */
+  headersFor(card: AgentCard | undefined | null): Record<string, string> {
+    const matches = this.matchAgent(card);
+    if (matches.length === 0) return {};
+    return { "a2a-extensions": matches.map(m => m.uri).join(", ") };
+  }
+
+  /** Interceptors for the subset of extensions an agent supports. */
+  interceptorsFor(card: AgentCard | undefined | null): ExtensionInterceptor[] {
+    return this.matchAgent(card)
+      .map(d => d.interceptor)
+      .filter((i): i is ExtensionInterceptor => !!i);
+  }
+
+  get size(): number {
+    return this.extensions.size;
+  }
+}
+
+/**
+ * Singleton used by the skill broker / A2A executor. Test code can construct
+ * its own ExtensionRegistry to avoid cross-test pollution.
+ */
+export const defaultExtensionRegistry = new ExtensionRegistry();

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -21,6 +21,10 @@ import { GraphitiClient } from "../../lib/memory/graphiti-client.ts";
 import { IdentityRegistry } from "../../lib/identity/identity-registry.ts";
 import type { LoggerPlugin, ConversationTurn } from "../../lib/plugins/logger.ts";
 import { ContextMailbox } from "../../lib/dm/context-mailbox.ts";
+import type { TaskTracker } from "./task-tracker.ts";
+import type { A2AExecutor } from "./executors/a2a-executor.ts";
+
+const WORKING_STATES = new Set(["submitted", "working"]);
 
 /**
  * Assemble a structured context envelope for the agent prompt.
@@ -95,6 +99,7 @@ export class SkillDispatcherPlugin implements Plugin {
   private readonly identityRegistry: IdentityRegistry;
   private readonly loggerPlugin: LoggerPlugin | undefined;
   private readonly mailbox: ContextMailbox | undefined;
+  private readonly taskTracker: TaskTracker | undefined;
 
   /**
    * In-flight execution tracking — set at the TOP of _dispatch() (before any
@@ -113,11 +118,14 @@ export class SkillDispatcherPlugin implements Plugin {
     loggerPlugin?: LoggerPlugin,
     /** Optional mailbox for mid-execution DM queuing. */
     mailbox?: ContextMailbox,
+    /** Optional tracker for long-running A2A tasks. */
+    taskTracker?: TaskTracker,
   ) {
     this.graphiti = graphiti ?? new GraphitiClient();
     this.identityRegistry = new IdentityRegistry(workspaceDir);
     this.loggerPlugin = loggerPlugin;
     this.mailbox = mailbox;
+    this.taskTracker = taskTracker;
   }
 
   /** Check if an execution is currently active for a given correlationId. */
@@ -283,6 +291,58 @@ export class SkillDispatcherPlugin implements Plugin {
 
     try {
       const result = await executor.execute(req);
+
+      // Long-running A2A task — agent returned non-terminal state with a taskId.
+      // Hand off to TaskTracker; dispatcher exits without publishing response.
+      // Tracker will publish to replyTopic once the task reaches terminal state.
+      const taskState = result.data?.taskState;
+      const taskId = result.data?.taskId;
+      if (
+        this.taskTracker
+        && !result.isError
+        && taskState
+        && typeof taskState === "string"
+        && WORKING_STATES.has(taskState)
+        && taskId
+        && executor.type === "a2a"
+      ) {
+        const a2aExecutor = executor as A2AExecutor;
+        const callbackToken = crypto.randomUUID();
+        this.taskTracker.track({
+          correlationId,
+          taskId,
+          agentName: targets[0] ?? "unknown",
+          replyTopic,
+          executor: a2aExecutor,
+          parentId,
+          callbackToken,
+          sourceInterface: sourcePlatform,
+          sourceChannelId: sourceChannelId,
+          sourceUserId: sourceUserId,
+        });
+
+        // Try to register a push-notification webhook so the agent can POST
+        // completion back instead of us polling. Falls back to polling silently.
+        const callbackBaseUrl = process.env.WORKSTACEAN_BASE_URL;
+        if (callbackBaseUrl) {
+          const callbackUrl = `${callbackBaseUrl.replace(/\/$/, "")}/api/a2a/callback/${encodeURIComponent(taskId)}`;
+          void a2aExecutor.registerPushNotification(taskId, callbackUrl, callbackToken, correlationId, parentId)
+            .then(ok => {
+              if (ok) console.log(`[skill-dispatcher] Push-notification registered for ${taskId.slice(0, 8)}…`);
+            })
+            .catch(err => console.debug("[skill-dispatcher] push-notification register failed:", err));
+        }
+
+        this._publishFlowEvent("flow.item.updated", {
+          id: flowItemId,
+          status: "active",
+          stage: "running",
+          meta: { skill, taskId, taskState, trackedBy: "task-tracker" },
+        });
+        // Don't publish a response — tracker will do it. Still fall through to
+        // finally block so activeExecutions gets cleaned up.
+        return;
+      }
 
       if (result.isError) {
         console.error(

--- a/src/executor/task-tracker.ts
+++ b/src/executor/task-tracker.ts
@@ -1,0 +1,326 @@
+/**
+ * TaskTracker — tracks long-running A2A tasks that returned non-terminal state.
+ *
+ * When an A2AExecutor gets a task back in "working" or "submitted" state
+ * (i.e., the agent is still processing and hasn't returned a final result),
+ * the dispatcher hands it to the tracker. The tracker polls each task
+ * periodically and, when the state becomes terminal, publishes the final
+ * response to the original reply topic.
+ *
+ * This closes the "5 min timeout → dropped result" gap without changing
+ * the bus-facing dispatch contract: callers still receive exactly one
+ * response on the reply topic, just later.
+ */
+
+import type { EventBus, BusMessage, HITLRequest, HITLResponse } from "../../lib/types.ts";
+import type { A2AExecutor } from "./executors/a2a-executor.ts";
+import type { AgentSkillResponsePayload } from "../event-bus/payloads.ts";
+
+const TERMINAL_STATES = new Set(["completed", "failed", "canceled", "rejected"]);
+const HITL_TTL_MS = 30 * 60_000; // 30 min default input-required window
+
+export interface TrackedTask {
+  correlationId: string;
+  taskId: string;
+  agentName: string;
+  replyTopic: string;
+  executor: A2AExecutor;
+  parentId?: string;
+  registeredAt: number;
+  lastPolledAt: number;
+  pollIntervalMs: number;
+  /** Per-task secret for authenticating push-notification callbacks. */
+  callbackToken?: string;
+  /** Set when the task has asked for human input — suppresses polling until resumed. */
+  awaitingHuman?: boolean;
+  /** The Discord/etc interface that originated the request — reused for HITL routing. */
+  sourceInterface?: string;
+  /** Source channel ID for HITL rendering. */
+  sourceChannelId?: string;
+  /** User ID for HITL rendering. */
+  sourceUserId?: string;
+}
+
+export interface TaskTrackerOptions {
+  /** Event bus — tracker publishes responses here on terminal state. */
+  bus: EventBus;
+  /** How often to sweep the task map (ms). Default: 10s. */
+  sweepIntervalMs?: number;
+  /** Default per-task poll interval (ms). Default: 30s. */
+  defaultPollIntervalMs?: number;
+  /** Max time to track a task before giving up (ms). Default: 1hr. */
+  maxTrackingMs?: number;
+}
+
+export class TaskTracker {
+  private readonly tasks = new Map<string, TrackedTask>();
+  private readonly bus: EventBus;
+  private readonly sweepIntervalMs: number;
+  private readonly defaultPollIntervalMs: number;
+  private readonly maxTrackingMs: number;
+  private readonly sweepTimer: ReturnType<typeof setInterval>;
+
+  constructor(opts: TaskTrackerOptions) {
+    this.bus = opts.bus;
+    this.sweepIntervalMs = opts.sweepIntervalMs ?? 10_000;
+    this.defaultPollIntervalMs = opts.defaultPollIntervalMs ?? 30_000;
+    this.maxTrackingMs = opts.maxTrackingMs ?? 60 * 60_000;
+    this.sweepTimer = setInterval(() => { void this._sweep(); }, this.sweepIntervalMs);
+    this.sweepTimer.unref?.();
+
+    // Subscribe to HITL responses — when a tracked task was awaiting input
+    // and a human responds, resume the task via sendMessage(taskId, decisionText).
+    this.bus.subscribe("hitl.response.#", "task-tracker", (msg: BusMessage) => {
+      const resp = msg.payload as HITLResponse | undefined;
+      if (!resp || resp.type !== "hitl_response") return;
+      void this._resumeFromHitl(resp);
+    });
+  }
+
+  /** Register a task for tracking. Dispatcher calls this after executor returns working. */
+  track(params: {
+    correlationId: string;
+    taskId: string;
+    agentName: string;
+    replyTopic: string;
+    executor: A2AExecutor;
+    parentId?: string;
+    pollIntervalMs?: number;
+    /** Per-task token for authenticating push callbacks. Generated if omitted. */
+    callbackToken?: string;
+    /** Source interface/channel/user — reused to route input-required HITL requests. */
+    sourceInterface?: string;
+    sourceChannelId?: string;
+    sourceUserId?: string;
+  }): void {
+    const now = Date.now();
+    this.tasks.set(params.correlationId, {
+      correlationId: params.correlationId,
+      taskId: params.taskId,
+      agentName: params.agentName,
+      replyTopic: params.replyTopic,
+      executor: params.executor,
+      parentId: params.parentId,
+      registeredAt: now,
+      lastPolledAt: now,
+      pollIntervalMs: params.pollIntervalMs ?? this.defaultPollIntervalMs,
+      callbackToken: params.callbackToken ?? crypto.randomUUID(),
+      sourceInterface: params.sourceInterface,
+      sourceChannelId: params.sourceChannelId,
+      sourceUserId: params.sourceUserId,
+    });
+    console.log(
+      `[task-tracker] Tracking ${params.agentName} task ${params.taskId.slice(0, 8)}… (correlationId: ${params.correlationId.slice(0, 8)}…)`,
+    );
+  }
+
+  /** Look up the callback token for a tracked task. Used by the webhook route. */
+  getCallbackToken(correlationId: string): string | undefined {
+    return this.tasks.get(correlationId)?.callbackToken;
+  }
+
+  /**
+   * Handle an incoming push notification. Body is the A2A Task object.
+   * If the task is terminal, we publish the response and untrack. Otherwise
+   * we update lastPolledAt so the polling loop gives the task more time.
+   */
+  handleCallback(correlationId: string, body: Record<string, unknown>): void {
+    const task = this.tasks.get(correlationId);
+    if (!task) return;
+
+    const status = (body.status ?? {}) as { state?: string; message?: { parts?: Array<{ kind?: string; text?: string }> } };
+    const state = typeof status.state === "string" ? status.state : undefined;
+
+    task.lastPolledAt = Date.now();
+
+    if (state === "input-required") {
+      const statusText = status.message?.parts
+        ? status.message.parts.filter(p => p.kind === "text").map(p => p.text ?? "").join("")
+        : "";
+      this._raiseHitl(task, statusText);
+      return;
+    }
+
+    if (!state || !TERMINAL_STATES.has(state)) {
+      // Non-terminal update — just refresh the polled timestamp
+      return;
+    }
+
+    // Extract text from artifacts (primary) or status.message (fallback)
+    const artifacts = (body.artifacts ?? []) as Array<{ parts?: Array<{ kind?: string; text?: string }> }>;
+    const artifactText = artifacts
+      .flatMap(a => a.parts ?? [])
+      .filter((p): p is { kind: "text"; text: string } => p.kind === "text" && typeof p.text === "string")
+      .map(p => p.text)
+      .join("\n");
+    const statusText = status.message?.parts
+      ? status.message.parts.filter(p => p.kind === "text").map(p => p.text ?? "").join("")
+      : "";
+    const content = artifactText || statusText;
+    const isError = state === "failed" || state === "rejected";
+
+    this._publishResponse(task, isError ? undefined : content, isError ? (content || state) : undefined);
+    this.tasks.delete(correlationId);
+    console.log(
+      `[task-tracker] Callback for ${task.taskId.slice(0, 8)}… → terminal state "${state}" (via webhook)`,
+    );
+  }
+
+  /** Stop tracking a task (e.g., on cancel). */
+  untrack(correlationId: string): void {
+    this.tasks.delete(correlationId);
+  }
+
+  /** Get snapshot of currently-tracked tasks — for API endpoint. */
+  getAll(): TrackedTask[] {
+    return Array.from(this.tasks.values());
+  }
+
+  get size(): number {
+    return this.tasks.size;
+  }
+
+  destroy(): void {
+    clearInterval(this.sweepTimer);
+    this.tasks.clear();
+  }
+
+  /**
+   * Sweep all tracked tasks. For each due (lastPolledAt + pollIntervalMs < now),
+   * fetch its current state. On terminal: publish response, untrack. On stuck
+   * past maxTrackingMs: publish timeout response, untrack.
+   */
+  private async _sweep(): Promise<void> {
+    const now = Date.now();
+
+    for (const task of this.tasks.values()) {
+      // Age-out: task has been working for too long
+      if (now - task.registeredAt > this.maxTrackingMs) {
+        this._publishResponse(task, undefined, `Task tracking timeout (>${Math.round(this.maxTrackingMs / 60_000)}min)`);
+        this.tasks.delete(task.correlationId);
+        continue;
+      }
+
+      // Awaiting human input — don't poll, just wait for hitl.response.*
+      if (task.awaitingHuman) continue;
+
+      // Not yet due
+      if (now - task.lastPolledAt < task.pollIntervalMs) continue;
+
+      task.lastPolledAt = now;
+
+      try {
+        const result = await task.executor.pollTask(task.taskId, task.correlationId, task.parentId);
+        const state = result.data?.taskState;
+
+        if (state === "input-required") {
+          this._raiseHitl(task, result.text);
+          continue;
+        }
+
+        if (state && TERMINAL_STATES.has(state)) {
+          this._publishResponse(task, result.text, result.isError ? result.text : undefined);
+          this.tasks.delete(task.correlationId);
+          console.log(
+            `[task-tracker] Task ${task.taskId.slice(0, 8)}… reached terminal state "${state}" after ${Math.round((now - task.registeredAt) / 1000)}s`,
+          );
+        }
+      } catch (err) {
+        console.warn(
+          `[task-tracker] poll failed for ${task.taskId.slice(0, 8)}…:`,
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+  }
+
+  /**
+   * Emit a HITL request for a task that hit input-required. HITLPlugin will
+   * route to the registered renderer (Discord approval buttons, etc). The
+   * response flows back via hitl.response.# which we subscribe to.
+   */
+  private _raiseHitl(task: TrackedTask, question: string | undefined): void {
+    if (task.awaitingHuman) return; // already raised, avoid duplicate
+    task.awaitingHuman = true;
+
+    const req: HITLRequest = {
+      type: "hitl_request",
+      correlationId: task.correlationId,
+      title: `Input needed from ${task.agentName}`,
+      summary: question || "The agent is requesting input to continue.",
+      options: ["approve", "reject"],
+      expiresAt: new Date(Date.now() + HITL_TTL_MS).toISOString(),
+      replyTopic: `hitl.response.${task.correlationId}`,
+      sourceMeta: {
+        interface: task.sourceInterface ?? "discord",
+        channelId: task.sourceChannelId,
+        userId: task.sourceUserId,
+      },
+    };
+
+    this.bus.publish(`hitl.request.${task.correlationId}`, {
+      id: crypto.randomUUID(),
+      correlationId: task.correlationId,
+      topic: `hitl.request.${task.correlationId}`,
+      timestamp: Date.now(),
+      payload: req,
+    });
+
+    console.log(
+      `[task-tracker] input-required from ${task.agentName} — raised HITL request (correlationId: ${task.correlationId.slice(0, 8)}…)`,
+    );
+  }
+
+  /**
+   * When a HITL response arrives for a tracked task, resume the agent by
+   * sending a new message in the same taskId. Uses executor.execute() with
+   * the original skill context so memory enrichment still applies.
+   */
+  private async _resumeFromHitl(resp: HITLResponse): Promise<void> {
+    const task = this.tasks.get(resp.correlationId);
+    if (!task || !task.awaitingHuman) return;
+
+    const decisionText = [
+      `Human decision: ${resp.decision}`,
+      resp.feedback ? `Feedback: ${resp.feedback}` : "",
+      `Decided by: ${resp.decidedBy}`,
+    ].filter(Boolean).join("\n");
+
+    try {
+      await task.executor.resumeTask(
+        task.taskId,
+        task.correlationId,
+        decisionText,
+        task.correlationId,
+        task.parentId,
+      );
+      task.awaitingHuman = false;
+      task.lastPolledAt = Date.now();
+      console.log(
+        `[task-tracker] Resumed ${task.taskId.slice(0, 8)}… with decision "${resp.decision}" — polling resumes`,
+      );
+    } catch (err) {
+      console.error(
+        `[task-tracker] Failed to resume ${task.taskId.slice(0, 8)}…:`,
+        err instanceof Error ? err.message : String(err),
+      );
+      this._publishResponse(task, undefined, `Resume failed: ${err instanceof Error ? err.message : String(err)}`);
+      this.tasks.delete(task.correlationId);
+    }
+  }
+
+  private _publishResponse(task: TrackedTask, content: string | undefined, error: string | undefined): void {
+    const payload: AgentSkillResponsePayload = {
+      content,
+      error,
+      correlationId: task.correlationId,
+    };
+    this.bus.publish(task.replyTopic, {
+      id: crypto.randomUUID(),
+      correlationId: task.correlationId,
+      topic: task.replyTopic,
+      timestamp: Date.now(),
+      payload,
+    });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,10 @@ const bus = new InMemoryEventBus();
 import { ContextMailbox } from "../lib/dm/context-mailbox.ts";
 const contextMailbox = new ContextMailbox();
 
+// --- Task tracker — tracks long-running A2A tasks that returned non-terminal state ---
+import { TaskTracker } from "./executor/task-tracker.ts";
+const taskTracker = new TaskTracker({ bus });
+
 // --- ChannelRegistry — loaded from workspace/channels.yaml, shared by RouterPlugin + DiscordPlugin ---
 import { ChannelRegistry } from "../lib/channels/channel-registry.js";
 const channelRegistry = new ChannelRegistry(join(workspaceDir, "channels.yaml"));
@@ -252,7 +256,7 @@ const pluginRegistry: PluginRegistryEntry[] = [
     condition: () => true,
     factory: async () => {
       const { SkillDispatcherPlugin } = await import("./executor/skill-dispatcher-plugin.js");
-      return new SkillDispatcherPlugin(executorRegistry, workspaceDir, undefined, loggerPlugin, contextMailbox);
+      return new SkillDispatcherPlugin(executorRegistry, workspaceDir, undefined, loggerPlugin, contextMailbox, taskTracker);
     },
   },
   {
@@ -508,6 +512,7 @@ const apiContext: ApiContext = {
   telemetry,
   apiKey: API_KEY,
   mailbox: contextMailbox,
+  taskTracker,
 };
 
 const routes = createAllRoutes(apiContext);

--- a/src/plugins/skill-broker-plugin.ts
+++ b/src/plugins/skill-broker-plugin.ts
@@ -1,18 +1,27 @@
 /**
  * SkillBrokerPlugin — registers A2AExecutor instances with ExecutorRegistry.
  *
- * Reads workspace/agents.yaml on install, creates one A2AExecutor per agent
- * definition, and registers each skill declared for that agent.
+ * Reads workspace/agents.yaml on install, creates one A2AExecutor per agent,
+ * then auto-discovers skills from each agent's /.well-known/agent-card.json.
  *
- * This plugin is a registrar only — it does NOT subscribe to agent.skill.request.
- * SkillDispatcherPlugin is the sole subscriber and delegates to the registry.
+ * Skill sources (in order of priority):
+ *   1. agents.yaml `skills:` block (if present) — explicit overrides
+ *   2. Agent card `skills` field — auto-discovered on install + refreshed every 10 min
  *
- * Config: workspace/agents.yaml (A2A URLs and skill registrations)
+ * If agents.yaml omits `skills:` entirely, the card is the only source.
+ * If it lists skills, those take precedence and the card is used as a backup/diff.
+ *
+ * This plugin is a registrar only — SkillDispatcherPlugin is the sole
+ * subscriber to agent.skill.request.
+ *
+ * Config: workspace/agents.yaml (A2A URLs and optional skill overrides)
  */
 
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
+import { ClientFactory, JsonRpcTransportFactory } from "@a2a-js/sdk/client";
+import type { AgentCard } from "@a2a-js/sdk";
 import type { Plugin, EventBus } from "../../lib/types.ts";
 import type { ExecutorRegistry } from "../executor/executor-registry.ts";
 import { A2AExecutor } from "../executor/executors/a2a-executor.ts";
@@ -23,21 +32,36 @@ interface AgentSkill {
   description?: string;
 }
 
+interface AgentAuthDef {
+  /** One of: apiKey, bearer, hmac */
+  scheme: "apiKey" | "bearer" | "hmac";
+  credentialsEnv?: string;
+}
+
 interface AgentDef {
   name: string;
   url: string;
   apiKeyEnv?: string;
+  /** Structured auth (Phase 8) — preferred over apiKeyEnv when set. */
+  auth?: AgentAuthDef;
+  /** Extra static request headers — e.g. extension opt-in. */
+  headers?: Record<string, string>;
   streaming?: boolean;
   skills?: Array<AgentSkill | string>;
 }
 
+const CARD_REFRESH_INTERVAL_MS = 10 * 60_000; // 10 min
+
 export class SkillBrokerPlugin implements Plugin {
   readonly name = "skill-broker";
-  readonly description = "Registers A2AExecutors with ExecutorRegistry from workspace/agents.yaml";
+  readonly description = "Registers A2AExecutors with ExecutorRegistry from agents.yaml + auto-discovered agent cards";
   readonly capabilities = ["executor-registrar", "a2a-routing"];
 
   private readonly workspaceDir: string;
   private readonly executorRegistry: ExecutorRegistry;
+  private refreshTimer?: ReturnType<typeof setInterval>;
+  /** Tracks skills we registered per agent so we can cleanly re-register on refresh. */
+  private registeredSkills = new Map<string, Set<string>>();
 
   constructor(workspaceDir: string, executorRegistry: ExecutorRegistry) {
     this.workspaceDir = workspaceDir;
@@ -49,10 +73,13 @@ export class SkillBrokerPlugin implements Plugin {
     const opsChannel = process.env.DISCORD_AGENT_OPS_CHANNEL ?? "";
 
     for (const agent of agents) {
+      const resolvedUrl = resolveEnvVars(agent.url, "skill-broker");
       const executor = new A2AExecutor({
         name: agent.name,
-        url: resolveEnvVars(agent.url, "skill-broker"),
+        url: resolvedUrl,
         apiKeyEnv: agent.apiKeyEnv,
+        auth: agent.auth,
+        extraHeaders: agent.headers,
         streaming: agent.streaming ?? false,
         onStreamUpdate: opsChannel
           ? (update) => {
@@ -69,19 +96,91 @@ export class SkillBrokerPlugin implements Plugin {
           : undefined,
       });
 
+      // Register yaml-declared skills synchronously (explicit overrides)
+      const explicitSkills = new Set<string>();
       for (const s of agent.skills ?? []) {
         const skillName = typeof s === "string" ? s : s.name;
         this.executorRegistry.register(skillName, executor, {
           agentName: agent.name,
           priority: 5,
         });
+        explicitSkills.add(skillName);
       }
+      this.registeredSkills.set(agent.name, explicitSkills);
+
+      // Kick off async card discovery for any skills not in yaml
+      void this._discoverSkills(agent, executor, resolvedUrl);
     }
 
-    console.log(`[skill-broker] Registered ${agents.length} A2A agent(s)`);
+    console.log(`[skill-broker] Registered ${agents.length} A2A agent(s) (skills from yaml; discovery in progress)`);
+
+    // Periodic refresh — picks up new skills without a restart
+    this.refreshTimer = setInterval(() => {
+      for (const agent of agents) {
+        const executor = this.executorRegistry.list().find(r => r.agentName === agent.name)?.executor;
+        if (executor && executor.type === "a2a") {
+          void this._discoverSkills(agent, executor as A2AExecutor, resolveEnvVars(agent.url, "skill-broker"));
+        }
+      }
+    }, CARD_REFRESH_INTERVAL_MS);
+    this.refreshTimer.unref?.();
   }
 
-  uninstall(): void {}
+  uninstall(): void {
+    if (this.refreshTimer) clearInterval(this.refreshTimer);
+  }
+
+  /**
+   * Fetch the agent card and register any skills not already in yaml.
+   * Silent failure — card fetch errors are logged but don't break the broker.
+   */
+  private async _discoverSkills(agent: AgentDef, executor: A2AExecutor, url: string): Promise<void> {
+    try {
+      const card = await this._fetchCard(url);
+      if (!card) return;
+
+      const registered = this.registeredSkills.get(agent.name) ?? new Set();
+      let added = 0;
+
+      for (const cardSkill of card.skills ?? []) {
+        const skillName = cardSkill.id;
+        if (!skillName || registered.has(skillName)) continue;
+
+        this.executorRegistry.register(skillName, executor, {
+          agentName: agent.name,
+          priority: 5,
+        });
+        registered.add(skillName);
+        added++;
+      }
+
+      this.registeredSkills.set(agent.name, registered);
+      if (added > 0) {
+        console.log(`[skill-broker] ${agent.name}: discovered ${added} new skill(s) from agent card (${Array.from(registered).join(", ")})`);
+      }
+    } catch (err) {
+      console.debug(`[skill-broker] ${agent.name}: card discovery skipped:`, err instanceof Error ? err.message : err);
+    }
+  }
+
+  private async _fetchCard(url: string): Promise<AgentCard | null> {
+    const baseUrl = url.replace(/\/a2a\/?$/, "");
+    const factory = new ClientFactory({
+      transports: [new JsonRpcTransportFactory()],
+    });
+    try {
+      const client = await factory.createFromUrl(baseUrl);
+      return await client.getAgentCard();
+    } catch {
+      // Try legacy path
+      try {
+        const client = await factory.createFromUrl(baseUrl, "/.well-known/agent.json");
+        return await client.getAgentCard();
+      } catch {
+        return null;
+      }
+    }
+  }
 
   private _loadAgents(): AgentDef[] {
     const agentsPath = join(this.workspaceDir, "agents.yaml");

--- a/src/router/__tests__/router-plugin.test.ts
+++ b/src/router/__tests__/router-plugin.test.ts
@@ -356,14 +356,14 @@ describe("RouterPlugin", () => {
       } finally { cleanup(); }
     });
 
-    test("skips plan, plan_resume, deep_research", async () => {
+    test("skips plan, deep_research", async () => {
       const { workspaceDir, cleanup } = makeWorkspace({ agents: { "ava.yaml": onboardingAgent } });
       try {
         const bus = new InMemoryEventBus();
         const plugin = new RouterPlugin({ workspaceDir });
         plugin.install(bus);
 
-        for (const skill of ["plan", "plan_resume", "deep_research"]) {
+        for (const skill of ["plan", "deep_research"]) {
           const req = waitForSkillRequest(bus, 80);
           bus.publish(
             "message.inbound.discord.faf",

--- a/src/router/faf-skills.ts
+++ b/src/router/faf-skills.ts
@@ -22,6 +22,5 @@
 export const FIRE_AND_FORGET_SKILLS: ReadonlySet<string> = new Set([
   "onboard_project",
   "plan",
-  "plan_resume",
   "deep_research",
 ]);

--- a/workspace/agents.yaml.example
+++ b/workspace/agents.yaml.example
@@ -1,7 +1,14 @@
 # protoLabs A2A Agent Registry
 # Authoritative source for the agent fleet.
-# Skills are refreshed live from /.well-known/agent.json on startup.
-# apiKeyEnv: name of env var holding the API key for this agent's /a2a endpoint.
+# Skills are refreshed live from /.well-known/agent-card.json on startup
+# (with a fallback to /.well-known/agent.json for legacy agents).
+#
+# Auth options (Phase 8):
+#   apiKeyEnv: env var holding a value sent as X-API-Key (legacy shorthand)
+#   auth:      structured auth block — preferred. Fields:
+#                scheme:          "apiKey" | "bearer" | "hmac"
+#                credentialsEnv:  env var holding the credential value
+#   headers:   static request headers (e.g. a2a-extensions opt-in)
 
 agents:
   - name: ava
@@ -19,7 +26,11 @@ agents:
 
   - name: quinn
     url: http://your-quinn-host:7870/a2a
-    apiKeyEnv: QUINN_API_KEY
+    # Structured auth (Phase 8). Same behavior as apiKeyEnv: QUINN_API_KEY
+    # but makes the scheme explicit and leaves room for bearer/hmac.
+    auth:
+      scheme: apiKey
+      credentialsEnv: QUINN_API_KEY
     discordBotTokenEnvKey: DISCORD_BOT_TOKEN_QUINN
     skills:
       - name: bug_triage
@@ -29,3 +40,12 @@ agents:
     subscribesTo:
       - message.inbound.discord.#
       - message.inbound.github.#
+
+  # Example — an external agent served over bearer auth:
+  # - name: external_partner
+  #   url: https://partner.example.com/a2a
+  #   auth:
+  #     scheme: bearer
+  #     credentialsEnv: PARTNER_API_TOKEN
+  #   headers:
+  #     a2a-extensions: "https://a2a-protocol.org/ext/cost-v1"

--- a/workspace/agents/ava.yaml.example
+++ b/workspace/agents/ava.yaml.example
@@ -66,9 +66,6 @@ skills:
   - name: plan
     description: Build a feature plan from a PRD (requires HITL approval)
     keywords: [plan, idea, build, proposal, project idea, /plan, i want to, let's build]
-  - name: plan_resume
-    description: Resume plan execution after HITL approval
-    # no keywords — dispatched programmatically via HITLPlugin
   - name: triage
     description: Triage an incoming message and decide next action
     keywords: [help, question, not sure, what should, /triage]

--- a/workspace/plugins/a2a.ts
+++ b/workspace/plugins/a2a.ts
@@ -191,7 +191,6 @@ const SKILL_KEYWORDS: Record<string, string[]> = {
   pr_review:    ["pr", "pull request", "review", "merge", "ci", "/review"],
   // Ava
   plan:           ["build", "create feature", "new feature", "idea:", "let's build", "plan:", "i want to"],
-  plan_resume:    ["approve", "reject", "modify"],
   sitrep:         ["status", "sitrep", "situation", "what's up", "summary", "/status", "/sitrep"],
   manage_feature: ["unblock", "assign", "move to", "add to board"],
   board_health:   ["blocked", "stalled", "stuck", "health", "unhealthy"],


### PR DESCRIPTION
## Summary
Follow-up docs pass after A2A Phase 1-8 shipped to main (PR #174). No code changes.

- **Env docs** — add `WORKSTACEAN_BASE_URL`, note `WORKSTACEAN_API_KEY` also gates `POST /a2a`
- **Reachability callouts** — clarify that `/a2a` + `/.well-known/agent-card.json` go through port 3000, not the 8080 dashboard proxy
- **Auth alternatives** — structured `auth:` block + agent-card auto-discovery now documented in every relevant doc (add-an-agent, integrate-external-app, agent-identity, agent-skills)
- **README plugin table** — add TaskTracker row, note SkillBroker discovery
- **Guide index** — surface `a2a-streaming.md` and `hitl.md`

## Test plan
- [x] `bunx tsc --noEmit` — clean (no code changes expected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added A2A agent protocol support with JSON-RPC and streaming endpoints
  * Implemented task tracking for long-running operations with periodic polling
  * Added agent card auto-discovery from external agents
  * Integrated native HITL workflow for task resumption
  * Added webhook callbacks for push-based task updates
  * Extended authentication with multiple schemes (API key, bearer, HMAC)

* **Configuration**
  * New environment variables for HTTP port, API key, and base URL
  * Enhanced agent configuration with structured auth and static headers
  * Automatic skill refresh from agent cards every 10 minutes

* **Bug Fixes & Improvements**
  * Removed legacy `plan_resume` skill; replaced with native A2A input-required flow
  * Updated HITL logic for A2A task-based handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->