### PR TITLE
feat(ci): port prepare-release + auto-release workflows

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,110 @@
+name: Auto Release
+
+# Fires when a dev -> main PR is merged. Reads the version from package.json
+# on main, creates the matching v* tag, and opens a GitHub Release. The tag
+# push then triggers release.yml which posts release notes to Discord.
+#
+# Flow: prepare-release.yml bumps on dev → dev→main PR merges → this workflow
+# tags main → release.yml (on: tags) posts Discord notes.
+#
+# Simplified from protoMaker's staging-based flow — protoWorkstacean is
+# straight dev → main without a staging branch.
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Tag the current main HEAD even if the version is already tagged"
+        type: boolean
+        default: false
+
+permissions: read-all
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.merged == true &&
+       github.event.pull_request.base.ref == 'main' &&
+       github.repository == 'protoLabsAI/protoWorkstacean')
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Get version from package.json
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Detected version: v$VERSION"
+
+          if git tag -l "v$VERSION" | grep -q "v$VERSION"; then
+            echo "already_tagged=true" >> $GITHUB_OUTPUT
+            echo "v$VERSION is already tagged."
+          else
+            echo "already_tagged=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create tag
+        if: steps.version.outputs.already_tagged != 'true' || inputs.force == true
+        run: |
+          VERSION="v${{ steps.version.outputs.version }}"
+          git tag -a -f "$VERSION" -m "$VERSION"
+          git push origin "$VERSION" --force-with-lease
+
+      - name: Create GitHub Release
+        if: steps.version.outputs.already_tagged != 'true' || inputs.force == true
+        run: |
+          VERSION="v${{ steps.version.outputs.version }}"
+
+          # Skip if release already exists (e.g. after a force-retag)
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "GitHub Release $VERSION already exists — skipping create."
+            exit 0
+          fi
+
+          # Generate notes from auto-notes API; filter chore commits out unless
+          # they're the only entries.
+          RAW_NOTES=$(gh api "repos/${{ github.repository }}/releases/generate-notes" \
+            -f tag_name="$VERSION" --jq '.body')
+
+          ALL_LINES=$(echo "$RAW_NOTES" | grep '^\* ' || true)
+          NON_CHORE=$(echo "$ALL_LINES" | grep -vi '^\* chore' || true)
+
+          if [ -n "$NON_CHORE" ]; then
+            FILTERED=$(echo "$RAW_NOTES" | grep -vi '^\* chore')
+          else
+            FILTERED="$RAW_NOTES"
+          fi
+
+          gh release create "$VERSION" --title "$VERSION" --notes "$FILTERED"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        run: |
+          VERSION="v${{ steps.version.outputs.version }}"
+          if [ "${{ steps.version.outputs.already_tagged }}" = "true" ] && [ "${{ inputs.force }}" != "true" ]; then
+            echo "Skipped: $VERSION already tagged."
+          else
+            echo "Tagged $VERSION. release.yml will post Discord notes from the tag push."
+          fi

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,120 @@
+name: Prepare Release
+
+# Bumps version on the dev branch BEFORE promotion to main.
+# Run via workflow_dispatch; specify either an explicit version or a semver
+# part (patch/minor/major) to auto-compute the next version.
+#
+# After this completes, create a dev->main promotion PR and merge it.
+# auto-release.yml fires on that merge and tags main + creates the GitHub Release.
+#
+# Simplified from protoMaker's staging-based flow — protoWorkstacean skips
+# staging and goes dev → main directly.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump: patch | minor | major | or explicit x.y.z"
+        type: string
+        default: patch
+      dry_run:
+        description: "Dry run — show what would be bumped without pushing"
+        type: boolean
+        default: false
+
+permissions: read-all
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    if: github.repository == 'protoLabsAI/protoWorkstacean'
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout dev
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Compute next version
+        id: version
+        run: |
+          CURRENT=$(node -p "require('./package.json').version")
+          BUMP="${{ inputs.bump }}"
+
+          case "$BUMP" in
+            patch|minor|major)
+              # semver increment
+              NEXT=$(node -e "
+                const [M, m, p] = '$CURRENT'.split('.').map(Number);
+                const b = '$BUMP';
+                if (b === 'major') console.log(\`\${M + 1}.0.0\`);
+                else if (b === 'minor') console.log(\`\${M}.\${m + 1}.0\`);
+                else console.log(\`\${M}.\${m}.\${p + 1}\`);
+              ")
+              ;;
+            *)
+              # treat as explicit x.y.z
+              if ! echo "$BUMP" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+                echo "::error::Invalid bump value '$BUMP' — must be patch/minor/major or explicit x.y.z"
+                exit 1
+              fi
+              NEXT="$BUMP"
+              ;;
+          esac
+
+          echo "current=$CURRENT" >> $GITHUB_OUTPUT
+          echo "next=$NEXT" >> $GITHUB_OUTPUT
+          echo "Version bump: v$CURRENT → v$NEXT"
+
+      - name: Apply version bump
+        if: steps.version.outputs.current != steps.version.outputs.next
+        run: |
+          NEXT="${{ steps.version.outputs.next }}"
+          node -e "
+            const fs = require('fs');
+            for (const path of ['package.json', 'dashboard/package.json']) {
+              const p = JSON.parse(fs.readFileSync(path));
+              p.version = '$NEXT';
+              fs.writeFileSync(path, JSON.stringify(p, null, 2) + '\n');
+            }
+          "
+          git diff --stat
+
+      - name: Commit version bump to dev
+        if: steps.version.outputs.current != steps.version.outputs.next && inputs.dry_run != true
+        run: |
+          NEXT="${{ steps.version.outputs.next }}"
+          git add package.json dashboard/package.json
+          git commit -m "chore(release): bump to v${NEXT}"
+          git push origin dev
+
+      - name: Dry run summary
+        if: inputs.dry_run == true
+        run: |
+          echo "DRY RUN — would have committed:"
+          git diff --stat
+          echo ""
+          echo "Next version: v${{ steps.version.outputs.next }}"
+          echo "To promote: open a dev -> main PR; auto-release.yml tags on merge."
+
+      - name: Summary
+        if: inputs.dry_run != true
+        run: |
+          NEXT="v${{ steps.version.outputs.next }}"
+          if [ "${{ steps.version.outputs.current }}" = "${{ steps.version.outputs.next }}" ]; then
+            echo "No version change (already at $NEXT)."
+          else
+            echo "Release $NEXT prepared on dev."
+            echo "Next step: open a dev -> main promotion PR. auto-release.yml will tag on merge."
+          fi


### PR DESCRIPTION
Closes the release-automation gap for protoWorkstacean. Adapts protoMaker's workflows to our simpler dev→main flow (no staging, no changesets).