### PR TITLE
[Arc 2.1] SkillDispatcher emits autonomous.outcome.# for every terminal

### DIFF
--- a/src/event-bus/payloads.ts
+++ b/src/event-bus/payloads.ts
@@ -211,6 +211,46 @@ export interface WorktreeRecoveredPayload {
   recoveredAt: string;
 }
 
+// ── autonomous.outcome.* ─────────────────────────────────────────────────────
+
+/**
+ * Payload for `autonomous.outcome.{systemActor}.{skill}` — published by
+ * SkillDispatcherPlugin after every task reaches terminal state, whether via
+ * direct executor return or TaskTracker polling.
+ *
+ * Replaces the split between `world.action.outcome` and per-reply-topic
+ * responses so OutcomeAnalysis sees a single unified stream.
+ *
+ * effectDelta is reserved for Arc 4/5 — leave undefined for now.
+ */
+export interface AutonomousOutcomePayload {
+  /** Trace ID propagated from the originating bus message. */
+  correlationId: string;
+  /** Parent span ID — the bus message ID that triggered the skill request. */
+  parentId?: string;
+  /** Autonomous subsystem actor (e.g. "pr-remediator", "sweep") or "user". */
+  systemActor: string;
+  /** Skill name that was executed. */
+  skill: string;
+  /** True if the task completed without error. */
+  success: boolean;
+  /** Final A2A task lifecycle state (completed, failed, canceled, etc.). */
+  taskState?: string;
+  /** First 500 chars of the result text — for quick inspection. */
+  textPreview?: string;
+  /** Token usage reported by the executor. */
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+  /** Wall-clock time from dispatch to terminal state (ms). */
+  durationMs: number;
+  /** World-state delta produced by this task — populated in Arc 4/5. */
+  effectDelta?: Record<string, unknown>;
+}
+
 // ── world.goal.violated ──────────────────────────────────────────────────────
 // Defined in src/types/events.ts — re-exported here for convenience.
 export type { GoalViolatedEventPayload } from "../types/events.ts";

--- a/src/event-bus/topics.ts
+++ b/src/event-bus/topics.ts
@@ -25,6 +25,13 @@ export const TOPICS = {
 
   /** Published by ActionDispatcherPlugin to invoke an agent skill (unified dispatch). */
   AGENT_SKILL_REQUEST: "agent.skill.request",
+
+  /**
+   * Published by SkillDispatcherPlugin after every task reaches terminal state.
+   * Full topic is `autonomous.outcome.{systemActor}.{skill}`.
+   * Use this prefix to subscribe to all outcomes.
+   */
+  AUTONOMOUS_OUTCOME_PREFIX: "autonomous.outcome",
 } as const;
 
 export type TopicValue = (typeof TOPICS)[keyof typeof TOPICS];

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -16,7 +16,7 @@
 import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
 import type { ExecutorRegistry } from "./executor-registry.ts";
 import type { SkillRequest } from "./types.ts";
-import type { AgentSkillRequestPayload, FlowItemPayload } from "../event-bus/payloads.ts";
+import type { AgentSkillRequestPayload, AutonomousOutcomePayload, FlowItemPayload } from "../event-bus/payloads.ts";
 import { GraphitiClient } from "../../lib/memory/graphiti-client.ts";
 import { IdentityRegistry } from "../../lib/identity/identity-registry.ts";
 import type { LoggerPlugin, ConversationTurn } from "../../lib/plugins/logger.ts";
@@ -319,6 +319,18 @@ export class SkillDispatcherPlugin implements Plugin {
           sourceInterface: sourcePlatform,
           sourceChannelId: sourceChannelId,
           sourceUserId: sourceUserId,
+          onTerminal: (content, isError, taskState) => {
+            this._publishAutonomousOutcome({
+              correlationId,
+              parentId,
+              systemActor: systemActor ?? "user",
+              skill,
+              success: !isError,
+              taskState,
+              text: content,
+              durationMs: Date.now() - dispatchedAt,
+            });
+          },
         });
 
         // Try to register a push-notification webhook so the agent can POST
@@ -354,6 +366,17 @@ export class SkillDispatcherPlugin implements Plugin {
           stage: "error",
           meta: { skill, error: result.text },
         });
+        this._publishAutonomousOutcome({
+          correlationId,
+          parentId,
+          systemActor: systemActor ?? "user",
+          skill,
+          success: false,
+          taskState: result.data?.taskState ?? "failed",
+          text: result.text,
+          usage: result.data?.usage,
+          durationMs: Date.now() - dispatchedAt,
+        });
       } else {
         // Log a preview of the response so we can see what the executor actually
         // returned — critical for debugging A2A/agent behaviour when the skill
@@ -365,20 +388,33 @@ export class SkillDispatcherPlugin implements Plugin {
         if (result.data?.stopReason === "max_turns") {
           console.warn("[skill-dispatcher] Agent hit maxTurns limit");
         }
+        const completedAt = Date.now();
+        const durationMs = completedAt - dispatchedAt;
         this._publishFlowEvent("flow.item.completed", {
           id: flowItemId,
           status: "complete",
           stage: "done",
-          completedAt: Date.now(),
+          completedAt,
           meta: {
             skill,
             executorType: executor.type,
-            durationMs: Date.now() - dispatchedAt,
+            durationMs,
             inputTokens: result.data?.usage?.input_tokens,
             outputTokens: result.data?.usage?.output_tokens,
             numTurns: result.data?.numTurns,
             stopReason: result.data?.stopReason,
           },
+        });
+        this._publishAutonomousOutcome({
+          correlationId,
+          parentId,
+          systemActor: systemActor ?? "user",
+          skill,
+          success: true,
+          taskState: result.data?.taskState ?? "completed",
+          text: result.text,
+          usage: result.data?.usage,
+          durationMs,
         });
       }
 
@@ -426,6 +462,16 @@ export class SkillDispatcherPlugin implements Plugin {
         stage: "error",
         meta: { skill, error: errorMsg },
       });
