### PR TITLE
fix(dispatcher): restore tier_0 fast-path dropped by Arc 1.4

### DIFF
--- a/src/plugins/action-dispatcher-plugin.test.ts
+++ b/src/plugins/action-dispatcher-plugin.test.ts
@@ -19,7 +19,10 @@ const makeAction = (overrides: Partial<Action> = {}): Action => ({
   name: "Test Action",
   description: "Test",
   goalId: "test-goal",
-  tier: "tier_0",
+  // tier_1 by default — exercises the skill-dispatch path. Tier_0 actions
+  // are declarative world-state-only and short-circuit to success; tests that
+  // need that path override explicitly.
+  tier: "tier_1",
   preconditions: [],
   effects: [],
   cost: 0,

--- a/src/plugins/action-dispatcher-plugin.ts
+++ b/src/plugins/action-dispatcher-plugin.ts
@@ -162,6 +162,15 @@ export class ActionDispatcherPlugin implements Plugin {
     }
 
     try {
+      // Tier-0 actions are declarative world-state-only effects that don't require a
+      // skill call — their effects were already applied above. Resolve immediately as
+      // success without a dispatch. (Arc 1.4 removed the meta.topic indirection which
+      // used to gate this; the tier check preserves the original semantics.)
+      if (action.tier === "tier_0") {
+        await this.completeAction(action, correlationId, parentCorrelationId, startedAt, true);
+        return;
+      }
+
       // For fire-and-forget actions: publish to agent.skill.request then immediately succeed.
       // Use meta.fireAndForget for alerts, ceremony triggers, and other side-effect-only dispatches.
       if (action.meta.fireAndForget) {

--- a/test/integration/planner-dispatcher-flow.test.ts
+++ b/test/integration/planner-dispatcher-flow.test.ts
@@ -141,13 +141,15 @@ describe("Planner → Dispatcher integration flow", () => {
     const smallOrchestrator = new PlanningOrchestrator({ dispatcher: { wipLimit: 1 } });
     smallOrchestrator.install(bus);
 
-    // Register 3 actions that will all match but dispatch to a topic (in-flight)
+    // tier_1 actions dispatch to agent.skill.request and stay in-flight until
+    // a response arrives — which here never does, so they accumulate against WIP.
     for (let i = 0; i < 3; i++) {
       smallOrchestrator.getRegistry().register(
         makeAction({
           id: `action-${i}`,
           goalId: `goal-${i}`,
-          meta: { topic: `agent.task.${i}`, timeout: 30_000 },
+          tier: "tier_1",
+          meta: { timeout: 30_000 },
         })
       );
     }


### PR DESCRIPTION
## Summary
Hotfix for the integration-test regression that showed up on the v0.7.1 snapshot promote (#195). Arc 1.4 (#194) deleted the \`action.meta.topic\` indirection but also dropped the fast-path for \`tier_0\` actions (declarative world-state only, no skill call). Those actions were publishing to \`agent.skill.request\` and timing out after 30s instead of completing immediately as success.

Root cause: the old dispatcher had \`if (!action.meta.topic) { completeAsSuccess(); return; }\` — that branch was the implicit tier_0 fast-path. When Arc 1.4 removed it, tier_0 actions lost their short-circuit.

## Fix
- \`src/plugins/action-dispatcher-plugin.ts\` — explicit tier_0 check after optimistic effects apply, completes immediately.
- Test helpers — default \`makeAction\` tier bumped from tier_0 → tier_1 so tests exercising the skill-dispatch path don't short-circuit.

## Verification
- 769 / 769 tests pass
- \`bunx tsc --noEmit\` clean
- Both previously failing tests now green:
  - \`PlanningOrchestrator > dispatches action end-to-end after install\`
  - \`Planner → Dispatcher integration flow > full flow: world state update → dispatch → outcome\`