### PR TITLE
[Arc 0.1] ADR: Unified A2A + GOAP architecture

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -35,3 +35,21 @@ GRAPHITI_EMBEDDING_MODEL=text-embedding-3-small
 
 # Model configuration is in models.json (in repo root)
 # Pi SDK uses in-memory auth configured via models.json and OPENAI_API_KEY
+
+# ── HTTP API + A2A server ──────────────────────────────────────────────────────
+# Port the internal HTTP server listens on. Exposes:
+#   GET  /.well-known/agent-card.json   (A2A discovery)
+#   POST /a2a                           (A2A JSON-RPC endpoint)
+#   POST /api/a2a/callback/:taskId      (push-notification webhooks)
+#   POST /publish, /api/*               (internal API)
+WORKSTACEAN_HTTP_PORT=3000
+
+# API key required for authenticated endpoints. Gates /publish + POST /a2a.
+# Unset → auth skipped (dev mode).
+WORKSTACEAN_API_KEY=
+
+# Public base URL of this workstacean instance. Used to build the agent
+# card `url` field and to register push-notification callback URLs with
+# external A2A agents. Falls back to http://localhost:$WORKSTACEAN_HTTP_PORT.
+# Example: https://workstacean.example.com  or  http://workstacean:3000 (Docker net)
+WORKSTACEAN_BASE_URL=


### PR DESCRIPTION
## Summary

**Arc 0: Vision + design** (epic: Unified A2A + GOAP)

Write the architecture ADR at `docs/explanation/unified-a2a-goap.md` capturing: the heartbeat (skill→task→delta→re-evaluate), the three loops (reflex/health/growth), the five adaptation layers (tuning/discovery/composition/synthesis/fleet-homeostasis), and the protocol extensions table. This is the reference every downstream feature links to.

**Why**: Without a single source of truth for the unified model, the nine arcs will drift apart. Th...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added three new environment variables for server configuration: port settings, optional API authentication, and public instance URL configuration with automatic fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->