### PR TITLE
[Arc 7.1] input-required TTL policies on HITLRequest

### DIFF
--- a/lib/plugins/hitl.ts
+++ b/lib/plugins/hitl.ts
@@ -90,20 +90,40 @@ export class HITLPlugin implements Plugin {
         if (new Date(req.expiresAt).getTime() <= now) {
           pendingRequests.delete(correlationId);
           unrenderedCorrelationIds.delete(correlationId);
-          console.log(`[hitl] Expired HITLRequest (${correlationId})`);
-          bus.publish(`hitl.expired.${correlationId}`, {
-            id: crypto.randomUUID(),
-            correlationId,
-            topic: `hitl.expired.${correlationId}`,
-            timestamp: Date.now(),
-            payload: { type: "hitl_expired", correlationId, originalRequest: req },
-          });
-          const iface = req.sourceMeta?.interface ?? "unknown";
-          const renderer = renderers.get(iface);
-          if (renderer?.onExpired) {
-            renderer.onExpired(req, bus).catch(err =>
-              console.error(`[hitl] renderer.onExpired failed for ${correlationId}:`, err),
-            );
+
+          if (req.onTimeout === "approve" || req.onTimeout === "reject") {
+            // Auto-respond according to the TTL policy
+            console.log(`[hitl] TTL expired → auto-${req.onTimeout} (${correlationId})`);
+            const autoResp: HITLResponse = {
+              type: "hitl_response",
+              correlationId,
+              decision: req.onTimeout,
+              decidedBy: `auto-${req.onTimeout}`,
+            };
+            bus.publish(`hitl.response.${correlationId}`, {
+              id: crypto.randomUUID(),
+              correlationId,
+              topic: `hitl.response.${correlationId}`,
+              timestamp: Date.now(),
+              payload: autoResp,
+            });
+          } else {
+            // onTimeout === "escalate" or not set — emit expired event for escalation handlers
+            console.log(`[hitl] Expired HITLRequest (${correlationId})`);
+            bus.publish(`hitl.expired.${correlationId}`, {
+              id: crypto.randomUUID(),
+              correlationId,
+              topic: `hitl.expired.${correlationId}`,
+              timestamp: Date.now(),
+              payload: { type: "hitl_expired", correlationId, originalRequest: req },
+            });
+            const iface = req.sourceMeta?.interface ?? "unknown";
+            const renderer = renderers.get(iface);
+            if (renderer?.onExpired) {
+              renderer.onExpired(req, bus).catch(err =>
+                console.error(`[hitl] renderer.onExpired failed for ${correlationId}:`, err),
+              );
+            }
           }
         }
       }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -31,6 +31,10 @@ export interface HITLRequest {
   jonVerdict?: { score: number; concerns: string[]; verdict: string };
   options: string[];      // ["approve", "reject", "modify"]
   expiresAt: string;      // ISO timestamp
+  /** Optional TTL override in milliseconds. Callers may compute expiresAt from this. */
+  ttlMs?: number;
+  /** Policy to execute when the TTL expires without a human decision. */
+  onTimeout?: "approve" | "reject" | "escalate";
   replyTopic: string;     // where to publish HITLResponse
   sourceMeta?: BusMessage["source"]; // carry source through so HITL plugin knows how to render
   // ── Cost escalation fields (populated by BudgetPlugin L3 requests) ────────

--- a/workspace/actions.yaml
+++ b/workspace/actions.yaml
@@ -215,6 +215,9 @@ actions:
     effects: []
     meta:
       fireAndForget: true
+      hitlPolicy:
+        ttlMs: 1800000   # 30 minutes — auto-approve if no human responds
+        onTimeout: approve
 
   - id: action.pr_fix_ci
     goalId: pr.no_failing_checks
@@ -507,3 +510,6 @@ actions:
     effects: []
     meta:
       fireAndForget: true
+      hitlPolicy:
+        ttlMs: 3600000  # 1 hour — escalate (no auto-action) so humans must intervene
+        onTimeout: escalate


### PR DESCRIPTION
## Summary

**Arc 7: HITL gradient via TTL + auto-approve** (epic: Unified A2A + GOAP)

Extend `HITLRequest` with `ttlMs` and `onTimeout: 'approve' | 'reject' | 'escalate'`. HITLPlugin's sweep timer honors these. Per-action config in actions.yaml (soon to be per-skill on agent card) drives the values.

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Approval requests now support automatic timeout handling with configurable actions: auto-approve, auto-reject, or escalate after a specified time limit.
  * Select system actions have been configured with explicit timeout policies that define how long to wait for human review and what decision to take automatically if no action occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->