### PR TITLE
feat: [Arc 9.3] HITL gate for goals.yaml / actions.yaml / agent card changes

### DIFF
--- a/lib/plugins/config-change-hitl.ts
+++ b/lib/plugins/config-change-hitl.ts
@@ -1,0 +1,139 @@
+/**
+ * ConfigChangeHITLPlugin — dedicated gate for workspace config changes.
+ *
+ * Distinct from the operational HITLPlugin so operators can tell apart
+ * "this changes the rules of the system" (goals.yaml / actions.yaml edits)
+ * from "this is a one-shot approval" (PR merge, cost escalation, etc.).
+ *
+ * Interface plugins register a renderer during install():
+ *   configChangePlugin.registerRenderer("discord", renderer)
+ *
+ * Inbound topics:
+ *   config.change.request.#  — new config-change approval needed
+ *   config.change.response.# — human decision collected
+ *
+ * Pending requests are tracked in-memory with expiry. On a 60s interval,
+ * expired entries are removed, config.change.expired.{correlationId} is
+ * published, and the renderer's onExpired() is called.
+ *
+ * Payload shape for config.change.request.*: ConfigChangeRequest (lib/types.ts)
+ * Payload shape for config.change.response.*: ConfigChangeResponse (lib/types.ts)
+ */
+
+import type {
+  EventBus,
+  BusMessage,
+  Plugin,
+  ConfigChangeRequest,
+  ConfigChangeResponse,
+  ConfigChangeRenderer,
+} from "../types.ts";
+
+// ── Renderer registry ──────────────────────────────────────────────────────
+const renderers = new Map<string, ConfigChangeRenderer>();
+
+// ── Pending request store ──────────────────────────────────────────────────
+const pendingRequests = new Map<string, ConfigChangeRequest>();
+
+// ── Plugin ────────────────────────────────────────────────────────────────
+
+export class ConfigChangeHITLPlugin implements Plugin {
+  readonly name = "config-change-hitl";
+  readonly description =
+    "Config-change gate — routes goals.yaml / actions.yaml approval requests to interface plugins";
+  readonly capabilities = ["config-change-hitl-routing"];
+
+  private expiryTimer: ReturnType<typeof setInterval> | null = null;
+
+  /** All currently pending (unexpired, undecided) config-change requests. */
+  getPendingRequests(): ConfigChangeRequest[] {
+    return Array.from(pendingRequests.values());
+  }
+
+  /**
+   * Register a ConfigChangeRenderer for an interface.
+   * Call this from your plugin's install() before any requests arrive.
+   */
+  registerRenderer(interfaceName: string, renderer: ConfigChangeRenderer): void {
+    renderers.set(interfaceName, renderer);
+    console.log(`[config-change-hitl] Registered renderer for interface "${interfaceName}"`);
+  }
+
+  install(bus: EventBus): void {
+    // ── Expiry sweep: every 60s, remove expired pending requests ────────
+    this.expiryTimer = setInterval(() => {
+      const now = Date.now();
+      for (const [correlationId, req] of pendingRequests) {
+        if (new Date(req.expiresAt).getTime() <= now) {
+          pendingRequests.delete(correlationId);
+          console.log(`[config-change-hitl] Expired ConfigChangeRequest (${correlationId})`);
+          bus.publish(`config.change.expired.${correlationId}`, {
+            id: crypto.randomUUID(),
+            correlationId,
+            topic: `config.change.expired.${correlationId}`,
+            timestamp: Date.now(),
+            payload: {
+              type: "config_change_expired",
+              correlationId,
+              originalRequest: req,
+            },
+          });
+          const iface = req.sourceMeta?.interface ?? "unknown";
+          const renderer = renderers.get(iface);
+          if (renderer?.onExpired) {
+            renderer.onExpired(req, bus).catch((err) =>
+              console.error(
+                `[config-change-hitl] renderer.onExpired failed for ${correlationId}:`,
+                err,
+              ),
+            );
+          }
+        }
+      }
+    }, 60_000);
+
+    // ── Route ConfigChangeRequest to the correct interface ────────────
+    bus.subscribe("config.change.request.#", this.name, (msg: BusMessage) => {
+      const req = msg.payload as ConfigChangeRequest;
+      if (req?.type !== "config_change_request") return;
+
+      pendingRequests.set(req.correlationId, req);
+
+      const iface = req.sourceMeta?.interface ?? "unknown";
+      const renderer = renderers.get(iface);
+
+      if (!renderer) {
+        console.warn(
+          `[config-change-hitl] No renderer for interface "${iface}" — ` +
+            `config change request ${req.correlationId} will not be shown to operators`,
+        );
+        return;
+      }
+
+      console.log(
+        `[config-change-hitl] Dispatching ConfigChangeRequest (${req.correlationId}) ` +
+          `for "${req.configFile}" to "${iface}" renderer`,
+      );
+      renderer.render(req, bus).catch((err) =>
+        console.error(
+          `[config-change-hitl] renderer.render failed for ${req.correlationId}:`,
+          err,
+        ),
+      );
+    });
+
+    // ── Clean up pending map when a response arrives ──────────────────
+    bus.subscribe("config.change.response.#", this.name, (msg: BusMessage) => {
+      const resp = msg.payload as ConfigChangeResponse;
+      if (resp?.type !== "config_change_response") return;
+      pendingRequests.delete(resp.correlationId);
+    });
+  }
+
+  uninstall(): void {
+    if (this.expiryTimer) {
+      clearInterval(this.expiryTimer);
+      this.expiryTimer = null;
+    }
+  }
+}

