### PR TITLE
feat(extensions): [Arc 7.4] x-protolabs/hitl-mode-v1 per-skill HITL policy

### DIFF
--- a/src/executor/__tests__/hitl-mode-extension.test.ts
+++ b/src/executor/__tests__/hitl-mode-extension.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+  HitlModeRegistry,
+  registerHitlModeExtension,
+  HITL_MODE_URI,
+  HITL_MODE_ORDER,
+  type HitlMode,
+} from "../extensions/hitl-mode.ts";
+import { defaultExtensionRegistry } from "../extension-registry.ts";
+import type { ExtensionContext } from "../extension-registry.ts";
+
+function makeCtx(overrides: Partial<ExtensionContext> = {}): ExtensionContext {
+  return {
+    agentName: "quinn",
+    skill: "pr_review",
+    correlationId: "corr-1",
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe("HitlModeRegistry", () => {
+  test("stores and retrieves declarations", () => {
+    const r = new HitlModeRegistry();
+    r.declare({ agentName: "quinn", skill: "pr_review", mode: "gated" });
+    expect(r.get("quinn", "pr_review")?.mode).toBe("gated");
+    expect(r.get("quinn", "other")).toBeUndefined();
+  });
+
+  test("resolveMode falls back to autonomous by default", () => {
+    const r = new HitlModeRegistry();
+    expect(r.resolveMode("quinn", "unknown")).toBe("autonomous");
+    expect(r.resolveMode("quinn", "unknown", "gated")).toBe("gated");
+  });
+
+  test("resolveMode returns declared mode when present", () => {
+    const r = new HitlModeRegistry();
+    r.declare({ agentName: "frank", skill: "deploy_prod", mode: "gated" });
+    expect(r.resolveMode("frank", "deploy_prod")).toBe("gated");
+  });
+
+  test("compare() orders autonomous < notification < veto < gated < compound", () => {
+    const r = new HitlModeRegistry();
+    expect(r.compare("autonomous", "notification")).toBeLessThan(0);
+    expect(r.compare("compound", "gated")).toBeGreaterThan(0);
+    expect(r.compare("veto", "veto")).toBe(0);
+    expect(r.compare(undefined, undefined)).toBe(0);
+    expect(r.compare(undefined, "gated")).toBeLessThan(0);
+  });
+
+  test("HITL_MODE_ORDER is monotone", () => {
+    const order: HitlMode[] = ["autonomous", "notification", "veto", "gated", "compound"];
+    for (let i = 1; i < order.length; i++) {
+      expect(HITL_MODE_ORDER[order[i]]).toBeGreaterThan(HITL_MODE_ORDER[order[i - 1]]);
+    }
+  });
+
+  test("preserves vetoTtlMs when declared", () => {
+    const r = new HitlModeRegistry();
+    r.declare({ agentName: "a", skill: "s", mode: "veto", vetoTtlMs: 30_000 });
+    expect(r.get("a", "s")?.vetoTtlMs).toBe(30_000);
+  });
+
+  test("all() + clear() behave", () => {
+    const r = new HitlModeRegistry();
+    r.declare({ agentName: "a", skill: "s1", mode: "gated" });
+    r.declare({ agentName: "b", skill: "s2", mode: "autonomous" });
+    expect(r.all()).toHaveLength(2);
+    r.clear();
+    expect(r.size).toBe(0);
+  });
+});
+
+describe("hitl-mode-v1 extension interceptor", () => {
+  let registry: HitlModeRegistry;
+
+  beforeEach(() => {
+    registry = new HitlModeRegistry();
+    registerHitlModeExtension(registry);
+  });
+
+  test("registered on defaultExtensionRegistry", () => {
+    const uris = defaultExtensionRegistry.list().map(e => e.uri);
+    expect(uris).toContain(HITL_MODE_URI);
+  });
+
+  test("before() stamps x-hitl-mode when declared", () => {
+    registry.declare({ agentName: "quinn", skill: "pr_review", mode: "gated" });
+    const interceptor = defaultExtensionRegistry.list().find(e => e.uri === HITL_MODE_URI)?.interceptor;
+    const ctx = makeCtx();
+    interceptor!.before?.(ctx);
+    expect(ctx.metadata["x-hitl-mode"]).toBe("gated");
+  });
+
+  test("before() stamps x-hitl-veto-ttl-ms when declared with veto mode", () => {
+    registry.declare({ agentName: "quinn", skill: "pr_review", mode: "veto", vetoTtlMs: 15_000 });
+    const interceptor = defaultExtensionRegistry.list().find(e => e.uri === HITL_MODE_URI)?.interceptor;
+    const ctx = makeCtx();
+    interceptor!.before?.(ctx);
+    expect(ctx.metadata["x-hitl-mode"]).toBe("veto");
+    expect(ctx.metadata["x-hitl-veto-ttl-ms"]).toBe(15_000);
+  });
+
+  test("before() no-op when no declaration exists", () => {
+    const interceptor = defaultExtensionRegistry.list().find(e => e.uri === HITL_MODE_URI)?.interceptor;
+    const ctx = makeCtx();
+    interceptor!.before?.(ctx);
+    expect(ctx.metadata["x-hitl-mode"]).toBeUndefined();
+  });
+
+  test("after() is not defined — mode is read-side only", () => {
+    const interceptor = defaultExtensionRegistry.list().find(e => e.uri === HITL_MODE_URI)?.interceptor;
+    expect(interceptor?.after).toBeUndefined();
+  });
+});

--- a/src/executor/extensions/hitl-mode.ts
+++ b/src/executor/extensions/hitl-mode.ts
@@ -1,0 +1,138 @@
+/**
+ * HITL mode v1 extension — per-skill approval policy declared on the agent card.
+ *
+ * HITL is a gradient, not a binary. Skills span a range from fully autonomous
+ * through post-hoc veto windows to compound multi-step gates. Declaring the
+ * mode per-skill on the agent card lets the dispatcher + HITL plugin route
+ * each invocation to the right flow without goal-level config.
+ *
+ * Like blast-v1 this is a read-side declaration: `before(ctx)` stamps the
+ * declared mode on outbound metadata so downstream consumers (HITL plugin,
+ * TaskTracker) can read it without a second lookup. No `after(ctx)` — mode
+ * is policy, not observation.
+ *
+ * Extension URI: https://protolabs.ai/a2a/ext/hitl-mode-v1
+ */
+
+import {
+  defaultExtensionRegistry,
+  type ExtensionInterceptor,
+  type ExtensionContext,
+} from "../extension-registry.ts";
+
+export const HITL_MODE_URI = "https://protolabs.ai/a2a/ext/hitl-mode-v1";
+
+/**
+ * Approval policy for a single skill. Ordered from least-gated to most-gated.
+ *
+ * - `autonomous`   — no human in the loop. Task runs, outcome is what it is.
+ * - `notification` — runs autonomously; a read-only notification is rendered
+ *   to the originating surface (Discord, Plane) for awareness.
+ * - `veto`         — short TTL window after dispatch where a human can cancel
+ *   before side effects complete (via `tasks/cancel`). Auto-approved on TTL.
+ * - `gated`        — blocking `input-required` before any side effect. No
+ *   auto-approve; execution halts until a decision.
+ * - `compound`     — multi-checkpoint gated. Agent emits multiple
+ *   `input-required` states across the task lifecycle (draft → review →
+ *   publish); each one requires its own decision.
+ */
+export type HitlMode =
+  | "autonomous"
+  | "notification"
+  | "veto"
+  | "gated"
+  | "compound";
+
+export const HITL_MODE_ORDER: Record<HitlMode, number> = {
+  autonomous: 0,
+  notification: 1,
+  veto: 2,
+  gated: 3,
+  compound: 4,
+};
+
+export interface HitlModeDeclaration {
+  agentName: string;
+  skill: string;
+  mode: HitlMode;
+  /** Per-skill TTL for veto mode, in ms. Ignored for other modes. */
+  vetoTtlMs?: number;
+  /** Optional human-readable reason for the declared mode. */
+  note?: string;
+}
+
+/**
+ * Registry of per-(agent, skill) HITL mode declarations. Populated at agent
+ * card ingestion time by SkillBrokerPlugin, consulted at dispatch time by
+ * SkillDispatcher / HITLPlugin to decide gating behavior.
+ */
+export class HitlModeRegistry {
+  private readonly byKey = new Map<string, HitlModeDeclaration>();
+
+  static key(agentName: string, skill: string): string {
+    return `${agentName}::${skill}`;
+  }
+
+  declare(decl: HitlModeDeclaration): void {
+    this.byKey.set(HitlModeRegistry.key(decl.agentName, decl.skill), decl);
+  }
+
+  get(agentName: string, skill: string): HitlModeDeclaration | undefined {
+    return this.byKey.get(HitlModeRegistry.key(agentName, skill));
+  }
+
+  /** Resolve with a fallback default. `autonomous` is the safe default —
+   *  the planner caller decides whether to bump the mode based on blast. */
+  resolveMode(agentName: string, skill: string, fallback: HitlMode = "autonomous"): HitlMode {
+    return this.get(agentName, skill)?.mode ?? fallback;
+  }
+
+  /** Numeric comparison — higher == more gated. Unknown treats as autonomous. */
+  compare(a: HitlMode | undefined, b: HitlMode | undefined): number {
+    const av = a ? HITL_MODE_ORDER[a] : 0;
+    const bv = b ? HITL_MODE_ORDER[b] : 0;
+    return av - bv;
+  }
+
+  all(): HitlModeDeclaration[] {
+    return Array.from(this.byKey.values());
+  }
+
+  clear(): void {
+    this.byKey.clear();
+  }
+
+  get size(): number {
+    return this.byKey.size;
+  }
+}
+
+export const defaultHitlModeRegistry = new HitlModeRegistry();
+
+/**
+ * Register the hitl-mode-v1 extension interceptor. The registry is populated
+ * separately by SkillBrokerPlugin when it parses agent cards.
+ */
+export function registerHitlModeExtension(
+  registry: HitlModeRegistry = defaultHitlModeRegistry,
+): void {
+  const interceptor: ExtensionInterceptor = {
+    before(ctx: ExtensionContext): void {
+      const decl = registry.get(ctx.agentName, ctx.skill);
+      if (decl) {
+        ctx.metadata["x-hitl-mode"] = decl.mode;
+        if (decl.vetoTtlMs !== undefined) {
+          ctx.metadata["x-hitl-veto-ttl-ms"] = decl.vetoTtlMs;
+        }
+      }
+    },
+    // no after() — mode is policy, not observation
+  };
+
+  defaultExtensionRegistry.register({
+    uri: HITL_MODE_URI,
+    interceptor,
+    description:
+      "HITL mode v1: per-skill approval policy (autonomous/notification/veto/gated/compound); HITL plugin reads from the registry",
+  });
+}


### PR DESCRIPTION
Arc 7.4 — per-skill HITL mode declared on agent card. 12 tests, tsc clean.