### PR TITLE
feat: [Arc 9.4] Hot-reload goals/actions without restart

### DIFF
--- a/src/event-bus/all-topics.ts
+++ b/src/event-bus/all-topics.ts
@@ -67,4 +67,11 @@ export const WORLD_TOPICS = {
    * Full topic is `autonomous.outcome.{systemActor}.{skill}`.
    */
   AUTONOMOUS_OUTCOME_PREFIX: "autonomous.outcome",
+
+  /**
+   * Published to trigger a hot reload of goals.yaml and actions.yaml from disk.
+   * Subscribers (actions loader in src/index.ts, GoalEvaluatorPlugin) re-read,
+   * re-validate, and atomically swap their loaded config. Arc 9.4.
+   */
+  CONFIG_RELOAD: "config.reload",
 } as const;

--- a/src/event-bus/payloads.ts
+++ b/src/event-bus/payloads.ts
@@ -210,6 +210,16 @@ export interface WorktreeRecoveredPayload {
   recoveredAt: string;
 }
 
+// ── config.reload ─────────────────────────────────────────────────────────────
+
+/** Payload for `config.reload` — triggers hot reload of goals.yaml and actions.yaml. */
+export interface ConfigReloadPayload {
+  /** What triggered the reload (e.g. "api", "hitl", "ava"). */
+  source?: string;
+  /** Optional request ID for tracing. */
+  requestId?: string;
+}
+
 // ── autonomous.outcome.* ─────────────────────────────────────────────────────
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,9 @@ function loadActionsYaml(): void {
   try {
     const raw = parseYaml(readFileSync(actionsPath, "utf8")) as { actions?: Record<string, unknown>[] };
     const actionsData = raw?.actions ?? [];
+
+    // Parse and validate all actions before mutating the registry (fail-fast)
+    const parsed: Action[] = [];
     for (const a of actionsData) {
       try {
         const action: Action = {
@@ -87,10 +90,16 @@ function loadActionsYaml(): void {
             : [],
           meta: typeof a.meta === "object" && a.meta !== null ? (a.meta as Action["meta"]) : {},
         };
-        actionRegistry.upsert(action);
+        parsed.push(action);
       } catch (err) {
         console.warn(`[actions-loader] Skipping invalid action '${a.id}':`, err);
       }
+    }
+
+    // Atomic swap: clear existing registry then upsert all validated actions
+    actionRegistry.clear();
+    for (const action of parsed) {
+      actionRegistry.upsert(action);
     }
     console.info(`[actions-loader] Loaded ${actionRegistry.size} action(s) from workspace/actions.yaml`);
   } catch (err) {
@@ -544,6 +553,19 @@ const API_KEY = process.env.WORKSTACEAN_API_KEY;
 import { createAllRoutes, matchPath } from "./api/index.ts";
 import type { ApiContext } from "./api/index.ts";
 import { TOPICS } from "./event-bus/topics.ts";
+
+// ── config.reload — hot-reload goals.yaml + actions.yaml without restart ──────
+// Subscribers:
+//   - this handler re-reads actions.yaml and refreshes telemetry rows
+//   - GoalEvaluatorPlugin (in plugin registry) re-reads goals.yaml
+bus.subscribe(TOPICS.CONFIG_RELOAD, "config-reloader", () => {
+  console.info("[config-reload] Reloading actions from disk...");
+  loadActionsYaml();
+  for (const action of actionRegistry.getAll()) {
+    telemetry.registerKnown("action", action.id, ACTION_EVENTS);
+  }
+  console.info(`[config-reload] Actions reloaded: ${actionRegistry.size} active. Goals reload handled by goal-evaluator plugin.`);
+});
 
 const apiContext: ApiContext = {
   workspaceDir,

--- a/src/planner/action-registry.ts
+++ b/src/planner/action-registry.ts
@@ -61,6 +61,11 @@ export class ActionRegistry {
     this.actions.delete(id);
   }
 
+  /** Remove all registered actions. Used for atomic hot-reload. */
+  clear(): void {
+    this.actions.clear();
+  }
+
   /** Number of registered actions. */
   get size(): number {
     return this.actions.size;

--- a/src/plugins/goal_evaluator_plugin.ts
+++ b/src/plugins/goal_evaluator_plugin.ts
@@ -13,6 +13,7 @@ import { DiscordLogger } from "../integrations/discord_logger.ts";
 import type { GoalViolatedEventPayload } from "../types/events.ts";
 import type { TelemetryService } from "../telemetry/telemetry-service.ts";
 import { GOAL_EVENTS } from "../telemetry/telemetry-service.ts";
+import { TOPICS } from "../event-bus/topics.ts";
 
 /**
  * GoalEvaluatorPlugin — observe-only goal registry + evaluator.
@@ -67,12 +68,26 @@ export class GoalEvaluatorPlugin implements Plugin, IGoalEvaluatorPlugin {
     });
     this.subscriptionIds.push(subId);
 
-    // Hot-reload: re-read goals.yaml when GoalHotReloadPlugin approves a proposal
-    const reloadSubId = bus.subscribe("goals.reload", this.name, () => {
+    // Hot-reload triggers — two flavors live side by side:
+    //   goals.reload   — narrow signal from GoalHotReloadPlugin (Arc 9.2)
+    //                    after a HITL-approved goal proposal is written to
+    //                    goals.yaml. Single-file, single-purpose.
+    //   config.reload  — broad signal from the workspace config gate (Arc 9.4)
+    //                    after a ConfigChangeHITL approval lands. Covers
+    //                    goals.yaml + actions.yaml + agent cards.
+    // Both just re-read goals from disk; subscribing to both keeps each
+    // writer's contract intact without requiring them to coordinate.
+    const goalsReloadId = bus.subscribe("goals.reload", this.name, () => {
       console.log("[goal-evaluator] goals.reload received — reloading goals from disk");
       this.reloadGoals();
     });
-    this.subscriptionIds.push(reloadSubId);
+    this.subscriptionIds.push(goalsReloadId);
+
+    const configReloadId = bus.subscribe(TOPICS.CONFIG_RELOAD, this.name, () => {
+      console.info("[goal-evaluator] config.reload received — reloading goals from disk");
+      this.reloadGoals();
+    });
+    this.subscriptionIds.push(configReloadId);
 
     // Flush any buffered violations now that bus is available
     if (this.violationBuffer.length > 0) {


### PR DESCRIPTION
Re-cut of #289 on fresh dev.

Publishes on the `TOPICS.CONFIG_RELOAD` (`config.reload`) bus topic triggers a hot reload of `goals.yaml` and `actions.yaml` without restarting the server:

- `src/index.ts` handler: re-reads actions.yaml, re-validates, atomic swap on the `ActionRegistry`, re-registers action telemetry rows
- `GoalEvaluatorPlugin`: re-reads goals.yaml, re-validates, atomic swap
- `ActionRegistry` gets a new `clear()` method for the atomic-swap path
- New topic `CONFIG_RELOAD` in `all-topics.ts`

Together with Arc 9.2 (goal_proposal) and Arc 9.3 (ConfigChangeHITL), the loop is: outcome cluster → Ava proposes a goal → operator approves via Discord config-change button → `config.reload` fires → planner & evaluator pick up the change immediately. No restart required.

Conflict resolution: topics.ts was modernized to spread from `all-topics.ts` modules; moved the new `CONFIG_RELOAD` into `WORLD_TOPICS` in all-topics.ts instead. Duplicate `TOPICS` imports in src/index.ts collapsed into one. GoalEvaluator subscribes to both `goals.reload` (narrow, Arc 9.2) and `config.reload` (broad, Arc 9.4) — distinct writers, same effect; keeping both preserves each Arc's contract.

859/859 tests pass, typecheck clean. Closes #289.