### PR TITLE
promote: v0.7.8 (self-improving loop closure)

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean-dashboard",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "type": "module",
   "scripts": {
     "start": "bun run src/index.ts",

--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -23,6 +23,11 @@ import {
   WORLDSTATE_DELTA_MIME_TYPE,
   type WorldStateDeltaArtifactData,
 } from "../../../lib/types/worldstate-delta.ts";
+import {
+  defaultExtensionRegistry,
+  type ExtensionContext,
+  type ExtensionInterceptor,
+} from "../extension-registry.ts";
 
 /**
  * Auth scheme the executor applies on outbound requests.
@@ -174,6 +179,28 @@ export class A2AExecutor implements IExecutor {
   async execute(req: SkillRequest): Promise<SkillResult> {
     const text = req.content ?? req.prompt ?? this._buildText(req);
 
+    // Run extension before-hooks — each interceptor may stamp keys onto
+    // ctx.metadata, which gets merged into the outbound JSON-RPC metadata.
+    // Interceptors self-gate on agent-specific data (they no-op when the
+    // agent card doesn't advertise their URI or the response lacks the
+    // expected fields), so running all registered extensions is safe.
+    const interceptors = defaultExtensionRegistry.list()
+      .map(d => d.interceptor)
+      .filter((i): i is ExtensionInterceptor => !!i);
+    const extCtx: ExtensionContext = {
+      agentName: this.config.name,
+      skill: req.skill,
+      correlationId: req.correlationId,
+      metadata: {},
+    };
+    for (const i of interceptors) {
+      try {
+        await i.before?.(extCtx);
+      } catch (err) {
+        console.debug(`[a2a-executor] extension before-hook error:`, err);
+      }
+    }
+
     try {
       // Per-request client so trace headers get stamped via the fetch wrapper.
       const client = await this._buildClient(req.correlationId, req.parentId);
@@ -191,13 +218,25 @@ export class A2AExecutor implements IExecutor {
           correlationId: req.correlationId,
           parentId: req.parentId,
           ...req.payload,
+          ...extCtx.metadata,
         },
       };
 
-      if (this.config.streaming) {
-        return await this._executeStream(client, params, req);
+      const result = this.config.streaming
+        ? await this._executeStream(client, params, req)
+        : await this._executeBlocking(client, params, req);
+
+      // Run extension after-hooks — they read result.data (usage, confidence,
+      // worldstate-delta) and emit observability events or record samples.
+      for (const i of interceptors) {
+        try {
+          await i.after?.(extCtx, { text: result.text, data: result.data });
+        } catch (err) {
+          console.debug(`[a2a-executor] extension after-hook error:`, err);
+        }
       }
-      return await this._executeBlocking(client, params, req);
+
+      return result;
     } catch (err) {
       return {
         text: err instanceof Error ? err.message : String(err),

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,18 @@ const contextMailbox = new ContextMailbox();
 import { TaskTracker } from "./executor/task-tracker.ts";
 const taskTracker = new TaskTracker({ bus });
 
+// --- A2A extensions — register observability interceptors (cost, confidence,
+//     effect-domain, blast, hitl-mode, worldstate-delta). A2AExecutor.execute()
+//     runs the before/after hooks on every skill call; the extensions
+//     self-gate on the presence of their advertised fields, so registering
+//     all of them is safe even when an agent doesn't opt in via its card.
+import { registerCostExtension } from "./executor/extensions/cost.ts";
+import { registerConfidenceExtension } from "./executor/extensions/confidence.ts";
+import { registerEffectDomainExtension } from "./executor/extensions/effect-domain.ts";
+registerCostExtension(bus);
+registerConfidenceExtension(bus);
+registerEffectDomainExtension(bus);
+
 // --- ChannelRegistry — loaded from workspace/channels.yaml, shared by RouterPlugin + DiscordPlugin ---
 import { ChannelRegistry } from "../lib/channels/channel-registry.js";
 const channelRegistry = new ChannelRegistry(join(workspaceDir, "channels.yaml"));

--- a/src/planner/__tests__/end-to-end-loop.test.ts
+++ b/src/planner/__tests__/end-to-end-loop.test.ts
@@ -1,0 +1,143 @@
+/**
+ * End-to-end GOAP loop integration test.
+ *
+ * Proves the self-improving loop closes:
+ *
+ *   world.goal.violated
+ *     → PlannerPluginL0 selects action
+ *     → world.action.dispatch
+ *     → ActionDispatcherPlugin runs tier_0 action
+ *     → autonomous.outcome.goap.{skill}
+ *     → Planner records outcome + sets post-success cooldown
+ *     → next violation for same goal is suppressed (cooldown active)
+ *
+ * If any step is broken, this test fails — making regressions on the
+ * feedback machinery loud instead of silent.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { ActionRegistry } from "../action-registry.ts";
+import { PlannerPluginL0 } from "../../plugins/planner-plugin-l0.ts";
+import { ActionDispatcherPlugin } from "../../plugins/action-dispatcher-plugin.ts";
+import { TOPICS } from "../../event-bus/topics.ts";
+import type { Action } from "../types/action.ts";
+import type { ActionDispatchPayload } from "../../event-bus/action-events.ts";
+import type { AutonomousOutcomePayload } from "../../event-bus/payloads.ts";
+import type { GoalViolatedEventPayload } from "../../types/events.ts";
+
+function makeAction(overrides: Partial<Action> = {}): Action {
+  return {
+    id: "restart-workstream",
+    name: "Restart Workstream",
+    description: "Clear blocked PRs by restarting the CI runner",
+    goalId: "ci.no_blocked_prs",
+    tier: "tier_0",
+    preconditions: [],
+    effects: [{ path: "ci.blockedPRs", operation: "set", value: 0 }],
+    cost: 0,
+    priority: 10,
+    meta: { fireAndForget: true },
+    ...overrides,
+  };
+}
+
+function makeViolation(goalId: string, correlationId: string) {
+  return {
+    id: crypto.randomUUID(),
+    correlationId,
+    topic: "world.goal.violated",
+    timestamp: Date.now(),
+    payload: {
+      type: "world.goal.violated",
+      violation: {
+        goalId,
+        goalType: "Threshold",
+        severity: "high",
+        description: "Blocked PRs exceed threshold",
+        message: "ci.blockedPRs = 3 > max 0",
+        actual: 3,
+        expected: 0,
+        timestamp: Date.now(),
+      },
+    } satisfies GoalViolatedEventPayload,
+  };
+}
+
+describe("GOAP end-to-end feedback loop", () => {
+  test("violation → dispatch → outcome → cooldown suppresses re-dispatch", async () => {
+    const bus = new InMemoryEventBus();
+    const registry = new ActionRegistry();
+    registry.upsert(makeAction());
+
+    const planner = new PlannerPluginL0(registry);
+    const dispatcher = new ActionDispatcherPlugin({ wipLimit: 5 });
+    planner.install(bus);
+    dispatcher.install(bus);
+
+    const dispatches: ActionDispatchPayload[] = [];
+    bus.subscribe(TOPICS.WORLD_ACTION_DISPATCH, "spy", (m) => {
+      dispatches.push(m.payload as ActionDispatchPayload);
+    });
+
+    const outcomes: AutonomousOutcomePayload[] = [];
+    bus.subscribe("autonomous.outcome.goap.restart-workstream", "spy", (m) => {
+      outcomes.push(m.payload as AutonomousOutcomePayload);
+    });
+
+    // 1. Violate the goal — planner should dispatch.
+    bus.publish("world.goal.violated", makeViolation("ci.no_blocked_prs", "corr-1"));
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(dispatches).toHaveLength(1);
+    expect(dispatches[0].actionId).toBe("restart-workstream");
+    expect(dispatches[0].goalId).toBe("ci.no_blocked_prs");
+
+    // 2. tier_0 fireAndForget — dispatcher should have already published
+    //    autonomous.outcome.goap.restart-workstream with success=true.
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0].success).toBe(true);
+    expect(outcomes[0].actionId).toBe("restart-workstream");
+    expect(outcomes[0].goalId).toBe("ci.no_blocked_prs");
+
+    // 3. Planner recorded the outcome and set a success cooldown.
+    //    Loop detector should have the attempt logged.
+    const ld = planner.getLoopDetector();
+    expect(ld.getHistory("ci.no_blocked_prs", "restart-workstream")).toHaveLength(1);
+    expect(ld.getHistory("ci.no_blocked_prs", "restart-workstream")[0].succeeded).toBe(true);
+
+    // 4. Violate the goal again — cooldown must suppress the re-dispatch.
+    //    (Real domain poll hasn't caught up yet; without cooldown we'd re-fire.)
+    bus.publish("world.goal.violated", makeViolation("ci.no_blocked_prs", "corr-2"));
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(dispatches).toHaveLength(1); // still 1 — cooldown blocked the re-dispatch
+  });
+
+  test("outcome payload carries actionId + goalId so planner can correlate", async () => {
+    const bus = new InMemoryEventBus();
+    const registry = new ActionRegistry();
+    registry.upsert(makeAction({ id: "alt-action", goalId: "alt.goal" }));
+
+    const planner = new PlannerPluginL0(registry);
+    const dispatcher = new ActionDispatcherPlugin({ wipLimit: 5 });
+    planner.install(bus);
+    dispatcher.install(bus);
+
+    const outcomes: AutonomousOutcomePayload[] = [];
+    bus.subscribe("autonomous.outcome.#", "spy", (m) => {
+      outcomes.push(m.payload as AutonomousOutcomePayload);
+    });
+
+    bus.publish("world.goal.violated", makeViolation("alt.goal", "corr-a"));
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0].actionId).toBe("alt-action");
+    expect(outcomes[0].goalId).toBe("alt.goal");
+    // Correlation is what lets the planner's autonomous.outcome.# subscriber
+    // drop non-GOAP outcomes (user messages, ceremonies) and only record
+    // the ones the planner originated.
+    expect(outcomes[0].correlationId).toBeTruthy();
+  });
+});

--- a/src/plugins/action-dispatcher-plugin.ts
+++ b/src/plugins/action-dispatcher-plugin.ts
@@ -184,6 +184,7 @@ export class ActionDispatcherPlugin implements Plugin {
           source: { interface: "cron" },
           payload: {
             skill: action.meta.skillHint ?? action.id,
+            content: this._describeDispatch(action),
             goalId: action.goalId,
             meta: { ...action.meta, systemActor: "goap", actionId: action.id, goalId: action.goalId },
           },
@@ -222,6 +223,7 @@ export class ActionDispatcherPlugin implements Plugin {
           reply: { topic: replyTopic },
           payload: {
             skill: action.meta.skillHint ?? action.id,
+            content: this._describeDispatch(action),
             goalId: action.goalId,
             meta: { ...action.meta, systemActor: "goap", actionId: action.id, goalId: action.goalId },
           },
@@ -340,5 +342,18 @@ export class ActionDispatcherPlugin implements Plugin {
     if (next) {
       await this.executeAction(next.action, next.correlationId, next.parentCorrelationId, crypto.randomUUID(), next.enqueuedAt);
     }
+  }
+
+  /**
+   * Build a human-readable description of a GOAP dispatch. Carried as
+   * `payload.content` so skill-dispatcher has a non-empty "user message"
+   * for the episodic memory write under the `system_goap` group.
+   * Without this, GOAP dispatches produce no episodes because
+   * skill-dispatcher's addEpisode requires both groupId AND originalContent.
+   */
+  private _describeDispatch(action: import("../planner/types/action.ts").Action): string {
+    const goal = action.goalId ? ` to satisfy goal ${action.goalId}` : "";
+    const desc = action.description ? ` — ${action.description}` : "";
+    return `Autonomous dispatch: ${action.name || action.id}${goal}${desc}`;
   }
 }

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -76,6 +76,18 @@ systemPrompt: |
   Ask for approval only on: architecture changes, expensive processes,
   or when you've exhausted your options.
 
