### PR TITLE
promote: dev → main — v0.7.6 (quinn + researcher port fixes)

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean-dashboard",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "type": "module",
   "scripts": {
     "start": "bun run src/index.ts",

--- a/workspace/agents.yaml
+++ b/workspace/agents.yaml
@@ -18,9 +18,11 @@
 # needs per-environment wiring without editing this file.
 
 agents:
-  # Quinn — QA engineer (code review, bug triage, PR auditing)
+  # Quinn — QA engineer (code review, bug triage, PR auditing).
+  # NOTE: Quinn's internal container port is 7870 (host-mapped to 7873).
+  # Inside the docker-ai network we must use the internal port.
   - name: quinn
-    url: http://quinn:7873/a2a
+    url: http://quinn:7870/a2a
     auth:
       scheme: apiKey
       credentialsEnv: QUINN_API_KEY
@@ -41,9 +43,10 @@ agents:
     subscribesTo:
       - message.inbound.discord.#
 
-  # Researcher — rabbit-hole.io deep research agent
+  # Researcher — rabbit-hole.io deep research agent.
+  # Same host→container port mapping as Quinn: internal listen is 7870.
   - name: researcher
-    url: http://research-langgraph-agent:7874/a2a
+    url: http://research-langgraph-agent:7870/a2a
     auth:
       scheme: apiKey
       credentialsEnv: RESEARCHER_API_KEY


### PR DESCRIPTION
## Summary
v0.7.6 — two port-mapping fixes that bring fleet-health heartbeat coverage from 2/6 → 4/6 reachable.

- **#255** fix(agents): quinn + researcher URLs use internal port 7870
  (both containers map host:7873/7874 → container:7870; workstacean
  runs on docker-ai network so it needs the internal port)

## Dogfood
auto-release.yml will fire for the third consecutive release on this merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.7.6

<!-- end of auto-generated comment: release notes by coderabbit.ai -->