### PR TITLE
chore(release): bump to v0.7.6

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean-dashboard",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "type": "module",
   "scripts": {
     "start": "bun run src/index.ts",


### PR DESCRIPTION
Port fixes for Quinn + researcher. Once this + a promote land, heartbeat shows reachable 4/6 instead of 2/6.