### PR TITLE
feat(world-engine): [Arc 5.3] subscribe to world.state.delta + apply in-process

### DIFF
--- a/lib/plugins/__tests__/world-state-engine-delta.test.ts
+++ b/lib/plugins/__tests__/world-state-engine-delta.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Arc 5.3 tests — WorldStateEngine subscribes to world.state.delta and
+ * applies agent-declared deltas in-process.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { InMemoryEventBus } from "../../bus.ts";
+import { WorldStateEngine } from "../world-state-engine.ts";
+import type { BusMessage } from "../../types.ts";
+
+/**
+ * Seed the engine's internal state directly so tests don't depend on
+ * poll timers firing. We access the internal worldState via a registered
+ * domain's collector that completes synchronously, then trigger one manual
+ * collect via the private tick path — but that's fragile, so we take an
+ * escape hatch: `(engine as any).worldState` is the shared reference.
+ */
+function seedDomain(engine: WorldStateEngine, domain: string, data: Record<string, unknown>): void {
+  const state = (engine as unknown as { worldState: {
+    domains: Record<string, { data: Record<string, unknown>; metadata: Record<string, unknown> }>;
+    extensions: Record<string, unknown>;
+    timestamp: number;
+  } }).worldState;
+  state.domains[domain] = { data, metadata: { collectedAt: Date.now(), domain, tickNumber: 0 } };
+  state.extensions[`${domain}_available`] = true;
+}
+
+describe("WorldStateEngine — world.state.delta (Arc 5.3)", () => {
+  let bus: InMemoryEventBus;
+  let engine: WorldStateEngine;
+
+  beforeEach(() => {
+    bus = new InMemoryEventBus();
+    engine = new WorldStateEngine({ snapshotIntervalMs: 60_000_000 });
+    engine.install(bus);
+    seedDomain(engine, "ci", { blockedPRs: 5, projects: ["a", "b"] });
+  });
+
+  afterEach(() => {
+    engine.uninstall();
+  });
+
+  function publishDelta(deltas: unknown[]): void {
+    bus.publish("world.state.delta", {
+      id: crypto.randomUUID(),
+      correlationId: "c1",
+      topic: "world.state.delta",
+      timestamp: Date.now(),
+      payload: { deltas },
+    });
+  }
+
+  function readCi(): Record<string, unknown> | undefined {
+    return (engine.getWorldState({ domain: "ci" }) as { data?: Record<string, unknown> } | null)?.data;
+  }
+
+  test("applies 'set' op to a simple path", () => {
+    publishDelta([{ domain: "ci", path: "data.blockedPRs", op: "set", value: 3 }]);
+    expect(readCi()?.blockedPRs).toBe(3);
+  });
+
+  test("applies 'inc' op to an existing numeric (decrement via negative value)", () => {
+    publishDelta([{ domain: "ci", path: "data.blockedPRs", op: "inc", value: -2 }]);
+    expect(readCi()?.blockedPRs).toBe(3);
+  });
+
+  test("applies 'push' op to an existing array", () => {
+    publishDelta([{ domain: "ci", path: "data.projects", op: "push", value: "c" }]);
+    expect(readCi()?.projects).toEqual(["a", "b", "c"]);
+  });
+
+  test("publishes world.state.updated exactly when a delta is applied", () => {
+    const updates: BusMessage[] = [];
+    bus.subscribe("world.state.updated", "test", (msg) => { updates.push(msg); });
+
+    publishDelta([{ domain: "ci", path: "data.blockedPRs", op: "set", value: 0 }]);
+    expect(updates.length).toBe(1);
+  });
+
+  test("ignores delta targeting unknown domain — no mutation, no event", () => {
+    const updates: BusMessage[] = [];
+    bus.subscribe("world.state.updated", "test", (msg) => { updates.push(msg); });
+
+    publishDelta([{ domain: "nonexistent", path: "data.foo", op: "set", value: 1 }]);
+    expect(updates.length).toBe(0);
+  });
+
+  test("applies the valid sibling when one entry is malformed", () => {
+    publishDelta([
+      { domain: 5, path: "data.bad", op: "set", value: 0 },            // bad domain type
+      { domain: "ci", path: "data.blockedPRs", op: "set", value: 7 },  // valid
+      { domain: "ci", path: "data.blockedPRs", op: "fly", value: 0 },  // bad op
+    ]);
+    expect(readCi()?.blockedPRs).toBe(7);
+  });
+
+  test("ignores empty delta array — no event fired", () => {
+    const updates: BusMessage[] = [];
+    bus.subscribe("world.state.updated", "test", (msg) => { updates.push(msg); });
+
+    publishDelta([]);
+    expect(updates.length).toBe(0);
+  });
+
+  test("rejects 'inc' on non-numeric target without throwing", () => {
+    publishDelta([{ domain: "ci", path: "data.projects", op: "inc", value: 1 }]);
+    // projects is an array, inc should fail silently
+    expect(readCi()?.projects).toEqual(["a", "b"]);
+  });
+
+  test("rejects 'push' on non-array target without throwing", () => {
+    publishDelta([{ domain: "ci", path: "data.blockedPRs", op: "push", value: "x" }]);
+    expect(readCi()?.blockedPRs).toBe(5);
+  });
+});

