### PR TITLE
Define skill.progress bus topic and type

### DIFF
--- a/lib/types/events.ts
+++ b/lib/types/events.ts
@@ -1,0 +1,21 @@
+/**
+ * Typed bus event definitions for skill execution progress.
+ */
+
+export interface SkillProgressEvent {
+  /** Correlation ID linking this event to the originating skill request */
+  correlationId: string;
+  /** Name of the skill being executed */
+  skill: string;
+  /** Name of the agent executing the skill */
+  agentName: string;
+  /** Type of intermediate event emitted by the agent */
+  eventType: "tool_call" | "text" | "tool_result";
+  /** Raw content of the event (tool input/output, text chunk, etc.) */
+  content: unknown;
+  /** Unix timestamp (ms) when this event was emitted */
+  timestamp: number;
+}
+
+/** Bus topic for SkillProgressEvent messages */
+export const SKILL_PROGRESS_TOPIC = "skill.progress" as const;

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,0 +1,1 @@
+export * from "./events.ts";


### PR DESCRIPTION
## Summary

**Milestone:** Skill Progress Events

Add SkillProgressEvent to lib/types/events.ts. Topic: skill.progress. Payload: { correlationId, skill, agentName, eventType: 'tool_call' | 'text' | 'tool_result', content, timestamp }. Export from lib/types index.

**Files to Modify:**
- lib/types/events.ts
- lib/types/index.ts

**Acceptance Criteria:**
- [ ] SkillProgressEvent type exported from lib/types
- [ ] bun test has no new failures

**Complexity:** small

**Guardrails:** If this phase involves new o...

---
*Recovered automatically by Automaker post-agent hook*