### PR TITLE
feat: protobot provisioning skills + deep-agent reachability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ workspace/crons/
 workspace/*.log.automaker-lock
 workspace/incidents.yaml
 workspace/projects.yaml
-workspace/agents/*.yaml
 workspace/discord.yaml
 workspace/github.yaml
 workspace/google.yaml

--- a/src/api/discord.ts
+++ b/src/api/discord.ts
@@ -11,6 +11,8 @@
  *   POST /api/discord/channels/create   — create a channel (text/voice/category)
  *   POST /api/discord/send              — send a message to a channel
  *   GET  /api/discord/members           — list members (paginated)
+ *   GET  /api/discord/webhooks          — list webhooks across guild channels
+ *   POST /api/discord/webhooks/create   — create a webhook on a channel
  *   POST /api/discord/react             — react to the message that triggered a conversation
  *   POST /api/discord/progress          — send a progress update during a running conversation
  */
@@ -166,6 +168,69 @@ export function createRoutes(ctx: ApiContext): Route[] {
         }));
 
         return Response.json({ success: true, data: members });
+      },
+    },
+    {
+      method: "GET",
+      path: "/api/discord/webhooks",
+      handler: async () => {
+        const client = getDiscordClient(ctx);
+        if (!client) return Response.json({ success: false, error: "Discord not connected" }, { status: 503 });
+
+        const guild = client.guilds.cache.get(getGuildId());
+        if (!guild) return Response.json({ success: false, error: "Guild not found" }, { status: 404 });
+
+        try {
+          const hooks = await guild.fetchWebhooks();
+          const data = hooks.map((w: any) => ({
+            id: w.id,
+            name: w.name,
+            channelId: w.channelId,
+            url: w.url,
+            owner: w.owner?.username ?? null,
+          }));
+          return Response.json({ success: true, data });
+        } catch (e) {
+          return Response.json({ success: false, error: e instanceof Error ? e.message : String(e) }, { status: 500 });
+        }
+      },
+    },
+    {
+      method: "POST",
+      path: "/api/discord/webhooks/create",
+      handler: async (req) => {
+        const client = getDiscordClient(ctx);
+        if (!client) return Response.json({ success: false, error: "Discord not connected" }, { status: 503 });
+
+        const guild = client.guilds.cache.get(getGuildId());
+        if (!guild) return Response.json({ success: false, error: "Guild not found" }, { status: 404 });
+
+        let body: { channelId?: string; channelName?: string; name?: string; reason?: string };
+        try { body = await req.json() as typeof body; }
+        catch { return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 }); }
+
+        if (!body.name) return Response.json({ success: false, error: "name is required" }, { status: 400 });
+
+        let channel: any = null;
+        if (body.channelId) {
+          channel = guild.channels.cache.get(body.channelId);
+        } else if (body.channelName) {
+          channel = guild.channels.cache.find((ch: any) => ch.name === body.channelName);
+        }
+        if (!channel) return Response.json({ success: false, error: "Channel not found (pass channelId or channelName)" }, { status: 404 });
+        if (typeof channel.createWebhook !== "function") {
+          return Response.json({ success: false, error: "Channel type does not support webhooks" }, { status: 400 });
+        }
+
+        try {
+          const hook = await channel.createWebhook({ name: body.name, reason: body.reason });
+          return Response.json({
+            success: true,
+            data: { id: hook.id, name: hook.name, channelId: hook.channelId, url: hook.url },
+          });
+        } catch (e) {
+          return Response.json({ success: false, error: e instanceof Error ? e.message : String(e) }, { status: 500 });
+        }
       },
     },
     {

--- a/src/api/world-state.ts
+++ b/src/api/world-state.ts
@@ -151,6 +151,18 @@ export function createRoutes(ctx: ApiContext): Route[] {
       }
     }
 
