### PR TITLE
[Arc 4.3] Agent cards advertise effects (quinn, frank, ava, jon, researcher)

### DIFF
--- a/src/executor/extensions/effect-domain.ts
+++ b/src/executor/extensions/effect-domain.ts
@@ -1,0 +1,97 @@
+/**
+ * Effect-domain v1 extension — registers an interceptor that:
+ *
+ *   before(ctx): stamps the current skill name onto outbound metadata so the
+ *     agent can see which skill is being invoked and confirm the expected effects.
+ *
+ *   after(ctx, result): reads the agent's actual delta from the terminal
+ *     artifact's structured data and publishes a `world.state.delta` event so
+ *     the GOAP planner can update its world-state snapshot without waiting for
+ *     the next full poll.
+ *
+ * Call `registerEffectDomainExtension(bus)` once at startup (e.g. in src/index.ts)
+ * to wire this extension into the defaultExtensionRegistry.
+ *
+ * Extension URI: https://protolabs.ai/a2a/ext/effect-domain-v1
+ */
+
+import type { EventBus } from "../../../lib/types.ts";
+import {
+  defaultExtensionRegistry,
+  type ExtensionInterceptor,
+  type ExtensionContext,
+} from "../extension-registry.ts";
+
+export const EFFECT_DOMAIN_URI = "https://protolabs.ai/a2a/ext/effect-domain-v1";
+
+/** A single world-state mutation declared or observed for a skill execution. */
+export interface EffectDomainDelta {
+  /** Name of the world-state domain (e.g. "ci", "plane"). */
+  domain: string;
+  /** Dot-separated path into the domain's data object (e.g. "data.blockedPRs"). */
+  path: string;
+  /** Signed numeric change applied to the value at `path`. */
+  delta: number;
+  /** Planner weight in [0.0, 1.0]. */
+  confidence: number;
+}
+
+/**
+ * Payload published on `world.state.delta` after each skill execution that
+ * returns effect-domain data.
+ */
+export interface WorldStateDeltaPayload {
+  /** Agent that produced this delta. */
+  source: string;
+  /** Skill that was executed. */
+  skill: string;
+  /** Observed or declared deltas from the terminal artifact. */
+  delta: EffectDomainDelta[];
+}
+
+/**
+ * Creates and registers the effect-domain interceptor with `defaultExtensionRegistry`.
+ *
+ * Must be called once at startup with a live EventBus reference so the `after`
+ * hook can publish `world.state.delta`.
+ */
+export function registerEffectDomainExtension(bus: EventBus): void {
+  const interceptor: ExtensionInterceptor = {
+    before(ctx: ExtensionContext): void {
+      // Stamp the skill name onto outbound metadata so the agent knows which
+      // skill is being invoked and can include effect confirmation in its response.
+      ctx.metadata["x-effect-domain-skill"] = ctx.skill;
+    },
+
+    after(
+      ctx: ExtensionContext,
+      result: { text: string; data?: Record<string, unknown> },
+    ): void {
+      const effectData = result.data?.["x-effect-domain"] as
+        | { delta?: EffectDomainDelta[] }
+        | undefined;
+
+      if (!effectData?.delta?.length) return;
+
+      const topic = "world.state.delta";
+      bus.publish(topic, {
+        id: crypto.randomUUID(),
+        correlationId: ctx.correlationId,
+        topic,
+        timestamp: Date.now(),
+        payload: {
+          source: ctx.agentName,
+          skill: ctx.skill,
+          delta: effectData.delta,
+        } satisfies WorldStateDeltaPayload,
+      });
+    },
+  };
+
+  defaultExtensionRegistry.register({
+    uri: EFFECT_DOMAIN_URI,
+    interceptor,
+    description:
+      "Effect-domain v1: stamps skill name on outbound metadata and publishes world.state.delta after execution",
+  });
+}

--- a/workspace/agents/frank.yaml.example
+++ b/workspace/agents/frank.yaml.example
@@ -29,9 +29,20 @@ skills:
   - name: ci_debug
     description: Debug a CI failure — read logs, identify root cause
     keywords: [ci, pipeline, build failed, workflow, action failed, test failed, deploy failed]
+    effects:
+      - domain: ci
+        path: data.failingMainCount
+        delta: -1
+        confidence: 0.6
+      - domain: pr_pipeline
+        path: data.failingCi
+        delta: -1
+        confidence: 0.6
+
   - name: health_check
     description: Run a comprehensive health check across all services
     keywords: [health, unhealthy, down, unreachable, service, container, infra, /health]
+
   - name: deploy_check
     description: Verify a deployment is healthy after rollout
     keywords: [deploy, deployment, rollout, release, ship, pushed, /deploy]

--- a/workspace/agents/quinn.yaml.example
+++ b/workspace/agents/quinn.yaml.example
@@ -44,9 +44,26 @@ skills:
   - name: bug_triage
     description: Triage a bug report — severity, reproduction, root cause, Plane issue
     keywords: [bug, issue, broken, crash, error, fail, exception, triage, TypeError, ReferenceError, not working, regression]
+    effects:
+      - domain: plane
+        path: data.unassignedOpen
+        delta: -1
+        confidence: 0.9
+
   - name: pr_review
     description: Review a pull request diff for correctness and regressions
     keywords: [pr, pull request, review, merge, /review, code review, lgtm, looks good]
+    effects:
+      - domain: pr_pipeline
+        path: data.changesRequested
+        delta: -1
+        confidence: 0.7
+
   - name: security_triage
     description: Triage a security incident — assess severity, draft remediation plan
     keywords: [security, vulnerability, breach, leak, exposed, cve, exploit]
+    effects:
+      - domain: security
+        path: data.openCount
+        delta: -1
+        confidence: 0.7


### PR DESCRIPTION
## Summary

**Arc 4: Effect-driven planning** (epic: Unified A2A + GOAP)

Each external agent updates their own agent card to include the extension + per-skill effect declarations. This is partner work — file tracking issues in each agent repo. For in-process agents (ava, protobot), update `workspace/agents/*.yaml` to emit effects in the synthetic card.

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced effect-domain extension system to capture and publish state change events across system domains
  * Enables agents to declare effects with domain targets, state paths, delta values, and confidence metrics
  * Updated example agent configurations to demonstrate effect declarations for tracking impact of agent actions on system state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->