### PR TITLE
feat: [Arc 6.4] PlannerL0 ranks candidates by observed cost/confidence

### DIFF
--- a/src/planner/__tests__/candidate-ranking.test.ts
+++ b/src/planner/__tests__/candidate-ranking.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Arc 6.4 — unit tests for observation-weighted candidate ranking.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  rankByObservedMetrics,
+  scoreCandidate,
+  MIN_SAMPLES_FOR_TRUST,
+  type RankContext,
+} from "../candidate-ranking.ts";
+import type { EffectRegistration } from "../../executor/types.ts";
+import type { CostSummary } from "../../executor/extensions/cost.ts";
+import type { ConfidenceSummary } from "../../executor/extensions/confidence.ts";
+
+function reg(overrides: Partial<EffectRegistration> = {}): EffectRegistration {
+  return {
+    skill: "rebase_pr",
+    agentName: "quinn",
+    domain: "pr_pipeline",
+    path: "data.blockedPRs",
+    expectedDelta: -1,
+    confidence: 0.7,
+    ...overrides,
+  };
+}
+
+function ctx(
+  costs: Record<string, CostSummary>,
+  confidences: Record<string, ConfidenceSummary> = {},
+): RankContext {
+  const key = (a: string, s: string) => `${a}::${s}`;
+  return {
+    costSummary: (a, s) => costs[key(a, s)],
+    confidenceSummary: (a, s) => confidences[key(a, s)],
+  };
+}
+
+describe("scoreCandidate", () => {
+  test("cold start (no samples) → card's self-declared confidence wins", () => {
+    const c = reg({ confidence: 0.42 });
+    expect(scoreCandidate(c, ctx({}))).toBe(0.42);
+  });
+
+  test("fewer samples than MIN_SAMPLES_FOR_TRUST → still uses card prior", () => {
+    const c = reg({ confidence: 0.6 });
+    const costs: Record<string, CostSummary> = {
+      "quinn::rebase_pr": {
+        agentName: "quinn",
+        skill: "rebase_pr",
+        sampleCount: MIN_SAMPLES_FOR_TRUST - 1,
+        avgTokensIn: 0,
+        avgTokensOut: 0,
+        avgWallMs: 1000,
+        avgCostUsd: 0,
+        successRate: 1.0,
+      },
+    };
+    expect(scoreCandidate(c, ctx(costs))).toBe(0.6);
+  });
+
+  test("warm with high success rate outranks warm with low success rate", () => {
+    const a = reg({ agentName: "ava" });
+    const b = reg({ agentName: "quinn" });
+    const costs: Record<string, CostSummary> = {
+      "ava::rebase_pr":   { agentName: "ava",   skill: "rebase_pr", sampleCount: 10, avgTokensIn: 0, avgTokensOut: 0, avgWallMs: 1000, avgCostUsd: 0, successRate: 0.9 },
+      "quinn::rebase_pr": { agentName: "quinn", skill: "rebase_pr", sampleCount: 10, avgTokensIn: 0, avgTokensOut: 0, avgWallMs: 1000, avgCostUsd: 0, successRate: 0.3 },
+    };
+    expect(scoreCandidate(a, ctx(costs))).toBeGreaterThan(scoreCandidate(b, ctx(costs)));
+  });
+
+  test("observed success rate overrides card confidence", () => {
+    // Card says this agent is amazing (1.0) but observed success rate is 0.2.
+    // A different agent with lower card confidence (0.5) but 0.95 observed
+    // success should rank higher.
+    const hyped = reg({ agentName: "hyped", confidence: 1.0 });
+    const proven = reg({ agentName: "proven", confidence: 0.5 });
+    const costs: Record<string, CostSummary> = {
+      "hyped::rebase_pr":  { agentName: "hyped",  skill: "rebase_pr", sampleCount: 20, avgTokensIn: 0, avgTokensOut: 0, avgWallMs: 1000, avgCostUsd: 0, successRate: 0.2 },
+      "proven::rebase_pr": { agentName: "proven", skill: "rebase_pr", sampleCount: 20, avgTokensIn: 0, avgTokensOut: 0, avgWallMs: 1000, avgCostUsd: 0, successRate: 0.95 },
+    };
+    expect(scoreCandidate(proven, ctx(costs))).toBeGreaterThan(scoreCandidate(hyped, ctx(costs)));
+  });
+
+  test("wall-time penalty breaks ties on equal success rate", () => {
+    const fast = reg({ agentName: "fast" });
+    const slow = reg({ agentName: "slow" });
+    const costs: Record<string, CostSummary> = {
+      "fast::rebase_pr": { agentName: "fast", skill: "rebase_pr", sampleCount: 10, avgTokensIn: 0, avgTokensOut: 0, avgWallMs: 500,    avgCostUsd: 0, successRate: 0.8 },
+      "slow::rebase_pr": { agentName: "slow", skill: "rebase_pr", sampleCount: 10, avgTokensIn: 0, avgTokensOut: 0, avgWallMs: 90_000, avgCostUsd: 0, successRate: 0.8 },
+    };
+    expect(scoreCandidate(fast, ctx(costs))).toBeGreaterThan(scoreCandidate(slow, ctx(costs)));
+  });
+
+  test("observed confidence-on-success boosts score when samples exist", () => {
+    const sure = reg({ agentName: "sure" });
+    const unsure = reg({ agentName: "unsure" });
+    const costs: Record<string, CostSummary> = {
+      "sure::rebase_pr":   { agentName: "sure",   skill: "rebase_pr", sampleCount: 10, avgTokensIn: 0, avgTokensOut: 0, avgWallMs: 1000, avgCostUsd: 0, successRate: 0.8 },
+      "unsure::rebase_pr": { agentName: "unsure", skill: "rebase_pr", sampleCount: 10, avgTokensIn: 0, avgTokensOut: 0, avgWallMs: 1000, avgCostUsd: 0, successRate: 0.8 },
+    };
+    const confidences: Record<string, ConfidenceSummary> = {
+      "sure::rebase_pr":   { agentName: "sure",   skill: "rebase_pr", sampleCount: 10, avgConfidence: 0.9, avgConfidenceOnSuccess: 0.95, avgConfidenceOnFailure: 0.5, highConfFailures: 0 },
+      "unsure::rebase_pr": { agentName: "unsure", skill: "rebase_pr", sampleCount: 10, avgConfidence: 0.5, avgConfidenceOnSuccess: 0.40, avgConfidenceOnFailure: 0.5, highConfFailures: 0 },
+    };
+    expect(scoreCandidate(sure, ctx(costs, confidences)))
+      .toBeGreaterThan(scoreCandidate(unsure, ctx(costs, confidences)));
+  });
+
+  test("missing agentName → card prior only (store lookup impossible)", () => {
+    const c = reg({ agentName: undefined, confidence: 0.33 });
+    expect(scoreCandidate(c, ctx({}))).toBe(0.33);
+  });
+});
+
+describe("rankByObservedMetrics", () => {
+  test("sorts descending by score — warm data dominates cold priors", () => {
+    const alice = reg({ agentName: "alice", confidence: 0.3 });
+    const bob   = reg({ agentName: "bob",   confidence: 0.3 });
+    const carol = reg({ agentName: "carol", confidence: 0.9 });
+    const costs: Record<string, CostSummary> = {
+      "alice::rebase_pr": { agentName: "alice", skill: "rebase_pr", sampleCount: 10, avgTokensIn: 0, avgTokensOut: 0, avgWallMs: 1000, avgCostUsd: 0, successRate: 0.95 },
+      "bob::rebase_pr":   { agentName: "bob",   skill: "rebase_pr", sampleCount: 10, avgTokensIn: 0, avgTokensOut: 0, avgWallMs: 1000, avgCostUsd: 0, successRate: 0.50 },
+      // carol has no samples — falls back to card prior 0.9
+    };
+
+    const ranked = rankByObservedMetrics([bob, carol, alice], ctx(costs));
+
+    // alice warm-high (score ≈ 1.895) > bob warm-mid (≈ 0.995) > carol cold-high-prior (0.9).
+    // Intentional: observed data beats self-declared priors once warm. A
+    // card advertising 0.9 that has no supporting observations shouldn't
+    // outrank a skill with 10 runs at 50% success — real samples win.
+    expect(ranked.map((r) => r.agentName)).toEqual(["alice", "bob", "carol"]);
+  });
+
+  test("tiebreak on card confidence when scores are equal", () => {
+    // Two cold candidates — card confidences differ, both should appear in that order
+    const weak   = reg({ agentName: "weak",   confidence: 0.2 });
+    const strong = reg({ agentName: "strong", confidence: 0.9 });
+    const ranked = rankByObservedMetrics([weak, strong], ctx({}));
+    expect(ranked.map((r) => r.agentName)).toEqual(["strong", "weak"]);
+  });
+
+  test("input array is not mutated", () => {
+    const input = [reg({ agentName: "a" }), reg({ agentName: "b", confidence: 0.1 })];
+    const ranked = rankByObservedMetrics(input, ctx({}));
+    expect(input.map((r) => r.agentName)).toEqual(["a", "b"]);
+    expect(ranked).not.toBe(input);
+  });
+});

