### PR TITLE
refactor: decompose lib/plugins/discord.ts (1259 lines) into focused modules

### DIFF
--- a/lib/plugins/discord.ts
+++ b/lib/plugins/discord.ts
@@ -1,272 +1,31 @@
 /**
- * DiscordPlugin — bridges Discord gateway events to/from the Workstacean bus.
- *
- * Inbound:
- *   @mentions, DMs → message.inbound.discord.{channelId}
- *   📋 reactions   → message.inbound.discord.{channelId}  (skill hint: bug_triage)
- *   slash commands → message.inbound.discord.slash.{interactionId}
- *
- * Outbound:
- *   message.outbound.discord.#  → reply to originating message/interaction
- *   message.outbound.discord.push.{channelId} → unprompted post (cron, etc.)
- *
- * Config: workspace/discord.yaml (channels, moderation, commands)
- *
- * Env vars:
- *   DISCORD_BOT_TOKEN       (required)
- *   DISCORD_GUILD_ID        (required for slash command registration)
- *   DISCORD_DIGEST_CHANNEL  fallback channel ID for cron-triggered posts
+ * DiscordPlugin — plugin shell that wires all Discord submodules together.
+ * See lib/plugins/discord/ for module details.
  */
 
-import { readFileSync, existsSync, watchFile, unwatchFile, mkdirSync, readdirSync } from "node:fs";
-import type { ChannelRegistry } from "../channels/channel-registry.ts";
+import { watchFile, unwatchFile, existsSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { parse as parseYaml } from "yaml";
-import { Database } from "bun:sqlite";
-import {
-  Client,
-  GatewayIntentBits,
-  Partials,
-  Events,
-  EmbedBuilder,
-  ActionRowBuilder,
-  ButtonBuilder,
-  ButtonStyle,
-  type Message,
-  type ChatInputCommandInteraction,
-  type TextChannel,
-} from "discord.js";
-import type { EventBus, BusMessage, Plugin, HITLRequest } from "../types.ts";
+import { Events, type TextChannel } from "discord.js";
+import type { EventBus, Plugin } from "../types.ts";
+import type { ChannelRegistry } from "../channels/channel-registry.ts";
 import type { HITLPlugin } from "./hitl.ts";
-import { ConversationManager } from "../conversation/conversation-manager.ts";
-import { ConversationTracer, type TurnData } from "../conversation/conversation-tracer.ts";
-import { GraphitiClient } from "../memory/graphiti-client.ts";
-import { IdentityRegistry } from "../identity/identity-registry.ts";
-import { channelIdOf, type ProjectDiscordChannel } from "../project-schema.ts";
-import { DmAccumulator, type AccumulatorEntry } from "../dm/dm-accumulator.ts";
 import type { ContextMailbox } from "../dm/context-mailbox.ts";
+import { ConversationManager } from "../conversation/conversation-manager.ts";
+import { ConversationTracer } from "../conversation/conversation-tracer.ts";
+import { IdentityRegistry } from "../identity/identity-registry.ts";
 
-// ── Config types ──────────────────────────────────────────────────────────────
+import { loadConfig, createMainClient, buildContext, type DiscordContext } from "./discord/core.ts";
+import { compileSpamPatterns, openRateLimitDb } from "./discord/rate-limit.ts";
+import { warmDmChannels } from "./discord/dm-warming.ts";
+import { initAgentPool, reloadAgentPool } from "./discord/agent-pool.ts";
+import { registerInboundHandlers, handleDM, setupDmAccumulator } from "./discord/inbound.ts";
+import { registerSlashCommandHandlers, registerSlashCommands } from "./discord/slash-commands.ts";
+import { registerOutboundHandlers } from "./discord/outbound.ts";
 
-interface CommandOption {
-  name: string;
-  description: string;
-  type: "string" | "integer" | "boolean";
-  required?: boolean;
-  /** When true, Discord sends autocomplete interactions for this option. */
-  autocomplete?: boolean;
-}
+// Re-export for API routes (discord operations agent)
+export { pendingReplies, canSendProgress } from "./discord/outbound.ts";
 
-interface Subcommand {
-  name: string;
-  description: string;
-  content: string;
-  skillHint?: string;
-  options?: CommandOption[];
-}
-
-interface CommandConfig {
-  name: string;
-  description: string;
-  /** Subcommand-based commands (mutually exclusive with top-level `options`). */
-  subcommands?: Subcommand[];
-  /** Top-level options for flat commands (no subcommands). */
-  options?: CommandOption[];
-  /** Content template for flat commands — supports {optionName} placeholders. */
-  content?: string;
-  skillHint?: string;
-}
-
-interface DiscordConfig {
-  channels: {
-    digest?: string;
-    welcome?: string;
-    modLog?: string;
-  };
-  moderation: {
-    rateLimit: {
-      maxMessages: number;
-      windowSeconds: number;
-    };
-    spamPatterns: string[];
-  };
-  commands: CommandConfig[];
-  admins?: string[];
-}
-
-function loadConfig(workspaceDir: string): DiscordConfig {
-  const configPath = join(workspaceDir, "discord.yaml");
-  if (!existsSync(configPath)) {
-    console.log("[discord] No discord.yaml found — using defaults");
-    return {
-      channels: {},
-      moderation: {
-        rateLimit: { maxMessages: 5, windowSeconds: 10 },
-        spamPatterns: [],
-      },
-      commands: [],
-    };
-  }
-  return parseYaml(readFileSync(configPath, "utf8")) as DiscordConfig;
-}
-
-// ── Discord option type codes ─────────────────────────────────────────────────
-
-const OPTION_TYPE_CODES: Record<string, number> = {
-  string: 3,
-  integer: 4,
-  boolean: 5,
-};
-
-// ── Spam pattern compilation ──────────────────────────────────────────────────
-
-/**
- * Compile spam pattern strings to RegExp objects.
- * Invalid or catastrophically-backtracking patterns are skipped with a warning
- * rather than crashing the plugin.
- */
-function compileSpamPatterns(patterns: string[]): RegExp[] {
-  return patterns.flatMap(p => {
-    try {
-      // Basic ReDoS guard: reject patterns with nested quantifiers like (a+)+
-      if (/(\([^)]*[+*][^)]*\))[+*?]/.test(p)) {
-        console.warn(`[discord] Skipping potentially unsafe spam pattern (nested quantifiers): "${p}"`);
-        return [];
-      }
-      return [new RegExp(p, "i")];
-    } catch (err) {
-      console.warn(`[discord] Skipping invalid spam pattern "${p}":`, err);
-      return [];
-    }
-  });
-}
-
-// ── Pending reply handles ─────────────────────────────────────────────────────
-// Kept outside the bus payload so the SQLite logger never tries to serialize them.
-
-export const pendingReplies = new Map<
-  string,
-  { message?: Message; interaction?: ChatInputCommandInteraction }
->();
-
-// Progress update throttle — rate limits agent send_update calls per conversation.
-// Keyed by correlationId → timestamp of last update. Min interval: 5s.
-const progressLastSent = new Map<string, number>();
-const PROGRESS_MIN_INTERVAL_MS = 5_000;
-
-export function canSendProgress(correlationId: string): boolean {
-  const last = progressLastSent.get(correlationId) ?? 0;
-  if (Date.now() - last < PROGRESS_MIN_INTERVAL_MS) return false;
-  progressLastSent.set(correlationId, Date.now());
-  return true;
-}
-
-function makeId(): string {
-  return crypto.randomUUID();
-}
-
-// ── Agent client pool types ──────────────────────────────────────────────────
-
-interface AgentPoolEntry {
-  name: string;
-  discordBotTokenEnvKey?: string;
-}
-
-interface AgentsYaml {
-  agents: AgentPoolEntry[];
-}
-
-function loadAgentPoolDefs(workspaceDir: string): AgentPoolEntry[] {
-  const seen = new Map<string, AgentPoolEntry>();
-
-  // 1. A2A registry — workspace/agents.yaml (external agents)
-  const agentsPath = join(workspaceDir, "agents.yaml");
-  if (existsSync(agentsPath)) {
-    try {
-      const raw = readFileSync(agentsPath, "utf8");
-      const parsed = parseYaml(raw) as AgentsYaml;
-      for (const entry of parsed.agents ?? []) {
-        if (entry?.name) seen.set(entry.name, entry);
-      }
-    } catch (err) {
-      console.error("[discord] Failed to parse agents.yaml:", err);
-    }
-  }
-
-  // 2. In-process agents — workspace/agents/*.yaml (runtime agents loaded
-  //    by AgentRuntimePlugin). Each can also declare discordBotTokenEnvKey
-  //    so the agent pool spins up a dedicated Client for it — without
-  //    this second scan, in-process agents can never get their own
-  //    Discord bot identity.
-  const agentsDir = join(workspaceDir, "agents");
-  if (existsSync(agentsDir)) {
-    try {
-      for (const file of readdirSync(agentsDir)) {
-        if (!(file.endsWith(".yaml") || file.endsWith(".yml"))) continue;
-        if (file.endsWith(".example") || file.endsWith(".retired")) continue;
-        const filePath = join(agentsDir, file);
-        try {
-          const parsed = parseYaml(readFileSync(filePath, "utf8")) as {
-            name?: string;
-            discordBotTokenEnvKey?: string;
-          };
-          if (parsed?.name && typeof parsed.discordBotTokenEnvKey === "string") {
-            // First source wins — A2A registry takes precedence so external
-            // agents with a Discord surface aren't silently overridden by
-            // an in-process agent of the same name.
-            if (!seen.has(parsed.name)) {
-              seen.set(parsed.name, {
-                name: parsed.name,
-                discordBotTokenEnvKey: parsed.discordBotTokenEnvKey,
-              });
-            }
-          }
-        } catch (err) {
-          console.error(`[discord] Failed to parse agent file ${file}:`, err);
-        }
-      }
-    } catch (err) {
-      console.error("[discord] Failed to enumerate workspace/agents/:", err);
-    }
-  }
-
-  return Array.from(seen.values());
-}
-
-// ── Projects loader (for autocomplete + project resolution) ───────────────────
-
-interface ProjectEntry {
-  slug: string;
-  title: string;
-  github?: string;
-  status?: string;
-  discord?: {
-    general?: ProjectDiscordChannel;
-    updates?: ProjectDiscordChannel;
-    dev?: ProjectDiscordChannel;
-  };
-}
-
-interface ProjectsYaml {
-  projects: ProjectEntry[];
-}
-
-function loadProjectsDefs(workspaceDir: string): ProjectEntry[] {
-  const projectsPath = join(workspaceDir, "projects.yaml");
-  if (!existsSync(projectsPath)) return [];
-  try {
-    const raw = readFileSync(projectsPath, "utf8");
-    const parsed = parseYaml(raw) as ProjectsYaml;
-    return (parsed.projects ?? []).filter(
-      p => p.status !== "archived" && p.status !== "suspended"
-    );
-  } catch (err) {
-    console.error("[discord] Failed to parse projects.yaml:", err);
-    return [];
-  }
-}
-
-// ── Plugin ────────────────────────────────────────────────────────────────────
+// ── Plugin options ────────────────────────────────────────────────────────────
 
 export interface DiscordPluginOptions {
   workspaceDir: string;
@@ -278,51 +37,26 @@ export interface DiscordPluginOptions {
   isExecutionActive?: (correlationId: string) => boolean;
 }
 
+// ── Plugin ────────────────────────────────────────────────────────────────────
+
 export class DiscordPlugin implements Plugin {
   readonly name = "discord";
   readonly description = "Discord gateway — routes messages to/from the A2A agent fleet";
   readonly capabilities = ["discord-inbound", "discord-outbound"];
 
   /** Exposed for API routes (discord operations agent). */
-  client!: Client;
-  private busRef!: EventBus;
-  private config!: DiscordConfig;
+  client!: ReturnType<typeof createMainClient>;
+
   private workspaceDir: string;
-
-  // Per-agent Discord client pool (agentName → Client)
-  private agentClients = new Map<string, Client>();
-
-  // correlationId → agentName — tracks which agent should reply for a pending message
-  private pendingAgents = new Map<string, string>();
-
+  private dataDir: string | null;
   private channelRegistry?: ChannelRegistry;
   private hitlPlugin?: HITLPlugin;
   private mailbox?: ContextMailbox;
   private isExecutionActive?: (correlationId: string) => boolean;
 
-  // correlationId → { message, replyTopic } for active HITL approvals
-  private pendingHITLMessages = new Map<string, { message: Message; replyTopic: string }>();
-
-  // Multi-turn conversation tracking
   private conversationManager = new ConversationManager();
   private conversationTracer = new ConversationTracer();
-  private graphiti = new GraphitiClient();
-  private identityRegistry: IdentityRegistry | null = null;
-  // correlationId (= conversationId for conv turns) → pending Langfuse turn data
-  private pendingTurns = new Map<string, TurnData>();
-
-  // DM debounce accumulator — batches rapid-fire DMs before dispatch
-  private dmAccumulator?: DmAccumulator;
-
-  // Runtime rate-limit state (built from config on install)
-  private rateLimits = new Map<string, number[]>();
-  private rateMaxMessages = 5;
-  private rateWindowMs = 10_000;
-  private spamPatterns: RegExp[] = [];
-
-  // Persistent rate-limit DB
-  private rlDb: Database | null = null;
-  private dataDir: string | null = null;
+  private ctx: DiscordContext | null = null;
 
   constructor(opts: DiscordPluginOptions) {
     this.workspaceDir = opts.workspaceDir;
@@ -332,7 +66,6 @@ export class DiscordPlugin implements Plugin {
     this.mailbox = opts.mailbox;
     this.isExecutionActive = opts.isExecutionActive;
 
-    // When a conversation times out, finalize its Langfuse trace
     this.conversationManager.setTimeoutCallback((entry) => {
       this.conversationTracer.endTrace({
         conversationId: entry.conversationId,
@@ -348,1129 +81,118 @@ export class DiscordPlugin implements Plugin {
       return;
     }
 
-    this.busRef = bus;
-    this.config = loadConfig(this.workspaceDir);
-    this.identityRegistry = new IdentityRegistry(this.workspaceDir);
+    const config = loadConfig(this.workspaceDir);
+    this.client = createMainClient();
 
-    // DM debounce accumulator — batches rapid-fire DMs before dispatch/mailbox
-    this.dmAccumulator = new DmAccumulator({
-      debounceMs: Number(process.env.DM_DEBOUNCE_MS ?? 3000),
-      onFlush: (entry) => this._handleDMFlush(entry, bus),
-      fallbackMailbox: this.mailbox,
+    const ctx = buildContext({
+      bus,
+      config,
+      workspaceDir: this.workspaceDir,
+      client: this.client,
+      channelRegistry: this.channelRegistry,
+      hitlPlugin: this.hitlPlugin,
+      mailbox: this.mailbox,
+      isExecutionActive: this.isExecutionActive,
+      identityRegistry: new IdentityRegistry(this.workspaceDir),
+      conversationManager: this.conversationManager,
+      conversationTracer: this.conversationTracer,
     });
+    this.ctx = ctx;
 
     // Apply moderation config
-    const { rateLimit, spamPatterns } = this.config.moderation;
-    this.rateMaxMessages = rateLimit.maxMessages;
-    this.rateWindowMs = rateLimit.windowSeconds * 1_000;
-    this.spamPatterns = compileSpamPatterns(spamPatterns);
+    const { rateLimit, spamPatterns } = config.moderation;
+    ctx.rateMaxMessages = rateLimit.maxMessages;
+    ctx.rateWindowMs = rateLimit.windowSeconds * 1_000;
+    ctx.spamPatterns = compileSpamPatterns(spamPatterns);
 
     // Open persistent rate-limit store
-    this._openRateLimitDb();
+    if (this.dataDir) openRateLimitDb(ctx, this.dataDir);
 
-    this.client = new Client({
-      intents: [
-        GatewayIntentBits.Guilds,
-        GatewayIntentBits.GuildMessages,
-        GatewayIntentBits.GuildMessageReactions,
-        GatewayIntentBits.GuildMembers,
-        GatewayIntentBits.MessageContent,
-        GatewayIntentBits.DirectMessages,
-      ],
-      partials: [Partials.Channel, Partials.Message, Partials.Reaction],
-    });
+    // Setup DM accumulator
+    setupDmAccumulator(ctx);
 
-    // ── Ready ────────────────────────────────────────────────────────────────
-    this.client.once(Events.ClientReady, async client => {
-      console.log(`[discord] Logged in as ${client.user.tag}`);
-      await this._registerSlashCommands();
-      // Pre-warm DM channels for known users so Discord delivers gateway events.
-      // Discord only sends MESSAGE_CREATE for DM channels in this session's
-      // private_channels list; calling createDM() subscribes to the channel.
-      this._warmDmChannels(client).catch(() => {});
-    });
+    // Register event handlers
+    registerInboundHandlers(ctx);
+    registerSlashCommandHandlers(ctx);
+    registerOutboundHandlers(ctx);
 
-    // ── Message create ───────────────────────────────────────────────────────
-    this.client.on(Events.MessageCreate, async message => {
-      if (message.author.bot) return;
-
-      // DMs — auto conversation, no @mention needed, main bot has no assigned agent
-      if (!message.guild) {
-        await this._handleDM(message, undefined, bus);
-        return;
-      }
-
-      const isMentioned = message.mentions.has(this.client.user!);
-      const userId = message.author.id;
-
-      // Look up channel config early — needed for conversation settings check
-      const channelEntry = this.channelRegistry?.findByTopic(`message.inbound.discord.${message.channelId}`);
-      const convConfig = channelEntry?.conversation;
-      const convEnabled = convConfig?.enabled === true;
-
-      // Allow continuing an active conversation without an @mention
-      const continueWithoutMention =
-        convEnabled &&
-        convConfig?.requireMentionAfterFirst !== true &&
-        this.conversationManager.has(message.channelId, userId);
-
-      if (!isMentioned && !continueWithoutMention) return;
-
-      if (!this._isAdmin(userId)) {
-        console.log(`[discord] message from ${userId} ignored — not in admins list`);
-        return;
-      }
-
-      if (this._isSpam(message.content)) {
-        await message.delete().catch(() => {});
-        return;
-      }
-      if (this._isRateLimited(userId)) {
-        await message.reply("Easy there — you're sending messages too quickly.").catch(() => {});
-        return;
-      }
-
-      await message.react("👀").catch(() => {});
-
-      // Determine correlationId — stable across turns when conversation is enabled
-      let correlationId: string;
-      let isNewConversation = false;
-      let turnNumber = 1;
-
-      if (convEnabled) {
-        const conv = this.conversationManager.getOrCreate(
-          message.channelId,
-          userId,
-          convConfig?.timeoutMs ?? 5 * 60_000,
-          channelEntry?.agent,
-        );
-        correlationId = conv.conversationId;
-        isNewConversation = conv.isNew;
-        turnNumber = conv.turnNumber;
-      } else {
-        correlationId = makeId();
-      }
-
-      pendingReplies.set(correlationId, { message });
-
-      if (channelEntry?.agent) {
-        this.pendingAgents.set(correlationId, channelEntry.agent);
-      }
-
-      const content = message.cleanContent
-        .replace(/<@!?\d+>/g, "")
-        .trim();
-
-      // Langfuse conversation tracing
-      if (convEnabled) {
-        if (isNewConversation) {
-          this.conversationTracer.startTrace({
-            conversationId: correlationId,
-            userId,
-            channelId: message.channelId,
-            agentName: channelEntry?.agent,
-            platform: "discord",
-          }).catch(err => console.error("[discord] Langfuse startTrace error:", err));
-        }
-        // Store turn data — log raw content, not the memory-prefixed version
-        this.pendingTurns.set(correlationId, {
-          conversationId: correlationId,
-          turnNumber,
-          input: content,
-          userId,
-          agentName: channelEntry?.agent,
-          startTime: new Date(),
-        });
-      }
-
-      bus.publish(`message.inbound.discord.${message.channelId}`, {
-        id: message.id,
-        correlationId,
-        topic: `message.inbound.discord.${message.channelId}`,
-        timestamp: Date.now(),
-        payload: {
-          sender: userId,
-          channel: message.channelId,
-          content,
-          isThread: message.channel.isThread(),
-          guildId: message.guildId,
-          ...(channelEntry?.agent ? { agentId: channelEntry.agent } : {}),
-        },
-        source: { interface: "discord" as const, channelId: message.channelId, userId },
-        reply: { topic: `message.outbound.discord.${message.channelId}` },
-      });
-    });
-
-    // ── 📋 reaction → bug triage ─────────────────────────────────────────────
-    this.client.on(Events.MessageReactionAdd, async (reaction, user) => {
-      if (user.bot) return;
-      if (reaction.emoji.name !== "📋") return;
-      if (!this._isAdmin(user.id)) {
-        console.log(`[discord] reaction from ${user.id} ignored — not in admins list`);
-        return;
-      }
-
-      const message = reaction.partial
-        ? await reaction.message.fetch()
-        : reaction.message as Message;
-
-      await message.react("👀").catch(() => {});
-
-      const correlationId = makeId();
-      pendingReplies.set(correlationId, { message });
-
-      bus.publish(`message.inbound.discord.${message.channelId}`, {
-        id: `${message.id}-clip`,
-        correlationId,
-        topic: `message.inbound.discord.${message.channelId}`,
-        timestamp: Date.now(),
-        payload: {
-          sender: user.id,
-          channel: message.channelId,
-          content: message.content,
-          skillHint: "bug_triage",
-          isReaction: true,
-        },
-        source: { interface: "discord" as const, channelId: message.channelId, userId: user.id },
-        reply: { topic: `message.outbound.discord.${message.channelId}` },
-      });
-    });
-
-    // ── Slash commands + autocomplete ────────────────────────────────────────
-    this.client.on(Events.InteractionCreate, async interaction => {
-      // ── Autocomplete: filter projects.yaml by typed value ─────────────────
-      if (interaction.isAutocomplete()) {
-        const cmdConfig = this.config.commands.find(c => c.name === interaction.commandName);
-        if (!cmdConfig) return;
-
-        const focused = interaction.options.getFocused(true);
-        if (focused.name === "project") {
-          const projects = loadProjectsDefs(this.workspaceDir);
-          const typed = focused.value.toLowerCase();
-          const choices = projects
-            .filter(p =>
-              p.slug.toLowerCase().includes(typed) ||
-              p.title.toLowerCase().includes(typed)
-            )
-            .slice(0, 25)
-            .map(p => ({ name: p.title, value: p.slug }));
-          await interaction.respond(choices).catch(console.error);
-        }
-        return;
-      }
-
-      // ── HITL button interactions ─────────────────────────────────────────
-      if (interaction.isButton() && interaction.customId.startsWith("hitl:")) {
-        // Defer IMMEDIATELY — Discord's interaction token expires 3s after
-        // the click, and any work we do before this call eats into that
-        // budget. We've seen "Unknown interaction" errors when the handler
-        // did even small amounts of sync work first.
-        //
-        // If deferUpdate throws (e.g. token already expired because the
-        // click was on a very old message and Discord's state is gone, or
-        // network blip), fall through to the body so the decision still
-        // gets published on the bus — the UI just won't update.
-        try {
-          await interaction.deferUpdate();
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          console.warn(`[discord] HITL deferUpdate failed (${msg}) — processing decision anyway`);
-        }
-
-        const [, decision, correlationId] = interaction.customId.split(":");
-        if (!decision || !correlationId) {
-          console.warn(`[discord] HITL button with malformed customId: ${interaction.customId}`);
-          return;
-        }
-
-        const entry = this.pendingHITLMessages.get(correlationId);
-        // Recover the reply topic. If the container restarted since the
-        // message was rendered, pendingHITLMessages is empty. The request
-        // embed carries the topic on the footer only in some flows, so
-        // fall back to a sensible pattern-based topic for our stuck
-        // escalation flow (the only flow that uses non-approve/reject
-        // options today).
-        const replyTopic = entry?.replyTopic
-          ?? `hitl.response.pr.remediation_stuck.${correlationId}`;
-
-        try {
-          bus.publish(replyTopic, {
-            id: crypto.randomUUID(),
-            correlationId,
-            topic: replyTopic,
-            timestamp: Date.now(),
-            payload: {
-              type: "hitl_response",
-              correlationId,
-              decision,
-              decidedBy: interaction.user.id,
-            },
-          });
-        } catch (err) {
-          console.error(`[discord] HITL bus publish failed for ${correlationId}:`, err);
-        }
-
-        if (entry) this.pendingHITLMessages.delete(correlationId);
-
-        const COLOR_APPROVE = 0x22c55e;
-        const COLOR_REJECT = 0xef4444;
-        const COLOR_NEUTRAL = 0x6b7280;
-        let color: number;
-        if (decision === "approve") color = COLOR_APPROVE;
-        else if (decision === "reject") color = COLOR_REJECT;
-        else color = COLOR_NEUTRAL;
-        const label = decision.charAt(0).toUpperCase() + decision.slice(1).replace(/_/g, " ");
-        const decidedEmbed = new EmbedBuilder()
-          .setTitle(interaction.message.embeds[0]?.title ?? "Decision recorded")
-          .setDescription(`**${label}** by <@${interaction.user.id}>`)
-          .setColor(color);
-
-        // Best-effort UI update. If the bot can no longer edit the message
-        // (e.g. posted by an old session), swallow the error so the
-        // decision still counts.
-        await interaction.message.edit({ embeds: [decidedEmbed], components: [] }).catch(err => {
-          console.warn(`[discord] HITL message edit failed for ${correlationId}:`, err instanceof Error ? err.message : err);
-        });
-        return;
-      }
-
-      if (!interaction.isChatInputCommand()) return;
-
-      // Pre-warm DM channel so subsequent DMs from this user are delivered via gateway.
-      this.client.users.createDM(interaction.user.id).catch(() => {});
-
-      const cmdConfig = this.config.commands.find(c => c.name === interaction.commandName);
-      if (!cmdConfig) return;
-
-      if (!this._isAdmin(interaction.user.id)) {
-        console.log(`[discord] slash command from ${interaction.user.id} ignored — not in admins list`);
-        await interaction.reply({ content: "Not authorised.", ephemeral: true }).catch(() => {});
-        return;
-      }
-
-      // ── /memory — native handler (no bus dispatch) ────────────────────────
-      if (interaction.commandName === "memory") {
-        await interaction.deferReply({ ephemeral: true });
-        await this._handleMemoryCommand(interaction);
-        return;
-      }
-
-      await interaction.deferReply();
-
-      // ── Flat command (top-level options, no subcommands) ─────────────────
-      const isFlatCommand = !!cmdConfig.options?.length && !cmdConfig.subcommands?.length;
-      if (isFlatCommand) {
-        // Resolve project metadata from projects.yaml if a `project` option is present
-        const projectSlug = interaction.options.getString("project");
-        let devChannelId: string | undefined;
-        let projectRepo: string | undefined;
-
-        if (projectSlug) {
-          const projects = loadProjectsDefs(this.workspaceDir);
-          const project = projects.find(p => p.slug === projectSlug);
-          if (project) {
-            devChannelId = channelIdOf(project.discord?.dev) || undefined;
-            projectRepo = project.github || undefined;
-          }
-        }
-
-        const content = this._interpolateContent(
-          cmdConfig.content ?? "",
-          cmdConfig.options ?? [],
-          interaction,
-        );
-
-        const correlationId = makeId();
-        pendingReplies.set(correlationId, { interaction });
-
-        const topicSuffix = `slash.${interaction.id}`;
-        bus.publish(`message.inbound.discord.${topicSuffix}`, {
-          id: interaction.id,
-          correlationId,
-          topic: `message.inbound.discord.${topicSuffix}`,
-          timestamp: Date.now(),
-          payload: {
-            sender: interaction.user.id,
-            channel: interaction.channelId,
-            content,
-            skillHint: cmdConfig.skillHint,
-            ...(devChannelId ? { devChannelId } : {}),
-            ...(projectRepo ? { projectRepo } : {}),
-          },
-          source: { interface: "discord" as const, channelId: interaction.channelId, userId: interaction.user.id },
-          reply: { topic: `message.outbound.discord.${topicSuffix}` },
-        });
-        return;
-      }
-
-      // ── Subcommand-based command (existing behaviour) ─────────────────────
-      const subcommands = cmdConfig.subcommands ?? [];
-      const subName = interaction.options.getSubcommand(false) ?? subcommands[0]?.name;
-      const subConfig = subcommands.find(s => s.name === subName) ?? subcommands[0];
-
-      if (!subConfig) {
-        await interaction.editReply("Unknown subcommand.").catch(console.error);
-        return;
-      }
-
-      // Interpolate {optionName} placeholders from config content template
-      const content = this._interpolateContent(subConfig.content, subConfig.options ?? [], interaction);
-
-      const correlationId = makeId();
-      pendingReplies.set(correlationId, { interaction });
-
-      const topicSuffix = `slash.${interaction.id}`;
-      bus.publish(`message.inbound.discord.${topicSuffix}`, {
-        id: interaction.id,
-        correlationId,
-        topic: `message.inbound.discord.${topicSuffix}`,
-        timestamp: Date.now(),
-        payload: {
-          sender: interaction.user.id,
-          channel: interaction.channelId,
-          content,
-          skillHint: subConfig.skillHint,
-        },
-        source: { interface: "discord" as const, channelId: interaction.channelId, userId: interaction.user.id },
-        reply: { topic: `message.outbound.discord.${topicSuffix}` },
-      });
-    });
-
-    // ── Welcome new members ──────────────────────────────────────────────────
+    // ── Welcome new members ────────────────────────────────────────────────
     this.client.on(Events.GuildMemberAdd, async member => {
-      const channelId = this.config.channels.welcome || process.env.DISCORD_WELCOME_CHANNEL;
+      const channelId = config.channels.welcome || process.env.DISCORD_WELCOME_CHANNEL;
       if (!channelId) return;
       const ch = member.guild.channels.cache.get(channelId) as TextChannel | undefined;
       await ch?.send(`Welcome to the protoLabs community, <@${member.id}>! 👋`).catch(() => {});
     });
 
-    // ── Outbound: reply to pending messages / interactions ───────────────────
-    bus.subscribe("message.outbound.discord.#", "discord-outbound", async (msg: BusMessage) => {
-      const payload = msg.payload as Record<string, unknown>;
-      const content = String(payload.content ?? "").slice(0, 2000);
-      if (!content) return; // drop empty outbound messages silently
-      const correlationId = msg.correlationId;
-
-      // Resolve agent-specific client — payload.agentId wins, then pendingAgents map
-      const agentId = (payload.agentId as string | undefined)
-        ?? (correlationId ? this.pendingAgents.get(correlationId) : undefined);
-      const agentClient = agentId ? this.agentClients.get(agentId) : undefined;
-      if (agentId && !agentClient) {
-        console.debug(`[discord] No pool client for agent "${agentId}" — falling back to bus client`);
-      }
-
-      // 1. Pending reply from a prior inbound message
-      if (correlationId) {
-        const pending = pendingReplies.get(correlationId);
-        if (pending) {
-          pendingReplies.delete(correlationId);
-          this.pendingAgents.delete(correlationId);
-
-          // Finalize Langfuse generation + store episode in Graphiti
-          const pendingTurn = this.pendingTurns.get(correlationId);
-          if (pendingTurn) {
-            this.pendingTurns.delete(correlationId);
-            this.conversationTracer.traceTurn({
-              ...pendingTurn,
-              output: content,
-              endTime: new Date(),
-            }).catch(err => console.error("[discord] Langfuse traceTurn error:", err));
-
-            // Note: Graphiti addEpisode is handled by SkillDispatcherPlugin for all channels.
-          }
-
-          if (pending.interaction) {
-            // Slash command interactions always use the bus client
-            await pending.interaction.editReply({ content }).catch(console.error);
-            return;
-          }
-
-          if (pending.message) {
-            const isDM = !pending.message.guild;
-
-            if (isDM) {
-              // DMs: reply directly through the message's own channel (works for any bot client)
-              await (pending.message.channel as TextChannel).send({ content }).catch(console.error);
-            } else if (agentClient) {
-              // Guild message via agent's bot identity
-              const ch = agentClient.channels.cache.get(pending.message.channelId) as TextChannel | undefined;
-              if (ch) {
-                console.debug(`[discord] Routing reply via agent client "${agentId}"`);
-                await ch.send({ content }).catch(console.error);
-              } else {
-                console.warn(`[discord] Agent "${agentId}" channel cache miss — falling back to bus client`);
-                await pending.message.reply({ content }).catch(console.error);
-              }
-            } else {
-              const reply = await pending.message.reply({ content }).catch(console.error);
-              // Start a thread on first guild response if not already in one
-              if (reply && !pending.message.channel.isThread()) {
-                await reply.startThread({ name: content.slice(0, 50) || "Response" }).catch(() => {});
-              }
-            }
-
-            // Reactions: only in guild channels (the main client owns them there)
-            if (!isDM) {
-              await pending.message.reactions.resolve("👀")?.users.remove(this.client.user!).catch(() => {});
-              await pending.message.react("✅").catch(() => {});
-            }
-            return;
-          }
-        }
-      }
-
-      // 2. Unprompted push (cron, proactive notification)
-      const channelId = String(
-        payload.channel ?? payload.recipient
-          ?? this.config.channels.digest
-          ?? process.env.DISCORD_DIGEST_CHANNEL
-          ?? ""
-      );
-      if (channelId) {
-        const sendClient = agentClient ?? this.client;
-        if (agentClient) {
-          console.debug(`[discord] Routing push to channel ${channelId} via agent client "${agentId}"`);
-        }
-        const ch = sendClient.channels.cache.get(channelId) as TextChannel | undefined;
-        await ch?.send({ content }).catch(console.error);
-      }
+    // ── Ready ──────────────────────────────────────────────────────────────
+    this.client.once(Events.ClientReady, async c => {
+      console.log(`[discord] Logged in as ${c.user.tag}`);
+      await registerSlashCommands(ctx);
+      warmDmChannels(ctx, c).catch(() => {});
     });
 
-    // ── HITL renderer registration ───────────────────────────────────────────
-    if (this.hitlPlugin) {
-      this.hitlPlugin.registerRenderer("discord", {
-        render: async (request, _busRef) => {
-          const channelId = request.sourceMeta?.channelId;
-          if (!channelId) {
-            console.warn(`[discord] HITL ${request.correlationId} missing channelId — cannot render`);
-            return;
-          }
-          const ch = this.client.channels.cache.get(channelId) as TextChannel | undefined;
-          if (!ch) {
-            console.warn(`[discord] HITL channel ${channelId} not in cache — cannot render`);
-            return;
-          }
-          const embed = this._buildHITLEmbed(request);
-          const row = this._buildHITLButtons(request);
-          const msg = await ch.send({ embeds: [embed], components: [row] });
-          this.pendingHITLMessages.set(request.correlationId, {
-            message: msg,
-            replyTopic: request.replyTopic,
-          });
-          console.log(`[discord] HITL ${request.correlationId} rendered in channel ${channelId}`);
-        },
-        onExpired: async (request, _busRef) => {
-          const entry = this.pendingHITLMessages.get(request.correlationId);
-          if (!entry) return;
-          this.pendingHITLMessages.delete(request.correlationId);
-          const expiredEmbed = new EmbedBuilder()
-            .setTitle(request.title)
-            .setDescription("**Approval expired** — re-trigger if still needed.")
-            .setColor(0x6b7280);
-          await entry.message.edit({ embeds: [expiredEmbed], components: [] }).catch(console.error);
-          console.log(`[discord] HITL ${request.correlationId} marked expired`);
-        },
-      });
-    }
-
-    // ── Hot-reload discord.yaml ───────────────────────────────────────────────
-    // watchFile works even if the file doesn't exist yet (detects creation too).
+    // ── Hot-reload discord.yaml ────────────────────────────────────────────
     const configPath = join(this.workspaceDir, "discord.yaml");
     watchFile(configPath, { interval: 5_000 }, async () => {
-      const prev = this.config;
-      this.config = loadConfig(this.workspaceDir);
+      const prev = { commands: [...ctx.config.commands] };
+      const newConfig = loadConfig(this.workspaceDir);
+      Object.assign(ctx.config, newConfig);
 
-      // Apply updated moderation config
-      const { rateLimit, spamPatterns } = this.config.moderation;
-      this.rateMaxMessages = rateLimit.maxMessages;
-      this.rateWindowMs = rateLimit.windowSeconds * 1_000;
-      this.spamPatterns = compileSpamPatterns(spamPatterns);
+      const { rateLimit: rl, spamPatterns: sp } = newConfig.moderation;
+      ctx.rateMaxMessages = rl.maxMessages;
+      ctx.rateWindowMs = rl.windowSeconds * 1_000;
+      ctx.spamPatterns = compileSpamPatterns(sp);
 
-      // Re-register slash commands if command list changed
       const prevCmds = JSON.stringify(prev.commands ?? []);
-      const newCmds = JSON.stringify(this.config.commands ?? []);
+      const newCmds = JSON.stringify(newConfig.commands ?? []);
       if (prevCmds !== newCmds && this.client?.isReady()) {
         console.log("[discord] discord.yaml changed — re-registering slash commands");
-        await this._registerSlashCommands().catch(console.error);
+        await registerSlashCommands(ctx).catch(console.error);
       } else {
         console.log("[discord] discord.yaml reloaded");
       }
     });
 
-    // ── Bus client login ────────────────────────────────────────────────────
+    // ── Login ──────────────────────────────────────────────────────────────
     this.client.login(process.env.DISCORD_BOT_TOKEN);
 
-    // ── Agent client pool initialization ────────────────────────────────────
-    this._initAgentPool();
+    // ── Agent client pool ──────────────────────────────────────────────────
+    initAgentPool(ctx, (msg, agentName) => handleDM(ctx, msg, agentName));
 
-    // ── Hot-reload agent pool on agents.yaml changes ────────────────────────
     const agentsPath = join(this.workspaceDir, "agents.yaml");
     if (existsSync(agentsPath)) {
       watchFile(agentsPath, { interval: 5_000 }, () => {
         console.log("[discord] agents.yaml changed — reloading agent client pool");
-        this._reloadAgentPool();
+        reloadAgentPool(ctx);
       });
     }
   }
 
   uninstall(): void {
-    this.dmAccumulator?.destroy();
-    this.conversationManager.destroy();
-    this.pendingTurns.clear();
-    this.pendingHITLMessages.clear();
+    const ctx = this.ctx;
+    if (ctx) {
+      ctx.dmAccumulator?.destroy();
+      ctx.pendingTurns.clear();
+      ctx.pendingHITLMessages.clear();
 
-    // Destroy agent pool clients
-    for (const [name, client] of this.agentClients) {
-      client.destroy();
-      console.log(`[discord] Destroyed agent client: ${name}`);
+      for (const [name, client] of ctx.agentClients) {
+        client.destroy();
+        console.log(`[discord] Destroyed agent client: ${name}`);
+      }
+      ctx.agentClients.clear();
+
+      if (ctx.rlDb) {
+        ctx.rlDb.close();
+        ctx.rlDb = null;
+      }
     }
-    this.agentClients.clear();
 
-    // Stop watching config files
+    this.conversationManager.destroy();
+
     unwatchFile(join(this.workspaceDir, "discord.yaml"));
     unwatchFile(join(this.workspaceDir, "agents.yaml"));
 
     this.client?.destroy();
-
-    if (this.rlDb) {
-      this.rlDb.close();
-      this.rlDb = null;
-    }
-  }
-
-  // ── Private helpers ─────────────────────────────────────────────────────────
-
-  /**
-   * Pre-warm DM channels for all users in the identity registry that have a
-   * Discord ID set. Discord's gateway only delivers MESSAGE_CREATE for DM
-   * channels that appear in the session's private_channels list (sent in READY).
-   * Calling createDM() subscribes the bot to that channel for this session.
-   */
-  private async _warmDmChannels(client: Client<true>): Promise<void> {
-    // Collect all Discord IDs from the identity registry
-    const discordIds = this.identityRegistry
-      ?.memoryEnabledUsers()
-      .map(u => u.identities.discord)
-      .filter((id): id is string => !!id)
-      ?? [];
-    if (!discordIds.length) return;
-    let warmed = 0;
-    for (const discordId of discordIds) {
-      try {
-        await client.users.createDM(discordId);
-        warmed++;
-      } catch { /* skip if user not reachable */ }
-    }
-    if (warmed) console.log(`[discord] Pre-warmed ${warmed} DM channel(s)`);
-  }
-
-  private _isAdmin(userId: string): boolean {
-    if (!this.config.admins?.length) return true; // open if no list configured
-    return this.config.admins.includes(userId);
-  }
-
-  private _openRateLimitDb(): void {
-    if (!this.dataDir) return;
-
-    try {
-      if (!existsSync(this.dataDir)) {
-        mkdirSync(this.dataDir, { recursive: true });
-      }
-
-      this.rlDb = new Database(join(this.dataDir, "events.db"));
-      this.rlDb.exec("PRAGMA journal_mode=WAL");
-      this.rlDb.exec(`
-        CREATE TABLE IF NOT EXISTS rate_limits (
-          user_id TEXT NOT NULL,
-          ts INTEGER NOT NULL
-        )
-      `);
-      this.rlDb.exec("CREATE INDEX IF NOT EXISTS idx_rate_limits_user_ts ON rate_limits(user_id, ts)");
-
-      // Load persisted windows into memory
-      const cutoff = Date.now() - this.rateWindowMs;
-      const rows = this.rlDb
-        .query("SELECT user_id, ts FROM rate_limits WHERE ts > ?")
-        .all(cutoff) as { user_id: string; ts: number }[];
-
-      for (const row of rows) {
-        const hits = this.rateLimits.get(row.user_id) ?? [];
-        hits.push(row.ts);
-        this.rateLimits.set(row.user_id, hits);
-      }
-
-      console.log(`[discord] Rate-limit DB opened (${rows.length} persisted hit(s) loaded)`);
-    } catch (err) {
-      console.warn("[discord] Could not open rate-limit DB — falling back to in-memory only:", err);
-      this.rlDb = null;
-    }
-  }
-
-  private _isRateLimited(userId: string): boolean {
-    const now = Date.now();
-    const hits = (this.rateLimits.get(userId) ?? []).filter(t => now - t < this.rateWindowMs);
-    hits.push(now);
-    this.rateLimits.set(userId, hits);
-
-    // Persist new hit to DB (fire-and-forget; errors are non-fatal)
-    if (this.rlDb) {
-      try {
-        this.rlDb.run("INSERT INTO rate_limits (user_id, ts) VALUES (?, ?)", [userId, now]);
-        // Prune expired rows for this user to keep the table tidy
-        this.rlDb.run("DELETE FROM rate_limits WHERE user_id = ? AND ts <= ?", [userId, now - this.rateWindowMs]);
-      } catch (err) {
-        console.warn("[discord] Failed to persist rate-limit hit:", err);
-      }
-    }
-
-    return hits.length > this.rateMaxMessages;
-  }
-
-  private _isSpam(content: string): boolean {
-    return this.spamPatterns.some(p => p.test(content));
-  }
-
-  /** Replace {optionName} tokens in a content template with actual interaction values. */
-  private _interpolateContent(
-    template: string,
-    options: CommandOption[],
-    interaction: ChatInputCommandInteraction,
-  ): string {
-    let result = template;
-    for (const opt of options) {
-      const placeholder = `{${opt.name}}`;
-      if (!result.includes(placeholder)) continue;
-
-      let value = "";
-      if (opt.type === "string") {
-        value = interaction.options.getString(opt.name) ?? "";
-      } else if (opt.type === "integer") {
-        value = String(interaction.options.getInteger(opt.name) ?? "");
-      } else if (opt.type === "boolean") {
-        value = String(interaction.options.getBoolean(opt.name) ?? "");
-      }
-      result = result.replaceAll(placeholder, value);
-    }
-    return result.trim();
-  }
-
-  private async _handleMemoryCommand(interaction: ChatInputCommandInteraction): Promise<void> {
-    const userId = interaction.user.id;
-
-    if (!this.identityRegistry) {
-      await interaction.editReply("Memory not available.").catch(console.error);
-      return;
-    }
-
-    const groupId = this.identityRegistry.groupId("discord", userId);
-    const subName = interaction.options.getSubcommand(false);
-
-    if (!subName || subName === "show") {
-      const facts = await this.graphiti.search(groupId, "preferences habits goals context", 20).catch(() => []);
-      if (facts.length === 0) {
-        await interaction.editReply("No memory stored yet.").catch(console.error);
-        return;
-      }
-      const now = Date.now();
-      const active = facts.filter(f => {
-        if (f.invalid_at && new Date(f.invalid_at).getTime() <= now) return false;
-        if (f.expired_at && new Date(f.expired_at).getTime() <= now) return false;
-        return true;
-      });
-      if (active.length === 0) {
-        await interaction.editReply("No active memory facts.").catch(console.error);
-        return;
-      }
-      const lines = active.map((f, i) => `**${i + 1}.** ${f.fact}`).join("\n");
-      await interaction.editReply(`**Memory** (${active.length} facts):\n${lines}`.slice(0, 2000)).catch(console.error);
-
-    } else if (subName === "search") {
-      const query = interaction.options.getString("query", true);
-      const facts = await this.graphiti.search(groupId, query, 10).catch(() => []);
-      if (facts.length === 0) {
-        await interaction.editReply(`No facts found for: "${query}"`).catch(console.error);
-        return;
-      }
-      const lines = facts.map((f, i) => `**${i + 1}.** ${f.fact}`).join("\n");
-      await interaction.editReply(`**"${query}"** — ${facts.length} fact(s):\n${lines}`.slice(0, 2000)).catch(console.error);
-
-    } else if (subName === "clear") {
-      await this.graphiti.clearUser(groupId);
-      await interaction.editReply("Memory cleared.").catch(console.error);
-    }
-  }
-
-  private _buildHITLEmbed(request: HITLRequest): EmbedBuilder {
-    const embed = new EmbedBuilder()
-      .setTitle(request.title)
-      .setDescription(request.summary.slice(0, 4096))
-      .setColor(0xf59e0b);
-
-    if (request.avaVerdict) {
-      embed.addFields({
-        name: `Ava verdict (score: ${request.avaVerdict.score})`,
-        value: request.avaVerdict.verdict.slice(0, 1024),
-        inline: false,
-      });
-    }
-    if (request.jonVerdict) {
-      embed.addFields({
-        name: `Jon verdict (score: ${request.jonVerdict.score})`,
-        value: request.jonVerdict.verdict.slice(0, 1024),
-        inline: false,
-      });
-    }
-    if (request.escalationContext) {
-      const ctx = request.escalationContext;
-      embed.addFields({
-        name: "Cost",
-        value: `Est: **$${ctx.estimatedCost.toFixed(4)}** | Max: $${ctx.maxCost.toFixed(4)} | Tier: ${ctx.tier}`,
-        inline: false,
-      });
-    }
-
-    embed.setFooter({ text: `Expires ${new Date(request.expiresAt).toLocaleString()}` });
-    return embed;
-  }
-
-  private _buildHITLButtons(request: HITLRequest): ActionRowBuilder<ButtonBuilder> {
-    const row = new ActionRowBuilder<ButtonBuilder>();
-    const STYLE_BY_OPTION: Record<string, ButtonStyle> = {
-      approve: ButtonStyle.Success,
-      reject: ButtonStyle.Danger,
-    };
-    for (const option of request.options) {
-      const style = STYLE_BY_OPTION[option] ?? ButtonStyle.Secondary;
-      row.addComponents(
-        new ButtonBuilder()
-          .setCustomId(`hitl:${option}:${request.correlationId}`)
-          .setLabel(option.charAt(0).toUpperCase() + option.slice(1))
-          .setStyle(style),
-      );
-    }
-    return row;
-  }
-
-  /**
-   * Handle an inbound DM — called from both the main bot and agent pool bots.
-   *
-   * DMs are always conversation-enabled (no channels.yaml entry needed).
-   * The stable conversationId becomes the A2A contextId, giving the agent
-   * full memory of the exchange across turns.
-   *
-   * agentName is undefined when the main bus bot receives the DM (routed by
-   * A2A keyword matching). When an agent pool bot receives it, agentName is
-   * the specific agent so the A2A layer routes directly.
-   */
-  private async _handleDM(message: Message, agentName: string | undefined, bus: EventBus): Promise<void> {
-    const userId = message.author.id;
-
-    if (!this._isAdmin(userId)) return;
-    if (this._isSpam(message.content)) { await message.delete().catch(() => {}); return; }
-    if (this._isRateLimited(userId)) {
-      await (message.channel as TextChannel).send("Easy there — you're sending messages too quickly.").catch(() => {});
-      return;
-    }
-
-    const timeoutMs = Number(process.env.DM_CONVERSATION_TIMEOUT_MS ?? 15 * 60_000);
-    const conv = this.conversationManager.getOrCreate(message.channelId, userId, timeoutMs, agentName);
-    const { conversationId, isNew, turnNumber } = conv;
-
-    const content = message.cleanContent.replace(/<@!?\d+>/g, "").trim();
-    if (!content) return;
-
-    // Push into debounce accumulator — batches rapid-fire DMs
-    const isFirst = this.dmAccumulator!.push({
-      conversationId,
-      userId,
-      channelId: message.channelId,
-      agentName,
-      message: { id: message.id, channelId: message.channelId },
-      content,
-      turnNumber,
-      isNew,
-    });
-
-    // No auto-reaction — agents add their own via the `react` tool if they want.
-    void isFirst;
-  }
-
-  /**
-   * Flush callback for DmAccumulator — called when debounce timer fires.
-   *
-   * Checks if an agent execution is in-flight for this conversation:
-   *   - No  → dispatch normally via bus (standard DM flow)
-   *   - Yes → push to mailbox (drained on execution completion by SkillDispatcher)
-   */
-  private async _handleDMFlush(entry: Omit<AccumulatorEntry, "timer">, bus: EventBus): Promise<void> {
-    const {
-      conversationId, userId, channelId, agentName,
-      lastMessage, contents, turnNumber, isNew,
-    } = entry;
-
-    const batchedContent = contents.length === 1
-      ? contents[0]
-      : contents.map((c, i) => `[${i + 1}/${contents.length}] ${c}`).join("\n\n");
-
-    // If agent is mid-execution, queue to mailbox instead of dispatching
-    if (this.isExecutionActive?.(conversationId) && this.mailbox) {
-      console.log(
-        `[discord] Agent in-flight for ${conversationId} — queuing ${contents.length} message(s) to mailbox`,
-      );
-      this.mailbox.push(conversationId, {
-        content: batchedContent,
-        sender: userId,
-        receivedAt: Date.now(),
-      });
-      return;
-    }
-
-    // Normal dispatch path — no agent in-flight
-    // Resolve the original Discord message via the client that owns this DM channel.
-    // For agent pool DMs, that's the agent's own client; for main bot DMs, it's this.client.
-    const client = (agentName ? this.agentClients.get(agentName) : undefined) ?? this.client;
-    const discordChannel = client?.channels.cache.get(channelId);
-    const discordMessage = discordChannel && "messages" in discordChannel
-      ? await (discordChannel as TextChannel).messages.fetch(lastMessage.id).catch(() => null)
-      : null;
-
-    if (discordMessage) {
-      pendingReplies.set(conversationId, { message: discordMessage });
-    } else {
-      console.warn(`[discord] Could not fetch message for ${conversationId} via ${agentName ?? "main"} — reply will use unprompted push`);
-    }
-    if (agentName) this.pendingAgents.set(conversationId, agentName);
-
-    // Langfuse tracing
-    if (isNew) {
-      this.conversationTracer.startTrace({
-        conversationId,
-        userId,
-        channelId,
-        agentName,
-        platform: "discord-dm",
-      }).catch(err => console.error("[discord] Langfuse startTrace error:", err));
-    }
-    this.pendingTurns.set(conversationId, {
-      conversationId,
-      turnNumber,
-      input: batchedContent,
-      userId,
-      agentName,
-      startTime: new Date(),
-    });
-
-    if (agentName) {
-      // Agent pool DM — we know exactly which agent. Skip the router entirely,
-      // publish straight to agent.skill.request with the target.
-      bus.publish("agent.skill.request", {
-        id: lastMessage.id,
-        correlationId: conversationId,
-        topic: "agent.skill.request",
-        timestamp: Date.now(),
-        payload: {
-          skill: "chat",
-          content: batchedContent,
-          targets: [agentName],
-          isDM: true,
-        },
-        source: { interface: "discord" as const, channelId, userId },
-        reply: { topic: `message.outbound.discord.${channelId}` },
-      });
-    } else {
-      // Main bot DM — route through message.inbound for the router to resolve.
-      bus.publish(`message.inbound.discord.${channelId}`, {
-        id: lastMessage.id,
-        correlationId: conversationId,
-        topic: `message.inbound.discord.${channelId}`,
-        timestamp: Date.now(),
-        payload: {
-          sender: userId,
-          channel: channelId,
-          content: batchedContent,
-          isDM: true,
-        },
-        source: { interface: "discord" as const, channelId, userId },
-        reply: { topic: `message.outbound.discord.${channelId}` },
-      });
-    }
-  }
-
-  private _initAgentPool(): void {
-    // Sources: agents.yaml (legacy) + channels.yaml (preferred)
-    const agentsYamlEntries = loadAgentPoolDefs(this.workspaceDir)
-      .filter(a => a.discordBotTokenEnvKey)
-      .map(a => ({ name: a.name, tokenEnvKey: a.discordBotTokenEnvKey! }));
-
-    const channelEntries = this.channelRegistry
-      ? Array.from(this.channelRegistry.getDiscordBotTokenEnvs().entries())
-          .map(([name, tokenEnvKey]) => ({ name, tokenEnvKey }))
-      : [];
-
-    // Merge — channels.yaml wins on conflict
-    const byName = new Map<string, string>();
-    for (const { name, tokenEnvKey } of [...agentsYamlEntries, ...channelEntries]) {
-      byName.set(name, tokenEnvKey);
-    }
-
-    let created = 0;
-    for (const [agentName, tokenEnvKey] of byName) {
-      const token = process.env[tokenEnvKey];
-      if (!token) {
-        console.warn(`[discord] No token for agent "${agentName}" (env: ${tokenEnvKey}) — will use bus bot`);
-        continue;
-      }
-
-      try {
-        const agentClient = new Client({
-          intents: [
-            GatewayIntentBits.Guilds,
-            GatewayIntentBits.GuildMessages,
-            GatewayIntentBits.MessageContent,
-            GatewayIntentBits.DirectMessages,
-          ],
-          partials: [Partials.Channel, Partials.Message],
-        });
-
-        agentClient.once(Events.ClientReady, async c => {
-          console.log(`[discord] Agent client "${agentName}" logged in as ${c.user.tag}`);
-          // Pre-warm DM channels so Discord delivers MESSAGE_CREATE to this
-          // client. Discord's gateway only pushes DM events for channels in
-          // the session's private_channels list (sent in READY), so a client
-          // that never opened a DM with a user gets zero events for that DM.
-          // The primary client already does this on its own ClientReady —
-          // agent pool clients need the same treatment or their bot appears
-          // online in Discord but silently drops every DM.
-          await this._warmDmChannels(c).catch(err =>
-            console.warn(`[discord] Agent client "${agentName}" DM pre-warm failed:`, err),
-          );
-        });
-
-        // Handle DMs sent directly to this agent's bot
-        agentClient.on(Events.MessageCreate, async (message) => {
-          if (message.author.bot) return;
-          if (message.guild) return; // guild messages handled by main client
-          console.log(`[discord] Agent client "${agentName}" received DM from ${message.author.tag} (${message.author.id})`);
-          await this._handleDM(message, agentName, this.busRef!);
-        });
-
-        agentClient.login(token).catch(err => {
-          console.warn(`[discord] Agent client "${agentName}" login failed:`, err);
-          this.agentClients.delete(agentName);
-        });
-
-        this.agentClients.set(agentName, agentClient);
-        created++;
-      } catch (err) {
-        console.warn(`[discord] Failed to create client for agent "${agentName}":`, err);
-      }
-    }
-
-    console.log(`[discord] Agent client pool: ${created} client(s) initialized (${byName.size} agents configured)`);
-  }
-
-  private _reloadAgentPool(): void {
-    const agents = loadAgentPoolDefs(this.workspaceDir);
-    const newAgentNames = new Set(
-      agents.filter(a => a.discordBotTokenEnvKey && process.env[a.discordBotTokenEnvKey!])
-        .map(a => a.name)
-    );
-
-    // Remove clients for agents no longer in config
-    for (const [name, client] of this.agentClients) {
-      if (!newAgentNames.has(name)) {
-        client.destroy();
-        this.agentClients.delete(name);
-        console.log(`[discord] Pool: removed agent client "${name}"`);
-      }
-    }
-
-    // Add clients for new agents
-    for (const agent of agents) {
-      if (!agent.discordBotTokenEnvKey) continue;
-      if (this.agentClients.has(agent.name)) continue; // already active
-
-      const token = process.env[agent.discordBotTokenEnvKey];
-      if (!token) continue;
-
-      try {
-        const agentClient = new Client({
-          intents: [GatewayIntentBits.Guilds],
-        });
-
-        agentClient.once(Events.ClientReady, c => {
-          console.log(`[discord] Agent client "${agent.name}" logged in as ${c.user.tag}`);
-        });
-
-        agentClient.login(token).catch(err => {
-          console.warn(`[discord] Agent client "${agent.name}" login failed:`, err);
-          this.agentClients.delete(agent.name);
-        });
-
-        this.agentClients.set(agent.name, agentClient);
-        console.log(`[discord] Pool: added agent client "${agent.name}"`);
-      } catch (err) {
-        console.warn(`[discord] Failed to create client for agent "${agent.name}":`, err);
-      }
-    }
-
-    console.log(`[discord] Pool reloaded: ${this.agentClients.size} active agent client(s)`);
-  }
-
-  private async _registerSlashCommands(): Promise<void> {
-    const guildId = process.env.DISCORD_GUILD_ID;
-    if (!guildId) {
-      console.log("[discord] DISCORD_GUILD_ID not set — skipping slash command registration");
-      return;
-    }
-
-    const guild = this.client.guilds.cache.get(guildId);
-    if (!guild) {
-      console.log(`[discord] Guild ${guildId} not found`);
-      return;
-    }
-
-    if (!this.config.commands.length) {
-      console.log("[discord] No commands configured in discord.yaml");
-      return;
-    }
-
-    const commandData = this.config.commands.map(cmd => {
-      // Flat command: top-level options with optional autocomplete (no subcommands)
-      if (cmd.options?.length && !cmd.subcommands?.length) {
-        return {
-          name: cmd.name,
-          description: cmd.description,
-          options: cmd.options.map(opt => ({
-            name: opt.name,
-            description: opt.description,
-            type: OPTION_TYPE_CODES[opt.type] ?? 3,
-            required: opt.required ?? false,
-            autocomplete: opt.autocomplete ?? false,
-          })),
-        };
-      }
-      // Subcommand-based command (existing behaviour)
-      return {
-        name: cmd.name,
-        description: cmd.description,
-        options: (cmd.subcommands ?? []).map(sub => ({
-          name: sub.name,
-          type: 1, // SUB_COMMAND
-          description: sub.description,
-          options: (sub.options ?? []).map(opt => ({
-            name: opt.name,
-            description: opt.description,
-            type: OPTION_TYPE_CODES[opt.type] ?? 3,
-            required: opt.required ?? false,
-          })),
-        })),
-      };
-    });
-
-    await guild.commands.set(commandData);
-    console.log(
-      `[discord] Registered ${commandData.length} command(s): ${commandData.map(c => `/${c.name}`).join(", ")}`
-    );
+    this.ctx = null;
   }
 }

--- a/lib/plugins/discord/agent-pool.ts
+++ b/lib/plugins/discord/agent-pool.ts
@@ -1,0 +1,181 @@
+/**
+ * agent-pool.ts — Multi-bot Discord client pool.
+ *
+ * Reads DISCORD_BOT_TOKEN_* environment variables (one per agent) and creates
+ * dedicated Discord clients so each agent can post with its own bot identity.
+ */
+
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { Events, type Message } from "discord.js";
+import { createAgentClient } from "./core.ts";
+import { warmDmChannels } from "./dm-warming.ts";
+import type { DiscordContext } from "./core.ts";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface AgentPoolEntry {
+  name: string;
+  discordBotTokenEnvKey?: string;
+}
+
+interface AgentsYaml {
+  agents: AgentPoolEntry[];
+}
+
+// ── Loader ────────────────────────────────────────────────────────────────────
+
+export function loadAgentPoolDefs(workspaceDir: string): AgentPoolEntry[] {
+  const seen = new Map<string, AgentPoolEntry>();
+
+  const agentsPath = join(workspaceDir, "agents.yaml");
+  if (existsSync(agentsPath)) {
+    try {
+      const raw = readFileSync(agentsPath, "utf8");
+      const parsed = parseYaml(raw) as AgentsYaml;
+      for (const entry of parsed.agents ?? []) {
+        if (entry?.name) seen.set(entry.name, entry);
+      }
+    } catch (err) {
+      console.error("[discord] Failed to parse agents.yaml:", err);
+    }
+  }
+
+  const agentsDir = join(workspaceDir, "agents");
+  if (existsSync(agentsDir)) {
+    try {
+      for (const file of readdirSync(agentsDir)) {
+        if (!(file.endsWith(".yaml") || file.endsWith(".yml"))) continue;
+        if (file.endsWith(".example") || file.endsWith(".retired")) continue;
+        const filePath = join(agentsDir, file);
+        try {
+          const parsed = parseYaml(readFileSync(filePath, "utf8")) as {
+            name?: string;
+            discordBotTokenEnvKey?: string;
+          };
+          if (parsed?.name && typeof parsed.discordBotTokenEnvKey === "string") {
+            if (!seen.has(parsed.name)) {
+              seen.set(parsed.name, {
+                name: parsed.name,
+                discordBotTokenEnvKey: parsed.discordBotTokenEnvKey,
+              });
+            }
+          }
+        } catch (err) {
+          console.error(`[discord] Failed to parse agent file ${file}:`, err);
+        }
+      }
+    } catch (err) {
+      console.error("[discord] Failed to enumerate workspace/agents/:", err);
+    }
+  }
+
+  return Array.from(seen.values());
+}
+
+// ── Pool initialization ───────────────────────────────────────────────────────
+
+export function initAgentPool(
+  ctx: DiscordContext,
+  handleDM: (message: Message, agentName: string | undefined) => Promise<void>,
+): void {
+  const agentsYamlEntries = loadAgentPoolDefs(ctx.workspaceDir)
+    .filter(a => a.discordBotTokenEnvKey)
+    .map(a => ({ name: a.name, tokenEnvKey: a.discordBotTokenEnvKey! }));
+
+  const channelEntries = ctx.channelRegistry
+    ? Array.from(ctx.channelRegistry.getDiscordBotTokenEnvs().entries())
+        .map(([name, tokenEnvKey]) => ({ name, tokenEnvKey }))
+    : [];
+
+  const byName = new Map<string, string>();
+  for (const { name, tokenEnvKey } of [...agentsYamlEntries, ...channelEntries]) {
+    byName.set(name, tokenEnvKey);
+  }
+
+  let created = 0;
+  for (const [agentName, tokenEnvKey] of byName) {
+    const token = process.env[tokenEnvKey];
+    if (!token) {
+      console.warn(`[discord] No token for agent "${agentName}" (env: ${tokenEnvKey}) — will use bus bot`);
+      continue;
+    }
+
+    try {
+      const agentClient = createAgentClient();
+
+      agentClient.once(Events.ClientReady, async c => {
+        console.log(`[discord] Agent client "${agentName}" logged in as ${c.user.tag}`);
+        await warmDmChannels(ctx, c).catch(err =>
+          console.warn(`[discord] Agent client "${agentName}" DM pre-warm failed:`, err),
+        );
+      });
+
+      agentClient.on(Events.MessageCreate, async (message) => {
+        if (message.author.bot) return;
+        if (message.guild) return;
+        console.log(`[discord] Agent client "${agentName}" received DM from ${message.author.tag} (${message.author.id})`);
+        await handleDM(message, agentName);
+      });
+
+      agentClient.login(token).catch(err => {
+        console.warn(`[discord] Agent client "${agentName}" login failed:`, err);
+        ctx.agentClients.delete(agentName);
+      });
+
+      ctx.agentClients.set(agentName, agentClient);
+      created++;
+    } catch (err) {
+      console.warn(`[discord] Failed to create client for agent "${agentName}":`, err);
+    }
+  }
+
+  console.log(`[discord] Agent client pool: ${created} client(s) initialized (${byName.size} agents configured)`);
+}
+
+// ── Pool reload ───────────────────────────────────────────────────────────────
+
+export function reloadAgentPool(ctx: DiscordContext): void {
+  const agents = loadAgentPoolDefs(ctx.workspaceDir);
+  const newAgentNames = new Set(
+    agents.filter(a => a.discordBotTokenEnvKey && process.env[a.discordBotTokenEnvKey!])
+      .map(a => a.name)
+  );
+
+  for (const [name, client] of ctx.agentClients) {
+    if (!newAgentNames.has(name)) {
+      client.destroy();
+      ctx.agentClients.delete(name);
+      console.log(`[discord] Pool: removed agent client "${name}"`);
+    }
+  }
+
+  for (const agent of agents) {
+    if (!agent.discordBotTokenEnvKey) continue;
+    if (ctx.agentClients.has(agent.name)) continue;
+
+    const token = process.env[agent.discordBotTokenEnvKey];
+    if (!token) continue;
+
+    try {
+      const agentClient = createAgentClient();
+
+      agentClient.once(Events.ClientReady, c => {
+        console.log(`[discord] Agent client "${agent.name}" logged in as ${c.user.tag}`);
+      });
+
+      agentClient.login(token).catch(err => {
+        console.warn(`[discord] Agent client "${agent.name}" login failed:`, err);
+        ctx.agentClients.delete(agent.name);
+      });
+
+      ctx.agentClients.set(agent.name, agentClient);
+      console.log(`[discord] Pool: added agent client "${agent.name}"`);
+    } catch (err) {
+      console.warn(`[discord] Failed to create client for agent "${agent.name}":`, err);
+    }
+  }
+
+  console.log(`[discord] Pool reloaded: ${ctx.agentClients.size} active agent client(s)`);
+}

--- a/lib/plugins/discord/core.ts
+++ b/lib/plugins/discord/core.ts
@@ -1,0 +1,197 @@
+/**
+ * core.ts — Discord client factory, config types, and shared context interface.
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { Database } from "bun:sqlite";
+import {
+  Client,
+  GatewayIntentBits,
+  Partials,
+  type Message,
+  type ChatInputCommandInteraction,
+} from "discord.js";
+import type { EventBus } from "../../types.ts";
+import type { HITLPlugin } from "../hitl.ts";
+import type { ChannelRegistry } from "../../channels/channel-registry.ts";
+import { ConversationManager } from "../../conversation/conversation-manager.ts";
+import { ConversationTracer, type TurnData } from "../../conversation/conversation-tracer.ts";
+import { GraphitiClient } from "../../memory/graphiti-client.ts";
+import { IdentityRegistry } from "../../identity/identity-registry.ts";
+import type { DmAccumulator } from "../../dm/dm-accumulator.ts";
+import type { ContextMailbox } from "../../dm/context-mailbox.ts";
+
+// ── Config types ──────────────────────────────────────────────────────────────
+
+export interface CommandOption {
+  name: string;
+  description: string;
+  type: "string" | "integer" | "boolean";
+  required?: boolean;
+  autocomplete?: boolean;
+}
+
+export interface Subcommand {
+  name: string;
+  description: string;
+  content: string;
+  skillHint?: string;
+  options?: CommandOption[];
+}
+
+export interface CommandConfig {
+  name: string;
+  description: string;
+  subcommands?: Subcommand[];
+  options?: CommandOption[];
+  content?: string;
+  skillHint?: string;
+}
+
+export interface DiscordConfig {
+  channels: {
+    digest?: string;
+    welcome?: string;
+    modLog?: string;
+  };
+  moderation: {
+    rateLimit: {
+      maxMessages: number;
+      windowSeconds: number;
+    };
+    spamPatterns: string[];
+  };
+  commands: CommandConfig[];
+  admins?: string[];
+}
+
+export function loadConfig(workspaceDir: string): DiscordConfig {
+  const configPath = join(workspaceDir, "discord.yaml");
+  if (!existsSync(configPath)) {
+    console.log("[discord] No discord.yaml found — using defaults");
+    return {
+      channels: {},
+      moderation: {
+        rateLimit: { maxMessages: 5, windowSeconds: 10 },
+        spamPatterns: [],
+      },
+      commands: [],
+    };
+  }
+  return parseYaml(readFileSync(configPath, "utf8")) as DiscordConfig;
+}
+
+// ── Discord option type codes ─────────────────────────────────────────────────
+
+export const OPTION_TYPE_CODES: Record<string, number> = {
+  string: 3,
+  integer: 4,
+  boolean: 5,
+};
+
+// ── Shared utilities ──────────────────────────────────────────────────────────
+
+export function makeId(): string {
+  return crypto.randomUUID();
+}
+
+// ── Shared context interface ──────────────────────────────────────────────────
+
+export interface DiscordContext {
+  bus: EventBus;
+  config: DiscordConfig;
+  workspaceDir: string;
+  client: Client;
+  agentClients: Map<string, Client>;
+  pendingAgents: Map<string, string>;
+  channelRegistry?: ChannelRegistry;
+  hitlPlugin?: HITLPlugin;
+  mailbox?: ContextMailbox;
+  isExecutionActive?: (correlationId: string) => boolean;
+  pendingHITLMessages: Map<string, { message: Message; replyTopic: string }>;
+  conversationManager: ConversationManager;
+  conversationTracer: ConversationTracer;
+  graphiti: GraphitiClient;
+  identityRegistry: IdentityRegistry | null;
+  pendingTurns: Map<string, TurnData>;
+  dmAccumulator?: DmAccumulator;
+  // Rate limit state
+  rateLimits: Map<string, number[]>;
+  rateMaxMessages: number;
+  rateWindowMs: number;
+  spamPatterns: RegExp[];
+  rlDb: Database | null;
+}
+
+// ── Client factory ────────────────────────────────────────────────────────────
+
+export function createMainClient(): Client {
+  return new Client({
+    intents: [
+      GatewayIntentBits.Guilds,
+      GatewayIntentBits.GuildMessages,
+      GatewayIntentBits.GuildMessageReactions,
+      GatewayIntentBits.GuildMembers,
+      GatewayIntentBits.MessageContent,
+      GatewayIntentBits.DirectMessages,
+    ],
+    partials: [Partials.Channel, Partials.Message, Partials.Reaction],
+  });
+}
+
+export function createAgentClient(): Client {
+  return new Client({
+    intents: [
+      GatewayIntentBits.Guilds,
+      GatewayIntentBits.GuildMessages,
+      GatewayIntentBits.MessageContent,
+      GatewayIntentBits.DirectMessages,
+    ],
+    partials: [Partials.Channel, Partials.Message],
+  });
+}
+
+// ── Context factory ───────────────────────────────────────────────────────────
+
+export function buildContext(opts: {
+  bus: EventBus;
+  config: DiscordConfig;
+  workspaceDir: string;
+  client: Client;
+  channelRegistry?: ChannelRegistry;
+  hitlPlugin?: HITLPlugin;
+  mailbox?: ContextMailbox;
+  isExecutionActive?: (correlationId: string) => boolean;
+  identityRegistry: IdentityRegistry | null;
+  conversationManager: ConversationManager;
+  conversationTracer: ConversationTracer;
+}): DiscordContext {
+  return {
+    bus: opts.bus,
+    config: opts.config,
+    workspaceDir: opts.workspaceDir,
+    client: opts.client,
+    agentClients: new Map(),
+    pendingAgents: new Map(),
+    channelRegistry: opts.channelRegistry,
+    hitlPlugin: opts.hitlPlugin,
+    mailbox: opts.mailbox,
+    isExecutionActive: opts.isExecutionActive,
+    pendingHITLMessages: new Map(),
+    conversationManager: opts.conversationManager,
+    conversationTracer: opts.conversationTracer,
+    graphiti: new GraphitiClient(),
+    identityRegistry: opts.identityRegistry,
+    pendingTurns: new Map(),
+    dmAccumulator: undefined,
+    rateLimits: new Map(),
+    rateMaxMessages: 5,
+    rateWindowMs: 10_000,
+    spamPatterns: [],
+    rlDb: null,
+  };
+}
+
+export type { Message, ChatInputCommandInteraction, TurnData };

--- a/lib/plugins/discord/dm-warming.ts
+++ b/lib/plugins/discord/dm-warming.ts
@@ -1,0 +1,27 @@
+/**
+ * dm-warming.ts — Pre-warm DM channels so Discord delivers gateway events.
+ *
+ * Discord's gateway only sends MESSAGE_CREATE for DM channels in the session's
+ * private_channels list (sent in READY). Calling createDM() subscribes the bot
+ * to that channel for this session.
+ */
+
+import type { Client } from "discord.js";
+import type { DiscordContext } from "./core.ts";
+
+export async function warmDmChannels(ctx: DiscordContext, client: Client<true>): Promise<void> {
+  const discordIds = ctx.identityRegistry
+    ?.memoryEnabledUsers()
+    .map(u => u.identities.discord)
+    .filter((id): id is string => !!id)
+    ?? [];
+  if (!discordIds.length) return;
+  let warmed = 0;
+  for (const discordId of discordIds) {
+    try {
+      await client.users.createDM(discordId);
+      warmed++;
+    } catch { /* skip if user not reachable */ }
+  }
+  if (warmed) console.log(`[discord] Pre-warmed ${warmed} DM channel(s)`);
+}

--- a/lib/plugins/discord/inbound.ts
+++ b/lib/plugins/discord/inbound.ts
@@ -1,0 +1,299 @@
+/**
+ * inbound.ts — DM and guild message handlers.
+ *
+ * Registers MessageCreate and MessageReactionAdd event listeners on the main
+ * Discord client, and handles DM batching via DmAccumulator.
+ */
+
+import { Events, type Message, type TextChannel } from "discord.js";
+import { DmAccumulator, type AccumulatorEntry } from "../../dm/dm-accumulator.ts";
+import { makeId, type DiscordContext } from "./core.ts";
+import { isRateLimited, isSpam } from "./rate-limit.ts";
+import { pendingReplies } from "./outbound.ts";
+
+// ── Admin check ───────────────────────────────────────────────────────────────
+
+function isAdmin(ctx: DiscordContext, userId: string): boolean {
+  if (!ctx.config.admins?.length) return true;
+  return ctx.config.admins.includes(userId);
+}
+
+// ── DM handler ────────────────────────────────────────────────────────────────
+
+export async function handleDM(
+  ctx: DiscordContext,
+  message: Message,
+  agentName: string | undefined,
+): Promise<void> {
+  const userId = message.author.id;
+
+  if (!isAdmin(ctx, userId)) return;
+  if (isSpam(ctx, message.content)) { await message.delete().catch(() => {}); return; }
+  if (isRateLimited(ctx, userId)) {
+    await (message.channel as TextChannel).send("Easy there — you're sending messages too quickly.").catch(() => {});
+    return;
+  }
+
+  const timeoutMs = Number(process.env.DM_CONVERSATION_TIMEOUT_MS ?? 15 * 60_000);
+  const conv = ctx.conversationManager.getOrCreate(message.channelId, userId, timeoutMs, agentName);
+  const { conversationId, isNew, turnNumber } = conv;
+
+  const content = message.cleanContent.replace(/<@!?\d+>/g, "").trim();
+  if (!content) return;
+
+  ctx.dmAccumulator!.push({
+    conversationId,
+    userId,
+    channelId: message.channelId,
+    agentName,
+    message: { id: message.id, channelId: message.channelId },
+    content,
+    turnNumber,
+    isNew,
+  });
+}
+
+// ── DM flush callback ─────────────────────────────────────────────────────────
+
+export async function handleDMFlush(
+  ctx: DiscordContext,
+  entry: Omit<AccumulatorEntry, "timer">,
+): Promise<void> {
+  const {
+    conversationId, userId, channelId, agentName,
+    lastMessage, contents, turnNumber, isNew,
+  } = entry;
+
+  const batchedContent = contents.length === 1
+    ? contents[0]
+    : contents.map((c, i) => `[${i + 1}/${contents.length}] ${c}`).join("\n\n");
+
+  if (ctx.isExecutionActive?.(conversationId) && ctx.mailbox) {
+    console.log(
+      `[discord] Agent in-flight for ${conversationId} — queuing ${contents.length} message(s) to mailbox`,
+    );
+    ctx.mailbox.push(conversationId, {
+      content: batchedContent,
+      sender: userId,
+      receivedAt: Date.now(),
+    });
+    return;
+  }
+
+  const client = (agentName ? ctx.agentClients.get(agentName) : undefined) ?? ctx.client;
+  const discordChannel = client?.channels.cache.get(channelId);
+  const discordMessage = discordChannel && "messages" in discordChannel
+    ? await (discordChannel as TextChannel).messages.fetch(lastMessage.id).catch(() => null)
+    : null;
+
+  if (discordMessage) {
+    pendingReplies.set(conversationId, { message: discordMessage });
+  } else {
+    console.warn(`[discord] Could not fetch message for ${conversationId} via ${agentName ?? "main"} — reply will use unprompted push`);
+  }
+  if (agentName) ctx.pendingAgents.set(conversationId, agentName);
+
+  if (isNew) {
+    ctx.conversationTracer.startTrace({
+      conversationId,
+      userId,
+      channelId,
+      agentName,
+      platform: "discord-dm",
+    }).catch(err => console.error("[discord] Langfuse startTrace error:", err));
+  }
+  ctx.pendingTurns.set(conversationId, {
+    conversationId,
+    turnNumber,
+    input: batchedContent,
+    userId,
+    agentName,
+    startTime: new Date(),
+  });
+
+  if (agentName) {
+    ctx.bus.publish("agent.skill.request", {
+      id: lastMessage.id,
+      correlationId: conversationId,
+      topic: "agent.skill.request",
+      timestamp: Date.now(),
+      payload: {
+        skill: "chat",
+        content: batchedContent,
+        targets: [agentName],
+        isDM: true,
+      },
+      source: { interface: "discord" as const, channelId, userId },
+      reply: { topic: `message.outbound.discord.${channelId}` },
+    });
+  } else {
+    ctx.bus.publish(`message.inbound.discord.${channelId}`, {
+      id: lastMessage.id,
+      correlationId: conversationId,
+      topic: `message.inbound.discord.${channelId}`,
+      timestamp: Date.now(),
+      payload: {
+        sender: userId,
+        channel: channelId,
+        content: batchedContent,
+        isDM: true,
+      },
+      source: { interface: "discord" as const, channelId, userId },
+      reply: { topic: `message.outbound.discord.${channelId}` },
+    });
+  }
+}
+
+// ── Setup DmAccumulator ───────────────────────────────────────────────────────
+
+export function setupDmAccumulator(ctx: DiscordContext): void {
+  ctx.dmAccumulator = new DmAccumulator({
+    debounceMs: Number(process.env.DM_DEBOUNCE_MS ?? 3000),
+    onFlush: (entry) => handleDMFlush(ctx, entry),
+    fallbackMailbox: ctx.mailbox,
+  });
+}
+
+// ── Register inbound event handlers ──────────────────────────────────────────
+
+export function registerInboundHandlers(ctx: DiscordContext): void {
+  // ── DM and guild message handling ────────────────────────────────────────
+  ctx.client.on(Events.MessageCreate, async message => {
+    if (message.author.bot) return;
+
+    if (!message.guild) {
+      await handleDM(ctx, message, undefined);
+      return;
+    }
+
+    const isMentioned = message.mentions.has(ctx.client.user!);
+    const userId = message.author.id;
+
+    const channelEntry = ctx.channelRegistry?.findByTopic(`message.inbound.discord.${message.channelId}`);
+    const convConfig = channelEntry?.conversation;
+    const convEnabled = convConfig?.enabled === true;
+
+    const continueWithoutMention =
+      convEnabled &&
+      convConfig?.requireMentionAfterFirst !== true &&
+      ctx.conversationManager.has(message.channelId, userId);
+
+    if (!isMentioned && !continueWithoutMention) return;
+
+    if (!isAdmin(ctx, userId)) {
+      console.log(`[discord] message from ${userId} ignored — not in admins list`);
+      return;
+    }
+
+    if (isSpam(ctx, message.content)) {
+      await message.delete().catch(() => {});
+      return;
+    }
+    if (isRateLimited(ctx, userId)) {
+      await message.reply("Easy there — you're sending messages too quickly.").catch(() => {});
+      return;
+    }
+
+    await message.react("👀").catch(() => {});
+
+    let correlationId: string;
+    let isNewConversation = false;
+    let turnNumber = 1;
+
+    if (convEnabled) {
+      const conv = ctx.conversationManager.getOrCreate(
+        message.channelId,
+        userId,
+        convConfig?.timeoutMs ?? 5 * 60_000,
+        channelEntry?.agent,
+      );
+      correlationId = conv.conversationId;
+      isNewConversation = conv.isNew;
+      turnNumber = conv.turnNumber;
+    } else {
+      correlationId = makeId();
+    }
+
+    pendingReplies.set(correlationId, { message });
+
+    if (channelEntry?.agent) {
+      ctx.pendingAgents.set(correlationId, channelEntry.agent);
+    }
+
+    const content = message.cleanContent
+      .replace(/<@!?\d+>/g, "")
+      .trim();
+
+    if (convEnabled) {
+      if (isNewConversation) {
+        ctx.conversationTracer.startTrace({
+          conversationId: correlationId,
+          userId,
+          channelId: message.channelId,
+          agentName: channelEntry?.agent,
+          platform: "discord",
+        }).catch(err => console.error("[discord] Langfuse startTrace error:", err));
+      }
+      ctx.pendingTurns.set(correlationId, {
+        conversationId: correlationId,
+        turnNumber,
+        input: content,
+        userId,
+        agentName: channelEntry?.agent,
+        startTime: new Date(),
+      });
+    }
+
+    ctx.bus.publish(`message.inbound.discord.${message.channelId}`, {
+      id: message.id,
+      correlationId,
+      topic: `message.inbound.discord.${message.channelId}`,
+      timestamp: Date.now(),
+      payload: {
+        sender: userId,
+        channel: message.channelId,
+        content,
+        isThread: message.channel.isThread(),
+        guildId: message.guildId,
+        ...(channelEntry?.agent ? { agentId: channelEntry.agent } : {}),
+      },
+      source: { interface: "discord" as const, channelId: message.channelId, userId },
+      reply: { topic: `message.outbound.discord.${message.channelId}` },
+    });
+  });
+
+  // ── 📋 reaction → bug triage ─────────────────────────────────────────────
+  ctx.client.on(Events.MessageReactionAdd, async (reaction, user) => {
+    if (user.bot) return;
+    if (reaction.emoji.name !== "📋") return;
+    if (!isAdmin(ctx, user.id)) {
+      console.log(`[discord] reaction from ${user.id} ignored — not in admins list`);
+      return;
+    }
+
+    const message = reaction.partial
+      ? await reaction.message.fetch()
+      : reaction.message as Message;
+
+    await message.react("👀").catch(() => {});
+
+    const correlationId = makeId();
+    pendingReplies.set(correlationId, { message });
+
+    ctx.bus.publish(`message.inbound.discord.${message.channelId}`, {
+      id: `${message.id}-clip`,
+      correlationId,
+      topic: `message.inbound.discord.${message.channelId}`,
+      timestamp: Date.now(),
+      payload: {
+        sender: user.id,
+        channel: message.channelId,
+        content: message.content,
+        skillHint: "bug_triage",
+        isReaction: true,
+      },
+      source: { interface: "discord" as const, channelId: message.channelId, userId: user.id },
+      reply: { topic: `message.outbound.discord.${message.channelId}` },
+    });
+  });
+}

--- a/lib/plugins/discord/memory.ts
+++ b/lib/plugins/discord/memory.ts
@@ -1,0 +1,57 @@
+/**
+ * memory.ts — /memory slash command implementation.
+ *
+ * Handles show, search, and clear subcommands against the Graphiti memory store.
+ */
+
+import type { ChatInputCommandInteraction } from "discord.js";
+import type { DiscordContext } from "./core.ts";
+
+export async function handleMemoryCommand(
+  ctx: DiscordContext,
+  interaction: ChatInputCommandInteraction,
+): Promise<void> {
+  const userId = interaction.user.id;
+
+  if (!ctx.identityRegistry) {
+    await interaction.editReply("Memory not available.").catch(console.error);
+    return;
+  }
+
+  const groupId = ctx.identityRegistry.groupId("discord", userId);
+  const subName = interaction.options.getSubcommand(false);
+
+  if (!subName || subName === "show") {
+    const facts = await ctx.graphiti.search(groupId, "preferences habits goals context", 20).catch(() => []);
+    if (facts.length === 0) {
+      await interaction.editReply("No memory stored yet.").catch(console.error);
+      return;
+    }
+    const now = Date.now();
+    const active = facts.filter(f => {
+      if (f.invalid_at && new Date(f.invalid_at).getTime() <= now) return false;
+      if (f.expired_at && new Date(f.expired_at).getTime() <= now) return false;
+      return true;
+    });
+    if (active.length === 0) {
+      await interaction.editReply("No active memory facts.").catch(console.error);
+      return;
+    }
+    const lines = active.map((f, i) => `**${i + 1}.** ${f.fact}`).join("\n");
+    await interaction.editReply(`**Memory** (${active.length} facts):\n${lines}`.slice(0, 2000)).catch(console.error);
+
+  } else if (subName === "search") {
+    const query = interaction.options.getString("query", true);
+    const facts = await ctx.graphiti.search(groupId, query, 10).catch(() => []);
+    if (facts.length === 0) {
+      await interaction.editReply(`No facts found for: "${query}"`).catch(console.error);
+      return;
+    }
+    const lines = facts.map((f, i) => `**${i + 1}.** ${f.fact}`).join("\n");
+    await interaction.editReply(`**"${query}"** — ${facts.length} fact(s):\n${lines}`.slice(0, 2000)).catch(console.error);
+
+  } else if (subName === "clear") {
+    await ctx.graphiti.clearUser(groupId);
+    await interaction.editReply("Memory cleared.").catch(console.error);
+  }
+}

--- a/lib/plugins/discord/outbound.ts
+++ b/lib/plugins/discord/outbound.ts
@@ -1,0 +1,213 @@
+/**
+ * outbound.ts — Reply handling, HITL rendering, and outbound bus subscription.
+ *
+ * Owns the pendingReplies map (written by inbound/slash-commands, consumed here).
+ */
+
+import {
+  EmbedBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  type Message,
+  type ChatInputCommandInteraction,
+  type TextChannel,
+} from "discord.js";
+import type { BusMessage, HITLRequest } from "../../types.ts";
+import type { DiscordContext } from "./core.ts";
+
+// ── Pending reply handles ─────────────────────────────────────────────────────
+// Kept outside bus payload so the SQLite logger never tries to serialize them.
+
+export const pendingReplies = new Map<
+  string,
+  { message?: Message; interaction?: ChatInputCommandInteraction }
+>();
+
+// ── Progress update throttle ──────────────────────────────────────────────────
+
+const progressLastSent = new Map<string, number>();
+const PROGRESS_MIN_INTERVAL_MS = 5_000;
+
+export function canSendProgress(correlationId: string): boolean {
+  const last = progressLastSent.get(correlationId) ?? 0;
+  if (Date.now() - last < PROGRESS_MIN_INTERVAL_MS) return false;
+  progressLastSent.set(correlationId, Date.now());
+  return true;
+}
+
+// ── HITL embed/button builders ────────────────────────────────────────────────
+
+export function buildHITLEmbed(request: HITLRequest): EmbedBuilder {
+  const embed = new EmbedBuilder()
+    .setTitle(request.title)
+    .setDescription(request.summary.slice(0, 4096))
+    .setColor(0xf59e0b);
+
+  if (request.avaVerdict) {
+    embed.addFields({
+      name: `Ava verdict (score: ${request.avaVerdict.score})`,
+      value: request.avaVerdict.verdict.slice(0, 1024),
+      inline: false,
+    });
+  }
+  if (request.jonVerdict) {
+    embed.addFields({
+      name: `Jon verdict (score: ${request.jonVerdict.score})`,
+      value: request.jonVerdict.verdict.slice(0, 1024),
+      inline: false,
+    });
+  }
+  if (request.escalationContext) {
+    const ctx = request.escalationContext;
+    embed.addFields({
+      name: "Cost",
+      value: `Est: **$${ctx.estimatedCost.toFixed(4)}** | Max: $${ctx.maxCost.toFixed(4)} | Tier: ${ctx.tier}`,
+      inline: false,
+    });
+  }
+
+  embed.setFooter({ text: `Expires ${new Date(request.expiresAt).toLocaleString()}` });
+  return embed;
+}
+
+export function buildHITLButtons(request: HITLRequest): ActionRowBuilder<ButtonBuilder> {
+  const row = new ActionRowBuilder<ButtonBuilder>();
+  const STYLE_BY_OPTION: Record<string, ButtonStyle> = {
+    approve: ButtonStyle.Success,
+    reject: ButtonStyle.Danger,
+  };
+  for (const option of request.options) {
+    const style = STYLE_BY_OPTION[option] ?? ButtonStyle.Secondary;
+    row.addComponents(
+      new ButtonBuilder()
+        .setCustomId(`hitl:${option}:${request.correlationId}`)
+        .setLabel(option.charAt(0).toUpperCase() + option.slice(1))
+        .setStyle(style),
+    );
+  }
+  return row;
+}
+
+// ── Register outbound handlers ────────────────────────────────────────────────
+
+export function registerOutboundHandlers(ctx: DiscordContext): void {
+  // ── Bus subscription: outbound messages ──────────────────────────────────
+  ctx.bus.subscribe("message.outbound.discord.#", "discord-outbound", async (msg: BusMessage) => {
+    const payload = msg.payload as Record<string, unknown>;
+    const content = String(payload.content ?? "").slice(0, 2000);
+    if (!content) return;
+    const correlationId = msg.correlationId;
+
+    const agentId = (payload.agentId as string | undefined)
+      ?? (correlationId ? ctx.pendingAgents.get(correlationId) : undefined);
+    const agentClient = agentId ? ctx.agentClients.get(agentId) : undefined;
+    if (agentId && !agentClient) {
+      console.debug(`[discord] No pool client for agent "${agentId}" — falling back to bus client`);
+    }
+
+    if (correlationId) {
+      const pending = pendingReplies.get(correlationId);
+      if (pending) {
+        pendingReplies.delete(correlationId);
+        ctx.pendingAgents.delete(correlationId);
+
+        const pendingTurn = ctx.pendingTurns.get(correlationId);
+        if (pendingTurn) {
+          ctx.pendingTurns.delete(correlationId);
+          ctx.conversationTracer.traceTurn({
+            ...pendingTurn,
+            output: content,
+            endTime: new Date(),
+          }).catch(err => console.error("[discord] Langfuse traceTurn error:", err));
+        }
+
+        if (pending.interaction) {
+          await pending.interaction.editReply({ content }).catch(console.error);
+          return;
+        }
+
+        if (pending.message) {
+          const isDM = !pending.message.guild;
+
+          if (isDM) {
+            await (pending.message.channel as TextChannel).send({ content }).catch(console.error);
+          } else if (agentClient) {
+            const ch = agentClient.channels.cache.get(pending.message.channelId) as TextChannel | undefined;
+            if (ch) {
+              console.debug(`[discord] Routing reply via agent client "${agentId}"`);
+              await ch.send({ content }).catch(console.error);
+            } else {
+              console.warn(`[discord] Agent "${agentId}" channel cache miss — falling back to bus client`);
+              await pending.message.reply({ content }).catch(console.error);
+            }
+          } else {
+            const reply = await pending.message.reply({ content }).catch(console.error);
+            if (reply && !pending.message.channel.isThread()) {
+              await reply.startThread({ name: content.slice(0, 50) || "Response" }).catch(() => {});
+            }
+          }
+
+          if (!isDM) {
+            await pending.message.reactions.resolve("👀")?.users.remove(ctx.client.user!).catch(() => {});
+            await pending.message.react("✅").catch(() => {});
+          }
+          return;
+        }
+      }
+    }
+
+    // Unprompted push (cron, proactive notification)
+    const channelId = String(
+      payload.channel ?? payload.recipient
+        ?? ctx.config.channels.digest
+        ?? process.env.DISCORD_DIGEST_CHANNEL
+        ?? ""
+    );
+    if (channelId) {
+      const sendClient = agentClient ?? ctx.client;
+      if (agentClient) {
+        console.debug(`[discord] Routing push to channel ${channelId} via agent client "${agentId}"`);
+      }
+      const ch = sendClient.channels.cache.get(channelId) as TextChannel | undefined;
+      await ch?.send({ content }).catch(console.error);
+    }
+  });
+
+  // ── HITL renderer registration ────────────────────────────────────────────
+  if (ctx.hitlPlugin) {
+    ctx.hitlPlugin.registerRenderer("discord", {
+      render: async (request, _busRef) => {
+        const channelId = request.sourceMeta?.channelId;
+        if (!channelId) {
+          console.warn(`[discord] HITL ${request.correlationId} missing channelId — cannot render`);
+          return;
+        }
+        const ch = ctx.client.channels.cache.get(channelId) as TextChannel | undefined;
+        if (!ch) {
+          console.warn(`[discord] HITL channel ${channelId} not in cache — cannot render`);
+          return;
+        }
+        const embed = buildHITLEmbed(request);
+        const row = buildHITLButtons(request);
+        const msg = await ch.send({ embeds: [embed], components: [row] });
+        ctx.pendingHITLMessages.set(request.correlationId, {
+          message: msg,
+          replyTopic: request.replyTopic,
+        });
+        console.log(`[discord] HITL ${request.correlationId} rendered in channel ${channelId}`);
+      },
+      onExpired: async (request, _busRef) => {
+        const entry = ctx.pendingHITLMessages.get(request.correlationId);
+        if (!entry) return;
+        ctx.pendingHITLMessages.delete(request.correlationId);
+        const expiredEmbed = new EmbedBuilder()
+          .setTitle(request.title)
+          .setDescription("**Approval expired** — re-trigger if still needed.")
+          .setColor(0x6b7280);
+        await entry.message.edit({ embeds: [expiredEmbed], components: [] }).catch(console.error);
+        console.log(`[discord] HITL ${request.correlationId} marked expired`);
+      },
+    });
+  }
+}

--- a/lib/plugins/discord/rate-limit.ts
+++ b/lib/plugins/discord/rate-limit.ts
@@ -1,0 +1,87 @@
+/**
+ * rate-limit.ts — In-memory + SQLite rate limiter and spam pattern checker.
+ */
+
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import type { DiscordContext } from "./core.ts";
+
+// ── Spam pattern compilation ──────────────────────────────────────────────────
+
+export function compileSpamPatterns(patterns: string[]): RegExp[] {
+  return patterns.flatMap(p => {
+    try {
+      if (/(\([^)]*[+*][^)]*\))[+*?]/.test(p)) {
+        console.warn(`[discord] Skipping potentially unsafe spam pattern (nested quantifiers): "${p}"`);
+        return [];
+      }
+      return [new RegExp(p, "i")];
+    } catch (err) {
+      console.warn(`[discord] Skipping invalid spam pattern "${p}":`, err);
+      return [];
+    }
+  });
+}
+
+// ── SQLite persistence ────────────────────────────────────────────────────────
+
+export function openRateLimitDb(ctx: DiscordContext, dataDir: string): void {
+  try {
+    if (!existsSync(dataDir)) {
+      mkdirSync(dataDir, { recursive: true });
+    }
+
+    ctx.rlDb = new Database(join(dataDir, "events.db"));
+    ctx.rlDb.exec("PRAGMA journal_mode=WAL");
+    ctx.rlDb.exec(`
+      CREATE TABLE IF NOT EXISTS rate_limits (
+        user_id TEXT NOT NULL,
+        ts INTEGER NOT NULL
+      )
+    `);
+    ctx.rlDb.exec("CREATE INDEX IF NOT EXISTS idx_rate_limits_user_ts ON rate_limits(user_id, ts)");
+
+    const cutoff = Date.now() - ctx.rateWindowMs;
+    const rows = ctx.rlDb
+      .query("SELECT user_id, ts FROM rate_limits WHERE ts > ?")
+      .all(cutoff) as { user_id: string; ts: number }[];
+
+    for (const row of rows) {
+      const hits = ctx.rateLimits.get(row.user_id) ?? [];
+      hits.push(row.ts);
+      ctx.rateLimits.set(row.user_id, hits);
+    }
+
+    console.log(`[discord] Rate-limit DB opened (${rows.length} persisted hit(s) loaded)`);
+  } catch (err) {
+    console.warn("[discord] Could not open rate-limit DB — falling back to in-memory only:", err);
+    ctx.rlDb = null;
+  }
+}
+
+// ── Rate limit check ──────────────────────────────────────────────────────────
+
+export function isRateLimited(ctx: DiscordContext, userId: string): boolean {
+  const now = Date.now();
+  const hits = (ctx.rateLimits.get(userId) ?? []).filter(t => now - t < ctx.rateWindowMs);
+  hits.push(now);
+  ctx.rateLimits.set(userId, hits);
+
+  if (ctx.rlDb) {
+    try {
+      ctx.rlDb.run("INSERT INTO rate_limits (user_id, ts) VALUES (?, ?)", [userId, now]);
+      ctx.rlDb.run("DELETE FROM rate_limits WHERE user_id = ? AND ts <= ?", [userId, now - ctx.rateWindowMs]);
+    } catch (err) {
+      console.warn("[discord] Failed to persist rate-limit hit:", err);
+    }
+  }
+
+  return hits.length > ctx.rateMaxMessages;
+}
+
+// ── Spam check ────────────────────────────────────────────────────────────────
+
+export function isSpam(ctx: DiscordContext, content: string): boolean {
+  return ctx.spamPatterns.some(p => p.test(content));
+}

--- a/lib/plugins/discord/slash-commands.ts
+++ b/lib/plugins/discord/slash-commands.ts
@@ -1,0 +1,233 @@
+/**
+ * slash-commands.ts — Slash command registration and interaction handling.
+ *
+ * Handles: autocomplete, HITL button interactions, /memory command,
+ * flat commands, and subcommand-based commands.
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { Events, EmbedBuilder, type ChatInputCommandInteraction, type ButtonInteraction } from "discord.js";
+import { channelIdOf, type ProjectDiscordChannel } from "../../project-schema.ts";
+import { makeId, OPTION_TYPE_CODES } from "./core.ts";
+import { pendingReplies } from "./outbound.ts";
+import { handleMemoryCommand } from "./memory.ts";
+import type { DiscordContext, CommandOption } from "./core.ts";
+
+// ── Project types ─────────────────────────────────────────────────────────────
+
+interface ProjectEntry {
+  slug: string;
+  title: string;
+  github?: string;
+  status?: string;
+  discord?: {
+    general?: ProjectDiscordChannel;
+    updates?: ProjectDiscordChannel;
+    dev?: ProjectDiscordChannel;
+  };
+}
+
+interface ProjectsYaml {
+  projects: ProjectEntry[];
+}
+
+export function loadProjectsDefs(workspaceDir: string): ProjectEntry[] {
+  const projectsPath = join(workspaceDir, "projects.yaml");
+  if (!existsSync(projectsPath)) return [];
+  try {
+    const raw = readFileSync(projectsPath, "utf8");
+    const parsed = parseYaml(raw) as ProjectsYaml;
+    return (parsed.projects ?? []).filter(
+      p => p.status !== "archived" && p.status !== "suspended"
+    );
+  } catch (err) {
+    console.error("[discord] Failed to parse projects.yaml:", err);
+    return [];
+  }
+}
+
+// ── Content interpolation ─────────────────────────────────────────────────────
+
+export function interpolateContent(
+  template: string,
+  options: CommandOption[],
+  interaction: ChatInputCommandInteraction,
+): string {
+  let result = template;
+  for (const opt of options) {
+    const placeholder = `{${opt.name}}`;
+    if (!result.includes(placeholder)) continue;
+    let value = "";
+    if (opt.type === "string") value = interaction.options.getString(opt.name) ?? "";
+    else if (opt.type === "integer") value = String(interaction.options.getInteger(opt.name) ?? "");
+    else if (opt.type === "boolean") value = String(interaction.options.getBoolean(opt.name) ?? "");
+    result = result.replaceAll(placeholder, value);
+  }
+  return result.trim();
+}
+
+// ── HITL button interaction ───────────────────────────────────────────────────
+
+async function handleHITLButton(ctx: DiscordContext, interaction: ButtonInteraction): Promise<void> {
+  try { await interaction.deferUpdate(); } catch (err) {
+    console.warn(`[discord] HITL deferUpdate failed (${err instanceof Error ? err.message : err}) — processing decision anyway`);
+  }
+
+  const [, decision, correlationId] = interaction.customId.split(":");
+  if (!decision || !correlationId) {
+    console.warn(`[discord] HITL button with malformed customId: ${interaction.customId}`);
+    return;
+  }
+
+  const entry = ctx.pendingHITLMessages.get(correlationId);
+  const replyTopic = entry?.replyTopic ?? `hitl.response.pr.remediation_stuck.${correlationId}`;
+
+  try {
+    ctx.bus.publish(replyTopic, {
+      id: crypto.randomUUID(), correlationId, topic: replyTopic, timestamp: Date.now(),
+      payload: { type: "hitl_response", correlationId, decision, decidedBy: interaction.user.id },
+    });
+  } catch (err) {
+    console.error(`[discord] HITL bus publish failed for ${correlationId}:`, err);
+  }
+
+  if (entry) ctx.pendingHITLMessages.delete(correlationId);
+
+  const COLOR_MAP: Record<string, number> = { approve: 0x22c55e, reject: 0xef4444 };
+  const color = COLOR_MAP[decision] ?? 0x6b7280;
+  const label = decision.charAt(0).toUpperCase() + decision.slice(1).replace(/_/g, " ");
+  const decidedEmbed = new EmbedBuilder()
+    .setTitle(interaction.message.embeds[0]?.title ?? "Decision recorded")
+    .setDescription(`**${label}** by <@${interaction.user.id}>`)
+    .setColor(color);
+
+  await interaction.message.edit({ embeds: [decidedEmbed], components: [] }).catch(err => {
+    console.warn(`[discord] HITL message edit failed for ${correlationId}:`, err instanceof Error ? err.message : err);
+  });
+}
+
+// ── Slash command registration ────────────────────────────────────────────────
+
+export async function registerSlashCommands(ctx: DiscordContext): Promise<void> {
+  const guildId = process.env.DISCORD_GUILD_ID;
+  if (!guildId) { console.log("[discord] DISCORD_GUILD_ID not set — skipping slash command registration"); return; }
+
+  const guild = ctx.client.guilds.cache.get(guildId);
+  if (!guild) { console.log(`[discord] Guild ${guildId} not found`); return; }
+  if (!ctx.config.commands.length) { console.log("[discord] No commands configured in discord.yaml"); return; }
+
+  const commandData = ctx.config.commands.map(cmd => {
+    if (cmd.options?.length && !cmd.subcommands?.length) {
+      return {
+        name: cmd.name, description: cmd.description,
+        options: cmd.options.map(opt => ({
+          name: opt.name, description: opt.description,
+          type: OPTION_TYPE_CODES[opt.type] ?? 3, required: opt.required ?? false, autocomplete: opt.autocomplete ?? false,
+        })),
+      };
+    }
+    return {
+      name: cmd.name, description: cmd.description,
+      options: (cmd.subcommands ?? []).map(sub => ({
+        name: sub.name, type: 1, description: sub.description,
+        options: (sub.options ?? []).map(opt => ({
+          name: opt.name, description: opt.description,
+          type: OPTION_TYPE_CODES[opt.type] ?? 3, required: opt.required ?? false,
+        })),
+      })),
+    };
+  });
+
+  await guild.commands.set(commandData);
+  console.log(`[discord] Registered ${commandData.length} command(s): ${commandData.map(c => `/${c.name}`).join(", ")}`);
+}
+
+// ── Register interaction handlers ─────────────────────────────────────────────
+
+export function registerSlashCommandHandlers(ctx: DiscordContext): void {
+  ctx.client.on(Events.InteractionCreate, async interaction => {
+    if (interaction.isAutocomplete()) {
+      const cmdConfig = ctx.config.commands.find(c => c.name === interaction.commandName);
+      if (!cmdConfig) return;
+      const focused = interaction.options.getFocused(true);
+      if (focused.name === "project") {
+        const projects = loadProjectsDefs(ctx.workspaceDir);
+        const typed = focused.value.toLowerCase();
+        const choices = projects
+          .filter(p => p.slug.toLowerCase().includes(typed) || p.title.toLowerCase().includes(typed))
+          .slice(0, 25).map(p => ({ name: p.title, value: p.slug }));
+        await interaction.respond(choices).catch(console.error);
+      }
+      return;
+    }
+
+    if (interaction.isButton() && interaction.customId.startsWith("hitl:")) {
+      await handleHITLButton(ctx, interaction);
+      return;
+    }
+
+    if (!interaction.isChatInputCommand()) return;
+    ctx.client.users.createDM(interaction.user.id).catch(() => {});
+
+    const cmdConfig = ctx.config.commands.find(c => c.name === interaction.commandName);
+    if (!cmdConfig) return;
+
+    if (ctx.config.admins?.length && !ctx.config.admins.includes(interaction.user.id)) {
+      console.log(`[discord] slash command from ${interaction.user.id} ignored — not in admins list`);
+      await interaction.reply({ content: "Not authorised.", ephemeral: true }).catch(() => {});
+      return;
+    }
+
+    if (interaction.commandName === "memory") {
+      await interaction.deferReply({ ephemeral: true });
+      await handleMemoryCommand(ctx, interaction);
+      return;
+    }
+
+    await interaction.deferReply();
+
+    const isFlatCommand = !!cmdConfig.options?.length && !cmdConfig.subcommands?.length;
+    if (isFlatCommand) {
+      const projectSlug = interaction.options.getString("project");
+      let devChannelId: string | undefined;
+      let projectRepo: string | undefined;
+      if (projectSlug) {
+        const project = loadProjectsDefs(ctx.workspaceDir).find(p => p.slug === projectSlug);
+        if (project) {
+          devChannelId = channelIdOf(project.discord?.dev) || undefined;
+          projectRepo = project.github || undefined;
+        }
+      }
+      const content = interpolateContent(cmdConfig.content ?? "", cmdConfig.options ?? [], interaction);
+      const correlationId = makeId();
+      pendingReplies.set(correlationId, { interaction });
+      const topicSuffix = `slash.${interaction.id}`;
+      ctx.bus.publish(`message.inbound.discord.${topicSuffix}`, {
+        id: interaction.id, correlationId, topic: `message.inbound.discord.${topicSuffix}`, timestamp: Date.now(),
+        payload: { sender: interaction.user.id, channel: interaction.channelId, content, skillHint: cmdConfig.skillHint,
+          ...(devChannelId ? { devChannelId } : {}), ...(projectRepo ? { projectRepo } : {}) },
+        source: { interface: "discord" as const, channelId: interaction.channelId, userId: interaction.user.id },
+        reply: { topic: `message.outbound.discord.${topicSuffix}` },
+      });
+      return;
+    }
+
+    const subcommands = cmdConfig.subcommands ?? [];
+    const subName = interaction.options.getSubcommand(false) ?? subcommands[0]?.name;
+    const subConfig = subcommands.find(s => s.name === subName) ?? subcommands[0];
+    if (!subConfig) { await interaction.editReply("Unknown subcommand.").catch(console.error); return; }
+
+    const content = interpolateContent(subConfig.content, subConfig.options ?? [], interaction);
+    const correlationId = makeId();
+    pendingReplies.set(correlationId, { interaction });
+    const topicSuffix = `slash.${interaction.id}`;
+    ctx.bus.publish(`message.inbound.discord.${topicSuffix}`, {
+      id: interaction.id, correlationId, topic: `message.inbound.discord.${topicSuffix}`, timestamp: Date.now(),
+      payload: { sender: interaction.user.id, channel: interaction.channelId, content, skillHint: subConfig.skillHint },
+      source: { interface: "discord" as const, channelId: interaction.channelId, userId: interaction.user.id },
+      reply: { topic: `message.outbound.discord.${topicSuffix}` },
+    });
+  });
+}


### PR DESCRIPTION
## Summary

The Discord plugin has become a god file mixing too many concerns. Decompose into focused modules under `lib/plugins/discord/`:

- `lib/plugins/discord/core.ts` — client lifecycle, bot identity, connection status
- `lib/plugins/discord/inbound.ts` — DM and guild message handlers
- `lib/plugins/discord/slash-commands.ts` — /memory and future slash commands
- `lib/plugins/discord/outbound.ts` — reply handling, webhook posting, outbound routing
- `lib/plugins/discord/rate-limit.ts` — in-memory + SQ...

---
*Recovered automatically by Automaker post-agent hook*