### PR TITLE
docs: README + extensions + self-improving-loop explainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # protoWorkstacean
 
-Homeostatic agent orchestration platform. Monitors world state, evaluates goals, and drives the protoLabs agent fleet — the protoMaker team, Quinn, Ava, Jon, Frank — to close deviations continuously and autonomously.
+Homeostatic agent orchestration platform. Monitors world state, evaluates goals, and drives the protoLabs agent fleet — **Ava** (chief-of-staff), **protoBot** (Discord infrastructure: channels, categories, webhooks), **Quinn** (QA/PR review), **Researcher** (deep research), **Jon** (content strategy), **protoPen** (security/pentest), plus the protoMaker team — to close deviations continuously and autonomously.
+
+The loop observes skill execution through A2A extensions, writes episodic memory to Graphiti, and ranks future candidates by observed cost/confidence — so the planner gets better the more it runs. See [docs/explanation/self-improving-loop.md](docs/explanation/self-improving-loop.md).
 
 ---
 
@@ -45,6 +47,8 @@ bun run src/index.ts
 | `AVA_API_KEY` | For domain polling | protoMaker team API key (`X-API-Key`) |
 | `WORKSTACEAN_HTTP_PORT` | No | HTTP API port (default: `3000`) |
 | `WORKSTACEAN_API_KEY` | No | API key for `/publish` endpoint |
+| `WORKSTACEAN_BASE_URL` | For A2A push notifications | Externally-reachable URL of the workstacean API (e.g. `http://ava:8081`). Stamped into push-notification callback URLs registered with remote A2A agents that advertise `capabilities.pushNotifications: true`. Unset → silently falls back to task polling. |
+| `GRAPHITI_URL` | For memory enrichment | Base URL of the Graphiti knowledge-graph service (default: `http://graphiti:8000`). Skill dispatcher pulls `<recalled_memory>` context before every user-originated skill call and writes episodic memory on success. |
 | `ANTHROPIC_API_KEY` | For in-process agents | Claude API key |
 
 Full list: see `.env.dist`.