--- a/src/planner/candidate-ranking.ts
+++ b/src/planner/candidate-ranking.ts
@@ -1,0 +1,93 @@
+/**
+ * Arc 6.4 — rank effect-based candidates by observed metrics.
+ *
+ * The ExecutorRegistry gives us a list of `EffectRegistration` candidates
+ * that each claim to move world state toward a goal's desired (domain, path).
+ * Before Arc 6.4 the planner sorted purely by `reg.confidence` — the
+ * agent's self-declared card weight. That's a fine cold-start prior, but
+ * ignores everything we've actually observed about which agents succeed.
+ *
+ * This module layers observed metrics on top:
+ *   - success rate (from CostStore samples) — primary signal
+ *   - average confidence-on-success (from ConfidenceStore) — secondary
+ *   - average wall-time per call — tiebreak penalty (faster = better)
+ *
+ * Once an (agent, skill) pair has seen `MIN_SAMPLES_FOR_TRUST` samples we
+ * use observed metrics; before that we use the card's self-declared
+ * confidence so new agents aren't locked out of dispatch.
+ *
+ * Kept as a pure function + lookup-bag so tests can inject a fixed cost/
+ * confidence map and exercise the sort deterministically without spinning
+ * up the A2A extensions pipeline.
+ */
+
+import type { EffectRegistration } from "../executor/types.ts";
+import type { CostSummary } from "../executor/extensions/cost.ts";
+import type { ConfidenceSummary } from "../executor/extensions/confidence.ts";
+
+/**
+ * Minimum observed samples before we trust the metrics over the card's
+ * self-declared confidence. Below this we're still cold-starting.
+ */
+export const MIN_SAMPLES_FOR_TRUST = 5;
+
+export interface RankContext {
+  costSummary: (agentName: string, skill: string) => CostSummary | undefined;
+  confidenceSummary: (agentName: string, skill: string) => ConfidenceSummary | undefined;
+}
+
+/**
+ * Score a single candidate. Higher is better. Visible for testing.
+ *
+ * Scoring model (picked for interpretability, not optimality — can be
+ * swapped for a learned policy later without touching the sort sites):
+ *
+ *   warm candidate (>= MIN_SAMPLES_FOR_TRUST samples):
+ *     score = 2.0 * successRate                     // proven dominant signal
+ *           + 0.5 * avgConfidenceOnSuccess          // agent self-assessment
+ *           - 0.3 * clamp(avgWallMs / 60_000, 0, 2) // wall-time penalty (up to ~2min)
+ *
+ *   cold candidate (no samples or missing agentName):
+ *     score = reg.confidence                        // card's own prior
+ *
+ * The warm formula is deliberately favored when samples exist: a candidate
+ * with 80% success rate and mid-range confidence will beat a card-declared
+ * 1.0 confidence prior. That's the whole point — observations win over
+ * self-advertisement once we have them.
+ */
+export function scoreCandidate(reg: EffectRegistration, ctx: RankContext): number {
+  if (!reg.agentName) {
+    // Can't look up store without agentName — trust the card prior.
+    return reg.confidence;
+  }
+  const cost = ctx.costSummary(reg.agentName, reg.skill);
+  if (!cost || cost.sampleCount < MIN_SAMPLES_FOR_TRUST) {
+    return reg.confidence;
+  }
+
+  const confidence = ctx.confidenceSummary(reg.agentName, reg.skill);
+  const observedConfidence =
+    confidence && confidence.sampleCount >= MIN_SAMPLES_FOR_TRUST
+      ? confidence.avgConfidenceOnSuccess
+      : 0;
+
+  const wallPenalty = Math.min(Math.max(cost.avgWallMs / 60_000, 0), 2);
+
+  return 2.0 * cost.successRate + 0.5 * observedConfidence - 0.3 * wallPenalty;
+}
+
+/**
+ * Sort the candidate list in descending score order.
+ * Stable tiebreak on the card's self-declared confidence so deterministic
+ * orderings survive identical scores (e.g. two cold-start candidates).
+ */
+export function rankByObservedMetrics(
+  candidates: EffectRegistration[],
+  ctx: RankContext,
+): EffectRegistration[] {
+  return [...candidates].sort((a, b) => {
+    const diff = scoreCandidate(b, ctx) - scoreCandidate(a, ctx);
+    if (diff !== 0) return diff;
+    return b.confidence - a.confidence;
+  });
+}

