### PR TITLE
[Arc 4.4] ExecutorRegistry: index by effect

### DIFF
--- a/src/executor/__tests__/executor-registry.test.ts
+++ b/src/executor/__tests__/executor-registry.test.ts
@@ -100,6 +100,73 @@ describe("ExecutorRegistry", () => {
     });
   });
 
+  describe("registerEffect + resolveByEffect", () => {
+    it("returns candidates for a registered (domain, path)", () => {
+      const registry = new ExecutorRegistry();
+      registry.registerEffect("fix_ci", "ava", [
+        { domain: "ci", path: "data.blockedPRs", expectedDelta: -1, confidence: 0.9 },
+      ]);
+      const results = registry.resolveByEffect({ domain: "ci", path: "data.blockedPRs" });
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({
+        skill: "fix_ci",
+        agentName: "ava",
+        domain: "ci",
+        path: "data.blockedPRs",
+        expectedDelta: -1,
+        confidence: 0.9,
+      });
+    });
+
+    it("returns empty array when no match", () => {
+      const registry = new ExecutorRegistry();
+      expect(registry.resolveByEffect({ domain: "ci", path: "data.blockedPRs" })).toEqual([]);
+    });
+
+    it("accumulates multiple skills for the same (domain, path)", () => {
+      const registry = new ExecutorRegistry();
+      registry.registerEffect("fix_ci", "ava", [
+        { domain: "ci", path: "data.blockedPRs", expectedDelta: -1, confidence: 0.9 },
+      ]);
+      registry.registerEffect("triage_ci", "quinn", [
+        { domain: "ci", path: "data.blockedPRs", expectedDelta: -2, confidence: 0.6 },
+      ]);
+      const results = registry.resolveByEffect({ domain: "ci", path: "data.blockedPRs" });
+      expect(results).toHaveLength(2);
+      expect(results.map(r => r.skill)).toEqual(["fix_ci", "triage_ci"]);
+    });
+
+    it("a single registerEffect call with multiple effects populates all keys", () => {
+      const registry = new ExecutorRegistry();
+      registry.registerEffect("deploy", undefined, [
+        { domain: "ci", path: "data.failCount", expectedDelta: -1, confidence: 0.8 },
+        { domain: "plane", path: "data.openIssues", expectedDelta: -1, confidence: 0.7 },
+      ]);
+      expect(registry.resolveByEffect({ domain: "ci", path: "data.failCount" })).toHaveLength(1);
+      expect(registry.resolveByEffect({ domain: "plane", path: "data.openIssues" })).toHaveLength(1);
+    });
+
+    it("resolveByEffect returns a copy — mutations do not affect internal state", () => {
+      const registry = new ExecutorRegistry();
+      registry.registerEffect("fix_ci", undefined, [
+        { domain: "ci", path: "data.blockedPRs", expectedDelta: -1, confidence: 0.9 },
+      ]);
+      const results = registry.resolveByEffect({ domain: "ci", path: "data.blockedPRs" });
+      results.pop();
+      expect(registry.resolveByEffect({ domain: "ci", path: "data.blockedPRs" })).toHaveLength(1);
+    });
+
+    it("does not affect existing resolve() behaviour", () => {
+      const registry = new ExecutorRegistry();
+      const exec = makeExecutor("proto-sdk");
+      registry.register("fix_ci", exec);
+      registry.registerEffect("fix_ci", undefined, [
+        { domain: "ci", path: "data.blockedPRs", expectedDelta: -1, confidence: 0.9 },
+      ]);
+      expect(registry.resolve("fix_ci")).toBe(exec);
+    });
+  });
+
   describe("list + size", () => {
     it("tracks all registrations", () => {
       const registry = new ExecutorRegistry();

--- a/src/executor/executor-registry.ts
+++ b/src/executor/executor-registry.ts
@@ -8,11 +8,13 @@
  *   4. null — no executor found; SkillDispatcherPlugin logs and drops
  */
 
-import type { IExecutor, ExecutorRegistration } from "./types.ts";
+import type { IExecutor, ExecutorRegistration, EffectRegistration } from "./types.ts";
 
 export class ExecutorRegistry {
   private readonly _registrations: ExecutorRegistration[] = [];
   private _default: IExecutor | null = null;
+  /** Secondary index: `${domain}::${path}` → EffectRegistration[] */
+  private readonly _effectIndex = new Map<string, EffectRegistration[]>();
 
   /**
    * Register an executor for a specific skill.
@@ -61,6 +63,49 @@ export class ExecutorRegistry {
 
     // 3. Default
     return this._default;
+  }
+
+  /**
+   * Register a skill's declared world-state effects for effect-based planning.
+   * Multiple calls for the same (domain, path) accumulate — all candidates are
+   * returned by resolveByEffect so the planner can rank them.
+   *
+   * @param skill     - Skill name that produces these effects.
+   * @param agentName - Optional agent name for target-based routing.
+   * @param effects   - One or more effect entries: { domain, path, expectedDelta, confidence }.
+   */
+  registerEffect(
+    skill: string,
+    agentName: string | undefined,
+    effects: Array<{ domain: string; path: string; expectedDelta: number; confidence: number }>,
+  ): void {
+    for (const e of effects) {
+      const key = `${e.domain}::${e.path}`;
+      const entry: EffectRegistration = {
+        skill,
+        agentName,
+        domain: e.domain,
+        path: e.path,
+        expectedDelta: e.expectedDelta,
+        confidence: e.confidence,
+      };
+      const bucket = this._effectIndex.get(key);
+      if (bucket) {
+        bucket.push(entry);
+      } else {
+        this._effectIndex.set(key, [entry]);
+      }
+    }
+  }
+
+  /**
+   * Resolve all skills that declare an effect on a specific (domain, path) target.
+   * Returns candidates in registration order. Returns an empty array when nothing
+   * matches — callers should fall back to skill-name routing if needed.
+   */
+  resolveByEffect(target: { domain: string; path: string }): EffectRegistration[] {
+    const key = `${target.domain}::${target.path}`;
+    return [...(this._effectIndex.get(key) ?? [])];
   }
 
   /** All current registrations — useful for diagnostics and health checks. */

--- a/src/executor/extensions/effect-domain.ts
+++ b/src/executor/extensions/effect-domain.ts
@@ -1,0 +1,97 @@
+/**
+ * Effect-domain v1 extension — registers an interceptor that:
+ *
+ *   before(ctx): stamps the current skill name onto outbound metadata so the
+ *     agent can see which skill is being invoked and confirm the expected effects.
+ *
+ *   after(ctx, result): reads the agent's actual delta from the terminal
+ *     artifact's structured data and publishes a `world.state.delta` event so
+ *     the GOAP planner can update its world-state snapshot without waiting for
+ *     the next full poll.
+ *
+ * Call `registerEffectDomainExtension(bus)` once at startup (e.g. in src/index.ts)
+ * to wire this extension into the defaultExtensionRegistry.
+ *
+ * Extension URI: https://protolabs.ai/a2a/ext/effect-domain-v1
+ */
+
+import type { EventBus } from "../../../lib/types.ts";
+import {
+  defaultExtensionRegistry,
+  type ExtensionInterceptor,
+  type ExtensionContext,
+} from "../extension-registry.ts";
+
+export const EFFECT_DOMAIN_URI = "https://protolabs.ai/a2a/ext/effect-domain-v1";
+
+/** A single world-state mutation declared or observed for a skill execution. */
+export interface EffectDomainDelta {
+  /** Name of the world-state domain (e.g. "ci", "plane"). */
+  domain: string;
+  /** Dot-separated path into the domain's data object (e.g. "data.blockedPRs"). */
+  path: string;
+  /** Signed numeric change applied to the value at `path`. */
+  delta: number;
+  /** Planner weight in [0.0, 1.0]. */
+  confidence: number;
+}
+
+/**
+ * Payload published on `world.state.delta` after each skill execution that
+ * returns effect-domain data.
+ */
+export interface WorldStateDeltaPayload {
+  /** Agent that produced this delta. */
+  source: string;
+  /** Skill that was executed. */
+  skill: string;
+  /** Observed or declared deltas from the terminal artifact. */
+  delta: EffectDomainDelta[];
+}
+
+/**
+ * Creates and registers the effect-domain interceptor with `defaultExtensionRegistry`.
+ *
+ * Must be called once at startup with a live EventBus reference so the `after`
+ * hook can publish `world.state.delta`.
+ */
+export function registerEffectDomainExtension(bus: EventBus): void {
+  const interceptor: ExtensionInterceptor = {
+    before(ctx: ExtensionContext): void {
+      // Stamp the skill name onto outbound metadata so the agent knows which
+      // skill is being invoked and can include effect confirmation in its response.
+      ctx.metadata["x-effect-domain-skill"] = ctx.skill;
+    },
+
+    after(
+      ctx: ExtensionContext,
+      result: { text: string; data?: Record<string, unknown> },
+    ): void {
+      const effectData = result.data?.["x-effect-domain"] as
+        | { delta?: EffectDomainDelta[] }
+        | undefined;
+
+      if (!effectData?.delta?.length) return;
+
+      const topic = "world.state.delta";
+      bus.publish(topic, {
+        id: crypto.randomUUID(),
+        correlationId: ctx.correlationId,
+        topic,
+        timestamp: Date.now(),
+        payload: {
+          source: ctx.agentName,
+          skill: ctx.skill,
+          delta: effectData.delta,
+        } satisfies WorldStateDeltaPayload,
+      });
+    },
+  };
+
+  defaultExtensionRegistry.register({
+    uri: EFFECT_DOMAIN_URI,
+    interceptor,
+    description:
+      "Effect-domain v1: stamps skill name on outbound metadata and publishes world.state.delta after execution",
+  });
+}

--- a/src/executor/types.ts
+++ b/src/executor/types.ts
@@ -77,3 +77,22 @@ export interface ExecutorRegistration {
   /** Higher priority wins when multiple registrations match the same skill. */
   priority: number;
 }
+
+/**
+ * A single entry in the effect-based secondary index.
+ * Maps a world-state (domain, path) target to the skill that can produce it.
+ */
+export interface EffectRegistration {
+  /** Skill name that produces this effect. */
+  skill: string;
+  /** Agent name for target-based routing (optional). */
+  agentName?: string;
+  /** World-state domain (e.g. "ci", "plane"). */
+  domain: string;
+  /** Dot-separated path into the domain's data object (e.g. "data.blockedPRs"). */
+  path: string;
+  /** Expected signed numeric change applied to the value at `path`. */
+  expectedDelta: number;
+  /** Planner weight in [0.0, 1.0]. */
+  confidence: number;
+}


### PR DESCRIPTION
## Summary

**Arc 4: Effect-driven planning** (epic: Unified A2A + GOAP)

Extend `src/executor/executor-registry.ts` with a secondary index: `(domain, path) → [(skill, agentName, expectedDelta, confidence)]`. Exposes `resolveByEffect(targetDelta)` alongside the existing `resolve(skill, targets)`. Both indices coexist — effect-based planning is additive, skill-name routing still works for explicit dispatches.

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced effect-based skill resolution: register skills with their expected effects on world-state targets, then resolve which skills can achieve specific state changes.
  * Added world-state change event publishing to notify systems of state modifications.

* **Tests**
  * Added comprehensive test coverage for effect registration and resolution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->