### PR TITLE
feat(extensions): [Arc 6.2] x-protolabs/confidence-v1 extension

### DIFF
--- a/src/executor/__tests__/confidence-extension.test.ts
+++ b/src/executor/__tests__/confidence-extension.test.ts
@@ -1,0 +1,131 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import {
+  ConfidenceStore,
+  registerConfidenceExtension,
+  CONFIDENCE_URI,
+} from "../extensions/confidence.ts";
+import { defaultExtensionRegistry } from "../extension-registry.ts";
+import type { ExtensionContext } from "../extension-registry.ts";
+
+function makeCtx(overrides: Partial<ExtensionContext> = {}): ExtensionContext {
+  return {
+    agentName: "quinn",
+    skill: "pr_review",
+    correlationId: "corr-1",
+    metadata: { systemActor: "goap" },
+    ...overrides,
+  };
+}
+
+describe("ConfidenceStore", () => {
+  test("records samples and averages correctly", () => {
+    const s = new ConfidenceStore();
+    for (const [conf, ok] of [[0.9, true], [0.6, true], [0.3, false]] as const) {
+      s.record({
+        systemActor: "goap", agentName: "quinn", skill: "pr_review",
+        confidence: conf, success: ok, completedAt: Date.now(), correlationId: "c",
+      });
+    }
+    const sum = s.summary("quinn", "pr_review");
+    expect(sum?.sampleCount).toBe(3);
+    expect(sum?.avgConfidence).toBeCloseTo(0.6, 2);
+    expect(sum?.avgConfidenceOnSuccess).toBeCloseTo(0.75, 2);
+    expect(sum?.avgConfidenceOnFailure).toBeCloseTo(0.3, 2);
+  });
+
+  test("flags high-confidence failures as calibration warnings", () => {
+    const s = new ConfidenceStore();
+    // High confidence + failure = bad calibration
+    s.record({
+      systemActor: "goap", agentName: "quinn", skill: "pr_review",
+      confidence: 0.95, success: false, completedAt: Date.now(), correlationId: "c1",
+    });
+    s.record({
+      systemActor: "goap", agentName: "quinn", skill: "pr_review",
+      confidence: 0.4, success: false, completedAt: Date.now(), correlationId: "c2",
+    });
+    const sum = s.summary("quinn", "pr_review");
+    expect(sum?.highConfFailures).toBe(1); // only the 0.95 one crosses the 0.8 threshold
+  });
+
+  test("respects maxPerKey cap (FIFO)", () => {
+    const s = new ConfidenceStore(3);
+    for (let i = 0; i < 5; i++) {
+      s.record({
+        systemActor: "goap", agentName: "a", skill: "s",
+        confidence: i * 0.25, success: true, completedAt: 0, correlationId: `c${i}`,
+      });
+    }
+    const sum = s.summary("a", "s");
+    expect(sum?.sampleCount).toBe(3);
+    // Retained i=2,3,4 → confidences 0.5, 0.75, 1.0 → avg 0.75
+    expect(sum?.avgConfidence).toBeCloseTo(0.75, 2);
+  });
+
+  test("allSummaries enumerates every (agent, skill) key", () => {
+    const s = new ConfidenceStore();
+    s.record({ systemActor: "goap", agentName: "quinn", skill: "a", confidence: 1, success: true, completedAt: 0, correlationId: "c" });
+    s.record({ systemActor: "goap", agentName: "frank", skill: "b", confidence: 0.5, success: true, completedAt: 0, correlationId: "c" });
+    expect(s.allSummaries().length).toBe(2);
+  });
+
+  test("summary undefined for unseen key", () => {
+    expect(new ConfidenceStore().summary("none", "none")).toBeUndefined();
+  });
+});
+
+describe("confidence-v1 extension interceptor", () => {
+  let bus: InMemoryEventBus;
+  let store: ConfidenceStore;
+
+  beforeEach(() => {
+    bus = new InMemoryEventBus();
+    store = new ConfidenceStore();
+    registerConfidenceExtension(bus, store);
+  });
+
+  test("registered on defaultExtensionRegistry", () => {
+    const uris = defaultExtensionRegistry.list().map(e => e.uri);
+    expect(uris).toContain(CONFIDENCE_URI);
+  });
+
+  test("after() records confidence + publishes event", () => {
+    const interceptor = defaultExtensionRegistry.list().find(e => e.uri === CONFIDENCE_URI)?.interceptor;
+    const events: unknown[] = [];
+    bus.subscribe("autonomous.confidence.#", "test", (msg) => { events.push(msg); });
+
+    interceptor!.after?.(makeCtx(), {
+      text: "review complete",
+      data: { confidence: 0.82, confidenceExplanation: "high coverage, low ambiguity", success: true },
+    });
+
+    expect(store.size).toBe(1);
+    const sum = store.summary("quinn", "pr_review");
+    expect(sum?.avgConfidence).toBeCloseTo(0.82, 2);
+    expect(events).toHaveLength(1);
+  });
+
+  test("clamps out-of-range confidence to [0, 1]", () => {
+    const interceptor = defaultExtensionRegistry.list().find(e => e.uri === CONFIDENCE_URI)?.interceptor;
+    interceptor!.after?.(makeCtx(), { text: "", data: { confidence: 1.5, success: true } });
+    interceptor!.after?.(makeCtx({ correlationId: "c2" }), { text: "", data: { confidence: -0.2, success: true } });
+    const sum = store.summary("quinn", "pr_review");
+    expect(sum?.sampleCount).toBe(2);
+    // 1.5 clamped to 1, -0.2 clamped to 0 → avg 0.5
+    expect(sum?.avgConfidence).toBeCloseTo(0.5, 2);
+  });
+
+  test("no record when confidence is missing", () => {
+    const interceptor = defaultExtensionRegistry.list().find(e => e.uri === CONFIDENCE_URI)?.interceptor;
+    interceptor!.after?.(makeCtx(), { text: "", data: { success: true } });
+    expect(store.size).toBe(0);
+  });
+
+  test("before() stamps x-confidence-skill on metadata", () => {
+    const interceptor = defaultExtensionRegistry.list().find(e => e.uri === CONFIDENCE_URI)?.interceptor;
+    const ctx = makeCtx();
+    interceptor!.before?.(ctx);
+    expect(ctx.metadata["x-confidence-skill"]).toBe("pr_review");
+  });
+});

