### PR TITLE
[Arc 1.3] CeremonyPlugin: set msg.source + payload.meta.systemActor

### DIFF
--- a/src/plugins/CeremonyPlugin.ts
+++ b/src/plugins/CeremonyPlugin.ts
@@ -376,6 +376,7 @@ export class CeremonyPlugin implements Plugin {
           correlationId: context.runId,
           topic: skillRequestTopic,
           timestamp: Date.now(),
+          source: { interface: "cron" },
           payload: {
             skill: ceremony.skill,
             ceremonyId: ceremony.id,
@@ -383,6 +384,7 @@ export class CeremonyPlugin implements Plugin {
             targets: ceremony.targets,
             runId: context.runId,
             projectPaths: context.projectPaths,
+            meta: { systemActor: `ceremony/${ceremony.id}` },
           },
           reply: { topic: replyTopic },
         });


### PR DESCRIPTION
## Summary

**Arc 1: Unify dispatch** (epic: Unified A2A + GOAP)

Mirror the ActionDispatcher contract. CeremonyPlugin must set `msg.source: { interface: 'cron' }` and `payload.meta.systemActor: 'ceremony/' + ceremony.id`.

**Why**: Without it, TaskTracker can't route `input-required` HITL requests anywhere meaningful and Graphiti memory enrichment skips ceremony dispatches.

**Audit ref**: Gap #2, #4.

---
*Recovered automatically by Automaker post-agent hook*