### PR TITLE
feat: [Arc 9.2] Ava goal_proposal skill

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -327,6 +327,16 @@ const pluginRegistry: PluginRegistryEntry[] = [
       return new OutcomeAnalysisPlugin();
     },
   },
+  {
+    // Captures goal_proposal results from Ava, gates on HITL approval, then
+    // appends the approved entry to workspace/goals.yaml and triggers reload.
+    name: "goal-hot-reload",
+    condition: () => true,
+    factory: async () => {
+      const { GoalHotReloadPlugin } = await import("./plugins/goal-hot-reload-plugin.js");
+      return new GoalHotReloadPlugin(workspaceDir);
+    },
+  },
   // Built-ins: opt-in via ENABLED_PLUGINS=echo,...
   {
     name: "echo",

--- a/src/plugins/goal-hot-reload-plugin.ts
+++ b/src/plugins/goal-hot-reload-plugin.ts
@@ -1,0 +1,226 @@
+/**
+ * GoalHotReloadPlugin — the adaptive half of the growth loop.
+ *
+ * Listens for completed goal_proposal skill executions, presents the
+ * proposed goals.yaml entry to a human via the HITL gate, and on
+ * approval appends the entry to workspace/goals.yaml then publishes
+ * goals.reload so GoalEvaluatorPlugin picks it up without a restart.
+ *
+ * Flow:
+ *   1. agent.skill.request { skill: 'goal_proposal' }
+ *      → GoalHotReloadPlugin notes the correlationId
+ *   2. agent.skill.response.{correlationId} arrives with Ava's proposed YAML
+ *      → plugin raises hitl.request.{correlationId} for human review
+ *   3. hitl.response.{correlationId} arrives with decision "approve"
+ *      → plugin extracts the YAML block, appends to goals.yaml, publishes goals.reload
+ *
+ * Inbound:
+ *   agent.skill.request          — detect goal_proposal requests
+ *   agent.skill.response.#       — capture Ava's proposed YAML text
+ *   hitl.response.#              — receive human decision
+ *
+ * Outbound:
+ *   hitl.request.{correlationId} — HITL approval gate
+ *   goals.reload                 — trigger GoalEvaluatorPlugin to re-read goals.yaml
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import type { Plugin, EventBus, BusMessage, HITLRequest, HITLResponse } from "../../lib/types.ts";
+import type { AgentSkillRequestPayload } from "../event-bus/payloads.ts";
+import type { AgentSkillResponsePayload } from "../event-bus/payloads.ts";
+
+const HITL_TTL_MS = 30 * 60_000; // 30 min window for human review
+
+export class GoalHotReloadPlugin implements Plugin {
+  readonly name = "goal-hot-reload";
+  readonly description = "Captures goal_proposal results, gates on HITL approval, appends to goals.yaml on approve";
+  readonly capabilities = ["goal-hot-reload"];
+
+  private bus?: EventBus;
+  private readonly subscriptionIds: string[] = [];
+
+  /**
+   * correlationIds of in-flight goal_proposal skill requests.
+   * Populated on agent.skill.request, consumed on agent.skill.response.
+   */
+  private readonly pendingProposals = new Set<string>();
+
+  /**
+   * Proposed YAML content keyed by correlationId — stored between the
+   * skill response arriving and the HITL decision returning.
+   */
+  private readonly pendingApprovals = new Map<string, string>();
+
+  constructor(private readonly workspaceDir: string) {}
+
+  install(bus: EventBus): void {
+    this.bus = bus;
+
+    // 1. Track goal_proposal skill requests
+    this.subscriptionIds.push(
+      bus.subscribe("agent.skill.request", this.name, (msg: BusMessage) => {
+        const payload = msg.payload as AgentSkillRequestPayload | undefined;
+        if (payload?.skill !== "goal_proposal") return;
+        this.pendingProposals.add(msg.correlationId);
+        console.log(
+          `[goal-hot-reload] Tracking goal_proposal request (${msg.correlationId.slice(0, 8)}…)`,
+        );
+      }),
+    );
+
+    // 2. Capture the skill response and raise HITL
+    this.subscriptionIds.push(
+      bus.subscribe("agent.skill.response.#", this.name, (msg: BusMessage) => {
+        const payload = msg.payload as AgentSkillResponsePayload | undefined;
+        const correlationId = payload?.correlationId ?? msg.correlationId;
+        if (!this.pendingProposals.has(correlationId)) return;
+        this.pendingProposals.delete(correlationId);
+
+        const content = payload?.content;
+        if (!content) {
+          console.warn(
+            `[goal-hot-reload] goal_proposal (${correlationId.slice(0, 8)}…) returned empty — skipping HITL`,
+          );
+          return;
+        }
+
+        // Extract the fenced YAML block from Ava's response
+        const yamlBlock = this._extractYamlBlock(content);
+        if (!yamlBlock) {
+          console.warn(
+            `[goal-hot-reload] goal_proposal (${correlationId.slice(0, 8)}…) contained no YAML block — skipping HITL`,
+          );
+          return;
+        }
+
+        this.pendingApprovals.set(correlationId, yamlBlock);
+        this._raiseHitl(correlationId, content);
+      }),
+    );
+
+    // 3. Handle human decision
+    this.subscriptionIds.push(
+      bus.subscribe("hitl.response.#", this.name, (msg: BusMessage) => {
+        const resp = msg.payload as HITLResponse | undefined;
+        if (resp?.type !== "hitl_response") return;
+        const yamlBlock = this.pendingApprovals.get(resp.correlationId);
+        if (!yamlBlock) return; // not a goal_proposal approval
+
+        this.pendingApprovals.delete(resp.correlationId);
+
+        if (resp.decision !== "approve") {
+          console.log(
+            `[goal-hot-reload] Goal proposal (${resp.correlationId.slice(0, 8)}…) ${resp.decision}d — not writing`,
+          );
+          return;
+        }
+
+        try {
+          this._appendGoal(yamlBlock, resp.feedback);
+          console.log(
+            `[goal-hot-reload] Goal proposal approved by ${resp.decidedBy} — appended to goals.yaml, publishing goals.reload`,
+          );
+          this._publishReload();
+        } catch (err) {
+          console.error("[goal-hot-reload] Failed to append goal to goals.yaml:", err);
+        }
+      }),
+    );
+
+    console.log("[goal-hot-reload] Installed");
+  }
+
+  uninstall(): void {
+    if (this.bus) {
+      for (const id of this.subscriptionIds) {
+        this.bus.unsubscribe(id);
+      }
+    }
+    this.subscriptionIds.length = 0;
+    this.pendingProposals.clear();
+    this.pendingApprovals.clear();
+    this.bus = undefined;
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────────────────
+
+  /**
+   * Extract the first fenced ```yaml block from Ava's response text.
+   * Returns the content inside the fence (without the ``` lines).
+   */
+  private _extractYamlBlock(text: string): string | undefined {
+    const match = text.match(/```ya?ml\n([\s\S]*?)```/);
+    return match?.[1]?.trim();
+  }
+
+  /**
+   * Raise a HITL request so the human can review and approve/reject the proposed goal.
+   */
+  private _raiseHitl(correlationId: string, fullResponse: string): void {
+    if (!this.bus) return;
+
+    const req: HITLRequest = {
+      type: "hitl_request",
+      correlationId,
+      title: "New goal proposed by Ava — review and approve?",
+      summary: fullResponse,
+      options: ["approve", "reject"],
+      expiresAt: new Date(Date.now() + HITL_TTL_MS).toISOString(),
+      replyTopic: `hitl.response.${correlationId}`,
+      sourceMeta: {
+        interface: "discord",
+      },
+    };
+
+    this.bus.publish(`hitl.request.${correlationId}`, {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic: `hitl.request.${correlationId}`,
+      timestamp: Date.now(),
+      payload: req,
+    });
+
+    console.log(
+      `[goal-hot-reload] Raised HITL review for goal_proposal (${correlationId.slice(0, 8)}…)`,
+    );
+  }
+
+  /**
+   * Append the proposed goal entry to workspace/goals.yaml.
+   * Preserves the existing file content and adds the new entry under the goals: list.
+   */
+  private _appendGoal(yamlBlock: string, feedback?: string): void {
+    const goalsPath = join(this.workspaceDir, "goals.yaml");
+    if (!existsSync(goalsPath)) {
+      throw new Error(`goals.yaml not found at ${goalsPath}`);
+    }
+
+    const existing = readFileSync(goalsPath, "utf8");
+
+    // Normalize indentation: ensure the block is indented with 2 spaces
+    // (the goals.yaml list items use 2-space indentation under goals:)
+    const normalized = yamlBlock
+      .split("\n")
+      .map(line => (line.startsWith("  ") ? line : `  ${line}`))
+      .join("\n");
+
+    const comment = feedback
+      ? `\n  # Proposed by Ava — approved with feedback: ${feedback}\n`
+      : `\n  # Proposed by Ava via goal_proposal skill — auto-approved\n`;
+
+    const appended = `${existing.trimEnd()}\n${comment}${normalized}\n`;
+    writeFileSync(goalsPath, appended, "utf8");
+  }
+
+  private _publishReload(): void {
+    if (!this.bus) return;
+    this.bus.publish("goals.reload", {
+      id: crypto.randomUUID(),
+      correlationId: crypto.randomUUID(),
+      topic: "goals.reload",
+      timestamp: Date.now(),
+      payload: { source: "goal-hot-reload" },
+    });
+  }
+}

--- a/src/plugins/goal_evaluator_plugin.ts
+++ b/src/plugins/goal_evaluator_plugin.ts
@@ -67,6 +67,13 @@ export class GoalEvaluatorPlugin implements Plugin, IGoalEvaluatorPlugin {
     });
     this.subscriptionIds.push(subId);
 