--- a/src/executor/extensions/confidence.ts
+++ b/src/executor/extensions/confidence.ts
@@ -1,0 +1,182 @@
+/**
+ * Confidence v1 extension — captures the agent's self-reported confidence
+ * in its output so OutcomeAnalysis can weight failure/success signals by
+ * how sure the agent was.
+ *
+ * A high-confidence failure is a stronger signal than a low-confidence one;
+ * a low-confidence success shouldn't get the same weight as a high-confidence
+ * one in aggregate success-rate calculations. Arc 6.4's planner ranking
+ * reads from here when breaking ties between candidate skills.
+ *
+ *   before(ctx): stamps `x-confidence-skill` onto outbound metadata so the
+ *     agent can include a confidence score in its terminal message.
+ *
+ *   after(ctx, result): reads `result.data.confidence` (0.0–1.0) and
+ *     `result.data.confidenceExplanation` (optional string), records a
+ *     ConfidenceSample, publishes `autonomous.confidence.{systemActor}.{skill}`
+ *     for observability.
+ *
+ * Extension URI: https://protolabs.ai/a2a/ext/confidence-v1
+ */
+
+import type { EventBus } from "../../../lib/types.ts";
+import {
+  defaultExtensionRegistry,
+  type ExtensionInterceptor,
+  type ExtensionContext,
+} from "../extension-registry.ts";
+
+export const CONFIDENCE_URI = "https://protolabs.ai/a2a/ext/confidence-v1";
+
+/** One observed confidence score from a completed task. */
+export interface ConfidenceSample {
+  systemActor: string;
+  agentName: string;
+  skill: string;
+  /** Agent-reported confidence in the correctness of its output, 0.0–1.0. */
+  confidence: number;
+  /** Optional short free-text explanation from the agent. */
+  explanation?: string;
+  /** Whether the task itself succeeded. */
+  success: boolean;
+  completedAt: number;
+  correlationId: string;
+}
+
+/** Aggregated confidence statistics for a (agent, skill) pair. */
+export interface ConfidenceSummary {
+  agentName: string;
+  skill: string;
+  sampleCount: number;
+  /** Average confidence across recent samples. */
+  avgConfidence: number;
+  /** Average confidence for samples that succeeded. */
+  avgConfidenceOnSuccess: number;
+  /** Average confidence for samples that failed. */
+  avgConfidenceOnFailure: number;
+  /** Count of high-confidence-but-failed samples — a calibration warning. */
+  highConfFailures: number;
+}
+
+const HIGH_CONFIDENCE_THRESHOLD = 0.8;
+
+/**
+ * Rolling confidence store. In-memory by design — observational telemetry,
+ * not durable data. A later persistence layer is a separate concern.
+ */
+export class ConfidenceStore {
+  private readonly samples = new Map<string, ConfidenceSample[]>();
+  private readonly maxPerKey: number;
+
+  constructor(maxPerKey = 200) {
+    this.maxPerKey = maxPerKey;
+  }
+
+  static key(agentName: string, skill: string): string {
+    return `${agentName}::${skill}`;
+  }
+
+  record(sample: ConfidenceSample): void {
+    const k = ConfidenceStore.key(sample.agentName, sample.skill);
+    const arr = this.samples.get(k) ?? [];
+    arr.push(sample);
+    if (arr.length > this.maxPerKey) arr.splice(0, arr.length - this.maxPerKey);
+    this.samples.set(k, arr);
+  }
+
+  summary(agentName: string, skill: string): ConfidenceSummary | undefined {
+    const arr = this.samples.get(ConfidenceStore.key(agentName, skill));
+    if (!arr || arr.length === 0) return undefined;
+    const n = arr.length;
+    const successes = arr.filter(s => s.success);
+    const failures = arr.filter(s => !s.success);
+    const avg = (xs: ConfidenceSample[]): number =>
+      xs.length === 0 ? 0 : xs.reduce((a, s) => a + s.confidence, 0) / xs.length;
+    return {
+      agentName,
+      skill,
+      sampleCount: n,
+      avgConfidence: avg(arr),
+      avgConfidenceOnSuccess: avg(successes),
+      avgConfidenceOnFailure: avg(failures),
+      highConfFailures: failures.filter(s => s.confidence >= HIGH_CONFIDENCE_THRESHOLD).length,
+    };
+  }
+
+  allSummaries(): ConfidenceSummary[] {
+    return Array.from(this.samples.keys())
+      .map(k => {
+        const [agentName, skill] = k.split("::");
+        return this.summary(agentName, skill);
+      })
+      .filter((s): s is ConfidenceSummary => !!s);
+  }
+
+  get size(): number {
+    return this.samples.size;
+  }
+}
+
+export const defaultConfidenceStore = new ConfidenceStore();
+
+/**
+ * Registers the confidence interceptor with `defaultExtensionRegistry`.
+ * Call once at startup with a live EventBus reference.
+ */
+export function registerConfidenceExtension(
+  bus: EventBus,
+  store: ConfidenceStore = defaultConfidenceStore,
+): void {
+  const interceptor: ExtensionInterceptor = {
+    before(ctx: ExtensionContext): void {
+      ctx.metadata["x-confidence-skill"] = ctx.skill;
+    },
+
+    after(
+      ctx: ExtensionContext,
+      result: { text: string; data?: Record<string, unknown> },
+    ): void {
+      // Agent is expected to set these on the terminal message's data part.
+      const raw = result.data?.confidence;
+      if (typeof raw !== "number") return;
+      // Clamp to [0, 1] defensively — the spec says agents should stay in
+      // range but we don't want a bad payload to poison stats.
+      const confidence = Math.max(0, Math.min(1, raw));
+      const explanation = typeof result.data?.confidenceExplanation === "string"
+        ? (result.data.confidenceExplanation as string)
+        : undefined;
+      const success = result.data?.success !== false;
+      const systemActor = typeof ctx.metadata["systemActor"] === "string"
+        ? (ctx.metadata["systemActor"] as string)
+        : "user";
+
+      const sample: ConfidenceSample = {
+        systemActor,
+        agentName: ctx.agentName,
+        skill: ctx.skill,
+        confidence,
+        explanation,
+        success,
+        completedAt: Date.now(),
+        correlationId: ctx.correlationId,
+      };
+      store.record(sample);
+
+      const topic = `autonomous.confidence.${systemActor}.${ctx.skill}`;
+      bus.publish(topic, {
+        id: crypto.randomUUID(),
+        correlationId: ctx.correlationId,
+        topic,
+        timestamp: sample.completedAt,
+        payload: sample,
+      });
+    },
+  };
+
+  defaultExtensionRegistry.register({
+    uri: CONFIDENCE_URI,
+    interceptor,
+    description:
+      "Confidence v1: captures agent-reported confidence (0.0–1.0), flags high-confidence failures for calibration, publishes autonomous.confidence.*",
+  });
+}


### PR DESCRIPTION
Arc 6.2 — mirrors #229 (cost-v1) pattern. Agent-reported confidence scores, flagged high-confidence failures as calibration warnings for Arc 6.4 planner ranking. 10 new tests, 804/804 pass, tsc clean.