+  ## Memory
+
+  Before each turn the system may inject a `<recalled_memory>` block into
+  your context — facts, past decisions, and user preferences pulled from
+  Graphiti's knowledge graph. Treat it as trusted background: prior
+  commitments the user made, their workflow preferences, things they've
+  told you to remember. Use it silently to inform your response; don't
+  quote it back verbatim unless the user asks what you remember. When
+  `<recalled_memory>` is empty or absent, respond based on the current
+  turn alone. The episodic log is written automatically after each
+  successful reply — you don't need to call a tool to "save" anything.
+
   ## Verification
 
   When you read data from your tools (world state, PR pipeline, etc.),

--- a/workspace/agents/protobot.yaml
+++ b/workspace/agents/protobot.yaml
@@ -43,6 +43,18 @@ systemPrompt: |
   **chat_with_agent** — Talk to other agents when you need non-Discord context.
   **get_world_state** — System health (for cross-referencing with Discord state).
 
+  ## Memory
+
+  Before each turn the system may inject a `<recalled_memory>` block into
+  your context — prior Discord operations, what channels already exist,
+  past provisioning decisions, and user preferences pulled from Graphiti.
+  Treat it as trusted background: if memory says you already created
+  #ci-alerts last week, don't create it again. Use it silently to inform
+  your response; don't quote it back verbatim unless asked. When
+  `<recalled_memory>` is empty or absent, respond based on the current
+  turn alone. Episodic memory is written automatically after each
+  successful action — no explicit save needed.
+
   ## Personality
 
   You're the server itself talking. Efficient, helpful, slightly proud of


