### PR TITLE
[Arc 6.2] x-protolabs/confidence-v1 extension

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean-dashboard",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/dashboard/src/components/EventStream.tsx
+++ b/dashboard/src/components/EventStream.tsx
@@ -1,23 +1,11 @@
 import { useState, useEffect, useRef } from "preact/hooks";
 import { WebSocketManager } from "../lib/websocket";
 import type { WsMessage } from "../lib/websocket";
+import { topicMatchesFilter } from "../lib/topic-filter";
 import { EventRow } from "./EventRow";
 import { LogRow } from "./LogRow";
 
 type WsStatus = "connecting" | "connected" | "disconnected";
-
-// Wildcard topic filter — supports * (single segment) and # (any suffix)
-function topicMatchesFilter(topic: string, filter: string): boolean {
-  if (!filter) return true;
-  const parts = filter.split(".");
-  const topicParts = (topic || "").split(".");
-  for (let i = 0; i < parts.length; i++) {
-    if (parts[i] === "#") return true;
-    if (parts[i] === "*") continue;
-    if (parts[i] !== topicParts[i]) return false;
-  }
-  return parts.length === topicParts.length;
-}
 
 function isDebug(msg: WsMessage): boolean {
   return typeof msg.topic === "string" && msg.topic.startsWith("debug.");

--- a/dashboard/src/lib/__tests__/topic-filter.test.ts
+++ b/dashboard/src/lib/__tests__/topic-filter.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from "bun:test";
+import { topicMatchesFilter } from "../topic-filter";
+
+describe("topicMatchesFilter", () => {
+  test("empty filter matches everything", () => {
+    expect(topicMatchesFilter("agent.task.completed", "")).toBe(true);
+    expect(topicMatchesFilter("any.topic", "")).toBe(true);
+  });
+
+  test("exact match", () => {
+    expect(topicMatchesFilter("agent.task.completed", "agent.task.completed")).toBe(true);
+    expect(topicMatchesFilter("agent.task.completed", "agent.task.started")).toBe(false);
+  });
+
+  test("* matches single segment", () => {
+    expect(topicMatchesFilter("agent.task.completed", "agent.*.completed")).toBe(true);
+    expect(topicMatchesFilter("agent.task.completed", "*.task.completed")).toBe(true);
+    expect(topicMatchesFilter("agent.task.completed", "agent.*")).toBe(false); // length mismatch
+  });
+
+  test("# matches any suffix", () => {
+    expect(topicMatchesFilter("agent.task.completed", "agent.#")).toBe(true);
+    expect(topicMatchesFilter("agent.task.completed.extra", "agent.#")).toBe(true);
+    expect(topicMatchesFilter("agent.task.completed", "#")).toBe(true);
+    expect(topicMatchesFilter("agent.task.completed", "other.#")).toBe(false);
+  });
+
+  test("combined wildcards", () => {
+    expect(topicMatchesFilter("agent.task.completed", "agent.*.*")).toBe(true);
+    expect(topicMatchesFilter("debug.info.trace", "debug.#")).toBe(true);
+    expect(topicMatchesFilter("agent.task", "agent.*.completed")).toBe(false);
+  });
+
+  test("empty topic with non-empty filter", () => {
+    expect(topicMatchesFilter("", "agent.task")).toBe(false);
+    expect(topicMatchesFilter("", "")).toBe(true);
+    expect(topicMatchesFilter("", "#")).toBe(true);
+  });
+
+  test("single segment topics", () => {
+    expect(topicMatchesFilter("ping", "ping")).toBe(true);
+    expect(topicMatchesFilter("ping", "pong")).toBe(false);
+    expect(topicMatchesFilter("ping", "*")).toBe(true);
+    expect(topicMatchesFilter("ping", "#")).toBe(true);
+  });
+});

--- a/dashboard/src/lib/__tests__/websocket.test.ts
+++ b/dashboard/src/lib/__tests__/websocket.test.ts
@@ -1,0 +1,150 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { WebSocketManager } from "../websocket";
+
+// Minimal WebSocket mock — replaces the browser global during tests
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  url: string;
+  readyState = 0; // CONNECTING
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onmessage: ((evt: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  open() {
+    this.readyState = 1; // OPEN
+    this.onopen?.();
+  }
+
+  close() {
+    if (this.closed) return;
+    this.closed = true;
+    this.readyState = 3; // CLOSED
+    this.onclose?.();
+  }
+
+  send(_data: string) {}
+
+  receiveMessage(data: object) {
+    this.onmessage?.({ data: JSON.stringify(data) });
+  }
+}
+
+// Save and restore browser globals so other tests aren't affected
+let savedWebSocket: unknown;
+let savedLocation: unknown;
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+  savedWebSocket = (globalThis as Record<string, unknown>).WebSocket;
+  savedLocation = (globalThis as Record<string, unknown>).location;
+  (globalThis as Record<string, unknown>).WebSocket = MockWebSocket;
+  // Stub location so URL construction uses ws: not wss:
+  (globalThis as Record<string, unknown>).location = { protocol: "http:", host: "localhost:3000" };
+});
+
+afterEach(() => {
+  (globalThis as Record<string, unknown>).WebSocket = savedWebSocket;
+  (globalThis as Record<string, unknown>).location = savedLocation;
+  MockWebSocket.instances = [];
+});
+
+describe("WebSocketManager", () => {
+  test("emits 'connecting' status on connect()", () => {
+    const manager = new WebSocketManager("/ws");
+    const statuses: string[] = [];
+    manager.onStatus((s) => statuses.push(s));
+
+    manager.connect();
+
+    expect(statuses).toEqual(["connecting"]);
+    manager.destroy();
+  });
+
+  test("emits 'connected' when socket opens", () => {
+    const manager = new WebSocketManager("/ws");
+    const statuses: string[] = [];
+    manager.onStatus((s) => statuses.push(s));
+
+    manager.connect();
+    MockWebSocket.instances[0].open();
+
+    expect(statuses).toContain("connected");
+    manager.destroy();
+  });
+
+  test("emits 'disconnected' when socket closes", () => {
+    const manager = new WebSocketManager("/ws");
+    const statuses: string[] = [];
+    manager.onStatus((s) => statuses.push(s));
+
+    manager.connect();
+    MockWebSocket.instances[0].open();
+    MockWebSocket.instances[0].close();
+
+    expect(statuses).toContain("disconnected");
+    manager.destroy();
+  });
+
+  test("delivers parsed messages to onMessage handlers", () => {
+    const manager = new WebSocketManager("/ws");
+    const received: object[] = [];
+    manager.onMessage((msg) => received.push(msg));
+
+    manager.connect();
+    MockWebSocket.instances[0].receiveMessage({
+      topic: "agent.task.completed",
+      payload: { result: "ok" },
+      timestamp: "2026-04-14T00:00:00Z",
+    });
+
+    expect(received).toHaveLength(1);
+    expect((received[0] as { topic: string }).topic).toBe("agent.task.completed");
+    manager.destroy();
+  });
+
+  test("ignores malformed (non-JSON) messages", () => {
+    const manager = new WebSocketManager("/ws");
+    const received: object[] = [];
+    manager.onMessage((msg) => received.push(msg));
+
+    manager.connect();
+    // Directly trigger onmessage with bad JSON
+    MockWebSocket.instances[0].onmessage?.({ data: "not-json{{" });
+
+    expect(received).toHaveLength(0);
+    manager.destroy();
+  });
+
+  test("onStatus unsubscribe stops further notifications", () => {
+    const manager = new WebSocketManager("/ws");
+    const statuses: string[] = [];
+    const off = manager.onStatus((s) => statuses.push(s));
+
+    manager.connect(); // emits "connecting"
+    off(); // unsubscribe
+    MockWebSocket.instances[0].open(); // would emit "connected" but handler is gone
+
+    expect(statuses).toEqual(["connecting"]);
+    manager.destroy();
+  });
+
+  test("destroy() prevents new connections", () => {
+    const manager = new WebSocketManager("/ws");
+
+    manager.connect();
+    MockWebSocket.instances[0].open();
+    manager.destroy();
+
+    // After destroy, connect() is a no-op — no additional WebSocket created
+    manager.connect();
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+});

--- a/dashboard/src/lib/topic-filter.ts
+++ b/dashboard/src/lib/topic-filter.ts
@@ -1,0 +1,12 @@
+// Wildcard topic filter — supports * (single segment) and # (any suffix)
+export function topicMatchesFilter(topic: string, filter: string): boolean {
+  if (!filter) return true;
+  const parts = filter.split(".");
+  const topicParts = (topic || "").split(".");
+  for (let i = 0; i < parts.length; i++) {
+    if (parts[i] === "#") return true;
+    if (parts[i] === "*") continue;
+    if (parts[i] !== topicParts[i]) return false;
+  }
+  return parts.length === topicParts.length;
+}

--- a/docs/explanation/world-engine.md
+++ b/docs/explanation/world-engine.md
@@ -60,7 +60,7 @@ When a goal is violated, it emits `world.goal.violated` with the goal ID, severi
 
 **PlannerPluginL0** subscribes to `world.goal.violated`. It queries `ActionRegistry` for actions whose `goalId` matches the violated goal and whose `preconditions` are satisfied against the current world state. It packages the selected actions into a `world.action.plan` message.
 
-**ActionDispatcherPlugin** subscribes to `world.action.plan`. It fires each action by publishing to `action.meta.topic`, subject to a WIP (work-in-progress) limit to prevent runaway firing.
+**ActionDispatcherPlugin** subscribes to `world.action.plan`. It fires each action by publishing to `agent.skill.request`, subject to a WIP (work-in-progress) limit to prevent runaway firing.
 
 ## Why tier_0 vs tier_1 vs tier_2
 

--- a/docs/extensions/confidence-v1.md
+++ b/docs/extensions/confidence-v1.md
@@ -1,0 +1,119 @@
+---
+title: "Extension: x-protolabsconfidence-v1"
+---
+
+`x-protolabsconfidence-v1` is an A2A agent card extension that lets an agent attach a self-reported confidence score to its terminal message. OutcomeAnalysis uses these scores to weight failure signals — a high-confidence bad outcome is a stronger quality signal than a low-confidence one where the agent itself was uncertain.
+
+**Extension URI**: `https://protolabs.ai/a2a/ext/confidence-v1`
+
+---
+
+## Purpose
+
+Without confidence scores, OutcomeAnalysis treats every failure equally: each missed action counts as one failure regardless of how certain the agent was about its own outcome. This is noisy — an agent that says "I'm 10% confident this worked" failing is much less alarming than one that says "I'm 95% confident" and still failing.
+
+When an agent attaches a confidence score to its terminal message, OutcomeAnalysis can:
+
+- Weight each failure by the agent's reported confidence
+- Surface high-confidence chronic failures sooner (less evidence needed)
+- Avoid false alerts from fundamentally uncertain or exploratory skills
+- Include confidence metadata in the `ops.alert.action_quality` payload for diagnostics
+
+---
+
+## Schema
+
+The agent includes a `x-confidence` block in the `data` field of its terminal A2A task artifact:
+
+```json
+{
+  "x-confidence": {
+    "confidence": 0.72,
+    "explanation": "Three of the five test cases passed; the remaining two require manual review."
+  }
+}
+```
+
+### Field reference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `confidence` | `number` | yes | Self-reported confidence in the outcome, in `[0.0, 1.0]`. `1.0` = fully certain, `0.0` = no confidence |
+| `explanation` | `string` | no | Human-readable reason for the reported confidence score |
+
+---
+
+## How the extension works
+
+When an agent card declares the `confidence-v1` extension, the A2A executor applies the registered interceptor after each skill execution:
+
+1. **`after` hook** — reads `result.data["x-confidence"]` from the terminal artifact
+2. Publishes `autonomous.confidence.reported` to the bus with `{ correlationId, agentName, skill, confidence, explanation }`
+3. **OutcomeAnalysis** subscribes to `autonomous.confidence.reported`, caches confidence by `correlationId`
+4. When `world.action.outcome` arrives for the same correlationId, the plugin weights the failure score: `weightedFailures += confidence`
+5. Alert threshold checks `weightedFailures / total` alongside raw success rate — a few high-confidence failures can trigger the alert even when raw counts look borderline
+
+Agents that do not declare this extension continue to work normally; missing confidence defaults to `1.0` (full weight) so existing failure tracking is unchanged.
+
+---
+
+## Registering the extension (agent card)
+
+Add the extension URI to the agent's `/.well-known/agent-card.json`:
+
+```json
+{
+  "capabilities": {
+    "extensions": [
+      {
+        "uri": "https://protolabs.ai/a2a/ext/confidence-v1"
+      }
+    ]
+  }
+}
+```
+
+No `params` are needed — the extension has no static configuration on the card side. The confidence value is returned dynamically in each terminal message.
+
+---
+
+## In-process agents (workspace/agents/\<name\>.yaml)
+
+In-process agents built on `@protolabsai/sdk` can return confidence by including `x-confidence` in their tool result's structured data:
+
+```typescript
+return {
+  text: "PR review complete — 3 comments left, approval withheld pending CI.",
+  data: {
+    "x-confidence": {
+      confidence: 0.85,
+      explanation: "CI results were deterministic; approval decision is certain."
+    }
+  }
+};
+```
+
+---
+
+## Example: confidence-weighted alert
+
+Scenario: `pr_review` action runs 10 times. Six succeed. Four fail — but all four failures have `confidence: 0.9`.
+
+| Metric | Value |
+|--------|-------|
+| total | 10 |
+| success | 6 |
+| failure | 4 |
+| weightedFailures | 3.6 (4 × 0.9) |
+| successRate | 0.60 (60%) |
+| weightedFailureRate | 0.36 (36%) |
+
+The weighted failure rate (0.36) exceeds the `POOR_SUCCESS_THRESHOLD` (0.5)? No — but the raw success rate (0.60) is above 0.5 too, so no alert fires in this case. However, if those same four failures had `confidence: 1.0` (fully certain bad outcomes), `weightedFailureRate` = 0.40, still below threshold. The weighting primarily acts when combined with borderline raw success rates — e.g. five successes, five high-confidence failures gives `weightedFailureRate` = 0.50 exactly at threshold.
+
+The key effect: **low-confidence failures are discounted**, reducing false alerts for inherently uncertain skills while preserving sensitivity for confident ones.
+
+---
+
+## Versioning
+
+This is version 1 of the confidence extension. The URI `https://protolabs.ai/a2a/ext/confidence-v1` is stable. Changes to the confidence interpretation semantics or schema will be published under a new versioned URI.

--- a/docs/extensions/effect-domain-v1.md
+++ b/docs/extensions/effect-domain-v1.md
@@ -1,0 +1,142 @@
+---
+title: "Extension: x-protolabseffect-domain-v1"
+---
+
+`x-protolabseffect-domain-v1` is an A2A agent card extension that lets skills declare their expected world-state mutations. The L1 planner reads these declarations to score and select candidate skills when building a plan.
+
+**Extension URI**: `https://protolabs.ai/a2a/ext/effect-domain-v1`
+
+---
+
+## Purpose
+
+Without effect declarations, the planner treats skills as black boxes and must fall back to LLM reasoning (L2) to estimate which skill is most likely to move world state toward a goal. When a skill declares its effects, the L1 planner can:
+
+- Rank candidates by expected delta relative to the active goal
+- Detect conflicts (two skills writing the same path with opposing deltas)
+- Prefer high-confidence declarations over uncertain ones
+- Skip skills whose declared effects are irrelevant to the current goal
+
+---
+
+## Schema
+
+Declared inside the A2A agent card under `capabilities.extensions`:
+
+```yaml
+capabilities:
+  extensions:
+    - uri: https://protolabs.ai/a2a/ext/effect-domain-v1
+      params:
+        skills:
+          <skill_name>:
+            effects:
+              - domain: <domain>
+                path: <dot-separated path into domain data>
+                delta: <numeric change>
+                confidence: <0.0–1.0>
+```
+
+### Field reference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `domain` | `string` | yes | Name of the world-state domain as declared in `workspace/domains.yaml` |
+| `path` | `string` | yes | Dot-separated path into the domain's `data` object (e.g. `data.blockedPRs`) |
+| `delta` | `number` | yes | Expected signed change to the value at `path` after successful skill execution (negative = decrease, positive = increase) |
+| `confidence` | `number` | yes | Planner weight for this effect declaration, in the range `[0.0, 1.0]`. Use `1.0` for deterministic effects and lower values for probabilistic ones |
+
+A skill may declare multiple effects if it mutates more than one path.
+
+---
+
+## Example
+
+```yaml
+capabilities:
+  extensions:
+    - uri: https://protolabs.ai/a2a/ext/effect-domain-v1
+      params:
+        skills:
+          pr_review:
+            effects:
+              - domain: ci
+                path: data.blockedPRs
+                delta: -1
+                confidence: 0.8
+          bug_triage:
+            effects:
+              - domain: plane
+                path: data.untriaged
+                delta: -1
+                confidence: 0.9
+              - domain: plane
+                path: data.inProgress
+                delta: 1
+                confidence: 0.9
+```
+
+In this example, running `pr_review` is expected to reduce `ci.data.blockedPRs` by 1 with 80% confidence. Running `bug_triage` is expected to move one item from untriaged to in-progress with 90% confidence.
+
+---
+
+## How the planner uses effect declarations
+
+1. **Goal matching** — when a goal targets a world-state selector (e.g. `ci.blockedPRs` must reach `0`), the planner identifies all skills whose declared effects include a matching `domain` + `path`.
+2. **Candidate scoring** — candidates are scored by `|delta| × confidence`. Higher-scoring candidates are expanded first in the A* search.
+3. **Plan construction** — each selected skill becomes an action edge in the action graph. The expected post-execution state is computed by applying the declared deltas to the current world state snapshot.
+4. **Conflict detection** — two skills writing the same path with opposing deltas in the same plan raise a planning warning and the lower-confidence skill is dropped.
+
+Effect declarations are advisory — the planner still validates the actual world state after each skill executes and replans if the observed outcome diverges from the declared delta.
+
+---
+
+## Registering the extension
+
+### In-process agent (workspace/agents/\<name\>.yaml)
+
+In-process agent YAML does not use the full A2A agent card format. Declare effects inline under the skill entry:
+
+```yaml
+skills:
+  - name: pr_review
+    description: Review PRs and submit formal APPROVE/REQUEST_CHANGES
+    effects:
+      - domain: ci
+        path: data.blockedPRs
+        delta: -1
+        confidence: 0.8
+```
+
+### External A2A agent (agent card)
+
+Add the extension to the agent's `/.well-known/agent-card.json`:
+
+```json
+{
+  "capabilities": {
+    "extensions": [
+      {
+        "uri": "https://protolabs.ai/a2a/ext/effect-domain-v1",
+        "params": {
+          "skills": {
+            "pr_review": {
+              "effects": [
+                { "domain": "ci", "path": "data.blockedPRs", "delta": -1, "confidence": 0.8 }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+`SkillBrokerPlugin` reads extensions from the agent card during discovery and merges them into the executor registry.
+
+---
+
+## Versioning
+
+This is version 1 of the effect-domain extension. The URI `https://protolabs.ai/a2a/ext/effect-domain-v1` is stable. Breaking changes (field renames, semantic changes to `confidence` interpretation) will be published under a new versioned URI.

--- a/docs/guides/add-goals-and-actions.md
+++ b/docs/guides/add-goals-and-actions.md
@@ -110,7 +110,6 @@ actions:
         type: set
         value: true
     meta:
-      topic: "message.outbound.discord.push.1234567890"
       fireAndForget: true
 ```
 
@@ -190,10 +189,9 @@ Most alert and ceremony-trigger actions should be `tier_0`. Reserve higher tiers
 | `name` | No | string | Human-readable name. |
 | `preconditions` | No | array | Guard conditions. All must be true. |
 | `effects` | No | array | World state mutations applied after execution. |
-| `meta.topic` | Yes | string | Bus topic to publish on when the action fires. |
+| `meta.skillHint` | No | string | Skill name to invoke. Defaults to the action `id`. |
 | `meta.agentId` | No | string | Hint to route the action to a specific agent. |
 | `meta.fireAndForget` | No | boolean | Do not wait for a response. Default: `false`. |
-| `meta.payload` | No | object | Extra payload fields merged into the dispatched message. |
 
 ---
 
@@ -222,7 +220,6 @@ actions:
         operator: exists
     effects: []
     meta:
-      topic: "message.outbound.discord.push.ops-channel"
       fireAndForget: true
 
   - id: ceremony.health_check
@@ -236,7 +233,7 @@ actions:
         operator: exists
     effects: []
     meta:
-      topic: "ceremony.health_check.execute"
+      skillHint: health_check
       fireAndForget: true
 ```
 

--- a/docs/guides/integrate-external-app.md
+++ b/docs/guides/integrate-external-app.md
@@ -127,7 +127,6 @@ Append to `workspace/actions.yaml`. Every action must guard on domain availabili
         value: "ok"
     effects: []
     meta:
-      topic: "agent.skill.request"
       skillHint: diagnose
       agentId: myapp
       fireAndForget: true
@@ -135,7 +134,6 @@ Append to `workspace/actions.yaml`. Every action must guard on domain availabili
 
 Key fields:
 - `preconditions[0]` — **always guard on availability** to avoid firing on stale data
-- `meta.topic: "agent.skill.request"` — routes through SkillDispatcher to the A2A executor
 - `meta.skillHint` — which skill to invoke on the external agent
 - `meta.agentId` — which agent to route to (matches `name` in agents.yaml)
 - `meta.fireAndForget: true` — complete immediately (use `false` to wait for outcome)
@@ -217,7 +215,7 @@ GoalEvaluator detects violation
     ↓
 L0 Planner matches action preconditions against world state
     ↓
-ActionDispatcher publishes to meta.topic (agent.skill.request)
+ActionDispatcher publishes to agent.skill.request
     ↓
 SkillDispatcher extracts skillHint + agentId
     ↓

--- a/docs/tutorials/first-goap-goal.md
+++ b/docs/tutorials/first-goap-goal.md
@@ -21,7 +21,7 @@ WorldStateEngine polls domains
   → GoalEvaluatorPlugin checks goals against current state
     → Emits world.goal.violated when a goal is breached
       → PlannerPluginL0 maps violations to actions via goalId
-        → ActionDispatcherPlugin fires the action (publishes to action.meta.topic)
+        → ActionDispatcherPlugin fires the action (publishes to agent.skill.request)
 ```
 
 Goals express **what should be true**. Actions express **what to do when it is not**.
@@ -104,7 +104,6 @@ actions:
         value: 0.05
     effects: []
     meta:
-      topic: "message.outbound.discord.push.1234567890"
       fireAndForget: true
 ```
 
@@ -116,7 +115,7 @@ Action fields:
 | `tier` | `tier_0` = deterministic/cheap, `tier_1` = A* planned, `tier_2` = LLM |
 | `preconditions` | Guard — world state conditions that must be true before dispatching |
 | `effects` | State mutations the action applies after execution (can be empty for alerts) |
-| `meta.topic` | Bus topic ActionDispatcherPlugin publishes to when the action fires |
+| `meta.skillHint` | Skill name to invoke (defaults to the action `id`) |
 | `meta.fireAndForget` | Do not wait for a response |
 
 `preconditions` use the same dot-path selectors as goals. Supported operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `exists`, `not_exists`.
@@ -135,7 +134,7 @@ Wait up to `tickMs` (30 seconds) for the next poll. In the server logs you shoul
 [world-state] domain error_rate updated
 [goal-evaluator] VIOLATION services.error_rate_healthy — rate=0.15 > max=0.05
 [planner-l0] plan: [alert.error_rate_high]
-[action-dispatcher] firing action alert.error_rate_high → message.outbound.discord.push.1234567890
+[action-dispatcher] firing action alert.error_rate_high → agent.skill.request
 ```
 
 If DiscordPlugin is running, the alert appears in your configured channel. Otherwise, the outbound message is logged to the event log.

--- a/lib/plugins/pr-remediator.ts
+++ b/lib/plugins/pr-remediator.ts
@@ -166,8 +166,13 @@ const ATTEMPT_COOLDOWN_MS = 5 * 60 * 1000;
 // escalates to HITL once. Further triggers are silently ignored until a
 // human clears the entry (by the PR leaving pr_pipeline, e.g. merged/closed).
 const MAX_ATTEMPTS_PER_PR = 3;
+// After this many update_branch 422 failures, run diagnose_pr_stuck before
+// attempting another retry. The diagnose skill classifies the conflict so the
+// loop picks the right recovery path instead of banging on the same wall.
+const DIAGNOSE_AFTER_ATTEMPTS = 2;
 
 type RemediationKind = "fix_ci" | "address_feedback" | "merge_ready" | "update_branch";
+type DiagnosisVerdict = "redundant" | "rebasable" | "decomposable" | "genuine";
 
 interface InFlightEntry {
   kind: RemediationKind;
@@ -414,6 +419,72 @@ async function ghDispatchBackmerge(
   }
 }
 
+/**
+ * Close a PR on GitHub. Used by diagnose_pr_stuck verdicts (redundant,
+ * decomposable) to automatically close PRs that won't benefit from further
+ * retry attempts.
+ */
+async function ghClosePr(
+  repo: string,
+  num: number,
+): Promise<{ ok: boolean; status: number; error?: string }> {
+  if (!getGithubToken) return { ok: false, status: 0, error: "no GitHub credentials" };
+  const [owner, repoName] = repo.split("/");
+  if (!owner || !repoName) return { ok: false, status: 0, error: `malformed repo slug "${repo}"` };
+  try {
+    const token = await getGithubToken(owner, repoName);
+    const resp = await fetch(`https://api.github.com/repos/${repo}/pulls/${num}`, {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ state: "closed" }),
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (resp.ok) return { ok: true, status: resp.status };
+    const body = await resp.text().catch(() => "");
+    return { ok: false, status: resp.status, error: body.slice(0, 200) };
+  } catch (err) {
+    return { ok: false, status: 0, error: String(err) };
+  }
+}
+
+/**
+ * Post a comment on a PR/issue. Used by diagnose_pr_stuck to explain the
+ * auto-close decision before closing (redundant, decomposable verdicts).
+ */
+async function ghComment(
+  repo: string,
+  num: number,
+  body: string,
+): Promise<{ ok: boolean; status: number; error?: string }> {
+  if (!getGithubToken) return { ok: false, status: 0, error: "no GitHub credentials" };
+  const [owner, repoName] = repo.split("/");
+  if (!owner || !repoName) return { ok: false, status: 0, error: `malformed repo slug "${repo}"` };
+  try {
+    const token = await getGithubToken(owner, repoName);
+    const resp = await fetch(`https://api.github.com/repos/${repo}/issues/${num}/comments`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ body }),
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (resp.ok) return { ok: true, status: resp.status };
+    const errBody = await resp.text().catch(() => "");
+    return { ok: false, status: resp.status, error: errBody.slice(0, 200) };
+  } catch (err) {
+    return { ok: false, status: 0, error: String(err) };
+  }
+}
+
 // ── Plugin ───────────────────────────────────────────────────────────────────
 
 type BranchDriftData = {
@@ -446,6 +517,12 @@ export class PrRemediatorPlugin implements Plugin {
   private readonly autoModeKickAlertsAt = new Map<string, number>();
   /** `repo#number` → timestamp of last auto-approve attempt (avoid re-submitting on every tick while GitHub catches up). */
   private readonly autoApprovedAt = new Map<string, number>();
+  /**
+   * `repo#number` → correlationId of the in-flight diagnose_pr_stuck skill
+   * request. Prevents further update_branch retries while diagnosis is running
+   * and routes the skill response to _handleDiagnoseResponse.
+   */
+  private readonly diagnosisInFlight = new Map<string, string>();
 
   install(bus: EventBus): void {
     this.bus = bus;
@@ -525,6 +602,7 @@ export class PrRemediatorPlugin implements Plugin {
     this.latestPrData = null;
     this.pendingApprovals.clear();
     this.inFlight.clear();
+    this.diagnosisInFlight.clear();
   }
 
   // ── Loop protection helpers ────────────────────────────────────────────────
@@ -550,6 +628,15 @@ export class PrRemediatorPlugin implements Plugin {
     number: number,
     kind: RemediationKind,
   ): { ok: true } | { ok: false; reason: string } {
+    // Block update_branch retries while diagnose_pr_stuck is classifying the conflict.
+    if (kind === "update_branch") {
+      const prKey = `${repo}#${number}`;
+      const diagCid = this.diagnosisInFlight.get(prKey);
+      if (diagCid !== undefined) {
+        return { ok: false, reason: `diagnose_pr_stuck in-flight (correlationId: ${diagCid})` };
+      }
+    }
+
     const key = this._inFlightKey(repo, number, kind);
     const entry = this.inFlight.get(key);
     if (!entry) return { ok: true };
@@ -610,6 +697,7 @@ export class PrRemediatorPlugin implements Plugin {
     number: number,
     kind: RemediationKind,
     entry: InFlightEntry,
+    conflictDetails?: string,
   ): void {
     if (!this.bus) return;
 
@@ -649,6 +737,7 @@ export class PrRemediatorPlugin implements Plugin {
         `**Last correlationId**: \`${entry.correlationId}\``,
         ``,
         `The auto-remediation loop has dispatched ${kind} to Ava ${entry.attempts} times and the PR is still stuck. This is a bottleneck — either a new agent capability is needed, the root cause is outside Ava's reach, or a human merge / manual fix will break the cycle.`,
+        conflictDetails ? `\n**Conflict diagnosis (genuine)**:\n${conflictDetails}` : "",
         ``,
         `**Treat every stuck PR as a feature request**: what would have unblocked this automatically? That's the next thing to build on the board.`,
         ``,
@@ -866,11 +955,22 @@ export class PrRemediatorPlugin implements Plugin {
         // address_feedback paths take over.
       } else if (result.status === 422) {
         // The merge itself has conflicts — GitHub can't auto-resolve.
-        // Mark this dispatch as completed so cooldown kicks in, but don't
-        // escalate yet: _shouldDispatch will exhaust the attempt budget
-        // eventually and emit the stuck-HITL on its own. Real conflicts
-        // need human intervention.
         console.warn(`[pr-remediator] update_branch rejected ${pr.repo}#${pr.number}: ${result.error}`);
+        // After DIAGNOSE_AFTER_ATTEMPTS consecutive 422 failures, run
+        // diagnose_pr_stuck to classify the conflict before retrying. The
+        // diagnose skill returns a verdict (redundant/rebasable/decomposable/
+        // genuine) that drives the appropriate recovery action, instead of
+        // blindly retrying the same failing operation.
+        const ubKey = this._inFlightKey(pr.repo, pr.number, "update_branch");
+        const ubEntry = this.inFlight.get(ubKey);
+        const prKey = `${pr.repo}#${pr.number}`;
+        if (
+          ubEntry &&
+          ubEntry.attempts >= DIAGNOSE_AFTER_ATTEMPTS &&
+          !this.diagnosisInFlight.has(prKey)
+        ) {
+          void this._dispatchDiagnose(pr, msg.correlationId);
+        }
       } else if (result.status === 403) {
         // App lacks write permission on this repo. Silent skip, log once —
         // the goal will keep firing but the dedup gate will cool it down.
@@ -1184,6 +1284,251 @@ Critical rules:
       console.log(`[pr-remediator] HITL-approved merge succeeded ${pending.repo}#${pending.number}`);
     } else {
       console.warn(`[pr-remediator] HITL-approved merge FAILED ${pending.repo}#${pending.number}: ${result.error}`);
+    }
+  }
+
+  // ── diagnose_pr_stuck ──────────────────────────────────────────────────────
+  //
+  // Called after DIAGNOSE_AFTER_ATTEMPTS consecutive 422 failures from
+  // ghUpdateBranch. Dispatches the diagnose_pr_stuck skill to Ava which
+  // fetches the PR diff and recent base commits, then returns one of four
+  // verdicts: redundant, rebasable, decomposable, or genuine.
+  //
+  // The verdict is handled by _handleDiagnoseResponse:
+  //   redundant    → comment + close PR (intent already satisfied)
+  //   rebasable    → dispatch Ava merge-assist (textual conflicts only)
+  //   decomposable → comment proposing splits + close PR
+  //   genuine      → escalate HITL with conflict details (semantic conflict)
+
+  private _dispatchDiagnose(pr: PrDomainEntry, parentCorrelationId: string): void {
+    if (!this.bus) return;
+    const prKey = `${pr.repo}#${pr.number}`;
+    const correlationId = crypto.randomUUID();
+
+    // Mark as in-flight before publishing so concurrent world-state ticks
+    // can't race a second diagnose dispatch while we're publishing.
+    this.diagnosisInFlight.set(prKey, correlationId);
+    console.log(
+      `[pr-remediator] dispatching diagnose_pr_stuck for ${prKey} after ${DIAGNOSE_AFTER_ATTEMPTS} update_branch 422 failures`,
+    );
+
+    // Subscribe to the specific response topic before publishing so we
+    // never miss the reply even if the executor completes synchronously.
+    let subId: string;
+    subId = this.bus.subscribe(
+      `agent.skill.response.${correlationId}`,
+      this.name,
+      (msg) => {
+        this.bus?.unsubscribe(subId);
+        this.diagnosisInFlight.delete(prKey);
+        const responsePayload = msg.payload as { text?: string; result?: string; content?: string };
+        const responseText = responsePayload.text ?? responsePayload.result ?? responsePayload.content ?? "";
+        void this._handleDiagnoseResponse(pr, responseText, parentCorrelationId).catch((err) =>
+          console.error(`[pr-remediator] diagnose response handler error for ${prKey}:`, err),
+        );
+      },
+    );
+    this.subscriptionIds.push(subId);
+
+    this.bus.publish("agent.skill.request", {
+      id: crypto.randomUUID(),
+      correlationId,
+      parentId: parentCorrelationId,
+      topic: "agent.skill.request",
+      timestamp: Date.now(),
+      payload: {
+        skill: "diagnose_pr_stuck",
+        content: `Diagnose this stuck PR and return a JSON verdict.
+
+PR: ${pr.repo}#${pr.number} — ${pr.title}
+Author: ${pr.author}
+Base branch: ${pr.baseRef}
+Head SHA: ${pr.headSha}
+Mergeable: ${pr.mergeable}
+CI Status: ${pr.ciStatus}
+Review State: ${pr.reviewState}
+Labels: ${pr.labels.join(", ") || "none"}
+
+This PR has failed GitHub's update-branch API (merge base into head) ${DIAGNOSE_AFTER_ATTEMPTS} times with HTTP 422 (merge conflict).
+
+Analyze the PR and return a JSON object with this exact shape:
+\`\`\`json
+{
+  "verdict": "redundant" | "rebasable" | "decomposable" | "genuine",
+  "evidence": "explanation of your verdict",
+  "conflictingFiles": ["path/to/file1"],
+  "supersededBy": ["commit sha or description, only for redundant verdict"]
+}
+\`\`\`
+
+Verdict definitions:
+- "redundant": The PR's intent is already satisfied by commits on \`${pr.baseRef}\` since the PR was cut.
+- "rebasable": Conflicts are textual but non-semantic (whitespace, import order, doc section shuffle, auto-generated files). A three-way merge can resolve them without losing meaning.
+- "decomposable": Conflicts cluster in a small number of specific files. Splitting into smaller PRs would avoid the conflict.
+- "genuine": Semantic conflicts requiring human judgment — which lines mean what is ambiguous.
+
+Use your GitHub API tools to fetch:
+1. PR files diff: GET /repos/${pr.repo}/pulls/${pr.number}/files
+2. Recent base commits: GET /repos/${pr.repo}/commits?sha=${pr.baseRef}&per_page=20
+
+Return ONLY the JSON block. No other text.`,
+        meta: { agentId: "ava", skillHint: "diagnose_pr_stuck", systemActor: "pr-remediator" },
+        prRepo: pr.repo,
+        prNumber: pr.number,
+      },
+    });
+  }
+
+  private async _handleDiagnoseResponse(
+    pr: PrDomainEntry,
+    responseText: string,
+    parentCorrelationId: string,
+  ): Promise<void> {
+    const prKey = `${pr.repo}#${pr.number}`;
+
+    type DiagnosisResult = {
+      verdict: DiagnosisVerdict;
+      evidence: string;
+      conflictingFiles?: string[];
+      supersededBy?: string[];
+    };
+
+    let diagnosis: DiagnosisResult | null = null;
+
+    // Try to parse JSON from code block first, then bare object
+    const jsonBlockMatch = responseText.match(/```json\s*([\s\S]*?)\s*```/);
+    if (jsonBlockMatch?.[1]) {
+      try {
+        diagnosis = JSON.parse(jsonBlockMatch[1]) as DiagnosisResult;
+      } catch { /* fall through */ }
+    }
+    if (!diagnosis) {
+      const bareMatch = responseText.match(/\{[\s\S]*?"verdict"[\s\S]*?\}/);
+      if (bareMatch) {
+        try {
+          diagnosis = JSON.parse(bareMatch[0]) as DiagnosisResult;
+        } catch { /* fall through */ }
+      }
+    }
+    // Fallback: scan text for verdict keyword
+    if (!diagnosis) {
+      const kw = responseText.match(/\b(redundant|rebasable|decomposable|genuine)\b/i);
+      diagnosis = {
+        verdict: (kw?.[1]?.toLowerCase() ?? "genuine") as DiagnosisVerdict,
+        evidence: responseText.slice(0, 500),
+      };
+    }
+
+    console.log(`[pr-remediator] diagnose verdict for ${prKey}: ${diagnosis.verdict}`);
+
+    switch (diagnosis.verdict) {
+      case "redundant": {
+        const comment = [
+          `**Auto-remediation verdict: redundant** — closing automatically.`,
+          ``,
+          `This PR's intent appears to already be satisfied by recent commits on \`${pr.baseRef}\`.`,
+          ``,
+          `**Evidence:** ${diagnosis.evidence}`,
+          diagnosis.supersededBy?.length
+            ? `**Superseded by:** ${diagnosis.supersededBy.join(", ")}`
+            : "",
+          ``,
+          `If this is incorrect, reopen with a note on what still needs to be done.`,
+          ``,
+          `*Automated verdict by pr-remediator diagnose_pr_stuck skill.*`,
+        ].filter(Boolean).join("\n");
+        const commentResult = await ghComment(pr.repo, pr.number, comment);
+        if (!commentResult.ok) {
+          console.warn(`[pr-remediator] failed to post redundant comment on ${prKey}: ${commentResult.error}`);
+        }
+        const closeResult = await ghClosePr(pr.repo, pr.number);
+        if (closeResult.ok) {
+          console.log(`[pr-remediator] closed ${prKey} as redundant`);
+        } else {
+          console.warn(`[pr-remediator] failed to close ${prKey} as redundant: ${closeResult.error}`);
+        }
+        break;
+      }
+
+      case "rebasable": {
+        const fileList = diagnosis.conflictingFiles?.map((f) => `\`${f}\``).join(", ") ?? "unknown";
+        const content = `PR ${pr.repo}#${pr.number} has a dirty branch. Conflict diagnosis: **rebasable** (textual conflicts only).
+
+Evidence: ${diagnosis.evidence}
+Conflicting files: ${fileList}
+
+You are operating in **fully autonomous mode**. Perform a three-way merge assistance:
+1. Fetch the PR diff: GET /repos/${pr.repo}/pulls/${pr.number}/files
+2. For each conflicting file, resolve conflicts that are textual (whitespace, import order, doc reshuffling, auto-generated content) — do NOT touch semantic code changes
+3. If you can resolve all conflicts cleanly, commit the resolution and push to the PR branch
+4. If any conflict requires semantic judgment, stop and report exactly which hunks need human review
+
+Do NOT ask for confirmation. Act.`;
+        const correlationId = this._dispatchToAva(content, "bug_triage", parentCorrelationId, {
+          prRepo: pr.repo,
+          prNumber: pr.number,
+          diagnosisVerdict: "rebasable",
+        });
+        if (correlationId) {
+          this._recordDispatch(pr.repo, pr.number, "update_branch", correlationId);
+          console.log(`[pr-remediator] dispatched rebase-assist for ${prKey} (correlationId: ${correlationId})`);
+        }
+        break;
+      }
+
+      case "decomposable": {
+        const fileList = diagnosis.conflictingFiles?.length
+          ? diagnosis.conflictingFiles.map((f) => `- \`${f}\``).join("\n")
+          : "See diagnosis evidence above.";
+        const comment = [
+          `**Auto-remediation verdict: decomposable** — closing and proposing a split.`,
+          ``,
+          `This PR has merge conflicts that cluster into distinct file groups. Rather than attempting a complex merge, the recommended path is to split this PR into smaller, focused PRs — one per file cluster.`,
+          ``,
+          `**Conflicting file clusters:**`,
+          fileList,
+          ``,
+          `**Evidence:** ${diagnosis.evidence}`,
+          ``,
+          `Please re-cut this as smaller, focused PRs targeting each cluster independently. This avoids the conflict and makes each change easier to review.`,
+          ``,
+          `*Automated verdict by pr-remediator diagnose_pr_stuck skill.*`,
+        ].join("\n");
+        const commentResult = await ghComment(pr.repo, pr.number, comment);
+        if (!commentResult.ok) {
+          console.warn(`[pr-remediator] failed to post decomposable comment on ${prKey}: ${commentResult.error}`);
+        }
+        const closeResult = await ghClosePr(pr.repo, pr.number);
+        if (closeResult.ok) {
+          console.log(`[pr-remediator] closed ${prKey} as decomposable, proposed split`);
+        } else {
+          console.warn(`[pr-remediator] failed to close ${prKey} as decomposable: ${closeResult.error}`);
+        }
+        break;
+      }
+
+      case "genuine":
+      default: {
+        // Genuine semantic conflict — escalate to HITL immediately with the
+        // specific conflict details from the diagnosis, instead of waiting for
+        // the attempt budget to exhaust naturally.
+        const ubKey = this._inFlightKey(pr.repo, pr.number, "update_branch");
+        const entry = this.inFlight.get(ubKey);
+        if (entry) {
+          entry.exhausted = true;
+          entry.escalated = true;
+        }
+        const effectiveEntry: InFlightEntry = entry ?? {
+          kind: "update_branch",
+          startedAt: Date.now() - DIAGNOSE_AFTER_ATTEMPTS * IN_FLIGHT_TTL_MS,
+          correlationId: parentCorrelationId,
+          attempts: DIAGNOSE_AFTER_ATTEMPTS,
+          exhausted: true,
+          escalated: true,
+        };
+        this._emitStuckHitlEscalation(pr.repo, pr.number, "update_branch", effectiveEntry, diagnosis.evidence);
+        break;
+      }
     }
   }
 

--- a/lib/plugins/worktree-recovery-monitor.ts
+++ b/lib/plugins/worktree-recovery-monitor.ts
@@ -1,0 +1,143 @@
+/**
+ * WorktreeRecoveryMonitorPlugin — tracks dirty-worktree recovery events emitted
+ * by the automaker server on restart.
+ *
+ * When the automaker detects uncommitted work in a per-feature worktree on
+ * restart it either:
+ *   a) commits the WIP to a `recovery/` branch and resumes the feature
+ *      (outcome: `auto_recovered`), or
+ *   b) finds the worktree unrecoverable (merge conflicts / no branch) and
+ *      blocks the feature, escalating to HITL (outcome: `unrecoverable`)
+ *
+ * This plugin collects those events so downstream analysis can cluster
+ * recovery patterns and identify systemic issues.
+ *
+ * Inbound topics:
+ *   worktree.recovered   — published by the automaker after a recovery attempt
+ *
+ * Outbound topics:
+ *   hitl.request.worktree.unrecoverable.{featureId}
+ *     — raised for unrecoverable worktrees so a human can inspect the diff
+ */
+
+import { randomUUID } from "node:crypto";
+import type { Plugin, EventBus, BusMessage, HITLRequest } from "../types.ts";
+import type { WorktreeRecoveredPayload } from "../../src/event-bus/payloads.ts";
+
+/** Rolling window for clustering analysis — last N recovery events per project. */
+const MAX_EVENTS_PER_PROJECT = 50;
+
+interface RecoveryEvent {
+  featureId: string;
+  outcome: WorktreeRecoveredPayload["outcome"];
+  reason: string;
+  recoveryBranch?: string;
+  worktreePath?: string;
+  recordedAt: string;
+}
+
+export class WorktreeRecoveryMonitorPlugin implements Plugin {
+  readonly name = "worktree-recovery-monitor";
+  readonly description =
+    "Tracks dirty-worktree recovery events from the automaker server on restart";
+  readonly capabilities = ["worktree.recovery.tracking"];
+
+  /** projectPath → ordered list of recovery events (newest last). */
+  private readonly history = new Map<string, RecoveryEvent[]>();
+
+  private subscriptionId: string | null = null;
+
+  install(bus: EventBus): void {
+    this.subscriptionId = bus.subscribe(
+      "worktree.recovered",
+      this.name,
+      (msg: BusMessage) => this._handleWorktreeRecovered(msg, bus)
+    );
+    console.log("[WorktreeRecoveryMonitor] installed — listening on worktree.recovered");
+  }
+
+  uninstall(): void {
+    if (this.subscriptionId) {
+      console.log("[WorktreeRecoveryMonitor] uninstalled");
+      this.subscriptionId = null;
+    }
+  }
+
+  /** Expose history for tests and diagnostic tools. */
+  getHistory(projectPath: string): readonly RecoveryEvent[] {
+    return this.history.get(projectPath) ?? [];
+  }
+
+  private _handleWorktreeRecovered(msg: BusMessage, bus: EventBus): void {
+    const payload = msg.payload as WorktreeRecoveredPayload;
+
+    if (!payload?.featureId || !payload?.projectPath || !payload?.outcome) {
+      console.warn("[WorktreeRecoveryMonitor] Received malformed worktree.recovered payload");
+      return;
+    }
+
+    const event: RecoveryEvent = {
+      featureId: payload.featureId,
+      outcome: payload.outcome,
+      reason: payload.reason,
+      recoveryBranch: payload.recoveryBranch,
+      worktreePath: payload.worktreePath,
+      recordedAt: payload.recoveredAt ?? new Date().toISOString(),
+    };
+
+    // Append to project history
+    const projectHistory = this.history.get(payload.projectPath) ?? [];
+    projectHistory.push(event);
+    if (projectHistory.length > MAX_EVENTS_PER_PROJECT) {
+      projectHistory.shift();
+    }
+    this.history.set(payload.projectPath, projectHistory);
+
+    if (payload.outcome === "auto_recovered") {
+      console.log(
+        `[WorktreeRecoveryMonitor] Feature ${payload.featureId} auto-recovered → ${payload.recoveryBranch}`
+      );
+    } else {
+      // unrecoverable — escalate to HITL so a human can inspect the worktree
+      console.warn(
+        `[WorktreeRecoveryMonitor] Feature ${payload.featureId} worktree is unrecoverable — escalating to HITL`
+      );
+      this._escalateHITL(payload, bus);
+    }
+  }
+
+  private _escalateHITL(payload: WorktreeRecoveredPayload, bus: EventBus): void {
+    const correlationId = randomUUID();
+    const replyTopic = `hitl.response.worktree.unrecoverable.${correlationId}`;
+    const topic = `hitl.request.worktree.unrecoverable.${payload.featureId}`;
+
+    const request: HITLRequest = {
+      type: "hitl_request",
+      correlationId,
+      title: `Unrecoverable worktree — feature ${payload.featureId}`,
+      summary:
+        `The automaker server restarted and found an unrecoverable dirty worktree for ` +
+        `feature **${payload.featureId}**.\n\n` +
+        `**Reason:** ${payload.reason}\n\n` +
+        (payload.worktreePath
+          ? `**Worktree path:** \`${payload.worktreePath}\`\n\n`
+          : "") +
+        `Manual inspection and cleanup is required before this feature can be resumed.`,
+      options: ["acknowledge"],
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1_000).toISOString(),
+      replyTopic,
+    };
+
+    bus.publish(topic, {
+      id: randomUUID(),
+      correlationId,
+      topic,
+      timestamp: Date.now(),
+      payload: request,
+    });
+
+    console.log(
+      `[WorktreeRecoveryMonitor] HITL escalation published for feature ${payload.featureId} (correlationId: ${correlationId})`
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "scripts": {
     "start": "bun run src/index.ts",

--- a/src/event-bus/payloads.ts
+++ b/src/event-bus/payloads.ts
@@ -251,6 +251,18 @@ export interface AutonomousOutcomePayload {
   effectDelta?: Record<string, unknown>;
 }
 
+// ── autonomous.confidence.reported ───────────────────────────────────────────
+
+/**
+ * Payload for `autonomous.confidence.reported` — published by the confidence-v1
+ * extension interceptor after each skill execution where the agent attached a
+ * `x-confidence` block to its terminal message.
+ *
+ * OutcomeAnalysis uses this to weight failure signals: a high-confidence bad
+ * outcome is a stronger signal than a low-confidence one.
+ */
+export type { ConfidenceReportedPayload } from "../executor/extensions/confidence.ts";
+
 // ── world.goal.violated ──────────────────────────────────────────────────────
 // Defined in src/types/events.ts — re-exported here for convenience.
 export type { GoalViolatedEventPayload } from "../types/events.ts";

--- a/src/event-bus/payloads.ts
+++ b/src/event-bus/payloads.ts
@@ -180,6 +180,77 @@ export interface CeremonyExecutePayload {
   ceremonyId?: string;
 }
 
+// ── worktree.recovered ───────────────────────────────────────────────────────
+
+/** Classification of a dirty-worktree recovery attempt on automaker restart. */
+export type WorktreeRecoveryOutcome = 'auto_recovered' | 'unrecoverable';
+
+/**
+ * Payload for `worktree.recovered` — published by the automaker server when it
+ * encounters a dirty worktree on restart and attempts self-healing.
+ *
+ * `outcome: 'auto_recovered'` → WIP was committed to a recovery/ branch; the
+ *   feature will be resumed automatically.
+ * `outcome: 'unrecoverable'` → merge conflicts or no branch; HITL intervention
+ *   is required.
+ */
+export interface WorktreeRecoveredPayload {
+  /** Feature ID that owned the dirty worktree. */
+  featureId: string;
+  /** Absolute path to the project root. */
+  projectPath: string;
+  /** Absolute path to the affected worktree (if known). */
+  worktreePath?: string;
+  /** Recovery outcome classification. */
+  outcome: WorktreeRecoveryOutcome;
+  /** Human-readable description of what happened. */
+  reason: string;
+  /** The `recovery/<id>-<ts>` branch where WIP was committed (auto_recovered only). */
+  recoveryBranch?: string;
+  /** ISO 8601 timestamp when the recovery event occurred. */
+  recoveredAt: string;
+}
+
+// ── autonomous.outcome.* ─────────────────────────────────────────────────────
+
+/**
+ * Payload for `autonomous.outcome.{systemActor}.{skill}` — published by
+ * SkillDispatcherPlugin after every task reaches terminal state, whether via
+ * direct executor return or TaskTracker polling.
+ *
+ * Replaces the split between `world.action.outcome` and per-reply-topic
+ * responses so OutcomeAnalysis sees a single unified stream.
+ *
+ * effectDelta is reserved for Arc 4/5 — leave undefined for now.
+ */
+export interface AutonomousOutcomePayload {
+  /** Trace ID propagated from the originating bus message. */
+  correlationId: string;
+  /** Parent span ID — the bus message ID that triggered the skill request. */
+  parentId?: string;
+  /** Autonomous subsystem actor (e.g. "pr-remediator", "sweep") or "user". */
+  systemActor: string;
+  /** Skill name that was executed. */
+  skill: string;
+  /** True if the task completed without error. */
+  success: boolean;
+  /** Final A2A task lifecycle state (completed, failed, canceled, etc.). */
+  taskState?: string;
+  /** First 500 chars of the result text — for quick inspection. */
+  textPreview?: string;
+  /** Token usage reported by the executor. */
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+  /** Wall-clock time from dispatch to terminal state (ms). */
+  durationMs: number;
+  /** World-state delta produced by this task — populated in Arc 4/5. */
+  effectDelta?: Record<string, unknown>;
+}
+
 // ── world.goal.violated ──────────────────────────────────────────────────────
 // Defined in src/types/events.ts — re-exported here for convenience.
 export type { GoalViolatedEventPayload } from "../types/events.ts";

--- a/src/event-bus/topics.ts
+++ b/src/event-bus/topics.ts
@@ -22,6 +22,16 @@ export const TOPICS = {
 
   /** Published by PlannerPluginL0 when escalation to tier_1 is needed. */
   PLANNER_ESCALATE: "world.planner.escalate",
+
+  /** Published by ActionDispatcherPlugin to invoke an agent skill (unified dispatch). */
+  AGENT_SKILL_REQUEST: "agent.skill.request",
+
+  /**
+   * Published by SkillDispatcherPlugin after every task reaches terminal state.
+   * Full topic is `autonomous.outcome.{systemActor}.{skill}`.
+   * Use this prefix to subscribe to all outcomes.
+   */
+  AUTONOMOUS_OUTCOME_PREFIX: "autonomous.outcome",
 } as const;
 
 export type TopicValue = (typeof TOPICS)[keyof typeof TOPICS];

--- a/src/executor/extensions/confidence.ts
+++ b/src/executor/extensions/confidence.ts
@@ -1,0 +1,85 @@
+/**
+ * Confidence v1 extension — registers an interceptor that reads the agent's
+ * self-reported confidence score from the terminal artifact's structured data
+ * and publishes an `autonomous.confidence.reported` event so OutcomeAnalysis
+ * can weight failure signals by confidence.
+ *
+ * A high-confidence bad outcome is a stronger signal that the action needs
+ * attention than a low-confidence one (where the agent itself was uncertain).
+ *
+ * Call `registerConfidenceExtension(bus)` once at startup (e.g. in src/index.ts)
+ * to wire this extension into the defaultExtensionRegistry.
+ *
+ * Extension URI: https://protolabs.ai/a2a/ext/confidence-v1
+ */
+
+import type { EventBus } from "../../../lib/types.ts";
+import {
+  defaultExtensionRegistry,
+  type ExtensionInterceptor,
+  type ExtensionContext,
+} from "../extension-registry.ts";
+
+export const CONFIDENCE_URI = "https://protolabs.ai/a2a/ext/confidence-v1";
+
+/** Confidence score attached by the agent to its terminal message data. */
+export interface AgentConfidence {
+  /** Self-reported confidence in the outcome, in [0.0, 1.0]. */
+  confidence: number;
+  /** Optional human-readable explanation of the confidence score. */
+  explanation?: string;
+}
+
+/** Payload published on `autonomous.confidence.reported` after each skill execution. */
+export interface ConfidenceReportedPayload {
+  /** Trace ID propagated from the originating skill dispatch. */
+  correlationId: string;
+  /** Agent that reported this confidence. */
+  agentName: string;
+  /** Skill that was executed. */
+  skill: string;
+  /** Self-reported confidence in the outcome, in [0.0, 1.0]. */
+  confidence: number;
+  /** Optional human-readable explanation of the confidence score. */
+  explanation?: string;
+}
+
+/**
+ * Creates and registers the confidence interceptor with `defaultExtensionRegistry`.
+ *
+ * Must be called once at startup with a live EventBus reference so the `after`
+ * hook can publish `autonomous.confidence.reported`.
+ */
+export function registerConfidenceExtension(bus: EventBus): void {
+  const interceptor: ExtensionInterceptor = {
+    after(
+      ctx: ExtensionContext,
+      result: { text: string; data?: Record<string, unknown> },
+    ): void {
+      const conf = result.data?.["x-confidence"] as AgentConfidence | undefined;
+      if (!conf || typeof conf.confidence !== "number") return;
+
+      const topic = "autonomous.confidence.reported";
+      bus.publish(topic, {
+        id: crypto.randomUUID(),
+        correlationId: ctx.correlationId,
+        topic,
+        timestamp: Date.now(),
+        payload: {
+          correlationId: ctx.correlationId,
+          agentName: ctx.agentName,
+          skill: ctx.skill,
+          confidence: conf.confidence,
+          explanation: conf.explanation,
+        } satisfies ConfidenceReportedPayload,
+      });
+    },
+  };
+
+  defaultExtensionRegistry.register({
+    uri: CONFIDENCE_URI,
+    interceptor,
+    description:
+      "Confidence v1: reads agent self-reported confidence from terminal message and publishes autonomous.confidence.reported",
+  });
+}

--- a/src/executor/extensions/effect-domain.ts
+++ b/src/executor/extensions/effect-domain.ts
@@ -1,0 +1,97 @@
+/**
+ * Effect-domain v1 extension — registers an interceptor that:
+ *
+ *   before(ctx): stamps the current skill name onto outbound metadata so the
+ *     agent can see which skill is being invoked and confirm the expected effects.
+ *
+ *   after(ctx, result): reads the agent's actual delta from the terminal
+ *     artifact's structured data and publishes a `world.state.delta` event so
+ *     the GOAP planner can update its world-state snapshot without waiting for
+ *     the next full poll.
+ *
+ * Call `registerEffectDomainExtension(bus)` once at startup (e.g. in src/index.ts)
+ * to wire this extension into the defaultExtensionRegistry.
+ *
+ * Extension URI: https://protolabs.ai/a2a/ext/effect-domain-v1
+ */
+
+import type { EventBus } from "../../../lib/types.ts";
+import {
+  defaultExtensionRegistry,
+  type ExtensionInterceptor,
+  type ExtensionContext,
+} from "../extension-registry.ts";
+
+export const EFFECT_DOMAIN_URI = "https://protolabs.ai/a2a/ext/effect-domain-v1";
+
+/** A single world-state mutation declared or observed for a skill execution. */
+export interface EffectDomainDelta {
+  /** Name of the world-state domain (e.g. "ci", "plane"). */
+  domain: string;
+  /** Dot-separated path into the domain's data object (e.g. "data.blockedPRs"). */
+  path: string;
+  /** Signed numeric change applied to the value at `path`. */
+  delta: number;
+  /** Planner weight in [0.0, 1.0]. */
+  confidence: number;
+}
+
+/**
+ * Payload published on `world.state.delta` after each skill execution that
+ * returns effect-domain data.
+ */
+export interface WorldStateDeltaPayload {
+  /** Agent that produced this delta. */
+  source: string;
+  /** Skill that was executed. */
+  skill: string;
+  /** Observed or declared deltas from the terminal artifact. */
+  delta: EffectDomainDelta[];
+}
+
+/**
+ * Creates and registers the effect-domain interceptor with `defaultExtensionRegistry`.
+ *
+ * Must be called once at startup with a live EventBus reference so the `after`
+ * hook can publish `world.state.delta`.
+ */
+export function registerEffectDomainExtension(bus: EventBus): void {
+  const interceptor: ExtensionInterceptor = {
+    before(ctx: ExtensionContext): void {
+      // Stamp the skill name onto outbound metadata so the agent knows which
+      // skill is being invoked and can include effect confirmation in its response.
+      ctx.metadata["x-effect-domain-skill"] = ctx.skill;
+    },
+
+    after(
+      ctx: ExtensionContext,
+      result: { text: string; data?: Record<string, unknown> },
+    ): void {
+      const effectData = result.data?.["x-effect-domain"] as
+        | { delta?: EffectDomainDelta[] }
+        | undefined;
+
+      if (!effectData?.delta?.length) return;
+
+      const topic = "world.state.delta";
+      bus.publish(topic, {
+        id: crypto.randomUUID(),
+        correlationId: ctx.correlationId,
+        topic,
+        timestamp: Date.now(),
+        payload: {
+          source: ctx.agentName,
+          skill: ctx.skill,
+          delta: effectData.delta,
+        } satisfies WorldStateDeltaPayload,
+      });
+    },
+  };
+
+  defaultExtensionRegistry.register({
+    uri: EFFECT_DOMAIN_URI,
+    interceptor,
+    description:
+      "Effect-domain v1: stamps skill name on outbound metadata and publishes world.state.delta after execution",
+  });
+}

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -16,7 +16,7 @@
 import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
 import type { ExecutorRegistry } from "./executor-registry.ts";
 import type { SkillRequest } from "./types.ts";
-import type { AgentSkillRequestPayload, FlowItemPayload } from "../event-bus/payloads.ts";
+import type { AgentSkillRequestPayload, AutonomousOutcomePayload, FlowItemPayload } from "../event-bus/payloads.ts";
 import { GraphitiClient } from "../../lib/memory/graphiti-client.ts";
 import { IdentityRegistry } from "../../lib/identity/identity-registry.ts";
 import type { LoggerPlugin, ConversationTurn } from "../../lib/plugins/logger.ts";
@@ -319,6 +319,18 @@ export class SkillDispatcherPlugin implements Plugin {
           sourceInterface: sourcePlatform,
           sourceChannelId: sourceChannelId,
           sourceUserId: sourceUserId,
+          onTerminal: (content, isError, taskState) => {
+            this._publishAutonomousOutcome({
+              correlationId,
+              parentId,
+              systemActor: systemActor ?? "user",
+              skill,
+              success: !isError,
+              taskState,
+              text: content,
+              durationMs: Date.now() - dispatchedAt,
+            });
+          },
         });
 
         // Try to register a push-notification webhook so the agent can POST
@@ -354,6 +366,17 @@ export class SkillDispatcherPlugin implements Plugin {
           stage: "error",
           meta: { skill, error: result.text },
         });
+        this._publishAutonomousOutcome({
+          correlationId,
+          parentId,
+          systemActor: systemActor ?? "user",
+          skill,
+          success: false,
+          taskState: result.data?.taskState ?? "failed",
+          text: result.text,
+          usage: result.data?.usage,
+          durationMs: Date.now() - dispatchedAt,
+        });
       } else {
         // Log a preview of the response so we can see what the executor actually
         // returned — critical for debugging A2A/agent behaviour when the skill
@@ -365,20 +388,33 @@ export class SkillDispatcherPlugin implements Plugin {
         if (result.data?.stopReason === "max_turns") {
           console.warn("[skill-dispatcher] Agent hit maxTurns limit");
         }
+        const completedAt = Date.now();
+        const durationMs = completedAt - dispatchedAt;
         this._publishFlowEvent("flow.item.completed", {
           id: flowItemId,
           status: "complete",
           stage: "done",
-          completedAt: Date.now(),
+          completedAt,
           meta: {
             skill,
             executorType: executor.type,
-            durationMs: Date.now() - dispatchedAt,
+            durationMs,
             inputTokens: result.data?.usage?.input_tokens,
             outputTokens: result.data?.usage?.output_tokens,
             numTurns: result.data?.numTurns,
             stopReason: result.data?.stopReason,
           },
+        });
+        this._publishAutonomousOutcome({
+          correlationId,
+          parentId,
+          systemActor: systemActor ?? "user",
+          skill,
+          success: true,
+          taskState: result.data?.taskState ?? "completed",
+          text: result.text,
+          usage: result.data?.usage,
+          durationMs,
         });
       }
 
@@ -426,6 +462,16 @@ export class SkillDispatcherPlugin implements Plugin {
         stage: "error",
         meta: { skill, error: errorMsg },
       });
+      this._publishAutonomousOutcome({
+        correlationId,
+        parentId,
+        systemActor: systemActor ?? "user",
+        skill,
+        success: false,
+        taskState: "failed",
+        text: errorMsg,
+        durationMs: Date.now() - dispatchedAt,
+      });
       this._publishResponse(replyTopic, correlationId, undefined, errorMsg);
     } finally {
       this.activeExecutions.delete(correlationId);
@@ -471,6 +517,39 @@ export class SkillDispatcherPlugin implements Plugin {
       },
       source,
       reply: { topic: replyTopic },
+    });
+  }
+
+  private _publishAutonomousOutcome(opts: {
+    correlationId: string;
+    parentId: string | undefined;
+    systemActor: string;
+    skill: string;
+    success: boolean;
+    taskState?: string;
+    text?: string;
+    usage?: AutonomousOutcomePayload["usage"];
+    durationMs: number;
+  }): void {
+    if (!this.bus) return;
+    const topic = `autonomous.outcome.${opts.systemActor}.${opts.skill}`;
+    const payload: AutonomousOutcomePayload = {
+      correlationId: opts.correlationId,
+      parentId: opts.parentId,
+      systemActor: opts.systemActor,
+      skill: opts.skill,
+      success: opts.success,
+      taskState: opts.taskState,
+      textPreview: opts.text ? opts.text.slice(0, 500) : undefined,
+      usage: opts.usage,
+      durationMs: opts.durationMs,
+    };
+    this.bus.publish(topic, {
+      id: crypto.randomUUID(),
+      correlationId: opts.correlationId,
+      topic,
+      timestamp: Date.now(),
+      payload,
     });
   }
 

--- a/src/executor/task-tracker.ts
+++ b/src/executor/task-tracker.ts
@@ -39,6 +39,12 @@ export interface TrackedTask {
   sourceChannelId?: string;
   /** User ID for HITL rendering. */
   sourceUserId?: string;
+  /**
+   * Optional callback invoked when the task reaches terminal state.
+   * Called before publishing the reply-topic response so the outcome
+   * event is always emitted first.
+   */
+  onTerminal?: (content: string | undefined, isError: boolean, taskState: string) => void;
 }
 
 export interface TaskTrackerOptions {
@@ -92,6 +98,8 @@ export class TaskTracker {
     sourceInterface?: string;
     sourceChannelId?: string;
     sourceUserId?: string;
+    /** Invoked when the task reaches terminal state — before the reply-topic response is published. */
+    onTerminal?: (content: string | undefined, isError: boolean, taskState: string) => void;
   }): void {
     const now = Date.now();
     this.tasks.set(params.correlationId, {
@@ -108,6 +116,7 @@ export class TaskTracker {
       sourceInterface: params.sourceInterface,
       sourceChannelId: params.sourceChannelId,
       sourceUserId: params.sourceUserId,
+      onTerminal: params.onTerminal,
     });
     console.log(
       `[task-tracker] Tracking ${params.agentName} task ${params.taskId.slice(0, 8)}… (correlationId: ${params.correlationId.slice(0, 8)}…)`,
@@ -159,7 +168,7 @@ export class TaskTracker {
     const content = artifactText || statusText;
     const isError = state === "failed" || state === "rejected";
 
-    this._publishResponse(task, isError ? undefined : content, isError ? (content || state) : undefined);
+    this._publishResponse(task, isError ? undefined : content, isError ? (content || state) : undefined, state);
     this.tasks.delete(correlationId);
     console.log(
       `[task-tracker] Callback for ${task.taskId.slice(0, 8)}… → terminal state "${state}" (via webhook)`,
@@ -219,7 +228,7 @@ export class TaskTracker {
         }
 
         if (state && TERMINAL_STATES.has(state)) {
-          this._publishResponse(task, result.text, result.isError ? result.text : undefined);
+          this._publishResponse(task, result.text, result.isError ? result.text : undefined, state);
           this.tasks.delete(task.correlationId);
           console.log(
             `[task-tracker] Task ${task.taskId.slice(0, 8)}… reached terminal state "${state}" after ${Math.round((now - task.registeredAt) / 1000)}s`,
@@ -309,7 +318,16 @@ export class TaskTracker {
     }
   }
 
-  private _publishResponse(task: TrackedTask, content: string | undefined, error: string | undefined): void {
+  private _publishResponse(
+    task: TrackedTask,
+    content: string | undefined,
+    error: string | undefined,
+    taskState?: string,
+  ): void {
+    const isError = error !== undefined;
+    const resolvedState = taskState ?? (isError ? "failed" : "completed");
+    task.onTerminal?.(content, isError, resolvedState);
+
     const payload: AgentSkillResponsePayload = {
       content,
       error,

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,10 @@ const contextMailbox = new ContextMailbox();
 import { TaskTracker } from "./executor/task-tracker.ts";
 const taskTracker = new TaskTracker({ bus });
 
+// --- A2A extensions — registered before any executor is installed ---
+import { registerConfidenceExtension } from "./executor/extensions/confidence.ts";
+registerConfidenceExtension(bus);
+
 // --- ChannelRegistry — loaded from workspace/channels.yaml, shared by RouterPlugin + DiscordPlugin ---
 import { ChannelRegistry } from "../lib/channels/channel-registry.js";
 const channelRegistry = new ChannelRegistry(join(workspaceDir, "channels.yaml"));

--- a/src/loaders/ceremonyYamlLoader.ts
+++ b/src/loaders/ceremonyYamlLoader.ts
@@ -150,6 +150,7 @@ export class CeremonyYamlLoader {
       targets: c.targets as string[],
       notifyChannel: typeof c.notifyChannel === "string" ? c.notifyChannel : undefined,
       enabled: c.enabled !== false,
+      timeoutMs: typeof c.timeoutMs === "number" && c.timeoutMs > 0 ? c.timeoutMs : undefined,
     };
   }
 }

--- a/src/planner/types/action.ts
+++ b/src/planner/types/action.ts
@@ -40,8 +40,6 @@ export interface Effect {
 
 /** Routing and execution metadata for an action. */
 export interface ActionMeta {
-  /** EventBus topic to publish when dispatching (omit for internal/free actions). */
-  topic?: string;
   /** Agent ID to route the action to. */
   agentId?: string;
   /** Dispatch timeout in milliseconds. */

--- a/src/plugins/CeremonyPlugin.ts
+++ b/src/plugins/CeremonyPlugin.ts
@@ -27,9 +27,13 @@
  *  10. Deploy default ceremony YAML files on first run
  *
  * Topics published:
- *   ceremony.{id}.execute    — ceremony cron fired
- *   ceremony.{id}.completed  — ceremony run finished
- *   world.state.snapshot     — (via CeremonyStateExtension) ceremony state update
+ *   ceremony.{id}.execute                    — ceremony cron fired
+ *   ceremony.{id}.completed                  — ceremony run finished (kept for back-compat;
+ *                                              subscribe to autonomous.outcome.ceremony.{id}.{skill}
+ *                                              as the canonical unified outcome topic instead)
+ *   autonomous.outcome.ceremony.{id}.{skill} — canonical unified outcome; emitted automatically by
+ *                                              SkillDispatcherPlugin for every terminal task
+ *   world.state.snapshot                     — (via CeremonyStateExtension) ceremony state update
  *
  * Topics subscribed:
  *   ceremony.#               — intercepts completed events for persistence/notification
@@ -48,7 +52,6 @@ import { CeremonyNotifier } from "../integrations/discord/CeremonyNotifier.ts";
 
 const DEBUG = process.env.DEBUG === "1" || process.env.DEBUG === "true";
 const HOT_RELOAD_INTERVAL_MS = 5_000;
-const SKILL_DISPATCH_TIMEOUT_MS = 120_000; // 2 minutes
 
 function debug(...args: unknown[]): void {
   if (DEBUG) console.log("[DEBUG][ceremony]", ...args);
@@ -351,14 +354,10 @@ export class CeremonyPlugin implements Plugin {
       const replyTopic = `agent.skill.response.${context.runId}`;
 
       const skillResult = await new Promise<string | null>((resolve) => {
-        // Set up reply subscription with timeout
-        const timeoutTimer = setTimeout(() => {
-          if (this.bus) this.bus.unsubscribe(subId);
-          resolve(null);
-        }, SKILL_DISPATCH_TIMEOUT_MS);
+        let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
 
         const subId = this.bus!.subscribe(replyTopic, this.name, (msg: BusMessage) => {
-          clearTimeout(timeoutTimer);
+          if (timeoutTimer !== undefined) clearTimeout(timeoutTimer);
           this.bus?.unsubscribe(subId);
           const payload = msg.payload as { result?: string; error?: string };
           if (payload?.error) {
@@ -370,12 +369,21 @@ export class CeremonyPlugin implements Plugin {
           resolve(payload?.result ?? null);
         });
 
+        // Set up per-ceremony timeout only if configured
+        if (ceremony.timeoutMs !== undefined) {
+          timeoutTimer = setTimeout(() => {
+            this.bus?.unsubscribe(subId);
+            resolve(null);
+          }, ceremony.timeoutMs);
+        }
+
         // Publish skill request
         this.bus!.publish(skillRequestTopic, {
           id: crypto.randomUUID(),
           correlationId: context.runId,
           topic: skillRequestTopic,
           timestamp: Date.now(),
+          source: { interface: "cron" },
           payload: {
             skill: ceremony.skill,
             ceremonyId: ceremony.id,
@@ -383,15 +391,16 @@ export class CeremonyPlugin implements Plugin {
             targets: ceremony.targets,
             runId: context.runId,
             projectPaths: context.projectPaths,
+            meta: { systemActor: `ceremony.${ceremony.id}` },
           },
           reply: { topic: replyTopic },
         });
       });
 
-      if (skillResult === null && !error) {
-        // Timeout
+      if (skillResult === null && !error && ceremony.timeoutMs !== undefined) {
+        // Per-ceremony timeout fired
         status = "timeout";
-        error = `Skill dispatch timed out after ${SKILL_DISPATCH_TIMEOUT_MS / 1000}s`;
+        error = `Skill dispatch timed out after ${ceremony.timeoutMs / 1000}s`;
         console.warn(`[ceremony] Skill dispatch timeout for ${ceremony.id} (run ${context.runId})`);
       }
     } catch (err) {
@@ -413,7 +422,10 @@ export class CeremonyPlugin implements Plugin {
       error,
     };
 
-    // Publish completed event
+    // Publish completed event.
+    // NOTE: SkillDispatcherPlugin already emits autonomous.outcome.ceremony.{id}.{skill}
+    // for every terminal task — that is the canonical unified outcome topic. This publish
+    // is retained for back-compat with any subscribers listening on ceremony.{id}.completed.
     const completedTopic = `ceremony.${ceremony.id}.completed`;
     const completedPayload: CeremonyCompletedPayload = {
       type: "ceremony.completed",

--- a/src/plugins/CeremonyPlugin.types.ts
+++ b/src/plugins/CeremonyPlugin.types.ts
@@ -20,6 +20,8 @@ export interface Ceremony {
   notifyChannel?: string;
   /** Whether this ceremony is active */
   enabled: boolean;
+  /** Optional per-ceremony timeout in milliseconds. Defaults to no timeout. */
+  timeoutMs?: number;
 }
 
 export interface CeremonyRunContext {

--- a/src/plugins/action-dispatcher-plugin.test.ts
+++ b/src/plugins/action-dispatcher-plugin.test.ts
@@ -19,7 +19,10 @@ const makeAction = (overrides: Partial<Action> = {}): Action => ({
   name: "Test Action",
   description: "Test",
   goalId: "test-goal",
-  tier: "tier_0",
+  // tier_1 by default — exercises the skill-dispatch path. Tier_0 actions
+  // are declarative world-state-only and short-circuit to success; tests that
+  // need that path override explicitly.
+  tier: "tier_1",
   preconditions: [],
   effects: [],
   cost: 0,
@@ -60,7 +63,7 @@ describe("ActionDispatcherPlugin", () => {
       outcomes.push(msg.payload as ActionOutcomePayload);
     });
 
-    const action = makeAction({ tier: "tier_0" });
+    const action = makeAction({ tier: "tier_0", meta: { fireAndForget: true } });
     bus.publish(TOPICS.WORLD_ACTION_DISPATCH, makeDispatchMsg(action));
 
     // Allow microtasks to process
@@ -77,6 +80,7 @@ describe("ActionDispatcherPlugin", () => {
 
     const action = makeAction({
       effects: [{ path: "planner.auto_mode_running", operation: "set", value: true }],
+      meta: { fireAndForget: true },
     });
 
     bus.publish(TOPICS.WORLD_ACTION_DISPATCH, makeDispatchMsg(action));
@@ -96,11 +100,11 @@ describe("ActionDispatcherPlugin", () => {
       queueFullEvents.push(msg.payload as ActionQueueFullPayload);
     });
 
-    // Dispatch 3 actions with a topic (so they stay in-flight)
+    // Dispatch 3 actions without fireAndForget (so they stay in-flight waiting for agent.skill.response.*)
     for (let i = 0; i < 3; i++) {
       const action = makeAction({
         id: `action-${i}`,
-        meta: { topic: "agent.execute", timeout: 30_000 },
+        meta: { timeout: 30_000 },
       });
       bus.publish(TOPICS.WORLD_ACTION_DISPATCH, makeDispatchMsg(action, `corr-${i}`));
     }
@@ -112,13 +116,83 @@ describe("ActionDispatcherPlugin", () => {
   });
 
   test("records outcome in tracker", async () => {
-    const action = makeAction();
+    const action = makeAction({ meta: { fireAndForget: true } });
     bus.publish(TOPICS.WORLD_ACTION_DISPATCH, makeDispatchMsg(action));
     await new Promise((r) => setTimeout(r, 10));
 
     const summary = dispatcher.getOutcomes().summary();
     expect(summary.total).toBe(1);
     expect(summary.success).toBe(1);
+  });
+
+  test("publishes to agent.skill.request with cron source and goap systemActor", async () => {
+    const skillRequests: BusMessage[] = [];
+    bus.subscribe("agent.skill.request", "test", (msg) => {
+      skillRequests.push(msg);
+    });
+
+    const action = makeAction({
+      id: "skill-action",
+      meta: { skillHint: "my_skill", timeout: 30_000 },
+    });
+    bus.publish(TOPICS.WORLD_ACTION_DISPATCH, makeDispatchMsg(action, "corr-skill"));
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(skillRequests).toHaveLength(1);
+    const req = skillRequests[0];
+    expect(req.source).toEqual({ interface: "cron" });
+    expect(req.reply?.topic).toBe("agent.skill.response.corr-skill");
+    const payload = req.payload as Record<string, unknown>;
+    expect(payload.skill).toBe("my_skill");
+    expect((payload.meta as Record<string, unknown>).systemActor).toBe("goap");
+  });
+
+  test("uses action.id as skill when skillHint is absent", async () => {
+    const skillRequests: BusMessage[] = [];
+    bus.subscribe("agent.skill.request", "test", (msg) => {
+      skillRequests.push(msg);
+    });
+
+    const action = makeAction({
+      id: "fallback-action",
+      meta: { timeout: 30_000 },
+    });
+    bus.publish(TOPICS.WORLD_ACTION_DISPATCH, makeDispatchMsg(action, "corr-fallback"));
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(skillRequests).toHaveLength(1);
+    const payload = skillRequests[0].payload as Record<string, unknown>;
+    expect(payload.skill).toBe("fallback-action");
+  });
+
+  test("completes action when agent.skill.response.* is received", async () => {
+    const outcomes: import("../event-bus/action-events.ts").ActionOutcomePayload[] = [];
+    bus.subscribe(TOPICS.WORLD_ACTION_OUTCOME, "test", (msg) => {
+      outcomes.push(msg.payload as import("../event-bus/action-events.ts").ActionOutcomePayload);
+    });
+
+    const action = makeAction({
+      id: "response-action",
+      meta: { skillHint: "my_skill", timeout: 5_000 },
+    });
+    bus.publish(TOPICS.WORLD_ACTION_DISPATCH, makeDispatchMsg(action, "corr-resp"));
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Simulate skill response
+    bus.publish("agent.skill.response.corr-resp", {
+      id: crypto.randomUUID(),
+      correlationId: "corr-resp",
+      topic: "agent.skill.response.corr-resp",
+      timestamp: Date.now(),
+      payload: { correlationId: "corr-resp", content: "done" },
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0].success).toBe(true);
+    expect(outcomes[0].actionId).toBe("response-action");
   });
 
   test("updates world state on world.state.updated", () => {

--- a/src/plugins/action-dispatcher-plugin.ts
+++ b/src/plugins/action-dispatcher-plugin.ts
@@ -3,19 +3,20 @@
  * optimistic state updates.
  *
  * Subscribes to: world.action.dispatch
- * Publishes:     world.action.outcome, world.action.queue_full
+ * Publishes:     agent.skill.request, world.action.outcome, world.action.queue_full
  *
  * On receiving a dispatch event:
  *   1. Checks WIP limit; if at capacity, queues action and publishes queue_full
  *   2. Applies optimistic state effects via StateUpdater
- *   3. If action has meta.topic, publishes to that topic and waits for outcome
- *   4. For free/internal (tier_0, no meta.topic) actions: resolves immediately as success
- *   5. Publishes world.action.outcome with result
+ *   3. Publishes to agent.skill.request with source.interface='cron',
+ *      payload.meta.systemActor='goap', and reply.topic=`agent.skill.response.${correlationId}`
+ *   4. Publishes world.action.outcome with result
  *   6. On failure: triggers rollback via StateRollbackRegistry
  */
 
 import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
 import type { ActionDispatchPayload, ActionOutcomePayload, ActionQueueFullPayload } from "../event-bus/action-events.ts";
+import type { AgentSkillResponsePayload } from "../event-bus/payloads.ts";
 import type { WorldState } from "../../lib/types/world-state.ts";
 import { TOPICS } from "../event-bus/topics.ts";
 import { DispatchQueue } from "../dispatcher/dispatch-queue.ts";
@@ -161,33 +162,38 @@ export class ActionDispatcherPlugin implements Plugin {
     }
 
     try {
-      // For tier_0 / no-topic actions: resolve immediately as success
-      if (!action.meta.topic) {
+      // Tier-0 actions are declarative world-state-only effects that don't require a
+      // skill call — their effects were already applied above. Resolve immediately as
+      // success without a dispatch. (Arc 1.4 removed the meta.topic indirection which
+      // used to gate this; the tier check preserves the original semantics.)
+      if (action.tier === "tier_0") {
         await this.completeAction(action, correlationId, parentCorrelationId, startedAt, true);
         return;
       }
 
-      // For fire-and-forget actions: publish to topic then immediately succeed.
+      // For fire-and-forget actions: publish to agent.skill.request then immediately succeed.
       // Use meta.fireAndForget for alerts, ceremony triggers, and other side-effect-only dispatches.
       if (action.meta.fireAndForget) {
-        this.bus.publish(action.meta.topic, {
+        this.bus.publish(TOPICS.AGENT_SKILL_REQUEST, {
           id: crypto.randomUUID(),
           correlationId,
           parentId: parentMsgId,
-          topic: action.meta.topic,
+          topic: TOPICS.AGENT_SKILL_REQUEST,
           timestamp: Date.now(),
+          source: { interface: "cron" },
           payload: {
-            actionId: action.id,
+            skill: action.meta.skillHint ?? action.id,
             goalId: action.goalId,
-            meta: action.meta,
+            meta: { ...action.meta, systemActor: "goap" },
           },
         });
         await this.completeAction(action, correlationId, parentCorrelationId, startedAt, true);
         return;
       }
 
-      // For actions with a dispatch topic, publish and wait for outcome via timeout
+      // For actions with a dispatch topic, publish to agent.skill.request and wait for skill response
       const timeoutMs = action.meta.timeout ?? this.config.defaultTimeoutMs ?? 30_000;
+      const replyTopic = `agent.skill.response.${correlationId}`;
 
       await new Promise<void>((resolve) => {
         // Set up timeout
@@ -204,27 +210,28 @@ export class ActionDispatcherPlugin implements Plugin {
         }, timeoutMs);
         this.pendingTimeouts.set(correlationId, timer);
 
-        // Publish to action's target topic
-        this.bus.publish(action.meta.topic!, {
+        // Publish to unified skill dispatch topic
+        this.bus.publish(TOPICS.AGENT_SKILL_REQUEST, {
           id: crypto.randomUUID(),
           correlationId,
           parentId: parentMsgId,
-          topic: action.meta.topic!,
+          topic: TOPICS.AGENT_SKILL_REQUEST,
           timestamp: Date.now(),
+          source: { interface: "cron" },
+          reply: { topic: replyTopic },
           payload: {
-            actionId: action.id,
+            skill: action.meta.skillHint ?? action.id,
             goalId: action.goalId,
-            meta: action.meta,
+            meta: { ...action.meta, systemActor: "goap" },
           },
         });
 
-        // Subscribe to outcome for this specific correlationId
-        const outcomeSubId = this.bus.subscribe(
-          TOPICS.WORLD_ACTION_OUTCOME,
+        // Subscribe to skill response for this specific correlationId
+        const responseSubId = this.bus.subscribe(
+          replyTopic,
           this.name + ".await." + correlationId,
-          (outcomeMsg: BusMessage) => {
-            const outcome = outcomeMsg.payload as ActionOutcomePayload;
-            if (outcome.correlationId !== correlationId) return;
+          (responseMsg: BusMessage) => {
+            const response = responseMsg.payload as AgentSkillResponsePayload;
 
             // Cancel timeout
             const t = this.pendingTimeouts.get(correlationId);
@@ -232,15 +239,15 @@ export class ActionDispatcherPlugin implements Plugin {
               clearTimeout(t);
               this.pendingTimeouts.delete(correlationId);
             }
-            this.bus.unsubscribe(outcomeSubId);
+            this.bus.unsubscribe(responseSubId);
 
             void this.completeAction(
               action,
               correlationId,
               parentCorrelationId,
               startedAt,
-              outcome.success,
-              outcome.error
+              !response.error,
+              response.error
             ).then(resolve);
           }
         );

--- a/src/plugins/outcome-analysis-plugin.ts
+++ b/src/plugins/outcome-analysis-plugin.ts
@@ -30,6 +30,12 @@ interface ActionStats {
   success: number;
   failure: number;
   timeout: number;
+  /**
+   * Confidence-weighted failure score. Each failure contributes its agent-reported
+   * confidence (in [0.0, 1.0]) — or 1.0 if unknown — so high-confidence bad
+   * outcomes weigh more heavily than uncertain ones.
+   */
+  weightedFailures: number;
   lastEvaluatedAt: number;
   alertedAt?: number;
 }
@@ -58,6 +64,8 @@ export class OutcomeAnalysisPlugin implements Plugin {
   private readonly subscriptionIds: string[] = [];
   private readonly actionStats = new Map<string, ActionStats>();
   private readonly hitlStats = new Map<string, HitlStats>();
+  /** Short-term cache of agent-reported confidence scores keyed by correlationId. */
+  private readonly confidenceCache = new Map<string, number>();
   private analysisTimer?: ReturnType<typeof setInterval>;
 
   install(bus: EventBus): void {
@@ -68,6 +76,9 @@ export class OutcomeAnalysisPlugin implements Plugin {
     );
     this.subscriptionIds.push(
       bus.subscribe("hitl.escalation", this.name, (msg) => this._onHitlEscalation(msg)),
+    );
+    this.subscriptionIds.push(
+      bus.subscribe("autonomous.confidence.reported", this.name, (msg) => this._onConfidence(msg)),
     );
 
     this.analysisTimer = setInterval(() => this._runAnalysis(), ANALYSIS_INTERVAL_MS);
@@ -85,6 +96,14 @@ export class OutcomeAnalysisPlugin implements Plugin {
     this.bus = undefined;
   }
 
+  private _onConfidence(msg: BusMessage): void {
+    const p = msg.payload as Record<string, unknown> | undefined;
+    const correlationId = typeof p?.correlationId === "string" ? p.correlationId : undefined;
+    const confidence = typeof p?.confidence === "number" ? p.confidence : undefined;
+    if (!correlationId || confidence === undefined) return;
+    this.confidenceCache.set(correlationId, confidence);
+  }
+
   private _onOutcome(msg: BusMessage): void {
     const p = msg.payload as Record<string, unknown> | undefined;
     const actionId = typeof p?.actionId === "string" ? p.actionId : undefined;
@@ -93,6 +112,7 @@ export class OutcomeAnalysisPlugin implements Plugin {
     const success = p?.success === true;
     const error = typeof p?.error === "string" ? p.error : undefined;
     const isTimeout = error?.toLowerCase().includes("timeout") ?? false;
+    const correlationId = typeof p?.correlationId === "string" ? p.correlationId : undefined;
 
     const stats = this.actionStats.get(actionId) ?? {
       actionId,
@@ -100,16 +120,32 @@ export class OutcomeAnalysisPlugin implements Plugin {
       success: 0,
       failure: 0,
       timeout: 0,
+      weightedFailures: 0,
       lastEvaluatedAt: 0,
     };
 
     stats.total += 1;
-    if (success) stats.success += 1;
-    else if (isTimeout) stats.timeout += 1;
-    else stats.failure += 1;
+    if (success) {
+      stats.success += 1;
+    } else {
+      // Timeouts and plain failures both contribute to weighted failures.
+      // Use reported confidence if available, otherwise 1.0 (worst-case weight
+      // preserves existing behavior for agents without the confidence extension).
+      const reportedConfidence = correlationId ? this.confidenceCache.get(correlationId) : undefined;
+      const confidence: number = reportedConfidence ?? 1.0;
+      if (isTimeout) {
+        stats.timeout += 1;
+      } else {
+        stats.failure += 1;
+      }
+      stats.weightedFailures += confidence;
+    }
     stats.lastEvaluatedAt = Date.now();
 
     this.actionStats.set(actionId, stats);
+
+    // Evict used correlationId from the cache to keep it bounded.
+    if (correlationId) this.confidenceCache.delete(correlationId);
   }
 
   private _onHitlEscalation(msg: BusMessage): void {
@@ -131,9 +167,13 @@ export class OutcomeAnalysisPlugin implements Plugin {
   }
 
   /** Per-action success rate snapshot, sorted worst-first. Exposed for /api. */
-  getActionStats(): Array<ActionStats & { successRate: number }> {
+  getActionStats(): Array<ActionStats & { successRate: number; weightedFailureRate: number }> {
     return Array.from(this.actionStats.values())
-      .map(s => ({ ...s, successRate: s.total > 0 ? s.success / s.total : 0 }))
+      .map(s => ({
+        ...s,
+        successRate: s.total > 0 ? s.success / s.total : 0,
+        weightedFailureRate: s.total > 0 ? s.weightedFailures / s.total : 0,
+      }))
       .sort((a, b) => a.successRate - b.successRate);
   }
 
@@ -147,11 +187,17 @@ export class OutcomeAnalysisPlugin implements Plugin {
     if (!this.bus) return;
     const now = Date.now();
 
-    // Detect chronically-failing actions
+    // Detect chronically-failing actions.
+    // Alert threshold uses the confidence-weighted failure rate so that
+    // high-confidence bad outcomes trigger alerts sooner than uncertain ones.
     for (const stats of this.actionStats.values()) {
       if (stats.total < MIN_ATTEMPTS_BEFORE_ALERT) continue;
-      const rate = stats.success / stats.total;
-      if (rate >= POOR_SUCCESS_THRESHOLD) continue;
+      const successRate = stats.success / stats.total;
+      const weightedFailureRate = stats.weightedFailures / stats.total;
+      // Alert when either the raw success rate is poor OR the weighted failure
+      // rate is high (a few high-confidence failures can tip this threshold even
+      // if the raw count looks borderline).
+      if (successRate >= POOR_SUCCESS_THRESHOLD && weightedFailureRate < POOR_SUCCESS_THRESHOLD) continue;
 
       // Cooldown between repeat alerts for the same action
       if (stats.alertedAt && now - stats.alertedAt < ALERT_COOLDOWN_MS) continue;
@@ -164,15 +210,16 @@ export class OutcomeAnalysisPlugin implements Plugin {
         timestamp: now,
         payload: {
           actionId: stats.actionId,
-          successRate: rate,
+          successRate,
+          weightedFailureRate,
           total: stats.total,
           success: stats.success,
           failure: stats.failure,
           timeout: stats.timeout,
-          recommendation: `Action "${stats.actionId}" succeeded ${stats.success}/${stats.total} times (${(rate * 100).toFixed(0)}%). Consider rewriting preconditions, replacing the skill, or filing a feature to build a better capability.`,
+          recommendation: `Action "${stats.actionId}" succeeded ${stats.success}/${stats.total} times (${(successRate * 100).toFixed(0)}%, weighted failure rate ${(weightedFailureRate * 100).toFixed(0)}%). Consider rewriting preconditions, replacing the skill, or filing a feature to build a better capability.`,
         },
       });
-      console.warn(`[outcome-analysis] chronic failure: ${stats.actionId} ${(rate * 100).toFixed(0)}% over ${stats.total} attempts`);
+      console.warn(`[outcome-analysis] chronic failure: ${stats.actionId} ${(successRate * 100).toFixed(0)}% success, ${(weightedFailureRate * 100).toFixed(0)}% weighted failure over ${stats.total} attempts`);
     }
 
     // Detect HITL escalation patterns (feature-request signals)

--- a/src/pr-remediator.test.ts
+++ b/src/pr-remediator.test.ts
@@ -557,6 +557,27 @@ describe("PrRemediatorPlugin — world state tracking", () => {
       plugin.uninstall();
     });
 
+    test("update_branch is blocked while diagnose_pr_stuck is in-flight", async () => {
+      const bus = new InMemoryEventBus();
+      const plugin = new PrRemediatorPlugin();
+      plugin.install(bus);
+
+      pushWorldState(bus, [makePr({ number: 42, mergeable: "dirty", readyToMerge: false })]);
+
+      // Manually mark a diagnosis as in-flight for this PR
+      const diagnosisInFlight = (plugin as unknown as { diagnosisInFlight: Map<string, string> }).diagnosisInFlight;
+      diagnosisInFlight.set("acme/app#42", "fake-diagnosis-cid");
+
+      // The world-state poller fires update_branch — should be blocked
+      const skillCaptured = captureOn(bus, "agent.skill.request");
+      dispatch(bus, "pr.remediate.update_branch");
+      await flushMicrotasks();
+      // No agent.skill.request dispatched because diagnosis is blocking retries
+      expect(skillCaptured.length).toBe(0);
+
+      plugin.uninstall();
+    });
+
     test("address_feedback is guarded independently from fix_ci on the same PR", async () => {
       const bus = new InMemoryEventBus();
       const plugin = new PrRemediatorPlugin();
@@ -589,5 +610,190 @@ describe("PrRemediatorPlugin — world state tracking", () => {
 
       plugin.uninstall();
     });
+  });
+});
+
+// ── diagnose_pr_stuck ─────────────────────────────────────────────────────────
+//
+// Tests exercise the private API via `as unknown as` casting — same pattern as
+// the loop-protection tests that manipulate the inFlight map directly.
+
+describe("PrRemediatorPlugin — diagnose_pr_stuck", () => {
+  type PluginPrivate = {
+    _dispatchDiagnose(pr: PrEntry, correlationId: string): void;
+    diagnosisInFlight: Map<string, string>;
+  };
+
+  function privateOf(plugin: PrRemediatorPlugin): PluginPrivate {
+    return plugin as unknown as PluginPrivate;
+  }
+
+  test("_dispatchDiagnose publishes diagnose_pr_stuck skill request targeting Ava", async () => {
+    const bus = new InMemoryEventBus();
+    const plugin = new PrRemediatorPlugin();
+    plugin.install(bus);
+
+    const skillCaptured = captureOn(bus, "agent.skill.request");
+    const pr = makePr({ number: 55, mergeable: "dirty", readyToMerge: false });
+
+    privateOf(plugin)._dispatchDiagnose(pr, crypto.randomUUID());
+    await flushMicrotasks();
+
+    expect(skillCaptured.length).toBe(1);
+    const p = skillCaptured[0]!.payload as {
+      skill: string;
+      meta: { agentId: string; skillHint: string; systemActor: string };
+      content: string;
+    };
+    expect(p.skill).toBe("diagnose_pr_stuck");
+    expect(p.meta.agentId).toBe("ava");
+    expect(p.meta.skillHint).toBe("diagnose_pr_stuck");
+    expect(p.meta.systemActor).toBe("pr-remediator");
+    expect(p.content).toContain("#55");
+    expect(p.content).toContain("acme/app");
+
+    plugin.uninstall();
+  });
+
+  test("diagnosisInFlight is set while dispatch is in-flight and cleared after response", async () => {
+    const bus = new InMemoryEventBus();
+    const plugin = new PrRemediatorPlugin();
+    plugin.install(bus);
+
+    pushWorldState(bus, [makePr({ number: 88, mergeable: "dirty", readyToMerge: false })]);
+
+    const skillCaptured = captureOn(bus, "agent.skill.request");
+    const pr = makePr({ number: 88, mergeable: "dirty", readyToMerge: false });
+
+    privateOf(plugin)._dispatchDiagnose(pr, crypto.randomUUID());
+    await flushMicrotasks();
+
+    // While diagnosis is running, the entry should be present
+    expect(privateOf(plugin).diagnosisInFlight.has("acme/app#88")).toBe(true);
+
+    // Publish a response to clear it
+    const cid = skillCaptured[0]!.correlationId;
+    bus.publish(`agent.skill.response.${cid}`, {
+      id: crypto.randomUUID(),
+      correlationId: cid,
+      topic: `agent.skill.response.${cid}`,
+      timestamp: Date.now(),
+      payload: { text: '{"verdict":"genuine","evidence":"semantic conflict"}' },
+    });
+    await flushMicrotasks();
+
+    // After response, diagnosisInFlight must be cleared
+    expect(privateOf(plugin).diagnosisInFlight.has("acme/app#88")).toBe(false);
+
+    plugin.uninstall();
+  });
+
+  test("genuine verdict escalates to HITL with conflict details in summary", async () => {
+    const bus = new InMemoryEventBus();
+    const plugin = new PrRemediatorPlugin();
+    plugin.install(bus);
+
+    pushWorldState(bus, [makePr({ number: 55, mergeable: "dirty", readyToMerge: false })]);
+
+    const hitlCaptured = captureOn(bus, "hitl.request.pr.remediation_stuck.#");
+    const skillCaptured = captureOn(bus, "agent.skill.request");
+
+    const pr = makePr({ number: 55, mergeable: "dirty", readyToMerge: false });
+    privateOf(plugin)._dispatchDiagnose(pr, crypto.randomUUID());
+    await flushMicrotasks();
+
+    const cid = skillCaptured[0]!.correlationId;
+    bus.publish(`agent.skill.response.${cid}`, {
+      id: crypto.randomUUID(),
+      correlationId: cid,
+      topic: `agent.skill.response.${cid}`,
+      timestamp: Date.now(),
+      payload: {
+        text: '```json\n{"verdict":"genuine","evidence":"conflicting logic in src/auth.ts cannot be auto-resolved","conflictingFiles":["src/auth.ts"]}\n```',
+      },
+    });
+    await flushMicrotasks();
+
+    expect(hitlCaptured.length).toBeGreaterThan(0);
+    const req = hitlCaptured[0]!.payload as HITLRequest;
+    expect(req.type).toBe("hitl_request");
+    expect(req.title).toContain("#55");
+    expect(req.title).toContain("update_branch");
+    expect(req.summary).toContain("genuine");
+    expect(req.summary).toContain("conflicting logic in src/auth.ts");
+    expect(req.sourceMeta?.interface).toBe("discord");
+
+    plugin.uninstall();
+  });
+
+  test("rebasable verdict dispatches merge-assist via bug_triage to protomaker", async () => {
+    const bus = new InMemoryEventBus();
+    const plugin = new PrRemediatorPlugin();
+    plugin.install(bus);
+
+    pushWorldState(bus, [makePr({ number: 77, mergeable: "dirty", readyToMerge: false })]);
+
+    const skillCaptured = captureOn(bus, "agent.skill.request");
+    const pr = makePr({ number: 77, mergeable: "dirty", readyToMerge: false });
+
+    privateOf(plugin)._dispatchDiagnose(pr, crypto.randomUUID());
+    await flushMicrotasks();
+
+    const cid = skillCaptured[0]!.correlationId;
+    bus.publish(`agent.skill.response.${cid}`, {
+      id: crypto.randomUUID(),
+      correlationId: cid,
+      topic: `agent.skill.response.${cid}`,
+      timestamp: Date.now(),
+      payload: {
+        text: '```json\n{"verdict":"rebasable","evidence":"conflicts in docs/ are whitespace-only","conflictingFiles":["docs/api.md"]}\n```',
+      },
+    });
+    await flushMicrotasks();
+
+    // 1 diagnose dispatch + 1 merge-assist dispatch
+    expect(skillCaptured.length).toBe(2);
+    const mergeAssist = skillCaptured[1]!.payload as {
+      skill: string;
+      content: string;
+      meta: { agentId: string };
+    };
+    expect(mergeAssist.skill).toBe("bug_triage");
+    expect(mergeAssist.meta.agentId).toBe("protomaker");
+    expect(mergeAssist.content).toContain("rebasable");
+    expect(mergeAssist.content).toContain("#77");
+    expect(mergeAssist.content).toContain("three-way merge");
+
+    plugin.uninstall();
+  });
+
+  test("unknown/malformed response defaults to genuine verdict (HITL escalation)", async () => {
+    const bus = new InMemoryEventBus();
+    const plugin = new PrRemediatorPlugin();
+    plugin.install(bus);
+
+    pushWorldState(bus, [makePr({ number: 63, mergeable: "dirty", readyToMerge: false })]);
+
+    const hitlCaptured = captureOn(bus, "hitl.request.pr.remediation_stuck.#");
+    const skillCaptured = captureOn(bus, "agent.skill.request");
+
+    const pr = makePr({ number: 63, mergeable: "dirty", readyToMerge: false });
+    privateOf(plugin)._dispatchDiagnose(pr, crypto.randomUUID());
+    await flushMicrotasks();
+
+    const cid = skillCaptured[0]!.correlationId;
+    bus.publish(`agent.skill.response.${cid}`, {
+      id: crypto.randomUUID(),
+      correlationId: cid,
+      topic: `agent.skill.response.${cid}`,
+      timestamp: Date.now(),
+      payload: { text: "I could not determine the verdict for this PR." },
+    });
+    await flushMicrotasks();
+
+    // Malformed response falls back to genuine → HITL
+    expect(hitlCaptured.length).toBeGreaterThan(0);
+
+    plugin.uninstall();
   });
 });

--- a/src/schemas/yaml-schemas.ts
+++ b/src/schemas/yaml-schemas.ts
@@ -136,7 +136,6 @@ export const EffectSchema = z.object({
 });
 
 export const ActionMetaSchema = z.object({
-  topic: z.string().optional(),
   agentId: z.string().optional(),
   timeout: z.number().optional(),
   context: z.record(z.unknown()).optional(),

--- a/test/integration/planner-dispatcher-flow.test.ts
+++ b/test/integration/planner-dispatcher-flow.test.ts
@@ -141,13 +141,15 @@ describe("Planner → Dispatcher integration flow", () => {
     const smallOrchestrator = new PlanningOrchestrator({ dispatcher: { wipLimit: 1 } });
     smallOrchestrator.install(bus);
 
-    // Register 3 actions that will all match but dispatch to a topic (in-flight)
+    // tier_1 actions dispatch to agent.skill.request and stay in-flight until
+    // a response arrives — which here never does, so they accumulate against WIP.
     for (let i = 0; i < 3; i++) {
       smallOrchestrator.getRegistry().register(
         makeAction({
           id: `action-${i}`,
           goalId: `goal-${i}`,
-          meta: { topic: `agent.task.${i}`, timeout: 30_000 },
+          tier: "tier_1",
+          meta: { timeout: 30_000 },
         })
       );
     }

--- a/workspace/actions.yaml
+++ b/workspace/actions.yaml
@@ -20,7 +20,6 @@ actions:
         value: 0.35
     effects: []
     meta:
-      topic: "message.outbound.discord.alert"
       fireAndForget: true
 
   # alert.distribution_drift — REMOVED alongside flow.distribution_balanced goal
@@ -40,7 +39,6 @@ actions:
         value: 0
     effects: []
     meta:
-      topic: "message.outbound.discord.alert"
       fireAndForget: true
 
   - id: ceremony.security_triage
@@ -58,7 +56,6 @@ actions:
         value: 0
     effects: []
     meta:
-      topic: "ceremony.security-triage.execute"
       fireAndForget: true
 
   - id: alert.discord_disconnected
@@ -79,7 +76,6 @@ actions:
         value: true
     effects: []
     meta:
-      topic: "message.outbound.discord.alert"
       fireAndForget: true
 
   - id: alert.no_agents
@@ -97,7 +93,6 @@ actions:
         value: 1
     effects: []
     meta:
-      topic: "message.outbound.discord.alert"
       fireAndForget: true
 
   # ── Service + Agent Ceremonies ─────────────────────────────────────
@@ -120,7 +115,6 @@ actions:
         value: false
     effects: []
     meta:
-      topic: "ceremony.service-health.execute"
       fireAndForget: true
 
   # ── CI + PR Pipeline ─────────────────────────────────────────────
@@ -140,7 +134,24 @@ actions:
         value: 0.70
     effects: []
     meta:
-      topic: "message.outbound.discord.alert"
+      fireAndForget: true
+
+  - id: ci.debug_failures
+    goalId: ci.success_rate_healthy
+    tier: tier_0
+    priority: 20
+    cost: 1
+    name: "Dispatch agent to investigate CI failures across projects"
+    preconditions:
+      - path: "extensions.ci_available"
+        operator: eq
+        value: true
+      - path: "domains.ci.data.successRate"
+        operator: lt
+        value: 0.70
+    effects: []
+    meta:
+      skillHint: debug_ci_failures
       fireAndForget: true
 
   # alert.pr_conflicts was retired in favour of action.pr_update_branch below.
@@ -167,7 +178,6 @@ actions:
         value: 0
     effects: []
     meta:
-      topic: "pr.remediate.update_branch"
       fireAndForget: true
 
   - id: alert.pr_stale
@@ -185,7 +195,6 @@ actions:
         value: 0
     effects: []
     meta:
-      topic: "message.outbound.discord.alert"
       fireAndForget: true
 
   # ── PR Remediation — closes the loop via PrRemediatorPlugin ───────────────
@@ -205,7 +214,6 @@ actions:
         value: 0
     effects: []
     meta:
-      topic: "pr.remediate.merge_ready"
       fireAndForget: true
 
   - id: action.pr_fix_ci
@@ -223,7 +231,6 @@ actions:
         value: 0
     effects: []
     meta:
-      topic: "pr.remediate.fix_ci"
       fireAndForget: true
 
   - id: action.pr_address_feedback
@@ -241,7 +248,6 @@ actions:
         value: 0
     effects: []
     meta:
-      topic: "pr.remediate.address_feedback"
       fireAndForget: true
 
   - id: alert.branch_drift
@@ -259,7 +265,6 @@ actions:
         value: 30
     effects: []
     meta:
-      topic: "message.outbound.discord.alert"
       fireAndForget: true
 
   # ── protoMaker team (multi-agent board runtime) ──────────────────
@@ -279,7 +284,6 @@ actions:
         value: 3
     effects: []
     meta:
-      topic: "message.outbound.discord.alert"
       fireAndForget: true
 
   - id: action.protomaker_triage_blocked
@@ -297,7 +301,6 @@ actions:
         value: 3
     effects: []
     meta:
-      topic: "agent.skill.request"
       skillHint: board_health
       agentId: protomaker
       fireAndForget: true
@@ -317,7 +320,6 @@ actions:
         value: 10
     effects: []
     meta:
-      topic: "message.outbound.discord.alert"
       fireAndForget: true
 
   - id: action.protomaker_start_auto_mode
@@ -341,7 +343,6 @@ actions:
         value: 0
     effects: []
     meta:
-      topic: "agent.skill.request"
       skillHint: auto_mode
       agentId: protomaker
       fireAndForget: true
@@ -360,7 +361,6 @@ actions:
         value: 0
     effects: []
     meta:
-      topic: "message.outbound.discord.alert"
       fireAndForget: true
 
   - id: alert.branch_unprotected
@@ -375,7 +375,6 @@ actions:
         value: 0
     effects: []
     meta:
-      topic: "message.outbound.discord.alert"
       fireAndForget: true
 
   - id: alert.ci_main_red
@@ -390,7 +389,6 @@ actions:
         value: 0
     effects: []
     meta:
-      topic: "message.outbound.discord.alert"
       fireAndForget: true
 
   # ── Branch drift remediation ──────────────────────────────────────
@@ -413,7 +411,6 @@ actions:
         value: 30
     effects: []
     meta:
-      topic: "pr.backmerge.dispatch"
       fireAndForget: true
 
   # ── Plane board health ────────────────────────────────────────────
@@ -430,7 +427,6 @@ actions:
         value: 5
     effects: []
     meta:
-      topic: "message.outbound.discord.alert"
       fireAndForget: true
 
   - id: alert.plane_stale_backlog
@@ -445,7 +441,6 @@ actions:
         value: 10
     effects: []
     meta:
-      topic: "message.outbound.discord.alert"
       fireAndForget: true
 
   - id: alert.plane_unassigned_piling
@@ -460,7 +455,6 @@ actions:
         value: 20
     effects: []
     meta:
-      topic: "message.outbound.discord.alert"
       fireAndForget: true
 
   # ── Memory / Graphiti health ──────────────────────────────────────
@@ -477,7 +471,6 @@ actions:
         value: 0
     effects: []
     meta:
-      topic: "message.outbound.discord.alert"
       fireAndForget: true
 
   - id: alert.memory_search_broken
@@ -492,7 +485,6 @@ actions:
         value: 0
     effects: []
     meta:
-      topic: "message.outbound.discord.alert"
       fireAndForget: true
 
   # ── HITL routing health ───────────────────────────────────────────
@@ -514,5 +506,4 @@ actions:
         value: 0
     effects: []
     meta:
-      topic: "message.outbound.discord.alert"
       fireAndForget: true

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -117,3 +117,31 @@ skills:
   - name: chat
     description: Operational helm — system health, agent delegation, board management, issue filing, schedule control. The user's single control interface.
     keywords: []
+
+  - name: diagnose_pr_stuck
+    description: Diagnose a stuck PR with merge conflicts and return a structured verdict (redundant, rebasable, decomposable, genuine) with evidence to drive autonomous recovery.
+    keywords: [diagnose, conflict, stuck, merge, rebase, pr, dirty]
+    systemPromptOverride: |
+      You are a PR conflict diagnostician. Analyze the given PR and return ONLY a JSON verdict.
+
+      The four verdicts:
+      - "redundant": PR intent already satisfied by commits on the base branch since the PR was cut. Evidence: find base commits implementing the same change.
+      - "rebasable": Conflicts are textual but non-semantic — whitespace, import order, doc section shuffle, auto-generated files. A three-way merge can resolve them without losing semantic meaning.
+      - "decomposable": Conflicts cluster in a small number of specific files. Splitting the PR into smaller, focused PRs would avoid the conflict entirely.
+      - "genuine": Semantic conflicts requiring human judgment — which lines are correct is ambiguous and cannot be resolved mechanically.
+
+      Respond with ONLY this JSON structure (inside a json code block):
+      ```json
+      {
+        "verdict": "redundant" | "rebasable" | "decomposable" | "genuine",
+        "evidence": "brief explanation of your verdict (1-3 sentences)",
+        "conflictingFiles": ["path/to/file1", "path/to/file2"],
+        "supersededBy": ["commit sha or description — only for redundant verdict"]
+      }
+      ```
+
+      Use your tools to fetch the PR diff and recent base commits before deciding:
+      - PR files: the content field includes the specific files and their diff
+      - Use get_world_state or chat_with_agent(Quinn) to check recent base activity if needed
+
+      No preamble. No explanation outside the JSON block. Only the ```json block.


### PR DESCRIPTION
## Summary

**Arc 6: Cost, confidence, blast extensions** (epic: Unified A2A + GOAP)

Agent can attach a confidence score `{ confidence: 0.72, explanation: '...' }` to its terminal message. OutcomeAnalysis weights failure signals by confidence — a high-confidence bad outcome is worse than a low-confidence one.

---
*Recovered automatically by Automaker post-agent hook*