### PR TITLE
Implement SessionContext or file RFC

### DIFF
--- a/src/agent-runtime/agent-executor.ts
+++ b/src/agent-runtime/agent-executor.ts
@@ -27,6 +27,11 @@ export interface AgentRunOptions {
   correlationId: string;
   /** Working directory for the agent's file operations. Defaults to process.cwd(). */
   cwd?: string;
+  /**
+   * SDK session ID to resume from a previous run.
+   * When set, the query() call passes this as `resume` to continue conversation context.
+   */
+  resume?: string;
 }
 
 export interface AgentRunResult {
@@ -40,6 +45,11 @@ export interface AgentRunResult {
   usage?: ExtendedUsage;
   /** Number of agentic turns taken. */
   numTurns?: number;
+  /**
+   * SDK session ID from this run — use as `resume` on the next call to continue
+   * the conversation within the same session context.
+   */
+  sessionId?: string;
 }
 
 /**
@@ -71,7 +81,7 @@ export class AgentExecutor {
   }
 
   async run(opts: AgentRunOptions): Promise<AgentRunResult> {
-    const { prompt, correlationId, cwd } = opts;
+    const { prompt, correlationId, cwd, resume } = opts;
     const agentTools = this.toolRegistry.forAgent(this.agentDef.tools);
 
     // Build the embedded MCP server with this agent's whitelisted tools.
@@ -98,7 +108,9 @@ export class AgentExecutor {
         permissionMode: "yolo",
         systemPrompt: this.agentDef.systemPrompt,
         maxSessionTurns: this.agentDef.maxTurns,
-        sessionId: correlationId,
+        // When resuming, the session ID comes from the previous run. Otherwise
+        // use correlationId so LangFuse traces stay grouped under the same ID.
+        ...(resume ? { resume } : { sessionId: correlationId }),
         cwd: cwd ?? process.cwd(),
         stderr: (line: string) => console.error(`[agent:${this.agentDef.name}:stderr]`, line),
         ...(this.agentDef.allowedTools?.length ? { allowedTools: this.agentDef.allowedTools } : {}),
@@ -155,6 +167,7 @@ export class AgentExecutor {
 
     if (resultText.length > 0) process.stdout.write("\n");
 
-    return { text: resultText, isError, stopReason, usage, numTurns };
+    const sessionId = session.getSessionId();
+    return { text: resultText, isError, stopReason, usage, numTurns, sessionId };
   }
 }

--- a/src/agent-runtime/session-context.ts
+++ b/src/agent-runtime/session-context.ts
@@ -1,0 +1,53 @@
+/**
+ * SessionContext — tracks SDK session IDs for conversation continuity.
+ *
+ * The SDK supports resuming a previous session via the `resume` option on query().
+ * SessionStore holds in-memory session IDs keyed by `${correlationId}:${agentName}`,
+ * enabling SkillDispatcherPlugin to resume the right session when the same user
+ * sends a follow-up message to the same agent within the same conversation flow.
+ *
+ * Lifecycle:
+ *   1. First invocation: no session → query() creates a new session.
+ *   2. AgentExecutor.run() returns the session ID from session.getSessionId().
+ *   3. SkillDispatcherPlugin stores it in SessionStore.
+ *   4. Next invocation with the same correlationId+agentName: session ID is
+ *      retrieved and passed as `resume` to query(), resuming conversation context.
+ */
+
+export interface SessionContext {
+  /** SDK session ID to resume via query() options.resume */
+  sessionId: string;
+}
+
+/**
+ * In-memory store for SDK session IDs.
+ * Keyed by `${correlationId}:${agentName}`.
+ */
+export class SessionStore {
+  private readonly store = new Map<string, string>();
+
+  private key(correlationId: string, agentName: string): string {
+    return `${correlationId}:${agentName}`;
+  }
+
+  /** Return the stored session context, or undefined if none exists. */
+  get(correlationId: string, agentName: string): SessionContext | undefined {
+    const sessionId = this.store.get(this.key(correlationId, agentName));
+    return sessionId !== undefined ? { sessionId } : undefined;
+  }
+
+  /** Persist a session ID for future resumption. */
+  set(correlationId: string, agentName: string, sessionId: string): void {
+    this.store.set(this.key(correlationId, agentName), sessionId);
+  }
+
+  /** Remove a stored session (e.g. after a terminal error). */
+  delete(correlationId: string, agentName: string): void {
+    this.store.delete(this.key(correlationId, agentName));
+  }
+
+  /** Number of active sessions in the store. */
+  get size(): number {
+    return this.store.size;
+  }
+}

--- a/src/executor/executors/proto-sdk-executor.ts
+++ b/src/executor/executors/proto-sdk-executor.ts
@@ -30,6 +30,7 @@ export class ProtoSdkExecutor implements IExecutor {
     const result = await this.executor.run({
       prompt,
       correlationId: req.correlationId,
+      resume: req.resume,
     });
 
     return {
@@ -40,6 +41,7 @@ export class ProtoSdkExecutor implements IExecutor {
         usage: result.usage,
         numTurns: result.numTurns,
         stopReason: result.stopReason,
+        sessionId: result.sessionId,
       },
     };
   }

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -23,6 +23,7 @@ import type { LoggerPlugin, ConversationTurn } from "../../lib/plugins/logger.ts
 import { ContextMailbox } from "../../lib/dm/context-mailbox.ts";
 import type { TaskTracker } from "./task-tracker.ts";
 import type { A2AExecutor } from "./executors/a2a-executor.ts";
+import { SessionStore } from "../agent-runtime/session-context.ts";
 
 const WORKING_STATES = new Set(["submitted", "working"]);
 
@@ -100,6 +101,7 @@ export class SkillDispatcherPlugin implements Plugin {
   private readonly loggerPlugin: LoggerPlugin | undefined;
   private readonly mailbox: ContextMailbox | undefined;
   private readonly taskTracker: TaskTracker | undefined;
+  private readonly sessionStore: SessionStore;
 
   /**
    * In-flight execution tracking — set at the TOP of _dispatch() (before any
@@ -120,12 +122,15 @@ export class SkillDispatcherPlugin implements Plugin {
     mailbox?: ContextMailbox,
     /** Optional tracker for long-running A2A tasks. */
     taskTracker?: TaskTracker,
+    /** Optional session store for SDK session continuation across turns. */
+    sessionStore?: SessionStore,
   ) {
     this.graphiti = graphiti ?? new GraphitiClient();
     this.identityRegistry = new IdentityRegistry(workspaceDir);
     this.loggerPlugin = loggerPlugin;
     this.mailbox = mailbox;
     this.taskTracker = taskTracker;
+    this.sessionStore = sessionStore ?? new SessionStore();
   }
 
   /** Check if an execution is currently active for a given correlationId. */
@@ -275,6 +280,13 @@ export class SkillDispatcherPlugin implements Plugin {
     }
     // ── End memory enrichment ─────────────────────────────────────────────────
 
+    // Look up any existing SDK session for this correlationId+agent pair so the
+    // executor can resume conversation context across multiple skill turns.
+    const agentName = targets[0] ?? "";
+    const existingSession = agentName
+      ? this.sessionStore.get(correlationId, agentName)
+      : undefined;
+
     const req: SkillRequest = {
       skill,
       content: rawContent,
@@ -283,6 +295,7 @@ export class SkillDispatcherPlugin implements Plugin {
       parentId,
       replyTopic,
       payload,
+      ...(existingSession ? { resume: existingSession.sessionId } : {}),
     };
 
     const flowItemId = `skill-${correlationId}`;
@@ -406,6 +419,11 @@ export class SkillDispatcherPlugin implements Plugin {
         );
         if (result.data?.stopReason === "max_turns") {
           console.warn("[skill-dispatcher] Agent hit maxTurns limit");
+        }
+
+        // Persist the SDK session ID so the next turn for this agent can resume it.
+        if (result.data?.sessionId && agentName) {
+          this.sessionStore.set(correlationId, agentName, result.data.sessionId);
         }
         const completedAt = Date.now();
         const durationMs = completedAt - dispatchedAt;

--- a/src/executor/types.ts
+++ b/src/executor/types.ts
@@ -31,6 +31,12 @@ export interface SkillRequest {
   /** A2A context ID for multi-turn conversations. When set, A2AExecutor uses
    *  this instead of correlationId, enabling conversation continuity across turns. */
   contextId?: string;
+  /**
+   * SDK session ID to resume from a previous ProtoSdkExecutor run.
+   * Set by SkillDispatcherPlugin when a prior session exists for this
+   * correlationId+agentName pair. Only consumed by ProtoSdkExecutor.
+   */
+  resume?: string;
   /** Topic to publish the response on. */
   replyTopic: string;
   /** Full original bus message payload — typed with known agent.skill.request fields. */
@@ -57,6 +63,12 @@ export interface SkillResult {
     taskState?: string;
     /** Raw A2A artifacts from the terminal task — used by TaskTracker for worldstate-delta extraction. */
     artifacts?: unknown[];
+    /**
+     * SDK session ID from a completed ProtoSdkExecutor run.
+     * SkillDispatcherPlugin stores this in SessionStore so the next invocation
+     * for the same correlationId+agentName can resume the session.
+     */
+    sessionId?: string;
   };
 }
 


### PR DESCRIPTION
## Summary

**Milestone:** Session Continuation Research + Prototype

Based on audit findings: (A) If SDK supports continuation -- implement SessionContext interface, store in SkillDispatcherPlugin keyed by correlationId+agentName, pass to AgentExecutor. (B) If SDK does not -- implement plaintext-history fallback (append last N turns to context block) and file a proto-sdk issue documenting the required primitive.

**Files to Modify:**
- src/agent-runtime/session-context.ts
- src/executor/skill-dispatcher-pl...

---
*Recovered automatically by Automaker post-agent hook*