### PR TITLE
Emit skill.progress from AgentExecutor intermediate messages

### DIFF
--- a/src/agent-runtime/agent-executor.ts
+++ b/src/agent-runtime/agent-executor.ts
@@ -20,6 +20,17 @@ import type { SDKResultMessageSuccess, SDKResultMessageError, ExtendedUsage } fr
 import type { AgentDefinition } from "./types.ts";
 import type { ToolRegistry } from "./tool-registry.ts";
 
+export interface SkillProgressEvent {
+  /** Discriminates between tool invocations and assistant text chunks. */
+  eventType: "tool_call" | "text";
+  /** Propagated trace ID from the originating bus message. */
+  correlationId: string;
+  /** Tool name — present when eventType === 'tool_call'. */
+  toolName?: string;
+  /** Text content — present when eventType === 'text'. */
+  text?: string;
+}
+
 export interface AgentRunOptions {
   /** The prompt / task to send to the agent. */
   prompt: string;
@@ -27,6 +38,8 @@ export interface AgentRunOptions {
   correlationId: string;
   /** Working directory for the agent's file operations. Defaults to process.cwd(). */
   cwd?: string;
+  /** Optional callback invoked for each tool_use block and assistant text block in the stream. */
+  onProgress?: (event: SkillProgressEvent) => void;
 }
 
 export interface AgentRunResult {
@@ -71,7 +84,7 @@ export class AgentExecutor {
   }
 
   async run(opts: AgentRunOptions): Promise<AgentRunResult> {
-    const { prompt, correlationId, cwd } = opts;
+    const { prompt, correlationId, cwd, onProgress } = opts;
     const agentTools = this.toolRegistry.forAgent(this.agentDef.tools);
 
     // Build the embedded MCP server with this agent's whitelisted tools.
@@ -136,7 +149,7 @@ export class AgentExecutor {
           break;
         }
       }
-      // Stream text blocks for logging / debugging
+      // Stream assistant content blocks for logging and progress events
       if (
         message.type === "assistant" &&
         "message" in message &&
@@ -147,6 +160,9 @@ export class AgentExecutor {
             if (block.type === "text" && "text" in block) {
               // Progress visible in logs when running
               process.stdout.write(".");
+              onProgress?.({ eventType: "text", correlationId, text: String((block as { text: unknown }).text) });
+            } else if (block.type === "tool_use" && "name" in block) {
+              onProgress?.({ eventType: "tool_call", correlationId, toolName: String((block as { name: unknown }).name) });
             }
           }
         }

--- a/src/agent-runtime/agent-runtime-plugin.ts
+++ b/src/agent-runtime/agent-runtime-plugin.ts
@@ -34,13 +34,15 @@ export class AgentRuntimePlugin implements Plugin {
 
   private readonly config: AgentRuntimeConfig;
   private readonly executorRegistry: ExecutorRegistry;
+  private bus?: EventBus;
 
   constructor(config: AgentRuntimeConfig, executorRegistry: ExecutorRegistry) {
     this.config = config;
     this.executorRegistry = executorRegistry;
   }
 
-  install(_bus: EventBus): void {
+  install(bus: EventBus): void {
+    this.bus = bus;
     const definitions = loadAgentDefinitions(this.config.workspaceDir);
     const knownTools = new Set(BUS_TOOL_NAMES as readonly string[]);
 

--- a/src/executor/__tests__/skill-dispatcher-plugin.test.ts
+++ b/src/executor/__tests__/skill-dispatcher-plugin.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, mock, spyOn, beforeEach, afterEach } from "bun:test";
 import { SkillDispatcherPlugin, assembleContext } from "../skill-dispatcher-plugin.ts";
 import { ExecutorRegistry } from "../executor-registry.ts";
 import { FunctionExecutor } from "../executors/function-executor.ts";
+import { ProtoSdkExecutor } from "../executors/proto-sdk-executor.ts";
+import { AgentExecutor } from "../../agent-runtime/agent-executor.ts";
+import { ToolRegistry } from "../../agent-runtime/tool-registry.ts";
 import type { BusMessage } from "../../../lib/types.ts";
 import type { SkillRequest, SkillResult } from "../types.ts";
+import type { AgentDefinition } from "../../agent-runtime/types.ts";
 import type { GraphitiClient } from "../../../lib/memory/graphiti-client.ts";
 import type { ConversationTurn } from "../../../lib/plugins/logger.ts";
 
@@ -431,5 +435,143 @@ describe("assembleContext", () => {
     const result = assembleContext("", [], "Hello");
     expect(result).not.toContain("<recalled_memory>");
     expect(result).toBe("<current_message>\nHello\n</current_message>");
+  });
+});
+
+// ── skill.progress emission ────────────────────────────────────────────────────
+
+const minimalAgentDef: AgentDefinition = {
+  name: "test-agent",
+  role: "general",
+  model: "test-model",
+  systemPrompt: "You are a test agent.",
+  tools: [],
+  maxTurns: 5,
+  skills: [{ name: "test_skill" }],
+};
+
+describe("SkillDispatcherPlugin — skill.progress events", () => {
+  it("subscribes to skill.progress and observes tool_call events from ProtoSdkExecutor", async () => {
+    const bus = makeBus();
+    const registry = new ExecutorRegistry();
+
+    // Stub AgentExecutor.run to simulate a tool_use event via onProgress
+    const runSpy = spyOn(AgentExecutor.prototype, "run").mockImplementation(
+      async (opts) => {
+        opts.onProgress?.({
+          eventType: "tool_call",
+          correlationId: opts.correlationId,
+          toolName: "bash",
+        });
+        return { text: "done", isError: false };
+      },
+    );
+
+    const toolRegistry = new ToolRegistry();
+    const executor = new ProtoSdkExecutor(minimalAgentDef, toolRegistry, {}, bus as never);
+    registry.register("test_skill", executor);
+
+    const plugin = new SkillDispatcherPlugin(registry, "/tmp");
+    plugin.install(bus as never);
+
+    const progressEvents: BusMessage[] = [];
+    bus.subscribe("skill.progress", "test-observer", (msg) => progressEvents.push(msg));
+
+    bus.publish("agent.skill.request", makeMsg({
+      payload: { skill: "test_skill" },
+      reply: { topic: "reply.progress-test" },
+    }));
+
+    await new Promise(r => setTimeout(r, 30));
+
+    expect(progressEvents.length).toBeGreaterThan(0);
+    const ev = progressEvents[0]!;
+    expect((ev.payload as Record<string, unknown>).eventType).toBe("tool_call");
+    expect((ev.payload as Record<string, unknown>).toolName).toBe("bash");
+    expect(ev.topic).toBe("skill.progress");
+
+    runSpy.mockRestore();
+    plugin.uninstall();
+  });
+
+  it("emits skill.progress with text eventType for assistant text blocks", async () => {
+    const bus = makeBus();
+    const registry = new ExecutorRegistry();
+
+    const runSpy = spyOn(AgentExecutor.prototype, "run").mockImplementation(
+      async (opts) => {
+        opts.onProgress?.({
+          eventType: "text",
+          correlationId: opts.correlationId,
+          text: "thinking...",
+        });
+        return { text: "final result", isError: false };
+      },
+    );
+
+    const toolRegistry = new ToolRegistry();
+    const executor = new ProtoSdkExecutor(minimalAgentDef, toolRegistry, {}, bus as never);
+    registry.register("test_skill", executor);
+
+    const plugin = new SkillDispatcherPlugin(registry, "/tmp");
+    plugin.install(bus as never);
+
+    const progressEvents: BusMessage[] = [];
+    bus.subscribe("skill.progress", "test-observer-text", (msg) => progressEvents.push(msg));
+
+    bus.publish("agent.skill.request", makeMsg({
+      payload: { skill: "test_skill" },
+      reply: { topic: "reply.progress-text-test" },
+    }));
+
+    await new Promise(r => setTimeout(r, 30));
+
+    expect(progressEvents.length).toBeGreaterThan(0);
+    const ev = progressEvents[0]!;
+    expect((ev.payload as Record<string, unknown>).eventType).toBe("text");
+    expect((ev.payload as Record<string, unknown>).text).toBe("thinking...");
+
+    runSpy.mockRestore();
+    plugin.uninstall();
+  });
+
+  it("does not emit skill.progress when ProtoSdkExecutor has no bus", async () => {
+    const bus = makeBus();
+    const registry = new ExecutorRegistry();
+
+    const runSpy = spyOn(AgentExecutor.prototype, "run").mockImplementation(
+      async (opts) => {
+        // onProgress should be undefined when no bus is provided
+        opts.onProgress?.({
+          eventType: "tool_call",
+          correlationId: opts.correlationId,
+          toolName: "bash",
+        });
+        return { text: "done", isError: false };
+      },
+    );
+
+    const toolRegistry = new ToolRegistry();
+    // No bus passed — progress events should not be emitted
+    const executor = new ProtoSdkExecutor(minimalAgentDef, toolRegistry, {});
+    registry.register("test_skill", executor);
+
+    const plugin = new SkillDispatcherPlugin(registry, "/tmp");
+    plugin.install(bus as never);
+
+    const progressEvents: BusMessage[] = [];
+    bus.subscribe("skill.progress", "test-no-bus", (msg) => progressEvents.push(msg));
+
+    bus.publish("agent.skill.request", makeMsg({
+      payload: { skill: "test_skill" },
+      reply: { topic: "reply.no-bus-test" },
+    }));
+
+    await new Promise(r => setTimeout(r, 30));
+
+    expect(progressEvents.length).toBe(0);
+
+    runSpy.mockRestore();
+    plugin.uninstall();
   });
 });

--- a/src/executor/executors/proto-sdk-executor.ts
+++ b/src/executor/executors/proto-sdk-executor.ts
@@ -10,26 +10,43 @@ import type { AgentDefinition } from "../../agent-runtime/types.ts";
 import type { ToolRegistry } from "../../agent-runtime/tool-registry.ts";
 import type { AgentExecutorConfig } from "../../agent-runtime/agent-executor.ts";
 import type { IExecutor, SkillRequest, SkillResult } from "../types.ts";
+import type { EventBus } from "../../../lib/types.ts";
 
 export class ProtoSdkExecutor implements IExecutor {
   readonly type = "proto-sdk";
 
   private readonly executor: AgentExecutor;
+  private readonly bus?: EventBus;
 
   constructor(
     agentDef: AgentDefinition,
     toolRegistry: ToolRegistry,
     config: AgentExecutorConfig = {},
+    bus?: EventBus,
   ) {
     this.executor = new AgentExecutor(agentDef, toolRegistry, config);
+    this.bus = bus;
   }
 
   async execute(req: SkillRequest): Promise<SkillResult> {
     const prompt = req.content ?? req.prompt ?? this._buildPrompt(req);
+    const { bus } = this;
+    const { correlationId } = req;
 
     const result = await this.executor.run({
       prompt,
-      correlationId: req.correlationId,
+      correlationId,
+      onProgress: bus
+        ? (event) => {
+            bus.publish("skill.progress", {
+              id: crypto.randomUUID(),
+              correlationId,
+              topic: "skill.progress",
+              timestamp: Date.now(),
+              payload: event,
+            });
+          }
+        : undefined,
     });
 
     return {


### PR DESCRIPTION
## Summary

**Milestone:** Skill Progress Events

AgentExecutor currently logs intermediate messages as dots. Instead, emit a skill.progress event on the bus for each tool_use block and each assistant text block. Thread the bus reference and correlationId through from ProtoSdkExecutor -> AgentExecutor via an options callback.

**Files to Modify:**
- src/agent-runtime/agent-executor.ts
- src/executor/executors/proto-sdk-executor.ts
- src/agent-runtime/agent-runtime-plugin.ts

**Acceptance Criteria:**
- [ ] E...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent execution now emits real-time progress events, allowing users to monitor tool invocations and text generation during skill execution.

* **Tests**
  * Added test coverage for progress event emission and bus integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->