### PR TITLE
[Arc 0.2] Update HITL + a2a-streaming guides for unified model

### DIFF
--- a/docs/guides/a2a-streaming.md
+++ b/docs/guides/a2a-streaming.md
@@ -2,16 +2,31 @@
 title: A2A Streaming (SSE)
 ---
 
-How to add Server-Sent Events (SSE) streaming to an A2A agent so consumers (like Ava) get intermediate progress updates instead of blocking for the full response.
+How to add Server-Sent Events (SSE) streaming to an A2A agent so consumers get intermediate progress updates instead of blocking for the full response.
+
+## Where streaming fits in the dispatch pipeline
+
+All skill requests — whether triggered by a Discord DM, a Plane webhook, or an autonomous GOAP action — travel the same unified dispatch path:
+
+```
+inbound event
+  → RouterPlugin
+    → agent.skill.request (bus)
+      → SkillDispatcherPlugin
+        → ExecutorRegistry.resolve(skill, targets?)
+          → A2AExecutor
+```
+
+Streaming is a transport detail at the `A2AExecutor` layer. If the agent's card declares `streaming: true`, the executor sends `message/stream` instead of `message/send` and reads the SSE response as it arrives. The caller — `SkillDispatcherPlugin`, the GOAP loop, Ava — does not know or care whether the underlying call was streaming or blocking. The result arrives on `replyTopic` either way.
 
 ## Overview
 
-By default, A2A agents handle `message/send` — the client blocks until the agent finishes. For long-running skills (deep research, multi-step triage), this creates dead air. SSE streaming solves this:
+By default, A2A agents handle `message/send` — the executor blocks until the agent finishes. For long-running skills (deep research, multi-step triage), this creates dead air. SSE streaming solves this:
 
-1. Client sends `message/stream` instead of `message/send`
+1. `A2AExecutor` sends `message/stream` instead of `message/send`
 2. Agent returns `text/event-stream` with intermediate updates
-3. Client reads events as they arrive, publishes them to Discord for o11y
-4. Agent sends final artifact + `[DONE]` to close the stream
+3. Executor fires `onStreamUpdate` callbacks as events arrive (e.g. Discord o11y)
+4. Agent sends final artifact + `[DONE]` to close the stream; executor publishes to `replyTopic`
 
 ## Agent-side setup
 
@@ -36,7 +51,7 @@ import json, asyncio, queue
 @app.post("/a2a")
 async def a2a_handler(req: dict):
     method = req.get("method", "")