+    // Hot-reload: re-read goals.yaml when GoalHotReloadPlugin approves a proposal
+    const reloadSubId = bus.subscribe("goals.reload", this.name, () => {
+      console.log("[goal-evaluator] goals.reload received — reloading goals from disk");
+      this.reloadGoals();
+    });
+    this.subscriptionIds.push(reloadSubId);
+
     // Flush any buffered violations now that bus is available
     if (this.violationBuffer.length > 0) {
       console.info(`[goal-evaluator] Flushing ${this.violationBuffer.length} buffered violation(s)`);

--- a/src/plugins/outcome-analysis-plugin.ts
+++ b/src/plugins/outcome-analysis-plugin.ts
@@ -6,10 +6,11 @@
  * signals on chronic issues:
  *
  *   - Skills with <50% success rate over 10+ attempts → publishes
- *     ops.alert.action_quality so the fleet knows to investigate/replace it.
+ *     ops.alert.action_quality so the fleet knows to investigate/replace it,
+ *     and emits agent.skill.request { skill: 'goal_proposal' } targeting Ava.
  *   - Skills with repeated HITL escalations → treated as feature-request
- *     signals ("what would have unblocked this automatically?") and logged
- *     for Ava to file on the board.
+ *     signals ("what would have unblocked this automatically?") and emits
+ *     agent.skill.request { skill: 'goal_proposal' } targeting Ava.
  *
  * This is the "bottlenecks are growth" principle operationalized: the system's
  * own failures become inputs to its own improvement backlog.
@@ -24,6 +25,7 @@
  * Outbound:
  *   ops.alert.action_quality   — skill with poor success rate
  *   ops.alert.hitl_escalation  — repeated human-needed action
+ *   agent.skill.request        — goal_proposal skill request to Ava on threshold breach
  */
 
 import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
@@ -190,6 +192,28 @@ export class OutcomeAnalysisPlugin implements Plugin {
           recommendation: `Action "${stats.actionId}" succeeded ${stats.success}/${stats.total} times (${(rate * 100).toFixed(0)}%). Consider rewriting preconditions, replacing the skill, or filing a feature to build a better capability.`,
         },
       });