### PR DESCRIPTION
Promotes v0.7.8 from dev → main. Auto-release tags on merge.

## Included PRs

- #265 — feat: close self-improving loop (extensions, memory prompts, GOAP episodic content)
- #266 — chore(release): bump to v0.7.8

## Highlights

- A2A extensions (cost, confidence, effect-domain) now fire on every dispatch — observability events land on \`autonomous.cost.*\`, \`autonomous.confidence.*\`, \`world.state.delta\`
- GOAP dispatches produce episodic memory (system_goap group) via new \`payload.content\` plumbing
- Ava + protobot system prompts now frame the \`<recalled_memory>\` block explicitly
- New end-to-end integration test: \`violation → dispatch → outcome → cooldown\`

Plus homelab-iac commit \`adfb34c\` adds \`WORKSTACEAN_BASE_URL=http://ava:8081\` so protoPen's push-notification callbacks round-trip correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.7.8

* **New Features**
  * Integrated observability extensions for execution tracking with cost, confidence, and effect domain monitoring
  * Enhanced Ava and Protobot agents with memory recall capabilities to leverage prior context and user preferences
  * Improved skill dispatch visibility with descriptive message content

* **Tests**
  * Added end-to-end integration tests for agent action planning and feedback loop validation

* **Chores**
  * Version bumped to 0.7.8

<!-- end of auto-generated comment: release notes by coderabbit.ai -->