+    // Deep-agents run in-process — if they're in the ExecutorRegistry,
+    // the runtime loaded them and they're reachable by definition. Stamp
+    // a synthetic probe so the UI doesn't render them as "Not probed".
+    const now = Date.now();
+    for (const view of Object.values(agents)) {
+      if (view.executorType === "deep-agent" && view.reachable === undefined) {
+        view.reachable = true;
+        view.latencyMs = 0;
+        view.lastProbedAt = now;
+      }
+    }
+
     const reachableCount = Object.values(agents).filter(a => a.reachable === true).length;
 
     return Response.json({

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -307,6 +307,23 @@ function createLangChainTools(toolNames: string[], http: HttpClient, correlation
       async () => JSON.stringify(await http.get("/api/discord/members")),
       { name: "discord_list_members", description: "List Discord server members with roles.", schema: z.object({}) },
     ),
+    discord_list_webhooks: tool(
+      async () => JSON.stringify(await http.get("/api/discord/webhooks")),
+      { name: "discord_list_webhooks", description: "List all Discord webhooks across guild channels.", schema: z.object({}) },
+    ),
+    discord_create_webhook: tool(
+      async (input) => JSON.stringify(await http.post("/api/discord/webhooks/create", input)),
+      {
+        name: "discord_create_webhook",
+        description: "Create a Discord webhook on a channel for external integrations (GitHub, CI, etc.).",
+        schema: z.object({
+          name: z.string().describe("Webhook display name"),
+          channelId: z.string().optional().describe("Target channel ID"),
+          channelName: z.string().optional().describe("Target channel name (alternative to ID)"),
+          reason: z.string().optional().describe("Audit log reason"),
+        }),
+      },
+    ),
     // ── Conversation feedback tools (require correlationId) ──────────────────
     react: tool(
       async (input) => {

--- a/workspace/agents/protobot.yaml
+++ b/workspace/agents/protobot.yaml
@@ -1,0 +1,90 @@
+# protoBot — Discord operations agent.
+#
+# The entity behind the main Discord bot. Owns the server: provisions channels,
+# categories, and webhooks; tracks community activity; manages announcements;
+# and serves as the default DM contact for the fleet. When you DM the main
+# bot, you're talking to protoBot.
+#
+# protoBot does NOT do product work — for that, ask Ava. protoBot controls
+# Discord itself: channels, categories, webhooks, roles, announcements,
+# community pulse.
+
+name: protobot
+role: devops
+
+model: claude-sonnet-4-6
+
+systemPrompt: |
+  You are protoBot, the Discord operations agent for protoLabs.
+
+  You ARE the Discord server. You own it, you manage it, you know everything
+  happening in it. When someone talks to you, they're talking to the entity
+  that controls the server infrastructure.
+
+  ## Your domain
+
+  - Channel provisioning: create text, voice, announcement, forum channels
+  - Category provisioning: create category containers and organize channels under them
+  - Webhook provisioning: create webhooks for GitHub, CI, and other external integrations
+  - Server awareness: member count, channel layout, roles, boost level
+  - Announcements: send messages to any channel
+  - Community pulse: who's active, what's being discussed, server health
+  - Fleet coordination: you know which agent bots are online
+
+  ## Your tools
+
+  **discord_server_stats** — Server overview: members, channels, roles, boosts.
+  **discord_list_channels** — Full channel list with categories and types.
+  **discord_create_channel** — Provision new channels (text, voice, category, announcement, forum).
+  **discord_list_webhooks** — List webhooks across guild channels.
+  **discord_create_webhook** — Provision a webhook on a channel for external integrations.
+  **discord_send** — Post a message to any channel by name or ID.
+  **discord_list_members** — Who's in the server and their roles.
+  **chat_with_agent** — Talk to other agents when you need non-Discord context.
+  **get_world_state** — System health (for cross-referencing with Discord state).
+
+  ## Personality
+
+  You're the server itself talking. Efficient, helpful, slightly proud of
+  your server. You know the layout cold. When someone asks you to provision
+  something, you do it — no confirmation needed unless it's destructive
+  (deleting channels, mass actions).
+
+  ## What you DON'T do
+
+  - Product decisions — that's Ava
+  - Code review — that's Quinn
+  - Content creation — that's Jon
+  - If someone asks about those things, tell them which agent to talk to
+
+tools:
+  - discord_server_stats
+  - discord_list_channels
+  - discord_create_channel
+  - discord_list_webhooks
+  - discord_create_webhook
+  - discord_send
+  - discord_list_members
+  - chat_with_agent
+  - get_world_state
+  - react
+  - send_update
+
+maxTurns: 8
+
+skills:
+  - name: chat
+    description: Discord operations chat — server stats, provisioning, announcements, community pulse
+    keywords: [discord, chat, community, members, roles]
+  - name: provision_channel
+    description: Provision Discord channels (text, voice, announcement, forum) under optional categories
+    keywords: [channel, create, provision, text, voice, announcement, forum]
+  - name: provision_category
+    description: Provision Discord category containers for grouping related channels
+    keywords: [category, group, organize, section]
+  - name: provision_webhook
+    description: Provision Discord webhooks for external integrations (GitHub, CI, monitoring)
+    keywords: [webhook, integration, github, ci, external]
+  - name: server_stats
+    description: Discord server overview — member counts, channel layout, boost level, role inventory
+    keywords: [stats, overview, health, server, boost]


### PR DESCRIPTION
## Summary

Makes protobot a first-class fleet team member responsible for Discord infrastructure (channels, categories, webhooks) and closes the \"Not probed\" display gap for in-process deep-agents on \`/api/agent-health\`.

### Changes

- **\`/api/agent-health\`**: deep-agents (ava, protobot) run in-process — if the runtime loaded them they're reachable. Stamps a synthetic probe so the UI stops rendering them as \"Not probed\".
- **\`/api/discord\`**: new \`GET /webhooks\` and \`POST /webhooks/create\` routes backing webhook provisioning.
- **\`deep-agent-executor\`**: adds \`discord_list_webhooks\` + \`discord_create_webhook\` tools — protobot can now inspect and provision webhooks for GitHub, CI, monitoring, etc.
- **\`workspace/agents/protobot.yaml\`**: splits the single \`chat\` skill into distinct responsibilities (\`chat\`, \`provision_channel\`, \`provision_category\`, \`provision_webhook\`, \`server_stats\`). This lets the router + planner route provisioning requests to protobot by skill name rather than keyword-matching \`chat\`.
- **\`.gitignore\`**: un-ignores \`workspace/agents/*.yaml\` so fleet agent definitions ship as canonical schema. Matches the \`workspace/agents.yaml\` precedent — no secrets, only env var names.

### Why

Today's \`/api/agent-health\` shows:
| Agent | Status |
|---|---|
| Ava (me) | Online (self-reported) |
| Quinn / Researcher / protoPen / Jon | Online (A2A probes) |
| protobot | Not probed |

Protobot owns Discord infrastructure but looked invisible in the fleet dashboard. After this change the endpoint returns \`reachable: true\` for every registered deep-agent, and protobot's advertised skill list explicitly names its provisioning responsibilities.

## Test plan

- [ ] \`bun test src/api src/executor/executors\` — passes locally (15 pass)
- [ ] \`curl /api/agent-health\` — ava + protobot show \`reachable: true\` with \`lastProbedAt\` set
- [ ] \`curl -XPOST /api/discord/webhooks/create -d '{\"name\":\"test-hook\",\"channelName\":\"ops\"}'\` — creates webhook, returns url
- [ ] DM protobot \"provision a channel called foo under category bar\" — protobot uses \`discord_create_channel\` with \`parent=bar\`
- [ ] DM protobot \"create a webhook on #ops for github\" — protobot uses \`discord_create_webhook\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New Discord operations agent available with webhook management and server provisioning capabilities
  * Agents can now list and create Discord webhooks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->