### PR TITLE
feat(hitl): [Arc 7.3] compound gated task checkpointing

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -35,6 +35,18 @@ export interface HITLRequest {
   ttlMs?: number;
   /** Policy to execute when the TTL expires without a human decision. */
   onTimeout?: "approve" | "reject" | "escalate";
+  /**
+   * Compound-gate metadata (Arc 7.3). When a single A2A task emits multiple
+   * input-required states across its lifecycle (e.g. draft → review → publish),
+   * each prompt sets `checkpoint` so renderers can show "Checkpoint 2 of 3"
+   * instead of a bare "input-required".
+   */
+  checkpoint?: {
+    /** 1-based index of this prompt within the task's compound sequence. */
+    index: number;
+    /** Optional agent-declared total; may be unknown at the first prompt. */
+    total?: number;
+  };
   replyTopic: string;     // where to publish HITLResponse
   sourceMeta?: BusMessage["source"]; // carry source through so HITL plugin knows how to render
   // ── Cost escalation fields (populated by BudgetPlugin L3 requests) ────────

--- a/src/executor/__tests__/task-tracker.test.ts
+++ b/src/executor/__tests__/task-tracker.test.ts
@@ -177,4 +177,86 @@ describe("TaskTracker", () => {
     expect(received).toHaveLength(0);
     expect(tracker.size).toBe(1);
   });
+
+  // ── Arc 7.3: compound gated task checkpointing ────────────────────────────
+  describe("compound gated checkpointing (Arc 7.3)", () => {
+    test("increments checkpoint counter on each input-required cycle", async () => {
+      // Fake executor — resumeTask resolves, pollTask alternates input-required
+      // and working so the tracker can cycle through checkpoints.
+      let pollCalls = 0;
+      const fake = {
+        type: "a2a" as const,
+        execute: async () => ({ text: "", isError: false, correlationId: "" }),
+        pollTask: async (): Promise<SkillResult> => {
+          pollCalls += 1;
+          return pollCalls === 1
+            ? { text: "draft needs review", isError: false, correlationId: "c1", data: { taskState: "input-required", taskId: "t1", contextId: "ctx1" } }
+            : { text: "final approval?", isError: false, correlationId: "c1", data: { taskState: "input-required", taskId: "t1", contextId: "ctx1" } };
+        },
+        cancelTask: async () => ({ text: "canceled", isError: false, correlationId: "c1" }),
+        resubscribeTask: async () => { throw new Error("not used"); },
+        resumeTask: async () => {},
+      };
+      const executor = fake as unknown as A2AExecutor;
+
+      const requests: unknown[] = [];
+      bus.subscribe("hitl.request.#", "test", (msg) => { requests.push(msg.payload); });
+
+      tracker = new TaskTracker({ bus, sweepIntervalMs: 20, defaultPollIntervalMs: 10 });
+      tracker.track({
+        correlationId: "c1", taskId: "t1", agentName: "ava",
+        replyTopic: "agent.skill.response.c1", executor,
+        sourceInterface: "discord", sourceChannelId: "chan", sourceUserId: "user",
+      });
+
+      // Wait for first input-required → HITL raised
+      await new Promise(r => setTimeout(r, 50));
+      expect(requests.length).toBe(1);
+      expect((requests[0] as { checkpoint?: { index: number } }).checkpoint?.index).toBe(1);
+      expect((requests[0] as { title: string }).title).not.toContain("checkpoint");
+
+      // Simulate human decision → triggers resume; tracker clears awaitingHuman
+      bus.publish("hitl.response.c1", {
+        id: "r1", correlationId: "c1", topic: "hitl.response.c1", timestamp: Date.now(),
+        payload: { type: "hitl_response", correlationId: "c1", decision: "approve", decidedBy: "human" },
+      });
+
+      // Wait for next sweep cycle → second input-required → second HITL raise
+      await new Promise(r => setTimeout(r, 80));
+      expect(requests.length).toBe(2);
+      expect((requests[1] as { checkpoint?: { index: number } }).checkpoint?.index).toBe(2);
+      expect((requests[1] as { title: string }).title).toContain("checkpoint 2");
+    });
+
+    test("first checkpoint does not include counter in title", async () => {
+      const fake = {
+        type: "a2a" as const,
+        execute: async () => ({ text: "", isError: false, correlationId: "" }),
+        pollTask: async (): Promise<SkillResult> => ({
+          text: "please confirm", isError: false, correlationId: "c1",
+          data: { taskState: "input-required", taskId: "t1", contextId: "ctx1" },
+        }),
+        cancelTask: async () => ({ text: "", isError: false, correlationId: "c1" }),
+        resubscribeTask: async () => { throw new Error("not used"); },
+        resumeTask: async () => {},
+      };
+      const executor = fake as unknown as A2AExecutor;
+
+      const requests: unknown[] = [];
+      bus.subscribe("hitl.request.#", "test", (msg) => { requests.push(msg.payload); });
+
+      tracker = new TaskTracker({ bus, sweepIntervalMs: 20, defaultPollIntervalMs: 10 });
+      tracker.track({
+        correlationId: "c1", taskId: "t1", agentName: "ava",
+        replyTopic: "agent.skill.response.c1", executor,
+      });
+
+      await new Promise(r => setTimeout(r, 40));
+      expect(requests.length).toBe(1);
+      const first = requests[0] as { title: string; checkpoint?: { index: number } };
+      expect(first.checkpoint?.index).toBe(1);
+      expect(first.title).toBe("Input needed from ava");
+      expect(first.title).not.toContain("checkpoint");
+    });
+  });
 });