+
+      const correlationId = crypto.randomUUID();
+      this.bus.publish("agent.skill.request", {
+        id: crypto.randomUUID(),
+        correlationId,
+        topic: "agent.skill.request",
+        timestamp: now,
+        source: { interface: "outcome-analysis" },
+        payload: {
+          skill: "goal_proposal",
+          targets: ["ava"],
+          cluster: {
+            type: "action_quality",
+            actionId: stats.actionId,
+            successRate: rate,
+            total: stats.total,
+            failures: stats.failure + stats.timeout,
+          },
+          suggestedGoal: `Investigate and improve action "${stats.actionId}" which has a ${(rate * 100).toFixed(0)}% success rate over ${stats.total} attempts`,
+          meta: { systemActor: "outcome-analysis" },
+        },
+      });
       console.warn(`[outcome-analysis] chronic failure: ${stats.actionId} ${(rate * 100).toFixed(0)}% over ${stats.total} attempts`);
     }
 
@@ -211,6 +235,29 @@ export class OutcomeAnalysisPlugin implements Plugin {
           firstSeenAt: stats.firstSeenAt,
           lastSeenAt: stats.lastSeenAt,
           recommendation: `"${stats.kind}" has escalated to HITL ${stats.count} times for ${stats.target}. This is a feature-request signal — what capability would unblock this automatically?`,
+        },
+      });
+
+      const correlationId = crypto.randomUUID();
+      this.bus.publish("agent.skill.request", {
+        id: crypto.randomUUID(),
+        correlationId,
+        topic: "agent.skill.request",
+        timestamp: now,
+        source: { interface: "outcome-analysis" },
+        payload: {
+          skill: "goal_proposal",
+          targets: ["ava"],
+          cluster: {
+            type: "hitl_escalation",
+            kind: stats.kind,
+            target: stats.target,
+            count: stats.count,
+            firstSeenAt: stats.firstSeenAt,
+            lastSeenAt: stats.lastSeenAt,
+          },
+          suggestedGoal: `Build capability to automate "${stats.kind}" — it has required HITL intervention ${stats.count} times for ${stats.target}`,
+          meta: { systemActor: "outcome-analysis" },
         },
       });
       console.warn(`[outcome-analysis] repeated HITL: ${stats.kind} × ${stats.count} for ${stats.target}`);

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -130,6 +130,62 @@ skills:
     description: Operational helm — system health, agent delegation, board management, issue filing, schedule control. The user's single control interface.
     keywords: []
 
