### PR TITLE
feat(a2a): refresh streaming + pushNotifications from agent card

### DIFF
--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -56,8 +56,18 @@ export interface A2AAgentConfig {
   extraHeaders?: Record<string, string>;
   /** Request timeout in ms. Default: 300_000 (5 min). */
   timeoutMs?: number;
-  /** Whether the remote agent supports SSE streaming (from agent card). */
+  /**
+   * Whether the remote agent supports SSE streaming. Authoritative source is
+   * the agent card's `capabilities.streaming`, refreshed by SkillBrokerPlugin
+   * every 10 min via setCapabilities(). YAML value in agents.yaml is a
+   * bootstrap default used before the first card fetch lands.
+   */
   streaming?: boolean;
+  /**
+   * Whether the remote agent accepts push-notification registrations. Same
+   * source-of-truth story as streaming — card advertises, broker refreshes.
+   */
+  pushNotifications?: boolean;
   /** Callback for intermediate streaming updates (e.g. publish to bus). */
   onStreamUpdate?: (update: { type: string; text?: string; state?: string }) => void;
   /**
@@ -130,7 +140,36 @@ function buildFetch(
 export class A2AExecutor implements IExecutor {
   readonly type = "a2a";
 
-  constructor(private readonly config: A2AAgentConfig) {}
+  constructor(private config: A2AAgentConfig) {}
+
+  /** Expose name for diagnostics / registry wiring. */
+  get name(): string {
+    return this.config.name;
+  }
+
+  /**
+   * Update the streaming + pushNotifications capability flags from the agent
+   * card. Called by SkillBrokerPlugin after every card discovery pass so the
+   * executor picks the right transport path based on what the agent actually
+   * advertises, not stale YAML config.
+   */
+  setCapabilities(caps: { streaming?: boolean; pushNotifications?: boolean }): void {
+    this.config = {
+      ...this.config,
+      streaming: caps.streaming ?? this.config.streaming,
+      pushNotifications: caps.pushNotifications ?? this.config.pushNotifications,
+    };
+  }
+
+  /** Whether this executor is currently configured to use SSE streaming. */
+  get streaming(): boolean {
+    return this.config.streaming === true;
+  }
+
+  /** Whether push-notification registration should be attempted. */
+  get pushNotifications(): boolean {
+    return this.config.pushNotifications === true;
+  }
 
   async execute(req: SkillRequest): Promise<SkillResult> {
     const text = req.content ?? req.prompt ?? this._buildText(req);

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -343,16 +343,23 @@ export class SkillDispatcherPlugin implements Plugin {
           },
         });
 
-        // Try to register a push-notification webhook so the agent can POST
-        // completion back instead of us polling. Falls back to polling silently.
+        // Register a push-notification webhook only when the agent advertises
+        // capabilities.pushNotifications in its card. Without the gate we
+        // burn a round-trip on every long-running task against every agent,
+        // most of which reject. SkillBrokerPlugin refreshes the flag every
+        // 10 min so capability changes land automatically.
         const callbackBaseUrl = process.env.WORKSTACEAN_BASE_URL;
-        if (callbackBaseUrl) {
+        if (callbackBaseUrl && a2aExecutor.pushNotifications) {
           const callbackUrl = `${callbackBaseUrl.replace(/\/$/, "")}/api/a2a/callback/${encodeURIComponent(taskId)}`;
           void a2aExecutor.registerPushNotification(taskId, callbackUrl, callbackToken, correlationId, parentId)
             .then(ok => {
               if (ok) console.log(`[skill-dispatcher] Push-notification registered for ${taskId.slice(0, 8)}…`);
             })
             .catch(err => console.debug("[skill-dispatcher] push-notification register failed:", err));
+        } else if (callbackBaseUrl) {
+          console.log(
+            `[skill-dispatcher] ${a2aExecutor.name}: card.capabilities.pushNotifications=false — using polling for ${taskId.slice(0, 8)}…`,
+          );
         }
 
         this._publishFlowEvent("flow.item.updated", {

--- a/src/plugins/skill-broker-plugin.ts
+++ b/src/plugins/skill-broker-plugin.ts
@@ -139,6 +139,23 @@ export class SkillBrokerPlugin implements Plugin {
       const card = await this._fetchCard(url);
       if (!card) return;
 
+      // Refresh transport capability flags from the card — authoritative source
+      // for streaming + push-notifications. Without this, executors keep using
+      // the yaml bootstrap value even when the agent has changed its
+      // advertisement. Cost: one setter call per agent per refresh cycle.
+      const caps = card.capabilities ?? {};
+      const priorStreaming = executor.streaming;
+      const priorPush = executor.pushNotifications;
+      executor.setCapabilities({
+        streaming: caps.streaming === true,
+        pushNotifications: caps.pushNotifications === true,
+      });
+      if (priorStreaming !== executor.streaming || priorPush !== executor.pushNotifications) {
+        console.log(
+          `[skill-broker] ${agent.name}: capabilities updated — streaming=${executor.streaming} pushNotifications=${executor.pushNotifications}`,
+        );
+      }
+
       const registered = this.registeredSkills.get(agent.name) ?? new Set();
       let added = 0;
 


### PR DESCRIPTION
Stops using stale YAML for transport capability flags. Card is the source of truth, refreshed every 10 min. Push-notification registration gated on the agent actually advertising the capability. See commit for fleet baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added push notifications as a configurable capability for agents.
  * Agent capabilities can now be defined and updated via agent card configuration.
  * Webhook registration is now conditional on capability enablement, with automatic fallback to polling when push notifications are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->