### PR TITLE
[Arc 1.2] CeremonyPlugin: drop 120s timeout, await TaskTracker terminal

### DIFF
--- a/src/loaders/ceremonyYamlLoader.ts
+++ b/src/loaders/ceremonyYamlLoader.ts
@@ -150,6 +150,7 @@ export class CeremonyYamlLoader {
       targets: c.targets as string[],
       notifyChannel: typeof c.notifyChannel === "string" ? c.notifyChannel : undefined,
       enabled: c.enabled !== false,
+      timeoutMs: typeof c.timeoutMs === "number" && c.timeoutMs > 0 ? c.timeoutMs : undefined,
     };
   }
 }

--- a/src/plugins/CeremonyPlugin.ts
+++ b/src/plugins/CeremonyPlugin.ts
@@ -48,7 +48,6 @@ import { CeremonyNotifier } from "../integrations/discord/CeremonyNotifier.ts";
 
 const DEBUG = process.env.DEBUG === "1" || process.env.DEBUG === "true";
 const HOT_RELOAD_INTERVAL_MS = 5_000;
-const SKILL_DISPATCH_TIMEOUT_MS = 120_000; // 2 minutes
 
 function debug(...args: unknown[]): void {
   if (DEBUG) console.log("[DEBUG][ceremony]", ...args);
@@ -351,14 +350,10 @@ export class CeremonyPlugin implements Plugin {
       const replyTopic = `agent.skill.response.${context.runId}`;
 
       const skillResult = await new Promise<string | null>((resolve) => {
-        // Set up reply subscription with timeout
-        const timeoutTimer = setTimeout(() => {
-          if (this.bus) this.bus.unsubscribe(subId);
-          resolve(null);
-        }, SKILL_DISPATCH_TIMEOUT_MS);
+        let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
 
         const subId = this.bus!.subscribe(replyTopic, this.name, (msg: BusMessage) => {
-          clearTimeout(timeoutTimer);
+          if (timeoutTimer !== undefined) clearTimeout(timeoutTimer);
           this.bus?.unsubscribe(subId);
           const payload = msg.payload as { result?: string; error?: string };
           if (payload?.error) {
@@ -369,6 +364,14 @@ export class CeremonyPlugin implements Plugin {
           }
           resolve(payload?.result ?? null);
         });
+
+        // Set up per-ceremony timeout only if configured
+        if (ceremony.timeoutMs !== undefined) {
+          timeoutTimer = setTimeout(() => {
+            this.bus?.unsubscribe(subId);
+            resolve(null);
+          }, ceremony.timeoutMs);
+        }
 
         // Publish skill request
         this.bus!.publish(skillRequestTopic, {
@@ -388,10 +391,10 @@ export class CeremonyPlugin implements Plugin {
         });
       });
 
-      if (skillResult === null && !error) {
-        // Timeout
+      if (skillResult === null && !error && ceremony.timeoutMs !== undefined) {
+        // Per-ceremony timeout fired
         status = "timeout";
-        error = `Skill dispatch timed out after ${SKILL_DISPATCH_TIMEOUT_MS / 1000}s`;
+        error = `Skill dispatch timed out after ${ceremony.timeoutMs / 1000}s`;
         console.warn(`[ceremony] Skill dispatch timeout for ${ceremony.id} (run ${context.runId})`);
       }
     } catch (err) {

--- a/src/plugins/CeremonyPlugin.types.ts
+++ b/src/plugins/CeremonyPlugin.types.ts
@@ -20,6 +20,8 @@ export interface Ceremony {
   notifyChannel?: string;
   /** Whether this ceremony is active */
   enabled: boolean;
+  /** Optional per-ceremony timeout in milliseconds. Defaults to no timeout. */
+  timeoutMs?: number;
 }
 
 export interface CeremonyRunContext {


### PR DESCRIPTION
## Summary

**Arc 1: Unify dispatch** (epic: Unified A2A + GOAP)

Remove `SKILL_DISPATCH_TIMEOUT_MS` hard-coded wait in `src/plugins/CeremonyPlugin.ts:51`. Instead, subscribe to `agent.skill.response.${runId}` with no timeout — TaskTracker will eventually publish terminal state for long-running tasks. For ceremonies that genuinely shouldn't run longer than N minutes, expose the timeout per-ceremony in `workspace/ceremonies/*.yaml` (default: no timeout).

**Why**: Current behavior records `status: 'timeout'`...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ceremonies now support configurable per-ceremony timeout values via an optional `timeoutMs` field in YAML configuration, replacing the previous global fixed timeout approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->