-    
+
     if method == "message/stream":
         return StreamingResponse(
             sse_generator(req),
@@ -77,24 +92,24 @@ async def sse_generator(req):
     task_id = str(uuid.uuid4())
     context_id = req["params"].get("contextId", task_id)
     text = extract_text(req)
-    
+
     # Emit "working" status
     yield f"data: {json.dumps({'id': task_id, 'contextId': context_id, 'status': {'state': 'working', 'message': {'parts': [{'text': 'Starting...'}]}}})}\n\n"
-    
+
     # Run work with progress callback
     progress_q = queue.Queue()
-    
+
     async def on_progress(msg):
         progress_q.put(msg)
-    
+
     task = asyncio.create_task(do_work(text, on_progress))
-    
+
     while not task.done():
         await asyncio.sleep(0.5)
         while not progress_q.empty():
             msg = progress_q.get_nowait()
             yield f"data: {json.dumps({'id': task_id, 'contextId': context_id, 'status': {'state': 'working', 'message': {'parts': [{'text': msg}]}}})}\n\n"
-    
+
     result = task.result()
     yield f"data: {json.dumps({'id': task_id, 'contextId': context_id, 'status': {'state': 'completed'}, 'artifact': {'parts': [{'kind': 'text', 'text': result}]}})}\n\n"
     yield "data: [DONE]\n\n"
@@ -122,37 +137,41 @@ The `SkillBrokerPlugin` wires the `onStreamUpdate` callback automatically when t
 ## How it works end-to-end
 
 ```
-User DMs Ava: "research full-duplex voice AI"
-    ↓
-Ava calls chat_with_agent(agent="researcher", ...)
-    ↓
-ava-tools.ts POST /api/a2a/chat → ExecutorRegistry → A2AExecutor
-    ↓
-A2AExecutor sees streaming:true → sends message/stream
-    ↓
-protoResearcher returns text/event-stream:
-    data: {"status":{"state":"working","message":"Scanning HuggingFace..."}}
-    data: {"status":{"state":"working","message":"Reading paper: PersonaPlex..."}}
-    data: {"status":{"state":"working","message":"Synthesizing findings..."}}
-    data: {"artifact":{"parts":[{"kind":"text","text":"Full report..."}]}}
-    data: [DONE]
-    ↓
-Each "working" event → onStreamUpdate → Discord agent-ops channel
-Final artifact → returned as chat_with_agent response to Ava
+Inbound message: "research full-duplex voice AI"
+  → RouterPlugin → agent.skill.request (bus)
+    → SkillDispatcherPlugin
+      → ExecutorRegistry → A2AExecutor (streaming: true)
+        → POST /a2a  method: message/stream
+          ← text/event-stream:
+              data: {"status":{"state":"working","message":"Scanning HuggingFace..."}}
+              data: {"status":{"state":"working","message":"Reading paper: PersonaPlex..."}}
+              data: {"status":{"state":"working","message":"Synthesizing findings..."}}
+              data: {"artifact":{"parts":[{"kind":"text","text":"Full report..."}]}}
+              data: [DONE]
+        Each "working" event → onStreamUpdate → Discord agent-ops channel
+        Final artifact → published to replyTopic
 ```
+
+The caller receives the same `SkillResult` it would have received from a blocking call. Streaming is invisible above the executor layer.
 
 ## Task lifecycle states
 
 | State | Meaning | Stream behavior |
 |-------|---------|----------------|
 | `working` | Agent processing | Emitted as progress updates |
-| `input-required` | Agent needs more info | Client should send follow-up |
+| `input-required` | Agent needs human input | Stream pauses; HITL gate raised |
 | `completed` | Done | Final artifact emitted, stream closes |
 | `failed` | Error | Error message emitted, stream closes |
 
+## input-required and HITL
+
+If a streaming agent returns `input-required`, the task does not complete. `TaskTracker` detects the state, raises an `HITLRequest` on the bus, and the HITL renderer surfaces the pause point to a human on the originating interface. When the human responds, `TaskTracker` resumes the task via `message/send` with the same `taskId`. The agent picks up where it left off.
+
+This is the same flow whether the request came from a human message or an autonomous GOAP action. See [HITL guide](./hitl.md) for the full flow.
+
 ## Fallback behavior
 
-If the agent doesn't support streaming (card says `streaming: false` or omits it), A2AExecutor falls back to blocking `message/send`. No code changes needed on the client side.
+If the agent doesn't support streaming (card says `streaming: false` or omits it), `A2AExecutor` falls back to blocking `message/send`. No code changes needed on the caller side.
 
 If the agent supports streaming but the SSE connection fails, the executor catches the error and falls back to `message/send` automatically.
 
@@ -162,12 +181,10 @@ Agents can progressively stream a long artifact in multiple frames using `append
 
 - `append: false` (or omitted) → the incoming `parts` **replace** the buffer for that `artifactId`
 - `append: true` → the incoming `parts` are **concatenated** to the existing buffer
-- `lastChunk: true` → finalize the artifact; A2AExecutor fires `onStreamUpdate({ type: "artifact_complete", ... })`
+- `lastChunk: true` → finalize the artifact; `A2AExecutor` fires `onStreamUpdate({ type: "artifact_complete", ... })`
 
 This lets a researcher stream a 2000-word report as 20 × 100-word chunks. Each chunk surfaces live via `onStreamUpdate({ type: "artifact_chunk", ... })` to Discord, the dashboard, etc. The final concatenated text is what lands in the `SkillResult.text`.
 
-## Long-running tasks + input-required
+## Long-running tasks
 
-If your agent returns a non-terminal task (`working`, `submitted`, `input-required`) rather than a final result, workstacean's `TaskTracker` polls `tasks/get` (or uses `tasks/resubscribe` for streaming agents) and publishes the response on the original reply topic once terminal. No caller-side timeout tuning needed.
-
-For `input-required`, the tracker raises a HITL request automatically and resumes the task via `message/send` with the same `taskId` once a human decides. See [HITL guide](./hitl.md) for the full flow.
+If your agent returns a non-terminal task (`working`, `submitted`, `input-required`) rather than a final result, `TaskTracker` polls `tasks/get` (or uses `tasks/resubscribe` for streaming agents) and publishes the response on the original `replyTopic` once terminal. No caller-side timeout tuning needed.

--- a/docs/guides/hitl.md
+++ b/docs/guides/hitl.md
@@ -2,24 +2,42 @@
 title: HITL — Human-in-the-Loop Gate
 ---
 
-HITL is the approval gate that sits between an autonomous decision and its permanent side effects. It exists because some actions — board feature creation, infrastructure changes, high-cost agent runs — should not happen without a human in the loop.
+HITL is what happens when an executor returns `input-required` — or when any plugin decides a human must make a call before a side effect lands. It is not a separate flow. It is a pause point on the unified dispatch pipeline.
 
 `correlationId` is the spine that connects every hop.
 
 ---
 
+## The unified pipeline
+
+Every skill request — whether triggered by a Discord DM, a Plane webhook, or an autonomous GOAP action — travels the same path:
+
+```
+inbound event
+  → RouterPlugin
+    → agent.skill.request (bus)
+      → SkillDispatcherPlugin
+        → ExecutorRegistry.resolve(skill, targets?)
+          → executor.execute(SkillRequest)
+            → result published to replyTopic
+```
+
+HITL enters this pipeline at the executor boundary. When an executor returns a task with state `input-required`, the pipeline pauses — the task stays open, and control transfers to a human. When the human responds, the pipeline resumes from the same task.
+
+The HITL renderer is a **pure UI thin client** over `input-required`. It presents the pause point to a human on whichever interface originated the request (Discord, Plane, Signal, API). It has no business logic, no routing opinion, and no knowledge of what the agent is doing. It collects a decision and publishes an `HITLResponse` to the bus. That is its entire job.
+
+---
+
 ## Overview
 
-When any system component needs a human decision, it publishes an `HITLRequest` to the bus. `HITLPlugin` routes it to the registered renderer for the originating interface (Discord, Plane, Signal, API). A human responds. The interface plugin publishes an `HITLResponse`. The bus delivers it to whichever plugin subscribed to the `replyTopic`.
+Two classes of HITL request share the same infrastructure:
 
-Two types of HITL flow coexist on the same infrastructure:
-
-| Flow | Publisher | Callback path | Example |
+| Class | Who raises it | How it resumes | Example |
 |---|---|---|---|
-| **Plan gate** | A2A agent returns `input-required` | `TaskTracker` sends `message/send` with same `taskId` | Ava asks for approval mid-task |
-| **Operational gate** | Any plugin | `replyTopic` on the bus | Budget L3 escalation, goal violation, queue saturation |
+| **Executor gate** | A2A agent returns `input-required` | `TaskTracker` sends `message/send` with same `taskId` | Ava asks for plan approval mid-task |
+| **Operational gate** | Any plugin | Subscriber on `replyTopic` | Budget L3 escalation, goal violation, queue saturation |
 
-Both use the same `HITLRequest`/`HITLResponse` shapes, the same topic conventions, and the same renderer interface. The plan-gate path uses the native A2A `input-required` state machine — no custom `plan_resume` skill is required.
+Both use the same `HITLRequest`/`HITLResponse` shapes, the same topic conventions, and the same renderer interface.
 
 ---
 
@@ -41,10 +59,10 @@ interface HITLRequest {
     channelId?: string;
     userId?: string;
   };
-  // ── Plan gate fields (populated by Ava) ────────────────────────────────────
+  // ── Executor gate fields (populated by Ava) ────────────────────────────────
   avaVerdict?: { score: number; concerns: string[]; verdict: string };
   jonVerdict?: { score: number; concerns: string[]; verdict: string };
-  // ── Operational gate fields (populated by BudgetPlugin L3, etc.) ───────────
+  // ── Operational gate fields (populated by BudgetPlugin L3, etc.) ──────────
   escalation_reason?: string;
   escalationContext?: {
     estimatedCost: number;
@@ -102,6 +120,8 @@ Both paths are triggered by the single publish from the renderer. The A2A resume
 ---
 
 ## The renderer interface
+
+The renderer is a pure UI thin client. It receives an `HITLRequest`, surfaces it on the originating platform, and publishes an `HITLResponse` when the human responds. It has no awareness of what the agent is doing or what happens after the decision.
 
 Every channel plugin that wants to render HITL approvals implements two methods:
 
@@ -274,25 +294,27 @@ if (interaction.isButton() && interaction.customId.startsWith("hitl:")) {
 
 ---
 
-## Plan gate flow (Ava)
+## Executor gate flow (Ava / plan approval)
 
-The plan gate is one specific use of HITL, triggered after Ava generates a SPARC PRD and antagonistic review.
+This is the executor gate in action. The inbound message enters the unified pipeline like any other skill request:
 
 ```
 1. Inbound message with skillHint "plan"
+   → RouterPlugin → agent.skill.request → SkillDispatcherPlugin → A2AExecutor
 2. Ava generates SPARC PRD + antagonistic review
    - Ava verdict: operational feasibility, risk score
    - Jon verdict: strategic value, ROI score
-3. Ava returns Task { status: { state: "input-required", message: <PRD summary> } }
-4. TaskTracker detects input-required → raises HITLRequest
+3. A2AExecutor receives Task { status: { state: "input-required", message: <PRD summary> } }
+4. TaskTracker detects input-required → raises HITLRequest on the bus
 5. HITLPlugin routes to the registered renderer (Discord embed)
+   — the renderer is a pure UI thin client: it shows the PRD summary, nothing more
 6. Human approves/rejects/modifies
 7. Renderer publishes HITLResponse on hitl.response.{correlationId}
-8. TaskTracker intercepts the response → sends message/send with same taskId
+8. TaskTracker intercepts → sends message/send with same taskId
    carrying the decision text; Ava resumes the task natively
 ```
 
-### plan decisions (resume payload)
+### Plan decisions (resume payload)
 
 The decision is relayed verbatim as the resume message text. Ava parses it and takes the branch:
 
@@ -368,7 +390,7 @@ bus.publish(request.replyTopic, {
 });
 ```
 
-That's it. The rest — routing to `replyTopic`, A2A callback to Ava — is handled by `HITLPlugin`.
+That's it. The renderer handles presentation only. The rest — routing to `replyTopic`, A2A task resume — is handled by `HITLPlugin` and `TaskTracker`.
 
 ---
 
@@ -445,8 +467,10 @@ curl http://localhost:3000/api/hitl/pending
 
 ## Design principles
 
-**The bus routes. Interface plugins render. Requesters own their response logic.**
+**The pipeline is unified. The renderer is dumb. The requester owns the decision.**
 
+- Every skill request — human-initiated or autonomous — enters the same `agent.skill.request` pipeline. HITL is not a special path; it is a pause state within that path.
+- The HITL renderer is a pure UI thin client. It shows a prompt, collects a response, publishes to the bus. It has no knowledge of what comes before or after.
 - `HITLPlugin` is a router — it stores state, dispatches to renderers, and routes responses. It has no opinion on format, display, or what to do with the decision.
 - Each interface plugin (Discord, Plane, Signal, Slack, API) owns rendering for its platform.
 - The requester (BudgetPlugin, GoalEvaluator, Ava) owns what to do with the response — HITL doesn't know or care.


### PR DESCRIPTION
## Summary

**Arc 0: Vision + design** (epic: Unified A2A + GOAP)

Rewrite `docs/guides/hitl.md` and `docs/guides/a2a-streaming.md` to reference the unified dispatch contract instead of the current separate flows. Clarify that every skill request — human or autonomous — flows through the same pipeline, and the HITL renderer layer is a pure UI thin client over `input-required`.

**Depends on**: ADR (previous feature) landed first.

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced A2A streaming guide with clarified executor-layer streaming behavior, updated dispatch pipeline diagrams, and explicit input-required and HITL interaction documentation.
  * Updated HITL guide reframing architecture as a unified pipeline pause point, clarifying renderer as a pure UI client, and improving flow taxonomy descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->