+      this._publishAutonomousOutcome({
+        correlationId,
+        parentId,
+        systemActor: systemActor ?? "user",
+        skill,
+        success: false,
+        taskState: "failed",
+        text: errorMsg,
+        durationMs: Date.now() - dispatchedAt,
+      });
       this._publishResponse(replyTopic, correlationId, undefined, errorMsg);
     } finally {
       this.activeExecutions.delete(correlationId);
@@ -471,6 +517,39 @@ export class SkillDispatcherPlugin implements Plugin {
       },
       source,
       reply: { topic: replyTopic },
+    });
+  }
+
+  private _publishAutonomousOutcome(opts: {
+    correlationId: string;
+    parentId: string | undefined;
+    systemActor: string;
+    skill: string;
+    success: boolean;
+    taskState?: string;
+    text?: string;
+    usage?: AutonomousOutcomePayload["usage"];
+    durationMs: number;
+  }): void {
+    if (!this.bus) return;
+    const topic = `autonomous.outcome.${opts.systemActor}.${opts.skill}`;
+    const payload: AutonomousOutcomePayload = {
+      correlationId: opts.correlationId,
+      parentId: opts.parentId,
+      systemActor: opts.systemActor,
+      skill: opts.skill,
+      success: opts.success,
+      taskState: opts.taskState,
+      textPreview: opts.text ? opts.text.slice(0, 500) : undefined,
+      usage: opts.usage,
+      durationMs: opts.durationMs,
+    };
+    this.bus.publish(topic, {
+      id: crypto.randomUUID(),
+      correlationId: opts.correlationId,
+      topic,
+      timestamp: Date.now(),
+      payload,
     });
   }
 

--- a/src/executor/task-tracker.ts
+++ b/src/executor/task-tracker.ts
@@ -39,6 +39,12 @@ export interface TrackedTask {
   sourceChannelId?: string;
   /** User ID for HITL rendering. */
   sourceUserId?: string;
+  /**
+   * Optional callback invoked when the task reaches terminal state.
+   * Called before publishing the reply-topic response so the outcome
+   * event is always emitted first.
+   */
+  onTerminal?: (content: string | undefined, isError: boolean, taskState: string) => void;
 }
 
 export interface TaskTrackerOptions {
@@ -92,6 +98,8 @@ export class TaskTracker {
     sourceInterface?: string;
     sourceChannelId?: string;
     sourceUserId?: string;
+    /** Invoked when the task reaches terminal state — before the reply-topic response is published. */
+    onTerminal?: (content: string | undefined, isError: boolean, taskState: string) => void;
   }): void {
     const now = Date.now();
     this.tasks.set(params.correlationId, {
@@ -108,6 +116,7 @@ export class TaskTracker {
       sourceInterface: params.sourceInterface,
       sourceChannelId: params.sourceChannelId,
       sourceUserId: params.sourceUserId,
+      onTerminal: params.onTerminal,
     });
     console.log(
       `[task-tracker] Tracking ${params.agentName} task ${params.taskId.slice(0, 8)}… (correlationId: ${params.correlationId.slice(0, 8)}…)`,
@@ -159,7 +168,7 @@ export class TaskTracker {
     const content = artifactText || statusText;
     const isError = state === "failed" || state === "rejected";
 
-    this._publishResponse(task, isError ? undefined : content, isError ? (content || state) : undefined);
+    this._publishResponse(task, isError ? undefined : content, isError ? (content || state) : undefined, state);
     this.tasks.delete(correlationId);
     console.log(
       `[task-tracker] Callback for ${task.taskId.slice(0, 8)}… → terminal state "${state}" (via webhook)`,
@@ -219,7 +228,7 @@ export class TaskTracker {
         }
 
         if (state && TERMINAL_STATES.has(state)) {
-          this._publishResponse(task, result.text, result.isError ? result.text : undefined);
+          this._publishResponse(task, result.text, result.isError ? result.text : undefined, state);
           this.tasks.delete(task.correlationId);
           console.log(
             `[task-tracker] Task ${task.taskId.slice(0, 8)}… reached terminal state "${state}" after ${Math.round((now - task.registeredAt) / 1000)}s`,
@@ -309,7 +318,16 @@ export class TaskTracker {
     }
   }
 
-  private _publishResponse(task: TrackedTask, content: string | undefined, error: string | undefined): void {
+  private _publishResponse(
+    task: TrackedTask,
+    content: string | undefined,
+    error: string | undefined,
+    taskState?: string,
+  ): void {
+    const isError = error !== undefined;
+    const resolvedState = taskState ?? (isError ? "failed" : "completed");
+    task.onTerminal?.(content, isError, resolvedState);
+
     const payload: AgentSkillResponsePayload = {
       content,
       error,


### PR DESCRIPTION
## Summary

**Arc 2: Unify outcome** (epic: Unified A2A + GOAP)

In `src/executor/skill-dispatcher-plugin.ts`, after a Task reaches terminal state (via direct return OR via TaskTracker completing later), publish a canonical event `autonomous.outcome.${systemActor}.${skill}` carrying:
- correlationId, parentId, systemActor, skill
- success: boolean, taskState, text preview, usage, durationMs
- effectDelta (populated in Arc 4/5)

**Why**: A single outcome topic replaces the current split between `world.action...

---
*Recovered automatically by Automaker post-agent hook*