--- a/src/executor/task-tracker.ts
+++ b/src/executor/task-tracker.ts
@@ -36,6 +36,12 @@ export interface TrackedTask {
   callbackToken?: string;
   /** Set when the task has asked for human input — suppresses polling until resumed. */
   awaitingHuman?: boolean;
+  /**
+   * Compound-gate counter (Arc 7.3). Incremented every time the task enters
+   * input-required. Passed into the raised HITLRequest so renderers can show
+   * "Checkpoint N" for multi-step tasks. Reset is never needed — monotonic.
+   */
+  checkpointCount?: number;
   /** The Discord/etc interface that originated the request — reused for HITL routing. */
   sourceInterface?: string;
   /** Source channel ID for HITL rendering. */
@@ -259,14 +265,20 @@ export class TaskTracker {
   private _raiseHitl(task: TrackedTask, question: string | undefined): void {
     if (task.awaitingHuman) return; // already raised, avoid duplicate
     task.awaitingHuman = true;
+    // Arc 7.3: increment checkpoint counter so compound-gated tasks (multi-step
+    // input-required) surface which prompt this is in the sequence. 1-based.
+    task.checkpointCount = (task.checkpointCount ?? 0) + 1;
 
     const req: HITLRequest = {
       type: "hitl_request",
       correlationId: task.correlationId,
-      title: `Input needed from ${task.agentName}`,
+      title: task.checkpointCount > 1
+        ? `Input needed from ${task.agentName} (checkpoint ${task.checkpointCount})`
+        : `Input needed from ${task.agentName}`,
       summary: question || "The agent is requesting input to continue.",
       options: ["approve", "reject"],
       expiresAt: new Date(Date.now() + HITL_TTL_MS).toISOString(),
+      checkpoint: { index: task.checkpointCount },
       replyTopic: `hitl.response.${task.correlationId}`,
       sourceMeta: {
         interface: task.sourceInterface ?? "discord",


### PR DESCRIPTION
Arc 7.3 — multi-step input-required flows now carry checkpoint index metadata. Renderers can show 'checkpoint 2 of N' instead of bare 'input needed'. TaskTracker monotonically increments on each raise; HITLRequest extended with `checkpoint: { index, total? }`. 832 tests pass.