--- a/lib/plugins/discord.ts
+++ b/lib/plugins/discord.ts
@@ -9,6 +9,7 @@ import { Events, type TextChannel } from "discord.js";
 import type { EventBus, Plugin } from "../types.ts";
 import type { ChannelRegistry } from "../channels/channel-registry.ts";
 import type { HITLPlugin } from "./hitl.ts";
+import type { ConfigChangeHITLPlugin } from "./config-change-hitl.ts";
 import type { ContextMailbox } from "../dm/context-mailbox.ts";
 import { ConversationManager } from "../conversation/conversation-manager.ts";
 import { ConversationTracer } from "../conversation/conversation-tracer.ts";
@@ -32,6 +33,7 @@ export interface DiscordPluginOptions {
   dataDir?: string;
   channelRegistry?: ChannelRegistry;
   hitlPlugin?: HITLPlugin;
+  configChangePlugin?: ConfigChangeHITLPlugin;
   mailbox?: ContextMailbox;
   /** Check if an agent execution is in-flight for a given correlationId. */
   isExecutionActive?: (correlationId: string) => boolean;
@@ -51,6 +53,7 @@ export class DiscordPlugin implements Plugin {
   private dataDir: string | null;
   private channelRegistry?: ChannelRegistry;
   private hitlPlugin?: HITLPlugin;
+  private configChangePlugin?: ConfigChangeHITLPlugin;
   private mailbox?: ContextMailbox;
   private isExecutionActive?: (correlationId: string) => boolean;
 
@@ -63,6 +66,7 @@ export class DiscordPlugin implements Plugin {
     this.dataDir = opts.dataDir ? resolve(opts.dataDir) : null;
     this.channelRegistry = opts.channelRegistry;
     this.hitlPlugin = opts.hitlPlugin;
+    this.configChangePlugin = opts.configChangePlugin;
     this.mailbox = opts.mailbox;
     this.isExecutionActive = opts.isExecutionActive;
 
@@ -91,6 +95,7 @@ export class DiscordPlugin implements Plugin {
       client: this.client,
       channelRegistry: this.channelRegistry,
       hitlPlugin: this.hitlPlugin,
+      configChangePlugin: this.configChangePlugin,
       mailbox: this.mailbox,
       isExecutionActive: this.isExecutionActive,
       identityRegistry: new IdentityRegistry(this.workspaceDir),
@@ -174,6 +179,7 @@ export class DiscordPlugin implements Plugin {
       ctx.dmAccumulator?.destroy();
       ctx.pendingTurns.clear();
       ctx.pendingHITLMessages.clear();
+      ctx.pendingConfigChangeMessages.clear();
 
       for (const [name, client] of ctx.agentClients) {
         client.destroy();

--- a/lib/plugins/discord/core.ts
+++ b/lib/plugins/discord/core.ts
@@ -15,6 +15,7 @@ import {
 } from "discord.js";
 import type { EventBus } from "../../types.ts";
 import type { HITLPlugin } from "../hitl.ts";
+import type { ConfigChangeHITLPlugin } from "../config-change-hitl.ts";
 import type { ChannelRegistry } from "../../channels/channel-registry.ts";
 import { ConversationManager } from "../../conversation/conversation-manager.ts";
 import { ConversationTracer, type TurnData } from "../../conversation/conversation-tracer.ts";
@@ -108,9 +109,11 @@ export interface DiscordContext {
   pendingAgents: Map<string, string>;
   channelRegistry?: ChannelRegistry;
   hitlPlugin?: HITLPlugin;
+  configChangePlugin?: ConfigChangeHITLPlugin;
   mailbox?: ContextMailbox;
   isExecutionActive?: (correlationId: string) => boolean;
   pendingHITLMessages: Map<string, { message: Message; replyTopic: string }>;
+  pendingConfigChangeMessages: Map<string, { message: Message; replyTopic: string }>;
   conversationManager: ConversationManager;
   conversationTracer: ConversationTracer;
   graphiti: GraphitiClient;
@@ -162,6 +165,7 @@ export function buildContext(opts: {
   client: Client;
   channelRegistry?: ChannelRegistry;
   hitlPlugin?: HITLPlugin;
+  configChangePlugin?: ConfigChangeHITLPlugin;
   mailbox?: ContextMailbox;
   isExecutionActive?: (correlationId: string) => boolean;
   identityRegistry: IdentityRegistry | null;
@@ -177,9 +181,11 @@ export function buildContext(opts: {
     pendingAgents: new Map(),
     channelRegistry: opts.channelRegistry,
     hitlPlugin: opts.hitlPlugin,
+    configChangePlugin: opts.configChangePlugin,
     mailbox: opts.mailbox,
     isExecutionActive: opts.isExecutionActive,
     pendingHITLMessages: new Map(),
+    pendingConfigChangeMessages: new Map(),
     conversationManager: opts.conversationManager,
     conversationTracer: opts.conversationTracer,
     graphiti: new GraphitiClient(),

--- a/lib/plugins/discord/outbound.ts
+++ b/lib/plugins/discord/outbound.ts
@@ -13,7 +13,7 @@ import {
   type ChatInputCommandInteraction,
   type TextChannel,
 } from "discord.js";
-import type { BusMessage, HITLRequest } from "../../types.ts";
+import type { BusMessage, HITLRequest, ConfigChangeRequest } from "../../types.ts";
 import type { DiscordContext } from "./core.ts";
 
 // ── Pending reply handles ─────────────────────────────────────────────────────
@@ -82,6 +82,82 @@ export function buildHITLButtons(request: HITLRequest): ActionRowBuilder<ButtonB
     row.addComponents(
       new ButtonBuilder()
         .setCustomId(`hitl:${option}:${request.correlationId}`)
+        .setLabel(option.charAt(0).toUpperCase() + option.slice(1))
+        .setStyle(style),
+    );
+  }
+  return row;
+}
+
+// ── Config-change embed/button builders (Arc 9.3) ─────────────────────────────
+// Purple colour signals "the rules of the system are changing" vs the amber
+// "one-shot operational approval" colour used for regular HITL. Renders up to
+// three embeds: main info, YAML diff, GOAP/coverage impact analysis.
+
+export function buildConfigChangeEmbeds(request: ConfigChangeRequest): EmbedBuilder[] {
+  const embeds: EmbedBuilder[] = [];
+  const COLOR = 0x8b5cf6; // purple
+
+  const main = new EmbedBuilder()
+    .setTitle(`⚙️ Config Change — ${request.configFile}`)
+    .setDescription(`**${request.title}**\n\n${request.summary.slice(0, 3800)}`)
+    .setColor(COLOR)
+    .setFooter({
+      text: `config.change gate  •  Expires ${new Date(request.expiresAt).toLocaleString()}`,
+    });
+  embeds.push(main);
+
+  if (request.yamlDiff) {
+    // Discord code-block limit is 2000 chars per field; truncate gracefully.
+    const diff = request.yamlDiff.slice(0, 1900);
+    embeds.push(
+      new EmbedBuilder()
+        .setTitle("Proposed diff")
+        .setDescription(`\`\`\`diff\n${diff}\n\`\`\``)
+        .setColor(COLOR),
+    );
+  }
+
+  const impactLines: string[] = [];
+  if (request.goapImpact) {
+    impactLines.push(`**GOAP dry-run:** ${request.goapImpact.summary}`);
+    const imp = request.goapImpact;
+    if (imp.addedGoals?.length)     impactLines.push(`+ Goals added: ${imp.addedGoals.join(", ")}`);
+    if (imp.removedGoals?.length)   impactLines.push(`- Goals removed: ${imp.removedGoals.join(", ")}`);
+    if (imp.modifiedGoals?.length)  impactLines.push(`~ Goals modified: ${imp.modifiedGoals.join(", ")}`);
+    if (imp.addedActions?.length)   impactLines.push(`+ Actions added: ${imp.addedActions.join(", ")}`);
+    if (imp.removedActions?.length) impactLines.push(`- Actions removed: ${imp.removedActions.join(", ")}`);
+    if (imp.modifiedActions?.length)impactLines.push(`~ Actions modified: ${imp.modifiedActions.join(", ")}`);
+  }
+  if (request.coverageImpact) {
+    impactLines.push(`**Coverage:** ${request.coverageImpact.summary}`);
+    if (request.coverageImpact.affectedTestFiles.length) {
+      impactLines.push(`Affected test files: ${request.coverageImpact.affectedTestFiles.join(", ")}`);
+    }
+  }
+  if (impactLines.length) {
+    embeds.push(
+      new EmbedBuilder()
+        .setTitle("Impact analysis")
+        .setDescription(impactLines.join("\n").slice(0, 4096))
+        .setColor(COLOR),
+    );
+  }
+
+  return embeds;
+}
+
+export function buildConfigChangeButtons(request: ConfigChangeRequest): ActionRowBuilder<ButtonBuilder> {
+  const row = new ActionRowBuilder<ButtonBuilder>();
+  const STYLE_BY_OPTION: Record<string, ButtonStyle> = {
+    approve: ButtonStyle.Success,
+    reject: ButtonStyle.Danger,
+  };
+  for (const option of request.options) {
+    const style = STYLE_BY_OPTION[option] ?? ButtonStyle.Secondary;
+    row.addComponents(
+      new ButtonBuilder()
+        .setCustomId(`config_change:${option}:${request.correlationId}`)
         .setLabel(option.charAt(0).toUpperCase() + option.slice(1))
         .setStyle(style),
     );
@@ -207,6 +283,43 @@ export function registerOutboundHandlers(ctx: DiscordContext): void {
           .setColor(0x6b7280);
         await entry.message.edit({ embeds: [expiredEmbed], components: [] }).catch(console.error);
         console.log(`[discord] HITL ${request.correlationId} marked expired`);
+      },
+    });
+  }
+
+  // ── Config-change renderer registration (Arc 9.3) ────────────────────────
+  if (ctx.configChangePlugin) {
+    ctx.configChangePlugin.registerRenderer("discord", {
+      render: async (request, _busRef) => {
+        const channelId = request.sourceMeta?.channelId;
+        if (!channelId) {
+          console.warn(`[discord] config_change ${request.correlationId} missing channelId — cannot render`);
+          return;
+        }
+        const ch = ctx.client.channels.cache.get(channelId) as TextChannel | undefined;
+        if (!ch) {
+          console.warn(`[discord] config_change channel ${channelId} not in cache — cannot render`);
+          return;
+        }
+        const embeds = buildConfigChangeEmbeds(request);
+        const row = buildConfigChangeButtons(request);
+        const msg = await ch.send({ embeds, components: [row] });
+        ctx.pendingConfigChangeMessages.set(request.correlationId, {
+          message: msg,
+          replyTopic: request.replyTopic,
+        });
+        console.log(`[discord] config_change ${request.correlationId} rendered in channel ${channelId}`);
+      },
+      onExpired: async (request, _busRef) => {
+        const entry = ctx.pendingConfigChangeMessages.get(request.correlationId);
+        if (!entry) return;
+        ctx.pendingConfigChangeMessages.delete(request.correlationId);
+        const expiredEmbed = new EmbedBuilder()
+          .setTitle(request.title)
+          .setDescription("**Config change approval expired** — re-trigger if still needed.")
+          .setColor(0x6b7280);
+        await entry.message.edit({ embeds: [expiredEmbed], components: [] }).catch(console.error);
+        console.log(`[discord] config_change ${request.correlationId} marked expired`);
       },
     });
   }

--- a/lib/plugins/discord/slash-commands.ts
+++ b/lib/plugins/discord/slash-commands.ts
@@ -108,6 +108,45 @@ async function handleHITLButton(ctx: DiscordContext, interaction: ButtonInteract
   });
 }
 
+// ── Config-change button interaction ──────────────────────────────────────────
+
+async function handleConfigChangeButton(ctx: DiscordContext, interaction: ButtonInteraction): Promise<void> {
+  try { await interaction.deferUpdate(); } catch (err) {
+    console.warn(`[discord] config_change deferUpdate failed (${err instanceof Error ? err.message : err}) — processing decision anyway`);
+  }
+
+  const [, decision, correlationId] = interaction.customId.split(":");
+  if (!decision || !correlationId) {
+    console.warn(`[discord] config_change button with malformed customId: ${interaction.customId}`);
+    return;
+  }
+
+  const entry = ctx.pendingConfigChangeMessages.get(correlationId);
+  const replyTopic = entry?.replyTopic ?? `config.change.response.${correlationId}`;
+
+  try {
+    ctx.bus.publish(replyTopic, {
+      id: crypto.randomUUID(), correlationId, topic: replyTopic, timestamp: Date.now(),
+      payload: { type: "config_change_response", correlationId, decision, decidedBy: interaction.user.id },
+    });
+  } catch (err) {
+    console.error(`[discord] config_change bus publish failed for ${correlationId}:`, err);
+  }
+
+  if (entry) ctx.pendingConfigChangeMessages.delete(correlationId);
+
+  const color = decision === "approve" ? 0x22c55e : 0xef4444;
+  const label = decision.charAt(0).toUpperCase() + decision.slice(1);
+  const decidedEmbed = new EmbedBuilder()
+    .setTitle(interaction.message.embeds[0]?.title ?? "Config change decision recorded")
+    .setDescription(`**${label}** by <@${interaction.user.id}>`)
+    .setColor(color);
+
+  await interaction.message.edit({ embeds: [decidedEmbed], components: [] }).catch(err => {
+    console.warn(`[discord] config_change message edit failed for ${correlationId}:`, err instanceof Error ? err.message : err);
+  });
+}
+
 // ── Slash command registration ────────────────────────────────────────────────
 
 export async function registerSlashCommands(ctx: DiscordContext): Promise<void> {
@@ -165,6 +204,11 @@ export function registerSlashCommandHandlers(ctx: DiscordContext): void {
 
     if (interaction.isButton() && interaction.customId.startsWith("hitl:")) {
       await handleHITLButton(ctx, interaction);
+      return;
+    }
+
+    if (interaction.isButton() && interaction.customId.startsWith("config_change:")) {
+      await handleConfigChangeButton(ctx, interaction);
       return;
     }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -95,6 +95,60 @@ export interface HITLRenderer {
   onExpired?(request: HITLRequest, bus: EventBus): Promise<void>;
 }
 
+// ── Config-change gate types (Arc 9.3) ────────────────────────────────────────
+// Distinct from HITLRequest so operators see "this changes the rules of the
+// system" vs "this is a one-shot operational approval".
+
+export interface ConfigChangeRequest {
+  type: "config_change_request";
+  correlationId: string;
+  /** Which workspace config file is being changed. */
+  configFile: "goals.yaml" | "actions.yaml";
+  title: string;
+  summary: string;
+  /** Unified diff of the proposed change (before → after). */
+  yamlDiff: string;
+  /** Dry-run GOAP impact — which goals/actions are affected. */
+  goapImpact?: {
+    addedGoals?: string[];
+    removedGoals?: string[];
+    modifiedGoals?: string[];
+    addedActions?: string[];
+    removedActions?: string[];
+    modifiedActions?: string[];
+    /** Human-readable GOAP evaluation summary. */
+    summary: string;
+  };
+  /** Test coverage impact summary. */
+  coverageImpact?: {
+    affectedTestFiles: string[];
+    summary: string;
+  };
+  options: string[];   // ["approve", "reject"]
+  expiresAt: string;   // ISO timestamp
+  replyTopic: string;  // where to publish ConfigChangeResponse
+  sourceMeta?: BusMessage["source"];
+}
+
+export interface ConfigChangeResponse {
+  type: "config_change_response";
+  correlationId: string;
+  decision: "approve" | "reject";
+  feedback?: string;
+  decidedBy: string;
+}
+
+/**
+ * ConfigChangeRenderer — contract for interface plugins that want to surface
+ * config-change approval requests. Mirrors the HITLRenderer shape but is
+ * distinct so operators can visually separate "rules are changing" flows from
+ * "one-shot approval" flows.
+ */
+export interface ConfigChangeRenderer {
+  render(request: ConfigChangeRequest, bus: EventBus): Promise<void>;
+  onExpired?(request: ConfigChangeRequest, bus: EventBus): Promise<void>;
+}
+
 export interface Plugin {
   name: string;
   description: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,6 +172,7 @@ const pluginRegistry: PluginRegistryEntry[] = [
         dataDir,
         channelRegistry,
         hitlPlugin,
+        configChangePlugin,
         mailbox: contextMailbox,
         isExecutionActive: (correlationId: string) => {
           const dispatcher = registeredPlugins.find(p => p.name === "skill-dispatcher");
@@ -365,6 +366,13 @@ const { HITLPlugin } = await import("../lib/plugins/hitl.js");
 const hitlPlugin = new HITLPlugin(workspaceDir);
 hitlPlugin.install(bus);
 registeredPlugins.push(hitlPlugin);
+
+// ── ConfigChangeHITLPlugin — pre-installed so DiscordPlugin can register its renderer ──
+// Separate gate from operational HITL: "rules are changing" vs "one-shot approval".
+const { ConfigChangeHITLPlugin } = await import("../lib/plugins/config-change-hitl.js");
+const configChangePlugin = new ConfigChangeHITLPlugin();
+configChangePlugin.install(bus);
+registeredPlugins.push(configChangePlugin);
 
 for (const entry of pluginRegistry) {
   if (entry.condition()) {


### PR DESCRIPTION
Re-cut of #288 against the current decomposed lib/plugins/discord/*.ts layout.

## What it adds

A dedicated approval gate for workspace config changes — distinct from the operational HITLPlugin. goals.yaml / actions.yaml / agent-card edits rewrite the rules the system operates by, so they warrant a visually distinct (purple vs amber) review flow.

- **`lib/plugins/config-change-hitl.ts`** (new) — standalone plugin: subscribes to `config.change.request.#`, routes requests to a per-interface renderer, tracks pending with 60s expiry sweep, publishes `config.change.expired.{correlationId}` on timeout
- **`lib/types.ts`** — `ConfigChangeRequest` / `ConfigChangeResponse` / `ConfigChangeRenderer` (mirrors HITL shapes but distinct)
- **`src/index.ts`** — pre-installs `ConfigChangeHITLPlugin` alongside `HITLPlugin` and threads it through to DiscordPlugin opts
- **`lib/plugins/discord/*.ts`** — plumbed through shell → context → renderer:
  - New `config_change:<decision>:<corrId>` button handler in `slash-commands.ts` (mirrors the HITL button flow)
  - Purple-themed `buildConfigChangeEmbeds` + `buildConfigChangeButtons` in `outbound.ts` (up to 3 embeds: main info, YAML diff, GOAP/coverage impact)
  - Discord renderer registration so approval UIs surface in the requesting channel

Request payload supports optional GOAP dry-run impact (added/removed/modified goals and actions), coverage impact, and a unified YAML diff — so operators see exactly what's changing and what it will affect before approving.

## Verification

- `bun test` — 859/859 pass
- `bun run typecheck` — clean

Closes #288.