### PR TITLE
feat(extensions): [Arc 6.3] x-protolabs/blast-v1 extension

### DIFF
--- a/src/executor/__tests__/blast-extension.test.ts
+++ b/src/executor/__tests__/blast-extension.test.ts
@@ -1,0 +1,96 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+  BlastRegistry,
+  registerBlastExtension,
+  BLAST_URI,
+  BLAST_ORDER,
+  type BlastRadius,
+} from "../extensions/blast.ts";
+import { defaultExtensionRegistry } from "../extension-registry.ts";
+import type { ExtensionContext } from "../extension-registry.ts";
+
+function makeCtx(overrides: Partial<ExtensionContext> = {}): ExtensionContext {
+  return {
+    agentName: "quinn",
+    skill: "pr_review",
+    correlationId: "corr-1",
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe("BlastRegistry", () => {
+  test("stores and retrieves declarations by (agent, skill)", () => {
+    const r = new BlastRegistry();
+    r.declare({ agentName: "quinn", skill: "pr_review", radius: "repo" });
+    expect(r.get("quinn", "pr_review")?.radius).toBe("repo");
+    expect(r.get("quinn", "other")).toBeUndefined();
+  });
+
+  test("compare() orders radii self < project < repo < fleet < public", () => {
+    const r = new BlastRegistry();
+    expect(r.compare("self", "project")).toBeLessThan(0);
+    expect(r.compare("fleet", "repo")).toBeGreaterThan(0);
+    expect(r.compare("public", "public")).toBe(0);
+    expect(r.compare(undefined, undefined)).toBe(0);
+    // Unknown defaults to self — project > unknown
+    expect(r.compare(undefined, "project")).toBeLessThan(0);
+  });
+
+  test("BLAST_ORDER is monotone increasing", () => {
+    const order: BlastRadius[] = ["self", "project", "repo", "fleet", "public"];
+    for (let i = 1; i < order.length; i++) {
+      expect(BLAST_ORDER[order[i]]).toBeGreaterThan(BLAST_ORDER[order[i - 1]]);
+    }
+  });
+
+  test("all() enumerates declarations", () => {
+    const r = new BlastRegistry();
+    r.declare({ agentName: "quinn", skill: "pr_review", radius: "repo" });
+    r.declare({ agentName: "frank", skill: "deploy_prod", radius: "public" });
+    const all = r.all();
+    expect(all.length).toBe(2);
+    expect(all.map(d => d.radius).sort()).toEqual(["public", "repo"]);
+  });
+
+  test("clear() empties the registry", () => {
+    const r = new BlastRegistry();
+    r.declare({ agentName: "a", skill: "s", radius: "self" });
+    r.clear();
+    expect(r.size).toBe(0);
+  });
+});
+
+describe("blast-v1 extension interceptor", () => {
+  let registry: BlastRegistry;
+
+  beforeEach(() => {
+    registry = new BlastRegistry();
+    registerBlastExtension(registry);
+  });
+
+  test("registered on defaultExtensionRegistry", () => {
+    const uris = defaultExtensionRegistry.list().map(e => e.uri);
+    expect(uris).toContain(BLAST_URI);
+  });
+
+  test("before() stamps x-blast-radius when declared", () => {
+    registry.declare({ agentName: "quinn", skill: "pr_review", radius: "repo" });
+    const interceptor = defaultExtensionRegistry.list().find(e => e.uri === BLAST_URI)?.interceptor;
+    const ctx = makeCtx();
+    interceptor!.before?.(ctx);
+    expect(ctx.metadata["x-blast-radius"]).toBe("repo");
+  });
+
+  test("before() no-op when no declaration exists", () => {
+    const interceptor = defaultExtensionRegistry.list().find(e => e.uri === BLAST_URI)?.interceptor;
+    const ctx = makeCtx();
+    interceptor!.before?.(ctx);
+    expect(ctx.metadata["x-blast-radius"]).toBeUndefined();
+  });
+
+  test("after() is not defined — blast is read-side only", () => {
+    const interceptor = defaultExtensionRegistry.list().find(e => e.uri === BLAST_URI)?.interceptor;
+    expect(interceptor?.after).toBeUndefined();
+  });
+});

--- a/src/executor/extensions/blast.ts
+++ b/src/executor/extensions/blast.ts
@@ -1,0 +1,136 @@
+/**
+ * Blast v1 extension — declares the scope of effect for a skill so the
+ * planner can apply stricter HITL gates to higher-blast-radius work
+ * regardless of goal-level config (Arc 6.4 + 7.x coordination).
+ *
+ * Agents advertise a per-skill BlastRadius in their agent card. This
+ * extension does NOT mutate outbound traffic — it's purely a read-side
+ * declaration that downstream consumers (planner, HITL policy, dashboards)
+ * use to weight, gate, or report skills.
+ *
+ *   before(ctx): stamps `x-blast-radius` on outbound metadata with the
+ *     agent-declared blast radius for the skill, so consumers in the
+ *     execution chain can see it without a second lookup.
+ *
+ *   after(ctx, result): no-op — blast is a policy declaration, not an
+ *     observation. A separate consumer can subscribe to `autonomous.outcome.#`
+ *     and cross-reference the blast radius stored here.
+ *
+ * Extension URI: https://protolabs.ai/a2a/ext/blast-v1
+ */
+
+import {
+  defaultExtensionRegistry,
+  type ExtensionInterceptor,
+  type ExtensionContext,
+} from "../extension-registry.ts";
+
+export const BLAST_URI = "https://protolabs.ai/a2a/ext/blast-v1";
+
+/**
+ * Scope of effect for a skill. Ordered from narrowest to widest.
+ *
+ * - `self`    — only affects the agent's own internal state (e.g. a sitrep)
+ * - `project` — affects one project's state (e.g. updates a board feature)
+ * - `repo`    — affects a single git repository (e.g. opens a PR)
+ * - `fleet`   — affects multiple repos or agents (e.g. bulk migration)
+ * - `public`  — externally visible state (e.g. production deploy, public post)
+ */
+export type BlastRadius = "self" | "project" | "repo" | "fleet" | "public";
+
+/** Ordinal ranking used when comparing two radii numerically. */
+export const BLAST_ORDER: Record<BlastRadius, number> = {
+  self: 0,
+  project: 1,
+  repo: 2,
+  fleet: 3,
+  public: 4,
+};
+
+/**
+ * Per-(agent, skill) blast declaration from the agent card. Stored in the
+ * registry below so non-execution-path consumers (planner, HITL policy,
+ * dashboard) can look it up without going through the extension interceptor.
+ */
+export interface BlastDeclaration {
+  agentName: string;
+  skill: string;
+  radius: BlastRadius;
+  /** Optional human-readable explanation for the declared radius. */
+  note?: string;
+}
+
+/**
+ * Registry of declared blast radii. Populated at agent-card ingestion time
+ * (SkillBrokerPlugin + agent-card discovery) and queried by the planner.
+ *
+ * In-memory by design — re-populated on agent-card refresh.
+ */
+export class BlastRegistry {
+  private readonly byKey = new Map<string, BlastDeclaration>();
+
+  static key(agentName: string, skill: string): string {
+    return `${agentName}::${skill}`;
+  }
+
+  declare(decl: BlastDeclaration): void {
+    this.byKey.set(BlastRegistry.key(decl.agentName, decl.skill), decl);
+  }
+
+  get(agentName: string, skill: string): BlastDeclaration | undefined {
+    return this.byKey.get(BlastRegistry.key(agentName, skill));
+  }
+
+  /**
+   * Compare two declared radii. Returns a negative number if `a < b`, 0 if
+   * equal, positive if `a > b`. Unset defaults to `self` (conservative — an
+   * unmarked skill is assumed low-blast, not high-blast; the planner caller
+   * decides the safety bias).
+   */
+  compare(a: BlastRadius | undefined, b: BlastRadius | undefined): number {
+    const av = a ? BLAST_ORDER[a] : 0;
+    const bv = b ? BLAST_ORDER[b] : 0;
+    return av - bv;
+  }
+
+  /** Enumerate all declarations — for the dashboard + HITL policy init. */
+  all(): BlastDeclaration[] {
+    return Array.from(this.byKey.values());
+  }
+
+  clear(): void {
+    this.byKey.clear();
+  }
+
+  get size(): number {
+    return this.byKey.size;
+  }
+}
+
+export const defaultBlastRegistry = new BlastRegistry();
+
+/**
+ * Register the blast-v1 extension interceptor. The registry is populated
+ * separately by SkillBrokerPlugin when it parses agent cards — this
+ * function just wires the stamp-on-outbound behavior.
+ */
+export function registerBlastExtension(
+  registry: BlastRegistry = defaultBlastRegistry,
+): void {
+  const interceptor: ExtensionInterceptor = {
+    before(ctx: ExtensionContext): void {
+      const decl = registry.get(ctx.agentName, ctx.skill);
+      if (decl) {
+        ctx.metadata["x-blast-radius"] = decl.radius;
+      }
+    },
+    // no after() — blast is a declaration, not an observation
+  };
+
+  defaultExtensionRegistry.register({
+    uri: BLAST_URI,
+    interceptor,
+    description:
+      "Blast v1: per-skill effect-scope declaration (self/project/repo/fleet/public); planner + HITL policy read from the registry",
+  });
+}


### PR DESCRIPTION
Arc 6.3 — completes the cost/confidence/blast triple from Arc 6.1/6.2 — foundation for Arc 6.4 planner tiebreak. Read-side declaration (no after() hook). 9 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added blast radius declaration system allowing agents and skills to declare their scope of impact (self, project, fleet, public, or repo).
  * Integrated blast radius metadata into the extension system for automated scope tracking.

* **Tests**
  * Added comprehensive test coverage for blast extension functionality and registry operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->