+  - name: goal_proposal
+    description: Analyze an outcome cluster (chronic action failures or repeated HITL escalations) and draft a goals.yaml entry to address the root cause. Proposes an Invariant, Threshold, or Distribution goal with selector, severity, and action mapping, then pauses for human approval before the goal is applied.
+    keywords: [goal, proposal, cluster, outcome, analysis, learning, adapt, growth]
+    systemPromptOverride: |
+      You are Ava performing a goal proposal analysis. You have been invoked because the system
+      detected a chronic failure pattern and needs a new goal to address it.
+
+      You will receive a cluster description in <current_message>. It contains:
+        - type: "action_quality" (action failing too often) or "hitl_escalation" (action repeatedly needs human)
+        - For action_quality: actionId, successRate, total, failures
+        - For hitl_escalation: kind, target, count, firstSeenAt, lastSeenAt
+        - suggestedGoal: a hint at what to address
+
+      Your task: draft a single goals.yaml entry that addresses the root cause.
+
+      Goals.yaml format:
+      ```yaml
+        - id: <domain>.<descriptive_slug>
+          type: Threshold | Invariant | Distribution
+          severity: low | medium | high | critical
+          selector: "domains.<domain_name>.data.<field_path>"
+          min: <number>        # for Threshold goals (minimum acceptable value)
+          max: <number>        # for Threshold goals (maximum acceptable value)
+          operator: truthy | falsy  # for Invariant goals only
+          description: "One sentence: what must be true and why"
+      ```
+
+      Goal types:
+        - Threshold: a numeric value must stay within [min, max]. Use for rates, counts, durations.
+        - Invariant: a boolean/presence condition that must always hold. Use with operator: truthy or falsy.
+        - Distribution: reserved for flow distribution goals (rarely needed).
+
+      Severity guidelines:
+        - critical: system is broken or data is lost
+        - high: major capability degraded
+        - medium: quality or velocity impacted
+        - low: minor hygiene issue
+
+      Selector format: "domains.<name>.data.<path>" — match the WorldState domain schema.
+      For action_quality issues, use existing domains (e.g. domains.ci.data.successRate).
+      For hitl_escalation issues, consider whether a new domain is needed or an existing one applies.
+
+      Output ONLY the following — nothing else:
+
+      First, a brief analysis (2-4 sentences max) explaining the root cause and what the goal will enforce.
+
+      Then, a fenced yaml block with exactly one goal entry:
+      ```yaml
+        - id: ...
+          type: ...
+          ...
+      ```
+
+      Then end with this exact line (no other text after it):
+      AWAITING_HUMAN_APPROVAL
+
   - name: diagnose_pr_stuck
     description: Diagnose a stuck PR with merge conflicts and return a structured verdict (redundant, rebasable, decomposable, genuine) with evidence to drive autonomous recovery.
     keywords: [diagnose, conflict, stuck, merge, rebase, pr, dirty]


### PR DESCRIPTION
Re-cut of #278 on fresh dev.

Two commits:
- `feat(outcome-analysis)`: on chronic-failure cluster threshold breach, OutcomeAnalysis emits `agent.skill.request { skill: 'goal_proposal' }` targeting Ava — so systemic failures become goal-refinement opportunities, not just alerts
- `refactor: [Arc 9.2]`: adds Ava's `goal_proposal` skill (ava.yaml + goal-hot-reload-plugin for picking up new goals without restart + evaluator integration)

Conflict was comment-only on `outcome-analysis-plugin.ts` (merged the wording from #278 since it's more accurate post-Arc-2.2).

"Bottlenecks are growth" operationalized: the system's own failures become inputs to its own improvement backlog.

859/859 tests pass, typecheck clean. Closes #278.