### PR TITLE
feat(goap): [Arc 2.2] unify outcome stream — delete world.action.outcome

### DIFF
--- a/src/event-bus/action-events.test.ts
+++ b/src/event-bus/action-events.test.ts
@@ -2,24 +2,23 @@ import { describe, test, expect } from "bun:test";
 import { TOPICS } from "./topics.ts";
 import type {
   ActionDispatchPayload,
-  ActionOutcomePayload,
   PlannerEscalatePayload,
 } from "./action-events.ts";
+import type { AutonomousOutcomePayload } from "./payloads.ts";
 
 describe("EventBus Topics", () => {
   test("all expected topics are defined", () => {
     expect(TOPICS.WORLD_STATE_UPDATED).toBe("world.state.updated");
     expect(TOPICS.WORLD_ACTION_DISPATCH).toBe("world.action.dispatch");
-    expect(TOPICS.WORLD_ACTION_OUTCOME).toBe("world.action.outcome");
     expect(TOPICS.WORLD_ACTION_OSCILLATION).toBe("world.action.oscillation");
     expect(TOPICS.WORLD_ACTION_QUEUE_FULL).toBe("world.action.queue_full");
     expect(TOPICS.PLANNER_ESCALATE).toBe("world.planner.escalate");
+    expect(TOPICS.AUTONOMOUS_OUTCOME_PREFIX).toBe("autonomous.outcome");
   });
 
-  test("topic values follow world.action.* convention", () => {
+  test("dispatch + oscillation + queue_full stay under world.action.*", () => {
     const actionTopics = [
       TOPICS.WORLD_ACTION_DISPATCH,
-      TOPICS.WORLD_ACTION_OUTCOME,
       TOPICS.WORLD_ACTION_OSCILLATION,
       TOPICS.WORLD_ACTION_QUEUE_FULL,
     ];
@@ -56,34 +55,52 @@ describe("ActionDispatchPayload", () => {
   });
 });
 
-describe("ActionOutcomePayload", () => {
-  test("success outcome", () => {
-    const payload: ActionOutcomePayload = {
-      type: "outcome",
+describe("AutonomousOutcomePayload", () => {
+  test("success outcome with goap context", () => {
+    const payload: AutonomousOutcomePayload = {
+      correlationId: "corr-1",
+      systemActor: "goap",
+      skill: "unblock_feature",
       actionId: "act-1",
       goalId: "goal-1",
-      correlationId: "corr-1",
-      timestamp: Date.now(),
       success: true,
+      taskState: "completed",
       durationMs: 150,
     };
     expect(payload.success).toBe(true);
     expect(payload.error).toBeUndefined();
+    expect(payload.actionId).toBe("act-1");
+    expect(payload.goalId).toBe("goal-1");
   });
 
   test("failure outcome with error", () => {
-    const payload: ActionOutcomePayload = {
-      type: "outcome",
+    const payload: AutonomousOutcomePayload = {
+      correlationId: "corr-1",
+      systemActor: "goap",
+      skill: "unblock_feature",
       actionId: "act-1",
       goalId: "goal-1",
-      correlationId: "corr-1",
-      timestamp: Date.now(),
       success: false,
       error: "Precondition check failed",
+      taskState: "failed",
       durationMs: 10,
     };
     expect(payload.success).toBe(false);
     expect(payload.error).toBe("Precondition check failed");
+  });
+
+  test("ceremony-originated outcome (no actionId/goalId)", () => {
+    const payload: AutonomousOutcomePayload = {
+      correlationId: "corr-2",
+      systemActor: "ceremony",
+      skill: "daily_sitrep",
+      success: true,
+      taskState: "completed",
+      durationMs: 2500,
+    };
+    expect(payload.systemActor).toBe("ceremony");
+    expect(payload.actionId).toBeUndefined();
+    expect(payload.goalId).toBeUndefined();
   });
 });
 

--- a/src/event-bus/action-events.ts
+++ b/src/event-bus/action-events.ts
@@ -19,18 +19,6 @@ export interface ActionDispatchPayload {
   optimisticEffectsApplied: boolean;
 }
 
-/** Payload for world.action.outcome — published when an action completes or fails. */
-export interface ActionOutcomePayload {
-  type: "outcome";
-  actionId: string;
-  goalId: string;
-  correlationId: string;
-  timestamp: number;
-  success: boolean;
-  error?: string;
-  durationMs: number;
-}
-
 /** Payload for world.action.oscillation — published on loop detection breach. */
 export interface ActionOscillationPayload {
   type: "oscillation";

--- a/src/event-bus/all-topics.ts
+++ b/src/event-bus/all-topics.ts
@@ -50,9 +50,6 @@ export const WORLD_TOPICS = {
   /** Published by ActionDispatcherPlugin when an action is dispatched. */
   WORLD_ACTION_DISPATCH: "world.action.dispatch",
 
-  /** Published by ActionDispatcherPlugin when an action outcome is recorded. */
-  WORLD_ACTION_OUTCOME: "world.action.outcome",
-
   /** Published by LoopDetector when oscillation threshold is breached. */
   WORLD_ACTION_OSCILLATION: "world.action.oscillation",
 

--- a/src/event-bus/payloads.ts
+++ b/src/event-bus/payloads.ts
@@ -11,7 +11,6 @@
 // Re-export action event payloads (already defined)
 export type {
   ActionDispatchPayload,
-  ActionOutcomePayload,
   ActionOscillationPayload,
   ActionQueueFullPayload,
   PlannerEscalatePayload,
@@ -228,12 +227,21 @@ export interface AutonomousOutcomePayload {
   correlationId: string;
   /** Parent span ID — the bus message ID that triggered the skill request. */
   parentId?: string;
-  /** Autonomous subsystem actor (e.g. "pr-remediator", "sweep") or "user". */
+  /** Autonomous subsystem actor (e.g. "goap", "ceremony", "pr-remediator") or "user". */
   systemActor: string;
   /** Skill name that was executed. */
   skill: string;
+  /** GOAP action id when the outcome came from a planned action — optional,
+   *  unset for ad-hoc or ceremony dispatches. Kept distinct from `skill` so
+   *  the planner's loop-detector can reason about action identity even when
+   *  the skill name is shared across actions. */
+  actionId?: string;
+  /** Goal id that triggered this outcome (when originating from GOAP). */
+  goalId?: string;
   /** True if the task completed without error. */
   success: boolean;
+  /** Error message when success is false. */
+  error?: string;
   /** Final A2A task lifecycle state (completed, failed, canceled, etc.). */
   taskState?: string;
   /** First 500 chars of the result text — for quick inspection. */

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -225,6 +225,14 @@ export class SkillDispatcherPlugin implements Plugin {
       typeof msg.source?.channelId === "string" ? msg.source.channelId : undefined;
     const systemActor: string | undefined =
       typeof payload.meta?.systemActor === "string" ? payload.meta.systemActor : undefined;
+    // When GOAP publishes to agent.skill.request, it stamps actionId + goalId
+    // on meta so the autonomous outcome can carry them back to the planner's
+    // loop detector.
+    const goapActionId: string | undefined =
+      typeof payload.meta?.actionId === "string" ? payload.meta.actionId : undefined;
+    const goapGoalId: string | undefined =
+      typeof payload.meta?.goalId === "string" ? payload.meta.goalId
+      : (typeof payload.goalId === "string" ? payload.goalId : undefined);
 
     let rawContent = typeof payload.content === "string" ? payload.content : undefined;
     const originalContent = rawContent; // preserved for episode storage — never includes context prefix
@@ -325,6 +333,8 @@ export class SkillDispatcherPlugin implements Plugin {
               parentId,
               systemActor: systemActor ?? "user",
               skill,
+              actionId: goapActionId,
+              goalId: goapGoalId,
               success: !isError,
               taskState,
               text: content,
@@ -371,6 +381,8 @@ export class SkillDispatcherPlugin implements Plugin {
           parentId,
           systemActor: systemActor ?? "user",
           skill,
+          actionId: goapActionId,
+          goalId: goapGoalId,
           success: false,
           taskState: result.data?.taskState ?? "failed",
           text: result.text,
@@ -410,6 +422,8 @@ export class SkillDispatcherPlugin implements Plugin {
           parentId,
           systemActor: systemActor ?? "user",
           skill,
+          actionId: goapActionId,
+          goalId: goapGoalId,
           success: true,
           taskState: result.data?.taskState ?? "completed",
           text: result.text,
@@ -467,6 +481,8 @@ export class SkillDispatcherPlugin implements Plugin {
         parentId,
         systemActor: systemActor ?? "user",
         skill,
+        actionId: goapActionId,
+        goalId: goapGoalId,
         success: false,
         taskState: "failed",
         text: errorMsg,
@@ -525,7 +541,10 @@ export class SkillDispatcherPlugin implements Plugin {
     parentId: string | undefined;
     systemActor: string;
     skill: string;
+    actionId?: string;
+    goalId?: string;
     success: boolean;
+    error?: string;
     taskState?: string;
     text?: string;
     usage?: AutonomousOutcomePayload["usage"];
@@ -538,7 +557,10 @@ export class SkillDispatcherPlugin implements Plugin {
       parentId: opts.parentId,
       systemActor: opts.systemActor,
       skill: opts.skill,
+      actionId: opts.actionId,
+      goalId: opts.goalId,
       success: opts.success,
+      error: opts.error,
       taskState: opts.taskState,
       textPreview: opts.text ? opts.text.slice(0, 500) : undefined,
       usage: opts.usage,

--- a/src/planner/planning-orchestrator.test.ts
+++ b/src/planner/planning-orchestrator.test.ts
@@ -2,7 +2,8 @@ import { describe, test, expect, beforeEach } from "bun:test";
 import { InMemoryEventBus } from "../../lib/bus.ts";
 import { PlanningOrchestrator } from "./planning-orchestrator.ts";
 import { TOPICS } from "../event-bus/topics.ts";
-import type { ActionDispatchPayload, ActionOutcomePayload } from "../event-bus/action-events.ts";
+import type { ActionDispatchPayload } from "../event-bus/action-events.ts";
+import type { AutonomousOutcomePayload } from "../event-bus/payloads.ts";
 import type { WorldState } from "../../lib/types/world-state.ts";
 import type { Action } from "./types/action.ts";
 
@@ -68,9 +69,9 @@ describe("PlanningOrchestrator", () => {
     const action = makeAction();
     orchestrator.getRegistry().register(action);
 
-    const outcomes: ActionOutcomePayload[] = [];
-    bus.subscribe(TOPICS.WORLD_ACTION_OUTCOME, "test", (msg) => {
-      outcomes.push(msg.payload as ActionOutcomePayload);
+    const outcomes: AutonomousOutcomePayload[] = [];
+    bus.subscribe("autonomous.outcome.goap.test-action", "test", (msg) => {
+      outcomes.push(msg.payload as AutonomousOutcomePayload);
     });
 
     bus.publish(TOPICS.WORLD_STATE_UPDATED, {

--- a/src/plugins/action-dispatcher-plugin.test.ts
+++ b/src/plugins/action-dispatcher-plugin.test.ts
@@ -2,7 +2,8 @@ import { describe, test, expect, beforeEach } from "bun:test";
 import { InMemoryEventBus } from "../../lib/bus.ts";
 import { ActionDispatcherPlugin } from "./action-dispatcher-plugin.ts";
 import { TOPICS } from "../event-bus/topics.ts";
-import type { ActionDispatchPayload, ActionOutcomePayload, ActionQueueFullPayload } from "../event-bus/action-events.ts";
+import type { ActionDispatchPayload, ActionQueueFullPayload } from "../event-bus/action-events.ts";
+import type { AutonomousOutcomePayload } from "../event-bus/payloads.ts";
 import type { Action } from "../planner/types/action.ts";
 import type { BusMessage } from "../../lib/types.ts";
 import type { WorldState } from "../../lib/types/world-state.ts";
@@ -58,9 +59,9 @@ describe("ActionDispatcherPlugin", () => {
   });
 
   test("dispatches tier_0 action and publishes outcome", async () => {
-    const outcomes: ActionOutcomePayload[] = [];
-    bus.subscribe(TOPICS.WORLD_ACTION_OUTCOME, "test", (msg) => {
-      outcomes.push(msg.payload as ActionOutcomePayload);
+    const outcomes: AutonomousOutcomePayload[] = [];
+    bus.subscribe("autonomous.outcome.goap.test-action", "test", (msg) => {
+      outcomes.push(msg.payload as AutonomousOutcomePayload);
     });
 
     const action = makeAction({ tier: "tier_0", meta: { fireAndForget: true } });
@@ -87,7 +88,7 @@ describe("ActionDispatcherPlugin", () => {
     await new Promise((r) => setTimeout(r, 10));
 
     // Outcome should report success
-    const outcomes: ActionOutcomePayload[] = [];
+    const outcomes: AutonomousOutcomePayload[] = [];
     // Already dispatched — check queue instead
     expect(dispatcher.getQueue().activeCount).toBe(0);
     expect(dispatcher.getOutcomes().summary().success).toBe(1);
@@ -168,9 +169,9 @@ describe("ActionDispatcherPlugin", () => {
   });
 
   test("completes action when agent.skill.response.* is received", async () => {
-    const outcomes: import("../event-bus/action-events.ts").ActionOutcomePayload[] = [];
-    bus.subscribe(TOPICS.WORLD_ACTION_OUTCOME, "test", (msg) => {
-      outcomes.push(msg.payload as import("../event-bus/action-events.ts").ActionOutcomePayload);
+    const outcomes: AutonomousOutcomePayload[] = [];
+    bus.subscribe("autonomous.outcome.#", "test", (msg) => {
+      outcomes.push(msg.payload as AutonomousOutcomePayload);
     });
 
     const action = makeAction({

--- a/src/plugins/action-dispatcher-plugin.ts
+++ b/src/plugins/action-dispatcher-plugin.ts
@@ -3,19 +3,20 @@
  * optimistic state updates.
  *
  * Subscribes to: world.action.dispatch
- * Publishes:     agent.skill.request, world.action.outcome, world.action.queue_full
+ * Publishes:     agent.skill.request, autonomous.outcome.goap.{skill}, world.action.queue_full
  *
  * On receiving a dispatch event:
  *   1. Checks WIP limit; if at capacity, queues action and publishes queue_full
  *   2. Applies optimistic state effects via StateUpdater
  *   3. Publishes to agent.skill.request with source.interface='cron',
  *      payload.meta.systemActor='goap', and reply.topic=`agent.skill.response.${correlationId}`
- *   4. Publishes world.action.outcome with result
+ *   4. Publishes autonomous.outcome.goap.{skill} with the unified outcome payload
  *   6. On failure: triggers rollback via StateRollbackRegistry
  */
 
 import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
-import type { ActionDispatchPayload, ActionOutcomePayload, ActionQueueFullPayload } from "../event-bus/action-events.ts";
+import type { ActionDispatchPayload, ActionQueueFullPayload } from "../event-bus/action-events.ts";
+import type { AutonomousOutcomePayload } from "../event-bus/payloads.ts";
 import type { AgentSkillResponsePayload } from "../event-bus/payloads.ts";
 import type { WorldState } from "../../lib/types/world-state.ts";
 import { TOPICS } from "../event-bus/topics.ts";
@@ -184,7 +185,7 @@ export class ActionDispatcherPlugin implements Plugin {
           payload: {
             skill: action.meta.skillHint ?? action.id,
             goalId: action.goalId,
-            meta: { ...action.meta, systemActor: "goap" },
+            meta: { ...action.meta, systemActor: "goap", actionId: action.id, goalId: action.goalId },
           },
         });
         await this.completeAction(action, correlationId, parentCorrelationId, startedAt, true);
@@ -222,7 +223,7 @@ export class ActionDispatcherPlugin implements Plugin {
           payload: {
             skill: action.meta.skillHint ?? action.id,
             goalId: action.goalId,
-            meta: { ...action.meta, systemActor: "goap" },
+            meta: { ...action.meta, systemActor: "goap", actionId: action.id, goalId: action.goalId },
           },
         });
 
@@ -300,22 +301,28 @@ export class ActionDispatcherPlugin implements Plugin {
     });
     this.telemetry?.bump("action", action.id, status);
 
-    // Publish outcome event
-    const outcomePayload: ActionOutcomePayload = {
-      type: "outcome",
+    // Publish unified outcome event. ActionDispatcher is the outcome source
+    // for tier_0 (short-circuit) actions — for other tiers, SkillDispatcher
+    // emits the outcome after the skill completes. Both use the same topic
+    // shape so OutcomeAnalysis sees one unified stream.
+    const skill = action.meta.skillHint ?? action.id;
+    const outcomeTopic = `autonomous.outcome.goap.${skill}`;
+    const outcomePayload: AutonomousOutcomePayload = {
+      correlationId,
+      systemActor: "goap",
+      skill,
       actionId: action.id,
       goalId: action.goalId,
-      correlationId,
-      timestamp: completedAt,
       success,
       error,
+      taskState: success ? "completed" : (status === "timeout" ? "canceled" : "failed"),
       durationMs: completedAt - startedAt,
     };
 
-    this.bus.publish(TOPICS.WORLD_ACTION_OUTCOME, {
+    this.bus.publish(outcomeTopic, {
       id: crypto.randomUUID(),
       correlationId: parentCorrelationId,
-      topic: TOPICS.WORLD_ACTION_OUTCOME,
+      topic: outcomeTopic,
       timestamp: completedAt,
       payload: outcomePayload,
     });

--- a/src/plugins/outcome-analysis-plugin.ts
+++ b/src/plugins/outcome-analysis-plugin.ts
@@ -1,12 +1,13 @@
 /**
  * OutcomeAnalysisPlugin — closes the learning loop.
  *
- * Subscribes to world.action.outcome events, tracks per-action success rates
- * and HITL escalation frequency, and emits signals on chronic issues:
+ * Subscribes to the unified `autonomous.outcome.#` stream (Arc 2.1 / 2.2),
+ * tracks per-skill success rates and HITL escalation frequency, and emits
+ * signals on chronic issues:
  *
- *   - Actions with <50% success rate over 10+ attempts → publishes
+ *   - Skills with <50% success rate over 10+ attempts → publishes
  *     ops.alert.action_quality so the fleet knows to investigate/replace it.
- *   - Actions with repeated HITL escalations → treated as feature-request
+ *   - Skills with repeated HITL escalations → treated as feature-request
  *     signals ("what would have unblocked this automatically?") and logged
  *     for Ava to file on the board.
  *
@@ -14,18 +15,25 @@
  * own failures become inputs to its own improvement backlog.
  *
  * Inbound:
- *   world.action.outcome  — every action completion
+ *   autonomous.outcome.#  — unified terminal-state event for every autonomous
+ *                           action (GOAP, ceremony, FAF, any skill dispatch).
+ *                           Replaces the previous split between
+ *                           world.action.outcome and per-reply-topic responses.
  *   hitl.escalation       — every HITL timeout/exhaustion (per pr-remediator)
  *
  * Outbound:
- *   ops.alert.action_quality   — action with poor success rate
+ *   ops.alert.action_quality   — skill with poor success rate
  *   ops.alert.hitl_escalation  — repeated human-needed action
  */
 
 import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
+import type { AutonomousOutcomePayload } from "../event-bus/payloads.ts";
 
 interface ActionStats {
+  /** Stats key — either a skill name (unified stream) or a legacy actionId. */
   actionId: string;
+  /** Autonomous subsystem that dispatched this skill (e.g. "goap", "ceremony"). */
+  systemActor?: string;
   total: number;
   success: number;
   failure: number;
@@ -63,9 +71,13 @@ export class OutcomeAnalysisPlugin implements Plugin {
   install(bus: EventBus): void {
     this.bus = bus;
 
+    // Every skill dispatch — GOAP action, ceremony, FAF, user-triggered —
+    // produces exactly one event on autonomous.outcome.# when the task reaches
+    // terminal state. Single source of truth for outcome clustering.
     this.subscriptionIds.push(
-      bus.subscribe("world.action.outcome", this.name, (msg) => this._onOutcome(msg)),
+      bus.subscribe("autonomous.outcome.#", this.name, (msg) => this._onAutonomousOutcome(msg)),
     );
+
     this.subscriptionIds.push(
       bus.subscribe("hitl.escalation", this.name, (msg) => this._onHitlEscalation(msg)),
     );
@@ -85,17 +97,23 @@ export class OutcomeAnalysisPlugin implements Plugin {
     this.bus = undefined;
   }
 
-  private _onOutcome(msg: BusMessage): void {
-    const p = msg.payload as Record<string, unknown> | undefined;
-    const actionId = typeof p?.actionId === "string" ? p.actionId : undefined;
-    if (!actionId) return;
+  /**
+   * Handle the autonomous.outcome.# stream. Routes by `skill`, which for
+   * GOAP-dispatched actions matches action.id (ActionDispatcher uses
+   * `skill: meta.skillHint ?? action.id`), and for ceremonies / user-
+   * dispatches uses the skill name directly. systemActor is captured so
+   * downstream reporting can slice per subsystem.
+   */
+  private _onAutonomousOutcome(msg: BusMessage): void {
+    const p = msg.payload as AutonomousOutcomePayload | undefined;
+    if (!p || typeof p.skill !== "string" || !p.skill) return;
 
-    const success = p?.success === true;
-    const error = typeof p?.error === "string" ? p.error : undefined;
-    const isTimeout = error?.toLowerCase().includes("timeout") ?? false;
+    const preview = typeof p.textPreview === "string" ? p.textPreview.toLowerCase() : "";
+    const isTimeout = !p.success && (preview.includes("timeout") || p.taskState === "canceled");
 
-    const stats = this.actionStats.get(actionId) ?? {
-      actionId,
+    const stats = this.actionStats.get(p.skill) ?? {
+      actionId: p.skill,
+      systemActor: p.systemActor,
       total: 0,
       success: 0,
       failure: 0,
@@ -104,12 +122,12 @@ export class OutcomeAnalysisPlugin implements Plugin {
     };
 
     stats.total += 1;
-    if (success) stats.success += 1;
+    if (p.success) stats.success += 1;
     else if (isTimeout) stats.timeout += 1;
     else stats.failure += 1;
     stats.lastEvaluatedAt = Date.now();
 
-    this.actionStats.set(actionId, stats);
+    this.actionStats.set(p.skill, stats);
   }
 
   private _onHitlEscalation(msg: BusMessage): void {

--- a/src/plugins/planner-plugin-l0.test.ts
+++ b/src/plugins/planner-plugin-l0.test.ts
@@ -6,7 +6,8 @@ import { PlannerPluginL0 } from "./planner-plugin-l0.ts";
 import { TOPICS } from "../event-bus/topics.ts";
 import type { WorldState } from "../../lib/types/world-state.ts";
 import type { BusMessage } from "../../lib/types.ts";
-import type { ActionDispatchPayload, ActionOutcomePayload } from "../event-bus/action-events.ts";
+import type { ActionDispatchPayload } from "../event-bus/action-events.ts";
+import type { AutonomousOutcomePayload } from "../event-bus/payloads.ts";
 import type { Action } from "../planner/types/action.ts";
 import type { IExecutor, SkillRequest, SkillResult } from "../executor/types.ts";
 
@@ -178,26 +179,27 @@ describe("PlannerPluginL0", () => {
     expect(dispatched).toHaveLength(0);
   });
 
-  test("records outcome in loop detector on world.action.outcome", () => {
+  test("records outcome in loop detector on autonomous.outcome.#", () => {
     const action = makeAction();
     registry.register(action);
 
-    // Simulate a failure outcome
-    const outcomePayload: ActionOutcomePayload = {
-      type: "outcome",
+    // Simulate a failure outcome from a GOAP-originated skill dispatch
+    const outcomePayload: AutonomousOutcomePayload = {
+      correlationId: "corr-1",
+      systemActor: "goap",
+      skill: "test-action",
       actionId: "test-action",
       goalId: "test-goal",
-      correlationId: "corr-1",
-      timestamp: Date.now(),
       success: false,
       error: "Precondition failed at dispatch",
+      taskState: "failed",
       durationMs: 5,
     };
 
-    bus.publish(TOPICS.WORLD_ACTION_OUTCOME, {
+    bus.publish("autonomous.outcome.goap.test-action", {
       id: "1",
       correlationId: "corr-1",
-      topic: TOPICS.WORLD_ACTION_OUTCOME,
+      topic: "autonomous.outcome.goap.test-action",
       timestamp: Date.now(),
       payload: outcomePayload,
     });

--- a/src/plugins/planner-plugin-l0.ts
+++ b/src/plugins/planner-plugin-l0.ts
@@ -1,7 +1,7 @@
 /**
  * PlannerPluginL0 — deterministic L0 rule-based pattern matcher.
  *
- * Subscribes to: world.state.updated, world.action.outcome
+ * Subscribes to: world.state.updated, autonomous.outcome.#
  * Publishes:     world.action.dispatch, world.planner.escalate, world.action.oscillation
  *
  * Flow:
@@ -16,10 +16,10 @@ import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
 import type { WorldState } from "../../lib/types/world-state.ts";
 import type {
   ActionDispatchPayload,
-  ActionOutcomePayload,
   ActionOscillationPayload,
   PlannerEscalatePayload,
 } from "../event-bus/action-events.ts";
+import type { AutonomousOutcomePayload } from "../event-bus/payloads.ts";
 import type { GoalViolatedEventPayload } from "../types/events.ts";
 import type { Action } from "../planner/types/action.ts";
 import type { EffectRegistration } from "../executor/types.ts";
@@ -96,12 +96,17 @@ export class PlannerPluginL0 implements Plugin {
     );
     this.subscriptionIds.push(wsId);
 
-    // Track action outcomes for loop detection
+    // Track action outcomes for loop detection. autonomous.outcome.# is the
+    // unified stream — every skill dispatch (GOAP, ceremony, FAF, user) emits
+    // here on terminal state. For GOAP-originated outcomes the payload carries
+    // actionId + goalId; other sources leave those unset and we ignore them.
     const outcomeId = bus.subscribe(
-      TOPICS.WORLD_ACTION_OUTCOME,
+      "autonomous.outcome.#",
       this.name,
       (msg: BusMessage) => {
-        const outcome = msg.payload as ActionOutcomePayload;
+        const outcome = msg.payload as AutonomousOutcomePayload;
+        if (!outcome.actionId || !outcome.goalId) return;
+
         this.loopDetector.record(outcome.goalId, outcome.actionId, outcome.success);
         this.inFlightGoals.delete(outcome.goalId);
 

--- a/test/integration/planner-dispatcher-flow.test.ts
+++ b/test/integration/planner-dispatcher-flow.test.ts
@@ -6,7 +6,8 @@ import { describe, test, expect, beforeEach } from "bun:test";
 import { InMemoryEventBus } from "../../lib/bus.ts";
 import { PlanningOrchestrator } from "../../src/planner/planning-orchestrator.ts";
 import { TOPICS } from "../../src/event-bus/topics.ts";
-import type { ActionDispatchPayload, ActionOutcomePayload } from "../../src/event-bus/action-events.ts";
+import type { ActionDispatchPayload } from "../../src/event-bus/action-events.ts";
+import type { AutonomousOutcomePayload } from "../../src/event-bus/payloads.ts";
 import type { WorldState } from "../../lib/types/world-state.ts";
 import type { Action } from "../../src/planner/types/action.ts";
 
@@ -47,13 +48,13 @@ describe("Planner → Dispatcher integration flow", () => {
     orchestrator.getRegistry().register(action);
 
     const dispatched: ActionDispatchPayload[] = [];
-    const outcomes: ActionOutcomePayload[] = [];
+    const outcomes: AutonomousOutcomePayload[] = [];
 
     bus.subscribe(TOPICS.WORLD_ACTION_DISPATCH, "test", (msg) => {
       dispatched.push(msg.payload as ActionDispatchPayload);
     });
-    bus.subscribe(TOPICS.WORLD_ACTION_OUTCOME, "test", (msg) => {
-      outcomes.push(msg.payload as ActionOutcomePayload);
+    bus.subscribe("autonomous.outcome.goap.test-action", "test", (msg) => {
+      outcomes.push(msg.payload as AutonomousOutcomePayload);
     });
 
     bus.publish(TOPICS.WORLD_STATE_UPDATED, {


### PR DESCRIPTION
## Summary
Arc 2.2 complete. Greenfield rip of the legacy \`world.action.outcome\` topic — every autonomous outcome now rides the unified \`autonomous.outcome.{systemActor}.{skill}\` stream.

## Changes
**Deleted**:
- \`TOPICS.WORLD_ACTION_OUTCOME\`
- \`ActionOutcomePayload\` interface + its re-export
- OutcomeAnalysisPlugin's \`world.action.outcome\` subscription and dual-path bookkeeping

**Updated**:
- ActionDispatcher publishes \`autonomous.outcome.goap.{skill}\` directly (tier_0 fast-path + tier_1+ paths)
- SkillDispatcher's \`_publishAutonomousOutcome\` carries \`actionId\` + \`goalId\` pulled from \`payload.meta\` so GOAP flows preserve planner-level context end-to-end
- PlannerL0 subscribes to \`autonomous.outcome.#\` wildcard
- \`AutonomousOutcomePayload\` extended with optional \`actionId\`, \`goalId\`, \`error\`

**Tests**: all 5 test files migrated (action-events, planner-plugin-l0, planning-orchestrator, action-dispatcher-plugin, integration/planner-dispatcher-flow). 786/786 pass, \`tsc --noEmit\` clean.

## Why
Observed in today's headsdown session: OutcomeAnalysis was blind to ceremony + FAF outcomes because they never published to \`world.action.outcome\`. Arc 2.2 resolves that by collapsing the split — every autonomous action, regardless of origin, hits one stream.

Board feature: [Arc 2.2] OutcomeAnalysisPlugin subscribes to autonomous.outcome.#

## Merge strategy
Merge commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outcome event tracking by including action and goal identifiers, enabling better correlation of results with original requests.
  * Enhanced error reporting in outcome events with explicit error field support.

* **Refactor**
  * Restructured outcome event stream architecture for improved system clarity and consistency.
  * Updated outcome payload schema to include task state information for better operation visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->