### PR TITLE
feat(hitl): [Arc 7.2] formalize auto-approve-on-timeout + test coverage

### DIFF
--- a/lib/plugins/__tests__/hitl-expiry.test.ts
+++ b/lib/plugins/__tests__/hitl-expiry.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Arc 7.2 tests — HITL TTL policies drive auto-approve / auto-reject / escalate
+ * on expiry. Tests the sweepExpired hook directly with a controlled `now`.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { InMemoryEventBus } from "../../bus.ts";
+import { HITLPlugin } from "../hitl.ts";
+import type { HITLRequest, HITLResponse, BusMessage } from "../../types.ts";
+
+function makeRequest(overrides: Partial<HITLRequest> = {}): HITLRequest {
+  return {
+    type: "hitl_request",
+    correlationId: "test-1",
+    title: "Approve?",
+    summary: "test",
+    options: ["approve", "reject"],
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    replyTopic: "hitl.response.test-1",
+    sourceMeta: { interface: "discord" },
+    ...overrides,
+  };
+}
+
+function publishRequest(bus: InMemoryEventBus, req: HITLRequest): void {
+  bus.publish(`hitl.request.${req.correlationId}`, {
+    id: crypto.randomUUID(),
+    correlationId: req.correlationId,
+    topic: `hitl.request.${req.correlationId}`,
+    timestamp: Date.now(),
+    payload: req,
+  });
+}
+
+describe("HITLPlugin — TTL sweep (Arc 7.2)", () => {
+  let bus: InMemoryEventBus;
+  let plugin: HITLPlugin;
+
+  beforeEach(() => {
+    bus = new InMemoryEventBus();
+    plugin = new HITLPlugin("/tmp");
+    plugin.resetForTesting();
+    plugin.install(bus);
+  });
+
+  afterEach(() => {
+    plugin.uninstall();
+    plugin.resetForTesting();
+  });
+
+  test("onTimeout='approve' publishes synthetic approve HITLResponse on expiry", async () => {
+    const responses: HITLResponse[] = [];
+    bus.subscribe("hitl.response.timeout-approve", "test", (msg: BusMessage) => {
+      responses.push(msg.payload as HITLResponse);
+    });
+
+    const pastExpiry = new Date(Date.now() - 1000).toISOString();
+    const req = makeRequest({
+      correlationId: "timeout-approve",
+      onTimeout: "approve",
+      expiresAt: pastExpiry,
+    });
+    publishRequest(bus, req);
+    await new Promise(r => setTimeout(r, 5));
+
+    plugin.sweepExpired(bus, Date.now());
+    expect(responses).toHaveLength(1);
+    expect(responses[0].decision).toBe("approve");
+    expect(responses[0].decidedBy).toBe("auto-approve");
+    expect(responses[0].correlationId).toBe("timeout-approve");
+  });
+
+  test("onTimeout='reject' publishes synthetic reject HITLResponse on expiry", async () => {
+    const responses: HITLResponse[] = [];
+    bus.subscribe("hitl.response.timeout-reject", "test", (msg: BusMessage) => {
+      responses.push(msg.payload as HITLResponse);
+    });
+
+    const req = makeRequest({
+      correlationId: "timeout-reject",
+      onTimeout: "reject",
+      expiresAt: new Date(Date.now() - 1).toISOString(),
+    });
+    publishRequest(bus, req);
+    await new Promise(r => setTimeout(r, 5));
+
+    plugin.sweepExpired(bus, Date.now());
+    expect(responses).toHaveLength(1);
+    expect(responses[0].decision).toBe("reject");
+    expect(responses[0].decidedBy).toBe("auto-reject");
+  });
+
+  test("onTimeout='escalate' fires hitl.expired.* instead of auto-response", async () => {
+    const responses: HITLResponse[] = [];
+    const expired: BusMessage[] = [];
+    bus.subscribe("hitl.response.timeout-escalate", "test", (msg: BusMessage) => {
+      responses.push(msg.payload as HITLResponse);
+    });
+    bus.subscribe("hitl.expired.timeout-escalate", "test", (msg: BusMessage) => {
+      expired.push(msg);
+    });
+
+    const req = makeRequest({
+      correlationId: "timeout-escalate",
+      onTimeout: "escalate",
+      expiresAt: new Date(Date.now() - 1).toISOString(),
+    });
+    publishRequest(bus, req);
+    await new Promise(r => setTimeout(r, 5));
+
+    plugin.sweepExpired(bus, Date.now());
+    expect(responses).toHaveLength(0);
+    expect(expired).toHaveLength(1);
+  });
+
+  test("unset onTimeout falls through to escalate behavior", async () => {
+    const expired: BusMessage[] = [];
+    bus.subscribe("hitl.expired.default-escalate", "test", (msg: BusMessage) => {
+      expired.push(msg);
+    });
+
+    const req = makeRequest({
+      correlationId: "default-escalate",
+      // onTimeout omitted
+      expiresAt: new Date(Date.now() - 1).toISOString(),
+    });
+    publishRequest(bus, req);
+    await new Promise(r => setTimeout(r, 5));
+
+    plugin.sweepExpired(bus, Date.now());
+    expect(expired).toHaveLength(1);
+  });
+
+  test("unexpired requests are left alone", async () => {
+    const responses: HITLResponse[] = [];
+    const expired: BusMessage[] = [];
+    bus.subscribe("hitl.response.still-alive", "test", (msg: BusMessage) => {
+      responses.push(msg.payload as HITLResponse);
+    });
+    bus.subscribe("hitl.expired.still-alive", "test", (msg: BusMessage) => {
+      expired.push(msg);
+    });
+
+    const req = makeRequest({
+      correlationId: "still-alive",
+      onTimeout: "approve",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    publishRequest(bus, req);
+    await new Promise(r => setTimeout(r, 5));
+
+    plugin.sweepExpired(bus, Date.now());
+    expect(responses).toHaveLength(0);
+    expect(expired).toHaveLength(0);
+    expect(plugin.getPendingRequests()).toHaveLength(1);
+  });
+
+  test("sweep removes expired request from pending list", async () => {
+    const req = makeRequest({
+      correlationId: "cleanup",
+      onTimeout: "approve",
+      expiresAt: new Date(Date.now() - 1).toISOString(),
+    });
+    publishRequest(bus, req);
+    await new Promise(r => setTimeout(r, 5));
+    expect(plugin.getPendingRequests()).toHaveLength(1);
+
+    plugin.sweepExpired(bus, Date.now());
+    expect(plugin.getPendingRequests()).toHaveLength(0);
+  });
+
+  test("sweep with nowMs in the past does NOT expire anything", async () => {
+    const req = makeRequest({
+      correlationId: "past-sweep",
+      onTimeout: "approve",
+      expiresAt: new Date(Date.now() - 1).toISOString(),
+    });
+    publishRequest(bus, req);
+    await new Promise(r => setTimeout(r, 5));
+
+    // Sweep at an earlier moment — before expiresAt
+    plugin.sweepExpired(bus, Date.now() - 10_000);
+    expect(plugin.getPendingRequests()).toHaveLength(1);
+  });
+});

--- a/lib/plugins/hitl.ts
+++ b/lib/plugins/hitl.ts
@@ -60,6 +60,18 @@ export class HITLPlugin implements Plugin {
   }
 
   /**
+   * Reset all module-level state. Intended for tests — clears the pending
+   * request map, unrendered-id set, and renderer registry so each test
+   * starts from a clean slate. Production code doesn't need this because
+   * the plugin is a singleton with process-lifetime state.
+   */
+  resetForTesting(): void {
+    pendingRequests.clear();
+    unrenderedCorrelationIds.clear();
+    renderers.clear();
+  }
+
+  /**
    * Queue snapshot for the world-state `hitl_queue` domain.
    * - pendingCount: all pending (rendered + unrendered)
    * - unrenderedCount: pending that had no matching renderer (routing hole)
@@ -80,53 +92,67 @@ export class HITLPlugin implements Plugin {
     console.log(`[hitl] Registered renderer for interface "${interfaceName}"`);
   }
 
+  /**
+   * Sweep pending HITL requests whose `expiresAt` is at or before `nowMs`.
+   *
+   * For each expired request:
+   *   - `onTimeout === "approve" | "reject"` → publish a synthetic HITLResponse
+   *     on `hitl.response.{correlationId}` so the TaskTracker / replyTopic
+   *     consumer treats it as an auto-decision
+   *   - `onTimeout === "escalate"` or unset → publish `hitl.expired.{correlationId}`
+   *     and invoke the renderer's onExpired() hook so a human sees the timeout
+   *
+   * Exposed (not private) so tests can invoke it directly with a controlled
+   * `nowMs` instead of waiting for the 60s production sweep timer.
+   */
+  sweepExpired(bus: EventBus, nowMs: number): void {
+    for (const [correlationId, req] of pendingRequests) {
+      if (new Date(req.expiresAt).getTime() > nowMs) continue;
+
+      pendingRequests.delete(correlationId);
+      unrenderedCorrelationIds.delete(correlationId);
+
+      if (req.onTimeout === "approve" || req.onTimeout === "reject") {
+        console.log(`[hitl] TTL expired → auto-${req.onTimeout} (${correlationId})`);
+        const autoResp: HITLResponse = {
+          type: "hitl_response",
+          correlationId,
+          decision: req.onTimeout,
+          decidedBy: `auto-${req.onTimeout}`,
+        };
+        bus.publish(`hitl.response.${correlationId}`, {
+          id: crypto.randomUUID(),
+          correlationId,
+          topic: `hitl.response.${correlationId}`,
+          timestamp: nowMs,
+          payload: autoResp,
+        });
+      } else {
+        console.log(`[hitl] Expired HITLRequest (${correlationId})`);
+        bus.publish(`hitl.expired.${correlationId}`, {
+          id: crypto.randomUUID(),
+          correlationId,
+          topic: `hitl.expired.${correlationId}`,
+          timestamp: nowMs,
+          payload: { type: "hitl_expired", correlationId, originalRequest: req },
+        });
+        const iface = req.sourceMeta?.interface ?? "unknown";
+        const renderer = renderers.get(iface);
+        if (renderer?.onExpired) {
+          renderer.onExpired(req, bus).catch(err =>
+            console.error(`[hitl] renderer.onExpired failed for ${correlationId}:`, err),
+          );
+        }
+      }
+    }
+  }
+
   install(bus: EventBus): void {
     this.busRef = bus;
 
     // ── Expiry sweep: every 60s, remove expired pending requests ─────────
     this.expiryTimer = setInterval(() => {
-      const now = Date.now();
-      for (const [correlationId, req] of pendingRequests) {
-        if (new Date(req.expiresAt).getTime() <= now) {
-          pendingRequests.delete(correlationId);
-          unrenderedCorrelationIds.delete(correlationId);
-
-          if (req.onTimeout === "approve" || req.onTimeout === "reject") {
-            // Auto-respond according to the TTL policy
-            console.log(`[hitl] TTL expired → auto-${req.onTimeout} (${correlationId})`);
-            const autoResp: HITLResponse = {
-              type: "hitl_response",
-              correlationId,
-              decision: req.onTimeout,
-              decidedBy: `auto-${req.onTimeout}`,
-            };
-            bus.publish(`hitl.response.${correlationId}`, {
-              id: crypto.randomUUID(),
-              correlationId,
-              topic: `hitl.response.${correlationId}`,
-              timestamp: Date.now(),
-              payload: autoResp,
-            });
-          } else {
-            // onTimeout === "escalate" or not set — emit expired event for escalation handlers
-            console.log(`[hitl] Expired HITLRequest (${correlationId})`);
-            bus.publish(`hitl.expired.${correlationId}`, {
-              id: crypto.randomUUID(),
-              correlationId,
-              topic: `hitl.expired.${correlationId}`,
-              timestamp: Date.now(),
-              payload: { type: "hitl_expired", correlationId, originalRequest: req },
-            });
-            const iface = req.sourceMeta?.interface ?? "unknown";
-            const renderer = renderers.get(iface);
-            if (renderer?.onExpired) {
-              renderer.onExpired(req, bus).catch(err =>
-                console.error(`[hitl] renderer.onExpired failed for ${correlationId}:`, err),
-              );
-            }
-          }
-        }
-      }
+      this.sweepExpired(bus, Date.now());
     }, 60_000);
 
     // ── Route HITLRequest to the correct interface ───────────────────────


### PR DESCRIPTION
Arc 7.2 — the existing expiry-sweep auto-approve/reject logic is extracted into a testable method and given 7-test coverage. No production behavior change; purely makes the feature verifiable. 821/821 pass.