### PR TITLE
fix(agents): commit workspace/agents.yaml + support PROTOLABS_AGENTS_JSON override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ workspace/crons/
 workspace/*.log.automaker-lock
 workspace/incidents.yaml
 workspace/projects.yaml
-workspace/agents.yaml
 workspace/agents/*.yaml
 workspace/discord.yaml
 workspace/github.yaml

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -12,6 +12,7 @@ All environment variables recognised by protoWorkstacean, their defaults, and wh
 | `WORKSTACEAN_API_KEY` | _(none)_ | HTTP server | API key required for authenticated endpoints. If unset, auth is skipped. |
 | `WORKSTACEAN_PUBLIC_URL` | _(none)_ | HTTP server | Public base URL (used for webhook registration and self-links) |
 | `WORKSPACE_DIR` | `./workspace` | All loaders | Path to the workspace directory containing agent, goal, action, ceremony, and domain YAML files |
+| `PROTOLABS_AGENTS_JSON` | _(none)_ | SkillBrokerPlugin | If set, overrides `workspace/agents.yaml`. Expected shape: `{ "agents": [ { name, url, auth, ... } ] }`. Intended for Infisical-backed deployments where pushing a yaml file to every host is inconvenient — ship the whole registry through a single secret instead. |
 | `DATA_DIR` | `./data` | LoggerPlugin, SQLite | Directory for the SQLite event log (`events.db`) |
 | `TZ` | system default | SchedulerPlugin | Timezone for cron schedule evaluation |
 | `DEBUG` | _(none)_ | All | Set to any value to enable verbose debug logging |

--- a/src/plugins/skill-broker-plugin.ts
+++ b/src/plugins/skill-broker-plugin.ts
@@ -182,10 +182,40 @@ export class SkillBrokerPlugin implements Plugin {
     }
   }
 
+  /**
+   * Resolve the agent registry from one of two sources:
+   *
+   *   1. PROTOLABS_AGENTS_JSON env var — if set, parsed as JSON `{ agents: [...] }`.
+   *      Lets Infisical-backed deployments ship the entire registry through
+   *      a single secret without needing a file on disk.
+   *
+   *   2. workspace/agents.yaml — file on disk. The committed default covers
+   *      our standard fleet (Quinn, Jon, Researcher, Frank, protopen);
+   *      per-host overrides work by editing the file locally.
+   *
+   * If both are present, the env var wins. If neither resolves to a valid
+   * list, the broker registers zero external agents and logs a warning.
+   */
   private _loadAgents(): AgentDef[] {
+    // Try the env-var path first — deployments use this to avoid file state
+    const envOverride = process.env.PROTOLABS_AGENTS_JSON;
+    if (envOverride && envOverride.trim()) {
+      try {
+        const parsed = JSON.parse(envOverride) as { agents?: AgentDef[] };
+        if (Array.isArray(parsed.agents)) {
+          console.log(`[skill-broker] Loaded ${parsed.agents.length} agent(s) from PROTOLABS_AGENTS_JSON`);
+          return parsed.agents;
+        }
+        console.warn("[skill-broker] PROTOLABS_AGENTS_JSON parsed but has no `agents` array — falling back to yaml");
+      } catch (err) {
+        console.error("[skill-broker] Failed to parse PROTOLABS_AGENTS_JSON — falling back to yaml:", err);
+      }
+    }
+
+    // File path — committed default
     const agentsPath = join(this.workspaceDir, "agents.yaml");
     if (!existsSync(agentsPath)) {
-      console.warn("[skill-broker] agents.yaml not found — no A2A agents registered");
+      console.warn("[skill-broker] agents.yaml not found and PROTOLABS_AGENTS_JSON unset — no A2A agents registered");
       return [];
     }
     try {

--- a/workspace/agents.yaml
+++ b/workspace/agents.yaml
@@ -1,0 +1,74 @@
+# protoLabs A2A Agent Registry
+#
+# This file wires the external A2A agent fleet into workstacean:
+#   1. SkillBroker — creates one A2AExecutor per entry; skills are
+#      auto-discovered from each agent's /.well-known/agent-card.json
+#      (refreshed every 10 min). Yaml skills take precedence as overrides.
+#   2. DiscordPlugin agent pool — when `discordBotTokenEnvKey` is set,
+#      spins up a dedicated Client() per agent so users can DM each bot.
+#
+# No secrets live here — only env var NAMES. The actual credentials are
+# provided by Infisical at container startup (homelab-iac/stacks/ai).
+#
+# URLs use the docker-ai network service names (e.g. `quinn`, `protocontent`),
+# which resolve inside the container. For out-of-Docker deployments use
+# ${ENV_VAR} interpolation (see protopen at the bottom).
+#
+# Override the entire list via PROTOLABS_AGENTS_JSON env var if a deploy
+# needs per-environment wiring without editing this file.
+
+agents:
+  # Quinn — QA engineer (code review, bug triage, PR auditing)
+  - name: quinn
+    url: http://quinn:7873/a2a
+    auth:
+      scheme: apiKey
+      credentialsEnv: QUINN_API_KEY
+    streaming: true
+    discordBotTokenEnvKey: DISCORD_BOT_TOKEN_QUINN
+    subscribesTo:
+      - message.inbound.discord.#
+      - message.inbound.github.#
+
+  # Jon — content + communications (protoContent pipeline)
+  - name: jon
+    url: http://protocontent:18791/a2a
+    auth:
+      scheme: apiKey
+      credentialsEnv: PROTOCONTENT_API_KEY
+    streaming: true
+    discordBotTokenEnvKey: DISCORD_BOT_TOKEN_JON
+    subscribesTo:
+      - message.inbound.discord.#
+
+  # Researcher — rabbit-hole.io deep research agent
+  - name: researcher
+    url: http://research-langgraph-agent:7874/a2a
+    auth:
+      scheme: apiKey
+      credentialsEnv: RESEARCHER_API_KEY
+    streaming: true
+    subscribesTo:
+      - message.inbound.discord.#
+
+  # Frank — CI/CD + infrastructure
+  - name: frank
+    url: http://frank:7880/a2a
+    auth:
+      scheme: apiKey
+      credentialsEnv: FRANK_API_KEY
+    streaming: true
+    discordBotTokenEnvKey: DISCORD_BOT_TOKEN_FRANK
+    subscribesTo:
+      - message.inbound.discord.#
+      - message.inbound.github.#
+
+  # protopen — security/pentest/RF recon (remote via Tailscale)
+  - name: protopen
+    url: ${PROTOPEN_BASE_URL}/a2a
+    auth:
+      scheme: apiKey
+      credentialsEnv: PROTOPEN_API_KEY
+    streaming: false
+    subscribesTo:
+      - message.inbound.discord.#


### PR DESCRIPTION
Fixes 'fresh host → no external bots online'. Commits the agent registry (zero secrets, all env var references) + adds an Infisical-friendly PROTOLABS_AGENTS_JSON override. Quinn/Jon/Frank/Researcher/protopen stop going missing on every redeploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent configuration can now be managed via environment variable, enabling deployment flexibility without modifying configuration files.
  * Added reference agent registry configuration demonstrating credential management and topic subscription patterns.

* **Documentation**
  * Added environment variable reference documentation for agent configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->