--- a/lib/plugins/world-state-engine.ts
+++ b/lib/plugins/world-state-engine.ts
@@ -188,6 +188,16 @@ export class WorldStateEngine implements Plugin {
     });
     this.subscriptionIds.push(mcpSubId);
 
+    // Arc 5.3: subscribe to world.state.delta (published by the effect-domain-v1
+    // extension when a task's terminal artifact declares observed deltas).
+    // Applies each delta in-process instead of waiting for the next domain
+    // poll — closes the outcome → state feedback loop at task-terminal
+    // latency rather than tick-interval latency.
+    const deltaSubId = bus.subscribe("world.state.delta", this.name, (msg: BusMessage) => {
+      this._applyWorldStateDelta(msg);
+    });
+    this.subscriptionIds.push(deltaSubId);
+
     // Start tickers for any domains registered before install()
     for (const reg of this.domains.values()) {
       this._startTicker(reg);
@@ -538,6 +548,109 @@ export class WorldStateEngine implements Plugin {
   }
 
   // ── Bus tool handler ───────────────────────────────────────────────────────
+
+  /**
+   * Apply an agent-declared world-state delta in-process.
+   *
+   * Walks `path` into the domain's data object and applies the requested
+   * op. No-ops silently on unknown domains or invalid paths — agents can't
+   * bring the engine down with a bad delta, they just lose the delta.
+   *
+   * After applying, publishes `world.state.updated` so the planner re-evaluates
+   * immediately. This is the core of Arc 5.3: close the outcome→state feedback
+   * loop at task-terminal latency rather than the domain's polling interval.
+   */
+  private _applyWorldStateDelta(msg: BusMessage): void {
+    const payload = (msg.payload ?? {}) as { deltas?: unknown };
+    const deltas = Array.isArray(payload.deltas) ? payload.deltas : [];
+    if (deltas.length === 0) return;
+
+    let applied = 0;
+    for (const raw of deltas) {
+      const entry = raw as { domain?: unknown; path?: unknown; op?: unknown; value?: unknown };
+      if (typeof entry.domain !== "string" || typeof entry.path !== "string" || typeof entry.op !== "string") continue;
+      if (entry.op !== "set" && entry.op !== "inc" && entry.op !== "push") continue;
+
+      const domainData = this.worldState.domains[entry.domain];
+      if (!domainData) continue; // unknown domain — drop silently
+
+      try {
+        this._applyDeltaAtPath(
+          domainData as unknown as Record<string, unknown>,
+          entry.path,
+          entry.op,
+          entry.value,
+        );
+        applied += 1;
+      } catch {
+        // Malformed path or type mismatch — skip this entry, continue others
+      }
+    }
+
+    if (applied > 0 && this.bus) {
+      this.worldState.timestamp = Date.now();
+      this.bus.publish("world.state.updated", {
+        id: crypto.randomUUID(),
+        correlationId: msg.correlationId,
+        topic: "world.state.updated",
+        timestamp: Date.now(),
+        payload: this.worldState,
+      });
+    }
+  }
+
+  /**
+   * Walk a dot-separated path into `root` and apply `op` with `value`.
+   * Creates intermediate objects for `set` only (inc/push require the path
+   * to already exist with a compatible type).
+   */
+  private _applyDeltaAtPath(
+    root: Record<string, unknown>,
+    path: string,
+    op: "set" | "inc" | "push",
+    value: unknown,
+  ): void {
+    const parts = path.split(".").filter(Boolean);
+    if (parts.length === 0) throw new Error("empty path");
+
+    if (op === "set") {
+      let cursor = root;
+      for (let i = 0; i < parts.length - 1; i++) {
+        const key = parts[i];
+        if (typeof cursor[key] !== "object" || cursor[key] === null) {
+          cursor[key] = {};
+        }
+        cursor = cursor[key] as Record<string, unknown>;
+      }
+      cursor[parts[parts.length - 1]] = value;
+      return;
+    }
+
+    // For inc + push we require the full path to exist
+    let cursor: unknown = root;
+    for (let i = 0; i < parts.length - 1; i++) {
+      if (typeof cursor !== "object" || cursor === null) throw new Error("path not navigable");
+      cursor = (cursor as Record<string, unknown>)[parts[i]];
+    }
+    if (typeof cursor !== "object" || cursor === null) throw new Error("path not navigable");
+    const parent = cursor as Record<string, unknown>;
+    const leaf = parts[parts.length - 1];
+
+    if (op === "inc") {
+      if (typeof value !== "number") throw new Error("inc requires numeric value");
+      const current = parent[leaf];
+      // Allow inc on undefined (treat as 0, e.g. new counter) but reject on
+      // any other non-numeric target so we don't clobber arrays/objects/strings.
+      if (current !== undefined && typeof current !== "number") {
+        throw new Error("inc target is not a number");
+      }
+      parent[leaf] = (typeof current === "number" ? current : 0) + value;
+    } else if (op === "push") {
+      const arr = parent[leaf];
+      if (!Array.isArray(arr)) throw new Error("push target is not an array");
+      arr.push(value);
+    }
+  }
 
   private async _handleGetWorldState(msg: BusMessage): Promise<void> {
     const payload = (msg.payload ?? {}) as Record<string, unknown>;


### PR DESCRIPTION
Arc 5.3 — closes the outcome → state feedback loop. Agent-declared deltas now apply immediately instead of waiting for the next domain poll. See commit for details. 9 new tests pass, 803/803 total.