### PR TITLE
promote: dev → main — v0.7.4 (release automation + Arc 7.3/7.4)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,110 @@
+name: Auto Release
+
+# Fires when a dev -> main PR is merged. Reads the version from package.json
+# on main, creates the matching v* tag, and opens a GitHub Release. The tag
+# push then triggers release.yml which posts release notes to Discord.
+#
+# Flow: prepare-release.yml bumps on dev → dev→main PR merges → this workflow
+# tags main → release.yml (on: tags) posts Discord notes.
+#
+# Simplified from protoMaker's staging-based flow — protoWorkstacean is
+# straight dev → main without a staging branch.
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Tag the current main HEAD even if the version is already tagged"
+        type: boolean
+        default: false
+
+permissions: read-all
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.merged == true &&
+       github.event.pull_request.base.ref == 'main' &&
+       github.repository == 'protoLabsAI/protoWorkstacean')
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Get version from package.json
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Detected version: v$VERSION"
+
+          if git tag -l "v$VERSION" | grep -q "v$VERSION"; then
+            echo "already_tagged=true" >> $GITHUB_OUTPUT
+            echo "v$VERSION is already tagged."
+          else
+            echo "already_tagged=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create tag
+        if: steps.version.outputs.already_tagged != 'true' || inputs.force == true
+        run: |
+          VERSION="v${{ steps.version.outputs.version }}"
+          git tag -a -f "$VERSION" -m "$VERSION"
+          git push origin "$VERSION" --force-with-lease
+
+      - name: Create GitHub Release
+        if: steps.version.outputs.already_tagged != 'true' || inputs.force == true
+        run: |
+          VERSION="v${{ steps.version.outputs.version }}"
+
+          # Skip if release already exists (e.g. after a force-retag)
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "GitHub Release $VERSION already exists — skipping create."
+            exit 0
+          fi
+
+          # Generate notes from auto-notes API; filter chore commits out unless
+          # they're the only entries.
+          RAW_NOTES=$(gh api "repos/${{ github.repository }}/releases/generate-notes" \
+            -f tag_name="$VERSION" --jq '.body')
+
+          ALL_LINES=$(echo "$RAW_NOTES" | grep '^\* ' || true)
+          NON_CHORE=$(echo "$ALL_LINES" | grep -vi '^\* chore' || true)
+
+          if [ -n "$NON_CHORE" ]; then
+            FILTERED=$(echo "$RAW_NOTES" | grep -vi '^\* chore')
+          else
+            FILTERED="$RAW_NOTES"
+          fi
+
+          gh release create "$VERSION" --title "$VERSION" --notes "$FILTERED"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        run: |
+          VERSION="v${{ steps.version.outputs.version }}"
+          if [ "${{ steps.version.outputs.already_tagged }}" = "true" ] && [ "${{ inputs.force }}" != "true" ]; then
+            echo "Skipped: $VERSION already tagged."
+          else
+            echo "Tagged $VERSION. release.yml will post Discord notes from the tag push."
+          fi

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,120 @@
+name: Prepare Release
+
+# Bumps version on the dev branch BEFORE promotion to main.
+# Run via workflow_dispatch; specify either an explicit version or a semver
+# part (patch/minor/major) to auto-compute the next version.
+#
+# After this completes, create a dev->main promotion PR and merge it.
+# auto-release.yml fires on that merge and tags main + creates the GitHub Release.
+#
+# Simplified from protoMaker's staging-based flow — protoWorkstacean skips
+# staging and goes dev → main directly.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump: patch | minor | major | or explicit x.y.z"
+        type: string
+        default: patch
+      dry_run:
+        description: "Dry run — show what would be bumped without pushing"
+        type: boolean
+        default: false
+
+permissions: read-all
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    if: github.repository == 'protoLabsAI/protoWorkstacean'
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout dev
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Compute next version
+        id: version
+        run: |
+          CURRENT=$(node -p "require('./package.json').version")
+          BUMP="${{ inputs.bump }}"
+
+          case "$BUMP" in
+            patch|minor|major)
+              # semver increment
+              NEXT=$(node -e "
+                const [M, m, p] = '$CURRENT'.split('.').map(Number);
+                const b = '$BUMP';
+                if (b === 'major') console.log(\`\${M + 1}.0.0\`);
+                else if (b === 'minor') console.log(\`\${M}.\${m + 1}.0\`);
+                else console.log(\`\${M}.\${m}.\${p + 1}\`);
+              ")
+              ;;
+            *)
+              # treat as explicit x.y.z
+              if ! echo "$BUMP" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+                echo "::error::Invalid bump value '$BUMP' — must be patch/minor/major or explicit x.y.z"
+                exit 1
+              fi
+              NEXT="$BUMP"
+              ;;
+          esac
+
+          echo "current=$CURRENT" >> $GITHUB_OUTPUT
+          echo "next=$NEXT" >> $GITHUB_OUTPUT
+          echo "Version bump: v$CURRENT → v$NEXT"
+
+      - name: Apply version bump
+        if: steps.version.outputs.current != steps.version.outputs.next
+        run: |
+          NEXT="${{ steps.version.outputs.next }}"
+          node -e "
+            const fs = require('fs');
+            for (const path of ['package.json', 'dashboard/package.json']) {
+              const p = JSON.parse(fs.readFileSync(path));
+              p.version = '$NEXT';
+              fs.writeFileSync(path, JSON.stringify(p, null, 2) + '\n');
+            }
+          "
+          git diff --stat
+
+      - name: Commit version bump to dev
+        if: steps.version.outputs.current != steps.version.outputs.next && inputs.dry_run != true
+        run: |
+          NEXT="${{ steps.version.outputs.next }}"
+          git add package.json dashboard/package.json
+          git commit -m "chore(release): bump to v${NEXT}"
+          git push origin dev
+
+      - name: Dry run summary
+        if: inputs.dry_run == true
+        run: |
+          echo "DRY RUN — would have committed:"
+          git diff --stat
+          echo ""
+          echo "Next version: v${{ steps.version.outputs.next }}"
+          echo "To promote: open a dev -> main PR; auto-release.yml tags on merge."
+
+      - name: Summary
+        if: inputs.dry_run != true
+        run: |
+          NEXT="v${{ steps.version.outputs.next }}"
+          if [ "${{ steps.version.outputs.current }}" = "${{ steps.version.outputs.next }}" ]; then
+            echo "No version change (already at $NEXT)."
+          else
+            echo "Release $NEXT prepared on dev."
+            echo "Next step: open a dev -> main promotion PR. auto-release.yml will tag on merge."
+          fi

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean-dashboard",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -35,6 +35,18 @@ export interface HITLRequest {
   ttlMs?: number;
   /** Policy to execute when the TTL expires without a human decision. */
   onTimeout?: "approve" | "reject" | "escalate";
+  /**
+   * Compound-gate metadata (Arc 7.3). When a single A2A task emits multiple
+   * input-required states across its lifecycle (e.g. draft → review → publish),
+   * each prompt sets `checkpoint` so renderers can show "Checkpoint 2 of 3"
+   * instead of a bare "input-required".
+   */
+  checkpoint?: {
+    /** 1-based index of this prompt within the task's compound sequence. */
+    index: number;
+    /** Optional agent-declared total; may be unknown at the first prompt. */
+    total?: number;
+  };
   replyTopic: string;     // where to publish HITLResponse
   sourceMeta?: BusMessage["source"]; // carry source through so HITL plugin knows how to render
   // ── Cost escalation fields (populated by BudgetPlugin L3 requests) ────────

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "type": "module",
   "scripts": {
     "start": "bun run src/index.ts",

--- a/src/executor/__tests__/hitl-mode-extension.test.ts
+++ b/src/executor/__tests__/hitl-mode-extension.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+  HitlModeRegistry,
+  registerHitlModeExtension,
+  HITL_MODE_URI,
+  HITL_MODE_ORDER,
+  type HitlMode,
+} from "../extensions/hitl-mode.ts";
+import { defaultExtensionRegistry } from "../extension-registry.ts";
+import type { ExtensionContext } from "../extension-registry.ts";
+
+function makeCtx(overrides: Partial<ExtensionContext> = {}): ExtensionContext {
+  return {
+    agentName: "quinn",
+    skill: "pr_review",
+    correlationId: "corr-1",
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe("HitlModeRegistry", () => {
+  test("stores and retrieves declarations", () => {
+    const r = new HitlModeRegistry();
+    r.declare({ agentName: "quinn", skill: "pr_review", mode: "gated" });
+    expect(r.get("quinn", "pr_review")?.mode).toBe("gated");
+    expect(r.get("quinn", "other")).toBeUndefined();
+  });
+
+  test("resolveMode falls back to autonomous by default", () => {
+    const r = new HitlModeRegistry();
+    expect(r.resolveMode("quinn", "unknown")).toBe("autonomous");
+    expect(r.resolveMode("quinn", "unknown", "gated")).toBe("gated");
+  });
+
+  test("resolveMode returns declared mode when present", () => {
+    const r = new HitlModeRegistry();
+    r.declare({ agentName: "frank", skill: "deploy_prod", mode: "gated" });
+    expect(r.resolveMode("frank", "deploy_prod")).toBe("gated");
+  });
+
+  test("compare() orders autonomous < notification < veto < gated < compound", () => {
+    const r = new HitlModeRegistry();
+    expect(r.compare("autonomous", "notification")).toBeLessThan(0);
+    expect(r.compare("compound", "gated")).toBeGreaterThan(0);
+    expect(r.compare("veto", "veto")).toBe(0);
+    expect(r.compare(undefined, undefined)).toBe(0);
+    expect(r.compare(undefined, "gated")).toBeLessThan(0);
+  });
+
+  test("HITL_MODE_ORDER is monotone", () => {
+    const order: HitlMode[] = ["autonomous", "notification", "veto", "gated", "compound"];
+    for (let i = 1; i < order.length; i++) {
+      expect(HITL_MODE_ORDER[order[i]]).toBeGreaterThan(HITL_MODE_ORDER[order[i - 1]]);
+    }
+  });
+
+  test("preserves vetoTtlMs when declared", () => {
+    const r = new HitlModeRegistry();
+    r.declare({ agentName: "a", skill: "s", mode: "veto", vetoTtlMs: 30_000 });
+    expect(r.get("a", "s")?.vetoTtlMs).toBe(30_000);
+  });
+
+  test("all() + clear() behave", () => {
+    const r = new HitlModeRegistry();
+    r.declare({ agentName: "a", skill: "s1", mode: "gated" });
+    r.declare({ agentName: "b", skill: "s2", mode: "autonomous" });
+    expect(r.all()).toHaveLength(2);
+    r.clear();
+    expect(r.size).toBe(0);
+  });
+});
+
+describe("hitl-mode-v1 extension interceptor", () => {
+  let registry: HitlModeRegistry;
+
+  beforeEach(() => {
+    registry = new HitlModeRegistry();
+    registerHitlModeExtension(registry);
+  });
+
+  test("registered on defaultExtensionRegistry", () => {
+    const uris = defaultExtensionRegistry.list().map(e => e.uri);
+    expect(uris).toContain(HITL_MODE_URI);
+  });
+
+  test("before() stamps x-hitl-mode when declared", () => {
+    registry.declare({ agentName: "quinn", skill: "pr_review", mode: "gated" });
+    const interceptor = defaultExtensionRegistry.list().find(e => e.uri === HITL_MODE_URI)?.interceptor;
+    const ctx = makeCtx();
+    interceptor!.before?.(ctx);
+    expect(ctx.metadata["x-hitl-mode"]).toBe("gated");
+  });
+
+  test("before() stamps x-hitl-veto-ttl-ms when declared with veto mode", () => {
+    registry.declare({ agentName: "quinn", skill: "pr_review", mode: "veto", vetoTtlMs: 15_000 });
+    const interceptor = defaultExtensionRegistry.list().find(e => e.uri === HITL_MODE_URI)?.interceptor;
+    const ctx = makeCtx();
+    interceptor!.before?.(ctx);
+    expect(ctx.metadata["x-hitl-mode"]).toBe("veto");
+    expect(ctx.metadata["x-hitl-veto-ttl-ms"]).toBe(15_000);
+  });
+
+  test("before() no-op when no declaration exists", () => {
+    const interceptor = defaultExtensionRegistry.list().find(e => e.uri === HITL_MODE_URI)?.interceptor;
+    const ctx = makeCtx();
+    interceptor!.before?.(ctx);
+    expect(ctx.metadata["x-hitl-mode"]).toBeUndefined();
+  });
+
+  test("after() is not defined — mode is read-side only", () => {
+    const interceptor = defaultExtensionRegistry.list().find(e => e.uri === HITL_MODE_URI)?.interceptor;
+    expect(interceptor?.after).toBeUndefined();
+  });
+});

--- a/src/executor/__tests__/task-tracker.test.ts
+++ b/src/executor/__tests__/task-tracker.test.ts
@@ -177,4 +177,86 @@ describe("TaskTracker", () => {
     expect(received).toHaveLength(0);
     expect(tracker.size).toBe(1);
   });
+
+  // ── Arc 7.3: compound gated task checkpointing ────────────────────────────
+  describe("compound gated checkpointing (Arc 7.3)", () => {
+    test("increments checkpoint counter on each input-required cycle", async () => {
+      // Fake executor — resumeTask resolves, pollTask alternates input-required
+      // and working so the tracker can cycle through checkpoints.
+      let pollCalls = 0;
+      const fake = {
+        type: "a2a" as const,
+        execute: async () => ({ text: "", isError: false, correlationId: "" }),
+        pollTask: async (): Promise<SkillResult> => {
+          pollCalls += 1;
+          return pollCalls === 1
+            ? { text: "draft needs review", isError: false, correlationId: "c1", data: { taskState: "input-required", taskId: "t1", contextId: "ctx1" } }
+            : { text: "final approval?", isError: false, correlationId: "c1", data: { taskState: "input-required", taskId: "t1", contextId: "ctx1" } };
+        },
+        cancelTask: async () => ({ text: "canceled", isError: false, correlationId: "c1" }),
+        resubscribeTask: async () => { throw new Error("not used"); },
+        resumeTask: async () => {},
+      };
+      const executor = fake as unknown as A2AExecutor;
+
+      const requests: unknown[] = [];
+      bus.subscribe("hitl.request.#", "test", (msg) => { requests.push(msg.payload); });
+
+      tracker = new TaskTracker({ bus, sweepIntervalMs: 20, defaultPollIntervalMs: 10 });
+      tracker.track({
+        correlationId: "c1", taskId: "t1", agentName: "ava",
+        replyTopic: "agent.skill.response.c1", executor,
+        sourceInterface: "discord", sourceChannelId: "chan", sourceUserId: "user",
+      });
+
+      // Wait for first input-required → HITL raised
+      await new Promise(r => setTimeout(r, 50));
+      expect(requests.length).toBe(1);
+      expect((requests[0] as { checkpoint?: { index: number } }).checkpoint?.index).toBe(1);
+      expect((requests[0] as { title: string }).title).not.toContain("checkpoint");
+
+      // Simulate human decision → triggers resume; tracker clears awaitingHuman
+      bus.publish("hitl.response.c1", {
+        id: "r1", correlationId: "c1", topic: "hitl.response.c1", timestamp: Date.now(),
+        payload: { type: "hitl_response", correlationId: "c1", decision: "approve", decidedBy: "human" },
+      });
+
+      // Wait for next sweep cycle → second input-required → second HITL raise
+      await new Promise(r => setTimeout(r, 80));
+      expect(requests.length).toBe(2);
+      expect((requests[1] as { checkpoint?: { index: number } }).checkpoint?.index).toBe(2);
+      expect((requests[1] as { title: string }).title).toContain("checkpoint 2");
+    });
+
+    test("first checkpoint does not include counter in title", async () => {
+      const fake = {
+        type: "a2a" as const,
+        execute: async () => ({ text: "", isError: false, correlationId: "" }),
+        pollTask: async (): Promise<SkillResult> => ({
+          text: "please confirm", isError: false, correlationId: "c1",
+          data: { taskState: "input-required", taskId: "t1", contextId: "ctx1" },
+        }),
+        cancelTask: async () => ({ text: "", isError: false, correlationId: "c1" }),
+        resubscribeTask: async () => { throw new Error("not used"); },
+        resumeTask: async () => {},
+      };
+      const executor = fake as unknown as A2AExecutor;
+
+      const requests: unknown[] = [];
+      bus.subscribe("hitl.request.#", "test", (msg) => { requests.push(msg.payload); });
+
+      tracker = new TaskTracker({ bus, sweepIntervalMs: 20, defaultPollIntervalMs: 10 });
+      tracker.track({
+        correlationId: "c1", taskId: "t1", agentName: "ava",
+        replyTopic: "agent.skill.response.c1", executor,
+      });
+
+      await new Promise(r => setTimeout(r, 40));
+      expect(requests.length).toBe(1);
+      const first = requests[0] as { title: string; checkpoint?: { index: number } };
+      expect(first.checkpoint?.index).toBe(1);
+      expect(first.title).toBe("Input needed from ava");
+      expect(first.title).not.toContain("checkpoint");
+    });
+  });
 });

--- a/src/executor/extensions/hitl-mode.ts
+++ b/src/executor/extensions/hitl-mode.ts
@@ -1,0 +1,138 @@
+/**
+ * HITL mode v1 extension — per-skill approval policy declared on the agent card.
+ *
+ * HITL is a gradient, not a binary. Skills span a range from fully autonomous
+ * through post-hoc veto windows to compound multi-step gates. Declaring the
+ * mode per-skill on the agent card lets the dispatcher + HITL plugin route
+ * each invocation to the right flow without goal-level config.
+ *
+ * Like blast-v1 this is a read-side declaration: `before(ctx)` stamps the
+ * declared mode on outbound metadata so downstream consumers (HITL plugin,
+ * TaskTracker) can read it without a second lookup. No `after(ctx)` — mode
+ * is policy, not observation.
+ *
+ * Extension URI: https://protolabs.ai/a2a/ext/hitl-mode-v1
+ */
+
+import {
+  defaultExtensionRegistry,
+  type ExtensionInterceptor,
+  type ExtensionContext,
+} from "../extension-registry.ts";
+
+export const HITL_MODE_URI = "https://protolabs.ai/a2a/ext/hitl-mode-v1";
+
+/**
+ * Approval policy for a single skill. Ordered from least-gated to most-gated.
+ *
+ * - `autonomous`   — no human in the loop. Task runs, outcome is what it is.
+ * - `notification` — runs autonomously; a read-only notification is rendered
+ *   to the originating surface (Discord, Plane) for awareness.
+ * - `veto`         — short TTL window after dispatch where a human can cancel
+ *   before side effects complete (via `tasks/cancel`). Auto-approved on TTL.
+ * - `gated`        — blocking `input-required` before any side effect. No
+ *   auto-approve; execution halts until a decision.
+ * - `compound`     — multi-checkpoint gated. Agent emits multiple
+ *   `input-required` states across the task lifecycle (draft → review →
+ *   publish); each one requires its own decision.
+ */
+export type HitlMode =
+  | "autonomous"
+  | "notification"
+  | "veto"
+  | "gated"
+  | "compound";
+
+export const HITL_MODE_ORDER: Record<HitlMode, number> = {
+  autonomous: 0,
+  notification: 1,
+  veto: 2,
+  gated: 3,
+  compound: 4,
+};
+
+export interface HitlModeDeclaration {
+  agentName: string;
+  skill: string;
+  mode: HitlMode;
+  /** Per-skill TTL for veto mode, in ms. Ignored for other modes. */
+  vetoTtlMs?: number;
+  /** Optional human-readable reason for the declared mode. */
+  note?: string;
+}
+
+/**
+ * Registry of per-(agent, skill) HITL mode declarations. Populated at agent
+ * card ingestion time by SkillBrokerPlugin, consulted at dispatch time by
+ * SkillDispatcher / HITLPlugin to decide gating behavior.
+ */
+export class HitlModeRegistry {
+  private readonly byKey = new Map<string, HitlModeDeclaration>();
+
+  static key(agentName: string, skill: string): string {
+    return `${agentName}::${skill}`;
+  }
+
+  declare(decl: HitlModeDeclaration): void {
+    this.byKey.set(HitlModeRegistry.key(decl.agentName, decl.skill), decl);
+  }
+
+  get(agentName: string, skill: string): HitlModeDeclaration | undefined {
+    return this.byKey.get(HitlModeRegistry.key(agentName, skill));
+  }
+
+  /** Resolve with a fallback default. `autonomous` is the safe default —
+   *  the planner caller decides whether to bump the mode based on blast. */
+  resolveMode(agentName: string, skill: string, fallback: HitlMode = "autonomous"): HitlMode {
+    return this.get(agentName, skill)?.mode ?? fallback;
+  }
+
+  /** Numeric comparison — higher == more gated. Unknown treats as autonomous. */
+  compare(a: HitlMode | undefined, b: HitlMode | undefined): number {
+    const av = a ? HITL_MODE_ORDER[a] : 0;
+    const bv = b ? HITL_MODE_ORDER[b] : 0;
+    return av - bv;
+  }
+
+  all(): HitlModeDeclaration[] {
+    return Array.from(this.byKey.values());
+  }
+
+  clear(): void {
+    this.byKey.clear();
+  }
+
+  get size(): number {
+    return this.byKey.size;
+  }
+}
+
+export const defaultHitlModeRegistry = new HitlModeRegistry();
+
+/**
+ * Register the hitl-mode-v1 extension interceptor. The registry is populated
+ * separately by SkillBrokerPlugin when it parses agent cards.
+ */
+export function registerHitlModeExtension(
+  registry: HitlModeRegistry = defaultHitlModeRegistry,
+): void {
+  const interceptor: ExtensionInterceptor = {
+    before(ctx: ExtensionContext): void {
+      const decl = registry.get(ctx.agentName, ctx.skill);
+      if (decl) {
+        ctx.metadata["x-hitl-mode"] = decl.mode;
+        if (decl.vetoTtlMs !== undefined) {
+          ctx.metadata["x-hitl-veto-ttl-ms"] = decl.vetoTtlMs;
+        }
+      }
+    },
+    // no after() — mode is policy, not observation
+  };
+
+  defaultExtensionRegistry.register({
+    uri: HITL_MODE_URI,
+    interceptor,
+    description:
+      "HITL mode v1: per-skill approval policy (autonomous/notification/veto/gated/compound); HITL plugin reads from the registry",
+  });
+}

--- a/src/executor/task-tracker.ts
+++ b/src/executor/task-tracker.ts
@@ -36,6 +36,12 @@ export interface TrackedTask {
   callbackToken?: string;
   /** Set when the task has asked for human input — suppresses polling until resumed. */
   awaitingHuman?: boolean;
+  /**
+   * Compound-gate counter (Arc 7.3). Incremented every time the task enters
+   * input-required. Passed into the raised HITLRequest so renderers can show
+   * "Checkpoint N" for multi-step tasks. Reset is never needed — monotonic.
+   */
+  checkpointCount?: number;
   /** The Discord/etc interface that originated the request — reused for HITL routing. */
   sourceInterface?: string;
   /** Source channel ID for HITL rendering. */
@@ -259,14 +265,20 @@ export class TaskTracker {
   private _raiseHitl(task: TrackedTask, question: string | undefined): void {
     if (task.awaitingHuman) return; // already raised, avoid duplicate
     task.awaitingHuman = true;
+    // Arc 7.3: increment checkpoint counter so compound-gated tasks (multi-step
+    // input-required) surface which prompt this is in the sequence. 1-based.
+    task.checkpointCount = (task.checkpointCount ?? 0) + 1;
 
     const req: HITLRequest = {
       type: "hitl_request",
       correlationId: task.correlationId,
-      title: `Input needed from ${task.agentName}`,
+      title: task.checkpointCount > 1
+        ? `Input needed from ${task.agentName} (checkpoint ${task.checkpointCount})`
+        : `Input needed from ${task.agentName}`,
       summary: question || "The agent is requesting input to continue.",
       options: ["approve", "reject"],
       expiresAt: new Date(Date.now() + HITL_TTL_MS).toISOString(),
+      checkpoint: { index: task.checkpointCount },
       replyTopic: `hitl.response.${task.correlationId}`,
       sourceMeta: {
         interface: task.sourceInterface ?? "discord",


### PR DESCRIPTION
## Summary
v0.7.4 — three features shipped since v0.7.3.

### Release automation (dogfood trigger)
- **#238** feat(ci): port prepare-release + auto-release workflows
  After this merges, auto-release.yml fires and creates the v0.7.4 tag
  automatically — first autonomous release-tagging on this repo.

### Arc 7 HITL gradient (completion)
- **#239** [Arc 7.4] x-protolabs/hitl-mode-v1 per-skill HITL policy
- **#240** [Arc 7.3] compound gated task checkpointing

## Merge strategy
Merge commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added human-approval policy management system enabling per-skill approval modes (autonomous, notification, veto, gated, compound).
  * Added checkpoint tracking for multi-step approval workflows, displaying progress indicators (e.g., "Checkpoint 2 of 3").

* **Chores**
  * Automated release workflow processes.
  * Bumped version to 0.7.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->