### PR TITLE
feat: TOPICS constants for all bus topics — eliminate inline strings

### DIFF
--- a/src/event-bus/all-topics.ts
+++ b/src/event-bus/all-topics.ts
@@ -1,0 +1,73 @@
+/**
+ * Canonical bus topic constants, grouped by domain.
+ *
+ * All bus topic strings live here. Import from `src/event-bus/topics.ts`
+ * (the TOPICS barrel) in application code.
+ */
+
+export const MESSAGE_TOPICS = {
+  /** Wildcard subscription pattern — matches all inbound surface messages. */
+  MESSAGE_INBOUND_ALL: "message.inbound.#",
+
+  /** Prefix for GitHub inbound messages (used with startsWith). */
+  MESSAGE_INBOUND_GITHUB_PREFIX: "message.inbound.github.",
+
+  /** Outbound Discord alert channel. */
+  MESSAGE_OUTBOUND_DISCORD_ALERT: "message.outbound.discord.alert",
+
+  /** Base outbound Signal topic (append .{recipient} for DM, .cron for scheduled). */
+  MESSAGE_OUTBOUND_SIGNAL: "message.outbound.signal",
+} as const;
+
+export const ACTION_TOPICS = {
+  /** Published to invoke an agent skill (unified dispatch). */
+  AGENT_SKILL_REQUEST: "agent.skill.request",
+
+  /** Wildcard subscription pattern — matches all cron events from SchedulerPlugin. */
+  CRON_ALL: "cron.#",
+} as const;
+
+export const SECURITY_TOPICS = {
+  /** Published when a security incident is detected. */
+  SECURITY_INCIDENT_REPORTED: "security.incident.reported",
+} as const;
+
+export const FLOW_TOPICS = {
+  /** Published when a budget cost discrepancy is detected. */
+  FLOW_ALERT_BUDGET: "ops.alert.budget",
+
+  /** Published by OutcomeAnalysisPlugin when an action has chronic failures. */
+  FLOW_ALERT_ACTION_QUALITY: "ops.alert.action_quality",
+
+  /** Published by OutcomeAnalysisPlugin when repeated HITL escalations are detected. */
+  FLOW_ALERT_HITL_ESCALATION: "ops.alert.hitl_escalation",
+} as const;
+
+export const WORLD_TOPICS = {
+  /** Published by WorldStateCollector when a new snapshot is available. */
+  WORLD_STATE_UPDATED: "world.state.updated",
+
+  /** Published by ActionDispatcherPlugin when an action is dispatched. */
+  WORLD_ACTION_DISPATCH: "world.action.dispatch",
+
+  /** Published by ActionDispatcherPlugin when an action outcome is recorded. */
+  WORLD_ACTION_OUTCOME: "world.action.outcome",
+
+  /** Published by LoopDetector when oscillation threshold is breached. */
+  WORLD_ACTION_OSCILLATION: "world.action.oscillation",
+
+  /** Published by ActionDispatcherPlugin when WIP queue is at capacity. */
+  WORLD_ACTION_QUEUE_FULL: "world.action.queue_full",
+
+  /** Published by PlannerPluginL0 when escalation to tier_1 is needed. */
+  PLANNER_ESCALATE: "world.planner.escalate",
+
+  /** Published when a world goal violation is detected. */
+  WORLD_GOAL_VIOLATED: "world.goal.violated",
+
+  /**
+   * Published by SkillDispatcherPlugin after every task reaches terminal state.
+   * Full topic is `autonomous.outcome.{systemActor}.{skill}`.
+   */
+  AUTONOMOUS_OUTCOME_PREFIX: "autonomous.outcome",
+} as const;

--- a/src/event-bus/topics.ts
+++ b/src/event-bus/topics.ts
@@ -1,37 +1,34 @@
 /**
- * EventBus topic constants for the deterministic planner system.
+ * TOPICS — single barrel re-export of all bus topic constants.
+ *
+ * All domain groups are also exported individually for consumers that prefer
+ * a scoped import (e.g. `import { WORLD_TOPICS } from "./topics.ts"`).
  *
  * Convention: world.action.* for planner-related events.
  */
 