--- a/src/plugins/planner-plugin-l0.ts
+++ b/src/plugins/planner-plugin-l0.ts
@@ -29,6 +29,9 @@ import { ExecutorRegistry } from "../executor/executor-registry.ts";
 import { matchActions, evaluatePrecondition } from "../planner/pattern-matcher.ts";
 import { LoopDetector } from "../planner/loop-detector.ts";
 import { CooldownManager } from "../planner/cooldown-manager.ts";
+import { defaultCostStore, type CostStore } from "../executor/extensions/cost.ts";
+import { defaultConfidenceStore, type ConfidenceStore } from "../executor/extensions/confidence.ts";
+import { rankByObservedMetrics, type RankContext } from "../planner/candidate-ranking.ts";
 
 export interface PlannerPluginL0Config {
   loopDetector?: {
@@ -50,6 +53,17 @@ export interface PlannerPluginL0Config {
    * candidate selection (resolveByEffect) instead of ActionRegistry.getByGoal().
    */
   executorRegistry?: ExecutorRegistry;
+  /**
+   * Observed-cost store for Arc 6.4 candidate ranking. Defaults to the
+   * singleton populated by the cost-v1 A2A extension. Tests can inject a
+   * fresh instance to avoid cross-test pollution.
+   */
+  costStore?: CostStore;
+  /**
+   * Observed-confidence store for Arc 6.4 candidate ranking. Defaults to
+   * the singleton populated by the confidence-v1 A2A extension.
+   */
+  confidenceStore?: ConfidenceStore;
 }
 
 const DEFAULT_LOOP_CONFIG = { maxAttempts: 3, windowMinutes: 5 };
@@ -142,11 +156,13 @@ export class PlannerPluginL0 implements Plugin {
         if (violation.desiredEffect && executorRegistry) {
           // Effect-based selection: query ExecutorRegistry for skills whose
           // declared effect moves world state toward the desired (domain, path).
-          // Candidates are sorted by confidence desc (Arc 6 tiebreak: cost).
+          // Arc 6.4: rank by observed cost/confidence once we have samples;
+          // fall back to the card-declared confidence on cold start.
           const { domain, path } = violation.desiredEffect;
-          const candidates = executorRegistry
-            .resolveByEffect({ domain, path })
-            .sort((a, b) => b.confidence - a.confidence);
+          const candidates = rankByObservedMetrics(
+            executorRegistry.resolveByEffect({ domain, path }),
+            this._rankingContext(),
+          );
           matchingActions = candidates.map((reg) =>
             this.synthesizeActionFromEffect(reg, violation.goalId, domain, path)
           );
@@ -218,6 +234,16 @@ export class PlannerPluginL0 implements Plugin {
   /** Expose cooldown manager for introspection. */
   getCooldownManager(): CooldownManager {
     return this.cooldownManager;
+  }
+
+  /** Build the lookup functions the ranker uses to query observed metrics. */
+  private _rankingContext(): RankContext {
+    const costStore = this.pluginConfig.costStore ?? defaultCostStore;
+    const confidenceStore = this.pluginConfig.confidenceStore ?? defaultConfidenceStore;
+    return {
+      costSummary: (agentName, skill) => costStore.summary(agentName, skill),
+      confidenceSummary: (agentName, skill) => confidenceStore.summary(agentName, skill),
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes the feedback loop started in #265. Extensions (\`cost-v1\`, \`confidence-v1\`) have been populating their observation stores on every A2A call, but the planner was still sorting candidates by the agent's self-declared card confidence only. This PR layers observed metrics on top so the planner picks winners based on what actually happened, not what agents advertise about themselves.

## Scoring model

\`\`\`
warm (>= 5 samples):
  score = 2.0 * observedSuccessRate
        + 0.5 * avgConfidenceOnSuccess
        - 0.3 * clamp(avgWallMs / 60_000, 0, 2)

cold:
  score = reg.confidence   // card's own prior
\`\`\`

Stable tiebreak on card confidence so identical scores produce deterministic order.

## Design intent

Observed data dominates priors once warm — a card advertising 0.9 with no supporting observations won't outrank a skill with 10 runs at 50% success. Real samples win. Test \`sorts descending by score — warm data dominates cold priors\` documents this explicitly.

## Files

- **\`src/planner/candidate-ranking.ts\`** (new) — pure function, no plugin/bus deps, testable in isolation
- **\`src/plugins/planner-plugin-l0.ts\`** — swaps the \`.sort((a,b) => b.confidence - a.confidence)\` in the effect-based path for \`rankByObservedMetrics\`. Adds \`costStore\` / \`confidenceStore\` config overrides defaulting to extension singletons.
- **\`src/planner/__tests__/candidate-ranking.test.ts\`** (new) — 10 unit tests covering cold/warm crossover, wall-time penalty, confidence boost, no-agentName fallback, tiebreak, immutability.

## Verification

- \`bun test\` — 856/856 pass (10 new in ranking + 15 planner-l0 still green)
- \`bun run typecheck\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)