### PR TITLE
feat(ci): add ci.debug_failures action with availability guard

### DIFF
--- a/workspace/actions.yaml
+++ b/workspace/actions.yaml
@@ -143,6 +143,25 @@ actions:
       topic: "message.outbound.discord.alert"
       fireAndForget: true
 
+  - id: ci.debug_failures
+    goalId: ci.success_rate_healthy
+    tier: tier_0
+    priority: 20
+    cost: 1
+    name: "Dispatch agent to investigate CI failures across projects"
+    preconditions:
+      - path: "extensions.ci_available"
+        operator: eq
+        value: true
+      - path: "domains.ci.data.successRate"
+        operator: lt
+        value: 0.70
+    effects: []
+    meta:
+      topic: "agent.skill.request"
+      skillHint: debug_ci_failures
+      fireAndForget: true
+
   # alert.pr_conflicts was retired in favour of action.pr_update_branch below.
   # The planner-plugin-l0 violation path dispatches one action per goal per
   # tick (src/plugins/planner-plugin-l0.ts:114 claims the inFlightGoals slot


### PR DESCRIPTION
## Summary
- Adds `ci.debug_failures` action to `workspace/actions.yaml`, completing the CI health domain feature
- The action dispatches an agent to investigate CI failures when `successRate < 0.70`, guarded by `extensions.ci_available`
- All other components were already implemented: `/api/ci-health` endpoint, `ci` domain registration (300s poll), and `ci.success_rate_healthy` goal (min: 0.70)

## Test plan
- [ ] TypeScript check passes (`tsc --noEmit` exits 0)
- [ ] `workspace/actions.yaml` loads correctly — `ci.debug_failures` action appears in startup logs
- [ ] When CI success rate drops below 70%, `ci.debug_failures` action fires and dispatches `agent.skill.request` with `skillHint: debug_ci_failures`
- [ ] Action does NOT fire when `extensions.ci_available` is false (domain unreachable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)