+export {
+  MESSAGE_TOPICS,
+  ACTION_TOPICS,
+  SECURITY_TOPICS,
+  FLOW_TOPICS,
+  WORLD_TOPICS,
+} from "./all-topics.ts";
+
+import {
+  MESSAGE_TOPICS,
+  ACTION_TOPICS,
+  SECURITY_TOPICS,
+  FLOW_TOPICS,
+  WORLD_TOPICS,
+} from "./all-topics.ts";
+
 export const TOPICS = {
-  /** Published by WorldStateCollector when a new snapshot is available. */
-  WORLD_STATE_UPDATED: "world.state.updated",
-
-  /** Published by ActionDispatcherPlugin when an action is dispatched. */
-  WORLD_ACTION_DISPATCH: "world.action.dispatch",
-
-  /** Published by ActionDispatcherPlugin when an action outcome is recorded. */
-  WORLD_ACTION_OUTCOME: "world.action.outcome",
-
-  /** Published by LoopDetector when oscillation threshold is breached. */
-  WORLD_ACTION_OSCILLATION: "world.action.oscillation",
-
-  /** Published by ActionDispatcherPlugin when WIP queue is at capacity. */
-  WORLD_ACTION_QUEUE_FULL: "world.action.queue_full",
-
-  /** Published by PlannerPluginL0 when escalation to tier_1 is needed. */
-  PLANNER_ESCALATE: "world.planner.escalate",
-
-  /** Published by ActionDispatcherPlugin to invoke an agent skill (unified dispatch). */
-  AGENT_SKILL_REQUEST: "agent.skill.request",
-
-  /**
-   * Published by SkillDispatcherPlugin after every task reaches terminal state.
-   * Full topic is `autonomous.outcome.{systemActor}.{skill}`.
-   * Use this prefix to subscribe to all outcomes.
-   */
-  AUTONOMOUS_OUTCOME_PREFIX: "autonomous.outcome",
+  ...MESSAGE_TOPICS,
+  ...ACTION_TOPICS,
+  ...SECURITY_TOPICS,
+  ...FLOW_TOPICS,
+  ...WORLD_TOPICS,
 } as const;
 
 export type TopicValue = (typeof TOPICS)[keyof typeof TOPICS];

--- a/src/index.ts
+++ b/src/index.ts
@@ -434,53 +434,53 @@ const allPlugins = [...corePlugins, ...registeredPlugins, ...workspacePlugins];
 // ops.alert.budget and world.action.queue_full are published but had no consumers.
 // Forward both to message.outbound.discord.alert so they surface to operators.
 