@@ -139,14 +143,17 @@ Every bus message carries `correlationId` (trace-id, never changes) and `parentI
 | `workspace/goals.yaml` | GOAP goal definitions | yes |
 | `workspace/actions.yaml` | GOAP action rules (workstacean-level) | yes |
 | `workspace/ceremonies/*.yaml` | Ceremony schedules + skill routing | yes |
-| `workspace/agents/*.yaml` | In-process agent definitions | gitignored |
-| `workspace/agents.yaml` | External A2A agent registry | gitignored |
+| `workspace/agents/*.yaml` | In-process agent definitions (ava, protobot) | yes |
+| `workspace/agents.yaml` | External A2A agent registry (quinn, researcher, jon, protopen) | yes |
+| `workspace/channels.yaml` | Communication channel registry | yes |
 | `workspace/projects.yaml` | Project registry + domain discovery source | gitignored |
 | `workspace/domains.yaml` | Local domain registrations (optional) | gitignored |
-| `workspace/discord.yaml` | Discord bot config | gitignored |
+| `workspace/discord.yaml` | Discord bot config (env var names, channel IDs) | gitignored |
 | `workspace/incidents.yaml` | Live security incident state | gitignored |
 
-Copy `*.example` counterparts to bootstrap a new deployment.
+Agent and channel definitions are shared schema — no secrets live there (only env var *names* for bot tokens and API keys). The actual credentials come from Infisical at container start. Per-environment overrides can ship through `PROTOLABS_AGENTS_JSON` without editing files.
+
+Copy `*.example` counterparts where they exist to bootstrap a new deployment.
 
 ---
 
@@ -181,7 +188,14 @@ protoWorkstacean is a first-class [A2A](https://a2a-protocol.org) client **and**
 - **Client** — `A2AExecutor` speaks the full A2A v0.3 protocol: `message/send`, `message/stream`, `tasks/get`, `tasks/cancel`, `tasks/resubscribe`, push notifications, artifact chunking, and native `input-required` HITL.
 - **Server** — workstacean exposes `/.well-known/agent-card.json` + `POST /a2a` so external agents can call it. Incoming calls bridge through the bus and back via `BusAgentExecutor`.
 - **Auth** — per-agent structured auth config in `workspace/agents.yaml` (apiKey / bearer / hmac schemes).
-- **Extensions** — `ExtensionRegistry` scaffolding for opt-in A2A extensions; no extensions shipped by default.
+- **Push notifications** — when a remote agent advertises `capabilities.pushNotifications: true` (e.g. protoPen), the dispatcher registers a webhook at `{WORKSTACEAN_BASE_URL}/api/a2a/callback/{taskId}` with a per-task HMAC-unguessable bearer token. On task state changes the agent POSTs the Task snapshot and the tracker routes it to the original reply topic. Falls back to polling when the agent doesn't advertise push.
+- **Extensions** — `ExtensionRegistry` runs before/after interceptors on every A2A call. Shipped by default:
+  - [`cost-v1`](docs/extensions/cost-v1.md) — records per-(agent, skill) token + wall-time actuals, publishes `autonomous.cost.*`
+  - [`confidence-v1`](docs/extensions/confidence-v1.md) — captures agent-reported confidence (0.0–1.0), flags high-confidence failures
+  - [`effect-domain-v1`](docs/extensions/effect-domain-v1.md) — parses worldstate-delta artifacts, publishes `world.state.delta`
+  - [`worldstate-delta-v1`](docs/extensions/worldstate-delta-v1.md) — DataPart content type for observed domain mutations
+
+  Observations from cost-v1 + confidence-v1 feed `PlannerPluginL0`'s candidate ranking ([Arc 6.4](docs/explanation/self-improving-loop.md)): once a candidate has ≥5 samples the planner ranks by observed success rate × confidence × wall-time penalty; cold candidates fall back to the card's self-declared confidence.
 
 See [`docs/guides/add-an-agent.md`](docs/guides/add-an-agent.md) for the full agent-onboarding flow.
 

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -10,6 +10,7 @@ These docs explain the *why* behind protoWorkstacean's architecture. Read them w
 |----------|-----------------|
 | [Executor layer](../integrations/runtimes/) | Why the executor layer exists, how resolution works, the registrar pattern, and why `SkillDispatcherPlugin` is the sole `agent.skill.request` subscriber |
 | [World engine](./world-engine) | Why `WorldState` is a generic record, the GOAP loop design, domain discovery rationale |
+| [Self-improving loop](./self-improving-loop) | How A2A extensions feed observations into `PlannerPluginL0`'s candidate ranking, how episodic memory writes to Graphiti, and why the convergence loops don't diverge |
 | [Distributed tracing](./distributed-tracing) | How `correlationId` (trace-id) and `parentId` (span-id) flow from the bus through RouterPlugin, A2AExecutor, external agents (protoMaker team, Quinn), and back |
 | [Plugin system](./plugin-system) | The plugin lifecycle, core vs integration vs workspace plugins, ordering guarantees |
 

--- a/docs/explanation/self-improving-loop.md
+++ b/docs/explanation/self-improving-loop.md
@@ -1,0 +1,167 @@
+---
+title: The self-improving loop
+---
+
+protoWorkstacean's GOAP loop doesn't just react to world state — it learns from every dispatch and uses that history to make future decisions. This page explains how observations flow from A2A extensions into the planner's candidate ranking, where the learning is lossy on purpose, and what's still ahead.
+
+---
+
+## The pipeline
+
+```
+world state change
+   │
+   ▼
+┌─────────────────────┐
+│ WorldStateEngine    │  polls HTTP domains, publishes world.state.updated
+└─────────────────────┘
+   │
+   ▼
+┌─────────────────────┐
+│ GoalEvaluatorPlugin │  evaluates workspace/goals.yaml → world.goal.violated
+└─────────────────────┘
+   │
+   ▼
+┌─────────────────────┐
+│ PlannerPluginL0     │  selects candidate skills via ExecutorRegistry.resolveByEffect
+│   ├─ ranks by:      │  Arc 6.4 ranking (this page's focus)
+│   │   - observed    │
+│   │     success     │  ←──── cost-v1 extension populates CostStore
+│   │   - observed    │
+│   │     confidence  │  ←──── confidence-v1 extension populates ConfidenceStore
+│   │   - wall-time   │
+│   └─ cold fallback: │
+│     card confidence │
+└─────────────────────┘
+   │
+   ▼
+┌─────────────────────┐
+│ ActionDispatcher    │  publishes agent.skill.request with systemActor="goap"
+└─────────────────────┘
+   │
+   ▼
+┌─────────────────────┐
+│ SkillDispatcher     │  resolves executor → A2AExecutor.execute
+│                     │  writes system_goap episodic memory to Graphiti
+└─────────────────────┘
+   │
+   ▼
+┌─────────────────────┐
+│ A2AExecutor         │  runs extension before/after interceptors around the RPC
+│   before hooks:     │    - cost-v1 stamps x-cost-skill metadata
+│                     │    - confidence-v1 stamps x-confidence-skill
+│                     │    - effect-domain-v1 stamps x-effect-domain-skill
+│   after hooks:      │    - cost-v1 records tokens + wall-time → CostStore
+│                     │    - confidence-v1 records self-assessment → ConfidenceStore
+│                     │    - effect-domain-v1 publishes world.state.delta
+└─────────────────────┘
+   │
+   ▼
+┌─────────────────────┐
+│ autonomous.outcome  │  ActionDispatcher publishes terminal outcome on
+│   .goap.{skill}     │  autonomous.outcome.goap.{skill}
+└─────────────────────┘
+   │
+   ├──▶ PlannerPluginL0: records in LoopDetector, sets success cooldown
+   ├──▶ OutcomeAnalysisPlugin: aggregates per-skill stats, alerts on chronic failure
+   └──▶ Dashboard / external subscribers: fleet cost view
+```
+
+The next `world.goal.violated` for the same goal will land on a planner that's updated both its loop-detection history AND the candidate stores — so the ranking reflects what just happened.
+
+---
+
+## Arc 6.4 — how observations beat priors
+
+Before Arc 6.4, `PlannerPluginL0.resolveByEffect` ranked candidates purely by `reg.confidence` — the confidence each agent declares about itself in its `effect-domain-v1` card block. That's fine as a cold-start prior, but ignores every signal we've actually collected.
+
+The ranking module (`src/planner/candidate-ranking.ts`) replaces that sort with:
+
+```ts
+warm (>= 5 samples):
+  score = 2.0 * cost.successRate
+        + 0.5 * confidence.avgConfidenceOnSuccess
+        - 0.3 * clamp(cost.avgWallMs / 60_000, 0, 2)
+
+cold:
+  score = reg.confidence   // card's own prior
+```
+
+The design intent is **observed data dominates priors once warm**. A card advertising 0.9 confidence with no supporting observations won't outrank a skill with 10 runs at 50% success — real samples win. This is deliberate: it means new agents that over-promise in their card are quickly corrected by the world, and agents that correctly hedge keep their ranking.
+
+### Cold-start handling
+
+The `MIN_SAMPLES_FOR_TRUST` constant (default: 5) draws the cold/warm boundary. Below 5 samples, an agent's self-declared confidence is all we have, so we use it directly. Once warm, observations take over completely — there's no blended regime because it makes the ranking harder to reason about for little gain. Testing regressions this way is also straightforward: a single `sampleCount` threshold.
+
+### Stable tiebreak
+
+When two candidates score identically (common in the cold regime with matching card confidences) the sort tiebreaks on `reg.confidence` descending. Identical inputs produce identical ordering — deterministic enough to test.
+
+---
+
+## What each extension contributes
+
+| Extension | Reads from response | Writes to | Consumer |
+|---|---|---|---|
+| [`cost-v1`](../extensions/cost-v1.md) | `result.data.usage`, `durationMs`, `costUsd`, `success` | `defaultCostStore` + `autonomous.cost.*` topic | Planner ranking, dashboard, `OutcomeAnalysis` action-quality alerts |
+| [`confidence-v1`](../extensions/confidence-v1.md) | `result.data.confidence`, `confidenceExplanation`, `success` | `defaultConfidenceStore` + `autonomous.confidence.*` topic | Planner ranking, calibration dashboard |
+| [`effect-domain-v1`](../extensions/effect-domain-v1.md) | `worldstate-delta-v1` artifact DataPart | `world.state.delta` bus event | `WorldStateEngine` applies deltas, planner sees fresh state faster |
+
+All three interceptors are registered once at startup (`src/index.ts`) and fire on every A2A dispatch regardless of whether the agent's card opts in — they self-gate by checking for their expected response fields. Agents that don't implement an extension just produce no samples; agents that do get their samples counted. No config change needed on either side when a new agent joins the fleet.
+
+---
+
+## Episodic memory — the parallel track
+
+Observations aren't the only thing captured on each dispatch. `SkillDispatcherPlugin` also writes a Graphiti episode for every successful skill completion:
+
+- **Human-originated** dispatches write to two groups: `user_{platform}_{userId}` (shared across agents — the user's common memory) and `agent_{agentName}__{user_...}` (this specific agent's relationship with this user).
+- **Bot-originated** dispatches (`meta.systemActor` set, e.g. `"goap"`) write to a single `system_{actor}` group — the autonomous loop's own episodic log of what it did.
+
+On the next turn, before the skill fires, the dispatcher reads back a `<recalled_memory>` block from Graphiti and injects it into the prompt. Ava and protoBot's system prompts explicitly tell them what the block is ("trusted background — prior commitments, workflow preferences, past provisioning decisions") so they use it silently.
+
+The loop's episodic track gives the autonomous system its own long memory: it knows what it has tried, what worked, who the user is. Combined with the ranking track, future dispatches are informed both by aggregate statistics (the stores) and specific context (the graph).
+
+---
+
+## Why the loops don't diverge
+
+An earlier attempt to close `outcome → state` by republishing `world.state.updated` after each outcome caused infinite re-dispatch: the optimistic effects hadn't caught up to real domain state, so the goal was still violated, and the planner fired again. We disabled that re-publish (see `action-dispatcher-plugin.ts:330`) and now rely on two guards:
+
+1. **In-flight tracking** — `PlannerPluginL0.inFlightGoals` prevents a second dispatch for the same goal while one is running.
+2. **Post-success cooldown** — after a successful outcome with real effects, the planner sets a 90-second cooldown so the next real domain poll has time to confirm the change before the goal is re-evaluated.
+
+`world.state.delta` (from `effect-domain-v1`) is a more precise path forward: agents declare the exact mutation they made, `WorldStateEngine` applies it in-process, and the planner sees fresh state without waiting for the next poll or risking optimistic-effect drift. That path exists today but isn't the primary convergence mechanism yet.
+
+---
+
+## What's still ahead
+
+- **Ranking tiebreakers beyond Arc 6.4** — blast radius (cost-v1's `highConfFailures` companion in `confidence-v1`), per-user context (Graphiti memory as a ranking signal), recency decay on old samples
+- **Durable cost/confidence stores** — current stores are in-memory with 200-sample rolling windows; a SQLite-backed store would let rankings survive restarts and feed historical dashboards
+- **Learned policy replacing the hand-tuned weights** — the 2.0 / 0.5 / 0.3 coefficients are intuitive but not optimal. Once the observation stream is persistent, a bandit or Q-learner can pick weights that minimize regret on the goal-violated → dispatched pair
+- **Memory-health remediation actions** — `memory.graphiti_healthy` + `memory.search_working` goals evaluate correctly but have no registered action. Graphiti going dark today causes silent degradation rather than an alert + restart
+
+---
+
+## Seeing it in action
+
+```bash
+# Watch observation events
+docker logs workstacean -f 2>&1 | grep -E "autonomous\.(cost|confidence|outcome)"
+
+# Fleet cost summary via the bus
+curl -s http://localhost:8081/api/world-state | jq '.domains.flow.data.costs'
+
+# Current planner ranking for a goal (no dedicated endpoint yet —
+# inspect LoopDetector / cooldown state via planner introspection in tests)
+bun test src/planner/__tests__/candidate-ranking.test.ts
+
+# Verify extension interceptors fire by chatting with an A2A agent
+curl -s -X POST http://localhost:8081/api/a2a/chat \
+  -H "Content-Type: application/json" \
+  -d '{"agent":"quinn","skill":"pr_review","message":"Review the open queue briefly"}' \
+| jq .data
+```
+
+After the call, the cost + confidence topics will have fired. A few more calls populate the store; the 6th dispatch and beyond will use observation-weighted ranking for quinn's `pr_review` skill.

--- a/docs/extensions/confidence-v1.md
+++ b/docs/extensions/confidence-v1.md
@@ -1,0 +1,124 @@
+---
+title: "Extension: x-protolabs/confidence-v1"
+---
+
+`x-protolabs/confidence-v1` captures the agent's self-reported confidence in its output so OutcomeAnalysis can weight failure signals by how sure the agent was, and the planner can prefer high-confidence candidates when ranking.
+
+**Extension URI**: `https://protolabs.ai/a2a/ext/confidence-v1`
+
+---
+
+## Why observed confidence matters
+
+A high-confidence failure is a stronger signal than a low-confidence one. A low-confidence success shouldn't get the same weight as a high-confidence success in aggregate quality metrics. Without this signal, every success and failure counts equally — masking agents that are lucky at low confidence and flagging agents that correctly hedge.
+
+The companion metric `highConfFailures` tracks calibration drift: if an agent routinely reports 0.95 confidence on outputs that fail, their self-assessment is miscalibrated and should be down-weighted independently.
+
+---
+
+## Interceptor behavior
+
+Registered in `src/index.ts` at startup:
+
+```ts
+import { registerConfidenceExtension } from "./executor/extensions/confidence.ts";
+registerConfidenceExtension(bus);
+```
+
+`A2AExecutor.execute()` runs the interceptor before and after every outbound call:
+
+**before** — stamps `x-confidence-skill: <skill>` onto outbound JSON-RPC metadata. This gives the agent an explicit handle to attach a confidence score in its terminal message.
+
+**after** — reads `result.data.confidence` (a number in `[0, 1]`) and optional `result.data.confidenceExplanation`. If `confidence` isn't set the interceptor no-ops (agents that don't support the extension produce no samples). Values are clamped defensively — a badly-formatted `1.2` or `-0.1` won't poison the store.
+
+Records a `ConfidenceSample` to `defaultConfidenceStore` and publishes `autonomous.confidence.{systemActor}.{skill}`.
+
+---
+
+## Sample shape
+
+```ts
+interface ConfidenceSample {
+  systemActor: string;
+  agentName: string;
+  skill: string;
+  confidence: number;        // 0.0 - 1.0
+  explanation?: string;
+  success: boolean;          // from result.data.success
+  completedAt: number;
+  correlationId: string;
+}
+```
+
+---
+
+## Store API
+
+`ConfidenceStore` keeps the last 200 samples per `${agentName}::${skill}` key. Exposed via `defaultConfidenceStore`:
+
+```ts
+const summary = defaultConfidenceStore.summary("quinn", "pr_review");
+// {
+//   agentName: "quinn",
+//   skill: "pr_review",
+//   sampleCount: 18,
+//   avgConfidence: 0.87,
+//   avgConfidenceOnSuccess: 0.91,
+//   avgConfidenceOnFailure: 0.62,
+//   highConfFailures: 2       // calibration warning: ≥ 0.8 confidence but task failed
+// }
+```
+
+`highConfFailures` counts samples where `confidence >= 0.8` but `success === false`. A rising count is a signal the agent's self-assessment is overconfident and its priors should be discounted.
+
+---
+
+## Agent response contract
+
+An agent participating in confidence-v1 sets these fields on the terminal message's `data` part:
+
+```json
+{
+  "kind": "data",
+  "data": {
+    "confidence": 0.82,
+    "confidenceExplanation": "Spec was ambiguous on edge case; chose the conservative interpretation.",
+    "success": true
+  }
+}
+```
+
+Agents that don't implement the extension return normal A2A responses — the interceptor simply skips sample recording for them.
+
+---
+
+## Planner integration
+
+`PlannerPluginL0` reads `defaultConfidenceStore` alongside `defaultCostStore` when ranking effect-based candidates:
+
+```
+score (warm) = 2.0 * cost.successRate
+             + 0.5 * confidence.avgConfidenceOnSuccess
+             - 0.3 * clamp(cost.avgWallMs / 60_000, 0, 2)
+```
+
+`avgConfidenceOnSuccess` specifically (not overall average) is used — it answers "when this agent succeeds at this skill, how sure is it?" which is the right question for ranking future candidates.
+
+See [`self-improving-loop.md`](../explanation/self-improving-loop.md) for the full flow.
+
+---
+
+## Bus topic
+
+```
+autonomous.confidence.{systemActor}.{skill}
+```
+
+Payload is the raw `ConfidenceSample`. Subscribers: dashboard calibration view, OutcomeAnalysis (elevating high-confidence-failure clusters), external telemetry collectors.
+
+---
+
+## Related
+
+- [`cost-v1`](cost-v1.md) — companion metric; planner reads both together
+- [`effect-domain-v1`](effect-domain-v1.md) — card-side declaration of effects; observed confidence overrides the declared prior once warm

--- a/docs/extensions/cost-v1.md
+++ b/docs/extensions/cost-v1.md
@@ -1,0 +1,113 @@
+---
+title: "Extension: x-protolabs/cost-v1"
+---
+
+`x-protolabs/cost-v1` records per-(agent, skill) token + wall-time actuals for every A2A dispatch, feeds a rolling in-memory store, and publishes `autonomous.cost.*` observability events. The planner reads from the store to rank candidate skills by observed success rate + cost-per-call.
+
+**Extension URI**: `https://protolabs.ai/a2a/ext/cost-v1`
+
+---
+
+## Purpose
+
+Two signals the planner needs but couldn't get from the agent card alone:
+
+- **Success rate** — how often this (agent, skill) combination actually succeeds, independent of the agent's self-declared confidence
+- **Wall-time cost** — how long a call takes end-to-end, including retries and HITL round-trips
+
+Without observations, the planner falls back to the card's confidence field (what the agent claims about itself). cost-v1 replaces self-advertisement with measurement once ≥ 5 samples exist per key.
+
+---
+
+## Interceptor behavior
+
+Registered in `src/index.ts` at startup:
+
+```ts
+import { registerCostExtension } from "./executor/extensions/cost.ts";
+registerCostExtension(bus);
+```
+
+`A2AExecutor.execute()` runs the interceptor before and after every outbound call:
+
+**before** — stamps `x-cost-skill: <skill>` onto outbound JSON-RPC metadata so the agent can correlate cost advertisements with invocations.
+
+**after** — reads `result.data.usage` (A2A SDK surfaces Anthropic-shaped `{input_tokens, output_tokens, cache_*}`) plus `result.data.durationMs` and `result.data.costUsd`. Records a `CostSample` to `defaultCostStore` and publishes `autonomous.cost.{systemActor}.{skill}` on the bus.
+
+The interceptor self-gates: if the response lacks `usage` fields the sample records wall-time only, and no publish is suppressed — dashboards can observe what's available.
+
+---
+
+## Sample shape
+
+```ts
+interface CostSample {
+  systemActor: string;      // "user" | "goap" | "ceremony:<id>" | ...
+  agentName: string;
+  skill: string;
+  tokensIn?: number;
+  tokensOut?: number;
+  wallMs: number;
+  costUsd?: number;
+  success: boolean;
+  completedAt: number;      // ms epoch
+  correlationId: string;
+}
+```
+
+---
+
+## Store API
+
+`CostStore` keeps the last 200 samples per `${agentName}::${skill}` key (in-memory, rolling). Exposed via `defaultCostStore`:
+
+```ts
+const summary = defaultCostStore.summary("quinn", "pr_review");
+// {
+//   agentName: "quinn",
+//   skill: "pr_review",
+//   sampleCount: 23,
+//   avgTokensIn: 8520,
+//   avgTokensOut: 1204,
+//   avgWallMs: 14_230,
+//   avgCostUsd: 0.024,
+//   successRate: 0.96
+// }
+```
+
+`allSummaries()` returns one entry per (agent, skill) pair seen — drives the fleet cost-per-outcome dashboard view.
+
+**Intentionally in-memory.** Cost tracking here is observational telemetry, not billing. A durable persistence layer can subscribe to `autonomous.cost.#` and ingest samples independently.
+
+---
+
+## Planner integration
+
+`PlannerPluginL0` queries `defaultCostStore` when ranking candidates for effect-based dispatch:
+
+- ≥ 5 samples → warm: sort by `2.0 * successRate + 0.5 * avgConfidenceOnSuccess − 0.3 * clamp(avgWallMs / 60_000, 0, 2)`
+- \< 5 samples → cold: fall back to card-declared confidence
+
+See [`self-improving-loop.md`](../explanation/self-improving-loop.md) for the full observation → ranking flow.
+
+---
+
+## Bus topic
+
+```
+autonomous.cost.{systemActor}.{skill}
+```
+
+Payload is the raw `CostSample` above. Used for:
+
+- Dashboard fleet cost view
+- OutcomeAnalysis alerting (`ops.alert.action_quality` when success rate drops below 50% after 10+ attempts)
+- External collectors / billing systems that subscribe to `autonomous.cost.#`
+
+---
+
+## Related
+
+- [`confidence-v1`](confidence-v1.md) — companion extension for agent-reported confidence, read alongside cost in the same planner ranking
+- [`effect-domain-v1`](effect-domain-v1.md) — card-side effect declarations; Arc 6.4 ranking layers observed cost/confidence on top
+- [`worldstate-delta-v1`](worldstate-delta-v1.md) — artifact format for observed mutations

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -11,6 +11,7 @@ All environment variables recognised by protoWorkstacean, their defaults, and wh
 | `WORKSTACEAN_HTTP_PORT` | `3000` | HTTP server | Port the HTTP API listens on |
 | `WORKSTACEAN_API_KEY` | _(none)_ | HTTP server | API key required for authenticated endpoints. If unset, auth is skipped. |
 | `WORKSTACEAN_PUBLIC_URL` | _(none)_ | HTTP server | Public base URL (used for webhook registration and self-links) |
+| `WORKSTACEAN_BASE_URL` | _(none)_ | SkillDispatcherPlugin | Externally-reachable base URL for A2A push-notification callbacks (e.g. `http://ava:8081`). When an agent card advertises `capabilities.pushNotifications: true`, the dispatcher registers `{WORKSTACEAN_BASE_URL}/api/a2a/callback/{taskId}` with a per-task bearer token. If unset, push-notification registration is silently skipped and long tasks fall back to polling via `TaskTracker`. |
 | `WORKSPACE_DIR` | `./workspace` | All loaders | Path to the workspace directory containing agent, goal, action, ceremony, and domain YAML files |
 | `PROTOLABS_AGENTS_JSON` | _(none)_ | SkillBrokerPlugin | If set, overrides `workspace/agents.yaml`. Expected shape: `{ "agents": [ { name, url, auth, ... } ] }`. Intended for Infisical-backed deployments where pushing a yaml file to every host is inconvenient — ship the whole registry through a single secret instead. |
 | `DATA_DIR` | `./data` | LoggerPlugin, SQLite | Directory for the SQLite event log (`events.db`) |


### PR DESCRIPTION
Brings docs into line with what shipped this wave:

## Changes

- **README**:
  - Agent roster explicitly lists protoBot + its Discord-infra role (channels / categories / webhooks)
  - Workspace config table: \`workspace/agents.yaml\` and \`workspace/agents/*.yaml\` marked tracked (were labelled gitignored — untrue since the earlier agents-tracking fix)
  - Adds \`WORKSTACEAN_BASE_URL\` and \`GRAPHITI_URL\` to the env var table
  - A2A section lists the three extensions that ship by default (cost-v1, confidence-v1, effect-domain-v1) with links to their reference docs, and the push-notification callback wiring

- **\`docs/extensions/cost-v1.md\`** (new): interceptor behavior, sample shape, store API, planner integration, bus topic, cross-refs
- **\`docs/extensions/confidence-v1.md\`** (new): calibration framing, sample shape, agent response contract, planner integration
- **\`docs/explanation/self-improving-loop.md\`** (new): full observation → ranking → episodic-memory pipeline, Arc 6.4 scoring model, why convergence loops don't diverge, what's still ahead. Diagrammed ASCII art of the flow. Answers the \"how does this actually learn\" question without making readers grep source.
- **\`docs/explanation/index.md\`**: links to the new explainer
- **\`docs/reference/env-vars.md\`**: adds \`WORKSTACEAN_BASE_URL\` entry

No code changes. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the self-improving loop, detailing how A2A extensions feed observations for candidate ranking and episodic memory integration with Graphiti.
  * Documented four A2A extensions (`cost-v1`, `confidence-v1`, `effect-domain-v1`, `worldstate-delta-v1`) enabling observability and planner ranking optimization.
  * Added environment variables: `WORKSTACEAN_BASE_URL` for push-notification callbacks and `GRAPHITI_URL` for memory enrichment.
  * Updated README with fleet agent information, deployment configuration guidance, and expanded A2A protocol support details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->