### PR TITLE
chore(release): bump to v0.7.2

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean-dashboard",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "type": "module",
   "scripts": {
     "start": "bun run src/index.ts",


### PR DESCRIPTION
Version bump for v0.7.2 — Effect-driven planning (Arcs 4.3-4.5, partial) + worldstate deltas (Arc 5.1-5.2) + HITL TTL (Arc 7.1) live on dev. Promote to main follows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.7.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->