### PR TITLE
chore(release): bump to v0.7.0

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean-dashboard",
-  "version": "0.1.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean",
-  "version": "0.1.0",
+  "version": "0.7.0",
   "type": "module",
   "scripts": {
     "start": "bun run src/index.ts",


### PR DESCRIPTION
## Summary
Catch `package.json` (0.1.0 → 0.7.0) up with the v0.6.0 tag legacy and stage **v0.7.0** covering everything on main since 2026-04-10.

14 promote merges accumulated without a release. Version bump lands on dev, promotes to main, then a `v0.7.0` tag triggers `release.yml` which posts notes to Discord.

## What v0.7.0 ships
- **A2A Phases 1-8 complete** — `@a2a-js/sdk` adoption (client + server), `TaskTracker`, push-notification webhooks, native `input-required` HITL, agent-card auto-discovery, artifact chunking, structured auth (apiKey/bearer/hmac), `ExtensionRegistry` scaffolding
- **Workstacean as A2A server** — `POST /a2a` + `/.well-known/agent-card.json` expose the fleet
- GOAP loops hardened (post-success cooldown, feedback-loop + DM fixes)
- Dashboard OutcomeAnalysis view
- DM stress tests, CI/flow fixes, researcher → rabbit-hole.io rewire

## Followup (not in this PR)
Port protoMaker's `prepare-release.yml` + `auto-release.yml` into this repo so the `/promote` skill works end-to-end and version bumps are automatic. Filed as an Arc-10 feature on the epic.

## Merge strategy
Merge commit (per branch-strategy.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.7.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->