-bus.subscribe("ops.alert.budget", "alert-bridge", (msg) => {
+bus.subscribe(TOPICS.FLOW_ALERT_BUDGET, "alert-bridge", (msg) => {
   const p = (msg.payload ?? {}) as Record<string, unknown>;
   const text = p.type === "cost_discrepancy"
     ? `Budget alert — cost discrepancy on request \`${p.requestId}\``
     : `Budget alert — ${String(p.type ?? "unknown")}: ${String(p.report ?? "")}`;
-  bus.publish("message.outbound.discord.alert", {
+  bus.publish(TOPICS.MESSAGE_OUTBOUND_DISCORD_ALERT, {
     id: crypto.randomUUID(),
     correlationId: msg.correlationId,
-    topic: "message.outbound.discord.alert",
+    topic: TOPICS.MESSAGE_OUTBOUND_DISCORD_ALERT,
     timestamp: Date.now(),
     payload: { text, level: "warn", source: "budget" },
   });
 });
 
-bus.subscribe("world.action.queue_full", "alert-bridge", (msg) => {
+bus.subscribe(TOPICS.WORLD_ACTION_QUEUE_FULL, "alert-bridge", (msg) => {
   const p = (msg.payload ?? {}) as Record<string, unknown>;
   const text = `Action queue full — WIP ${p.wipCount}/${p.wipLimit}, pending: \`${p.pendingActionId}\``;
-  bus.publish("message.outbound.discord.alert", {
+  bus.publish(TOPICS.MESSAGE_OUTBOUND_DISCORD_ALERT, {
     id: crypto.randomUUID(),
     correlationId: msg.correlationId,
-    topic: "message.outbound.discord.alert",
+    topic: TOPICS.MESSAGE_OUTBOUND_DISCORD_ALERT,
     timestamp: Date.now(),
     payload: { text, level: "warn", source: "action-dispatcher" },
   });
 });
 
 // Outcome analysis alerts — chronic failures and repeated HITL escalations
-bus.subscribe("ops.alert.action_quality", "alert-bridge", (msg) => {
+bus.subscribe(TOPICS.FLOW_ALERT_ACTION_QUALITY, "alert-bridge", (msg) => {
   const p = (msg.payload ?? {}) as Record<string, unknown>;
   const rate = typeof p.successRate === "number" ? (p.successRate * 100).toFixed(0) : "?";
   const text = `🔻 Action quality alert — \`${p.actionId}\` success rate ${rate}% (${p.success}/${p.total}). ${p.recommendation ?? ""}`;
-  bus.publish("message.outbound.discord.alert", {
+  bus.publish(TOPICS.MESSAGE_OUTBOUND_DISCORD_ALERT, {
     id: crypto.randomUUID(),
     correlationId: msg.correlationId,
-    topic: "message.outbound.discord.alert",
+    topic: TOPICS.MESSAGE_OUTBOUND_DISCORD_ALERT,
     timestamp: Date.now(),
     payload: { text, level: "warn", source: "outcome-analysis" },
   });
 });
 
-bus.subscribe("ops.alert.hitl_escalation", "alert-bridge", (msg) => {
+bus.subscribe(TOPICS.FLOW_ALERT_HITL_ESCALATION, "alert-bridge", (msg) => {
   const p = (msg.payload ?? {}) as Record<string, unknown>;
   const text = `🔧 Feature-request signal — \`${p.kind}\` escalated to HITL ${p.count}× for \`${p.target}\`. ${p.recommendation ?? ""}`;
-  bus.publish("message.outbound.discord.alert", {
+  bus.publish(TOPICS.MESSAGE_OUTBOUND_DISCORD_ALERT, {
     id: crypto.randomUUID(),
     correlationId: msg.correlationId,
-    topic: "message.outbound.discord.alert",
+    topic: TOPICS.MESSAGE_OUTBOUND_DISCORD_ALERT,
     timestamp: Date.now(),
     payload: { text, level: "warn", source: "outcome-analysis" },
   });
@@ -503,6 +503,7 @@ const API_KEY = process.env.WORKSTACEAN_API_KEY;
 // ── API routes (modular) ──────────────────────────────────────────────────────
 import { createAllRoutes, matchPath } from "./api/index.ts";
 import type { ApiContext } from "./api/index.ts";
+import { TOPICS } from "./event-bus/topics.ts";
 
 const apiContext: ApiContext = {
   workspaceDir,

--- a/src/integrations/langfuse_logger.ts
+++ b/src/integrations/langfuse_logger.ts
@@ -1,5 +1,6 @@
 import type { GoalViolation } from "../types/goals.ts";
 import { HttpClient } from "../services/http-client.ts";
+import { TOPICS } from "../event-bus/topics.ts";
 
 interface LangfuseConfig {
   publicKey: string;
@@ -47,7 +48,7 @@ export class LangfuseLogger {
       id: crypto.randomUUID(),
       type: "event",
       timestamp: new Date(violation.timestamp).toISOString(),
-      name: "world.goal.violated",
+      name: TOPICS.WORLD_GOAL_VIOLATED,
       metadata: {
         goalId: violation.goalId,
         goalType: violation.goalType,
@@ -83,7 +84,7 @@ export class LangfuseLogger {
       id: crypto.randomUUID(),
       type: "event",
       timestamp: new Date(violation.timestamp).toISOString(),
-      name: "world.goal.violated",
+      name: TOPICS.WORLD_GOAL_VIOLATED,
       metadata: {
         goalId: violation.goalId,
         goalType: violation.goalType,

--- a/src/router/project-enricher.ts
+++ b/src/router/project-enricher.ts
@@ -11,6 +11,7 @@
 import { readFileSync, existsSync } from "node:fs";
 import { parse as parseYaml } from "yaml";
 import type { BusMessage } from "../../lib/types.ts";
+import { TOPICS } from "../event-bus/topics.ts";
 
 interface ProjectDiscordChannels {
   general?: string;
@@ -100,7 +101,7 @@ export class ProjectEnricher {
     if (payload.projectSlug !== undefined) return null;
 
     // Only enrich GitHub inbound messages
-    if (!msg.topic.startsWith("message.inbound.github.")) return null;
+    if (!msg.topic.startsWith(TOPICS.MESSAGE_INBOUND_GITHUB_PREFIX)) return null;
 
     const github = payload.github as Record<string, unknown> | undefined;
     const owner = github?.owner as string | undefined;

--- a/src/router/router-plugin.ts
+++ b/src/router/router-plugin.ts
@@ -38,6 +38,7 @@ import { FIRE_AND_FORGET_SKILLS } from "./faf-skills.ts";
 import { loadAgentDefinitions } from "../agent-runtime/agent-definition-loader.ts";
 import type { ChannelRegistry } from "../../lib/channels/channel-registry.ts";
 import { TTLCache } from "../../lib/ttl-cache.ts";
+import { TOPICS } from "../event-bus/topics.ts";
 
 export interface RouterConfig {
   workspaceDir: string;
@@ -115,14 +116,14 @@ export class RouterPlugin implements Plugin {
 
     // Subscribe to inbound messages from all surfaces
     this.subscriptionIds.push(
-      bus.subscribe("message.inbound.#", this.name, (msg) => {
+      bus.subscribe(TOPICS.MESSAGE_INBOUND_ALL, this.name, (msg) => {
         void this._handleInbound(msg);
       }),
     );
 
     // Subscribe to cron events from SchedulerPlugin
     this.subscriptionIds.push(
-      bus.subscribe("cron.#", this.name, (msg) => {
+      bus.subscribe(TOPICS.CRON_ALL, this.name, (msg) => {
         void this._handleCron(msg);
       }),
     );
@@ -264,7 +265,7 @@ export class RouterPlugin implements Plugin {
       id: crypto.randomUUID(),
       correlationId: workingMsg.correlationId,
       parentId: workingMsg.id,
-      topic: "agent.skill.request",
+      topic: TOPICS.AGENT_SKILL_REQUEST,
       timestamp: Date.now(),
       payload: {
         // Forward enriched payload fields (includes projectSlug if enriched)
@@ -281,7 +282,7 @@ export class RouterPlugin implements Plugin {
       source: workingMsg.source,
     };
 
-    this.bus.publish("agent.skill.request", skillRequest);
+    this.bus.publish(TOPICS.AGENT_SKILL_REQUEST, skillRequest);
   }
 
   private async _handleCron(msg: BusMessage): Promise<void> {
@@ -313,7 +314,7 @@ export class RouterPlugin implements Plugin {
       id: crypto.randomUUID(),
       correlationId: msg.correlationId,
       parentId: msg.id,
-      topic: "agent.skill.request",
+      topic: TOPICS.AGENT_SKILL_REQUEST,
       timestamp: Date.now(),
       payload: {
         ...payload,
@@ -327,6 +328,6 @@ export class RouterPlugin implements Plugin {
       source: msg.source ?? { interface: "cron" },
     };
 
-    this.bus.publish("agent.skill.request", skillRequest);
+    this.bus.publish(TOPICS.AGENT_SKILL_REQUEST, skillRequest);
   }
 }


### PR DESCRIPTION
## Summary

Bus topic strings are hardcoded in 6 files instead of using `TOPICS.*` constants. Breaks refactoring safety — renaming a topic requires grepping.

Files with inline topic strings:
- src/router/router-plugin.ts (x2)
- src/router/project-enricher.ts
- src/index.ts (x2): security.incident.reported, message.outbound.discord.alert
- src/integrations/langfuse_logger.ts

Create `src/event-bus/all-topics.ts`:
- Export all topics as const assertions
- Group by domain: MESSAGE_TOPICS, ACTION_TOPICS, SECUR...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-14T17:35:41.319Z -->