### PR TITLE
[Arc 8.1] New world state domain: agent_fleet_health

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -315,6 +315,14 @@ const pluginRegistry: PluginRegistryEntry[] = [
       return new OutcomeAnalysisPlugin();
     },
   },
+  {
+    name: "agent-fleet-health",
+    condition: () => true,
+    factory: async () => {
+      const { AgentFleetHealthPlugin } = await import("./plugins/agent-fleet-health-plugin.js");
+      return new AgentFleetHealthPlugin();
+    },
+  },
   // Built-ins: opt-in via ENABLED_PLUGINS=echo,...
   {
     name: "echo",
@@ -553,7 +561,18 @@ console.log(`HTTP API listening on port ${HTTP_PORT}`);
     engine.registerDomain("plane", createHttpCollector(`${base}/api/plane-board`), 120_000); // 2min — Plane REST list across projects
     engine.registerDomain("memory", createHttpCollector(`${base}/api/memory-health`), 60_000); // 1min — Graphiti health + search probe
 
-    console.log("[domain-discovery] Registered local domains: flow, services, agent_health, security, ci, pr_pipeline, branch_drift, branch_protection, hitl_queue, plane, memory");
+    // agent_fleet_health — bus-aggregated, no HTTP polling needed
+    const fleetHealth = registeredPlugins.find(p => p.name === "agent-fleet-health");
+    if (fleetHealth) {
+      type AgentFleetHealthPlugin = import("./plugins/agent-fleet-health-plugin.js").AgentFleetHealthPlugin;
+      engine.registerDomain(
+        "agent_fleet_health",
+        () => Promise.resolve((fleetHealth as unknown as AgentFleetHealthPlugin).getFleetHealth()),
+        60_000,
+      );
+    }
+
+    console.log("[domain-discovery] Registered local domains: flow, services, agent_health, security, ci, pr_pipeline, branch_drift, branch_protection, hitl_queue, plane, memory, agent_fleet_health");
 
     // All local + workspace/domains.yaml + per-project domains are now
     // registered. Defer prune briefly so any async per-project domain

--- a/src/plugins/agent-fleet-health-plugin.test.ts
+++ b/src/plugins/agent-fleet-health-plugin.test.ts
@@ -1,0 +1,209 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { InMemoryEventBus } from "../../lib/bus.ts";
+import { AgentFleetHealthPlugin } from "./agent-fleet-health-plugin.ts";
+import type { AutonomousOutcomePayload } from "../event-bus/payloads.ts";
+import type { BusMessage } from "../../lib/types.ts";
+
+const makeOutcomeMsg = (payload: Partial<AutonomousOutcomePayload> & { systemActor: string; skill: string }): BusMessage => ({
+  id: crypto.randomUUID(),
+  correlationId: payload.correlationId ?? crypto.randomUUID(),
+  topic: "autonomous.outcome.completed",
+  timestamp: Date.now(),
+  payload: {
+    correlationId: payload.correlationId ?? crypto.randomUUID(),
+    systemActor: payload.systemActor,
+    skill: payload.skill,
+    success: payload.success ?? true,
+    durationMs: payload.durationMs ?? 500,
+    taskState: payload.taskState,
+    usage: payload.usage,
+  } satisfies AutonomousOutcomePayload,
+});
+
+describe("AgentFleetHealthPlugin", () => {
+  let bus: InMemoryEventBus;
+  let plugin: AgentFleetHealthPlugin;
+
+  beforeEach(() => {
+    bus = new InMemoryEventBus();
+    plugin = new AgentFleetHealthPlugin();
+    plugin.install(bus);
+  });
+
+  test("returns empty agents array when no outcomes recorded", () => {
+    const snapshot = plugin.getFleetHealth();
+    expect(snapshot.agents).toHaveLength(0);
+    expect(snapshot.windowHours).toBe(24);
+    expect(snapshot.collectedAt).toBeGreaterThan(0);
+  });
+
+  test("records a successful outcome and computes successRate=1", async () => {
+    bus.publish("autonomous.outcome.completed", makeOutcomeMsg({
+      systemActor: "ava",
+      skill: "plan",
+      success: true,
+      durationMs: 1000,
+    }));
+
+    // allow async handler to settle
+    await new Promise(r => setTimeout(r, 10));
+
+    const snapshot = plugin.getFleetHealth();
+    expect(snapshot.agents).toHaveLength(1);
+    const agent = snapshot.agents[0];
+    expect(agent.agentName).toBe("ava");
+    expect(agent.successRate).toBe(1);
+    expect(agent.totalOutcomes).toBe(1);
+    expect(agent.recentFailures).toHaveLength(0);
+    expect(agent.p50LatencyMs).toBe(1000);
+    expect(agent.p95LatencyMs).toBe(1000);
+  });
+
+  test("records a failed outcome and computes successRate=0", async () => {
+    bus.publish("autonomous.outcome.failed", makeOutcomeMsg({
+      systemActor: "quinn",
+      skill: "sweep",
+      success: false,
+      durationMs: 300,
+      taskState: "failed",
+    }));
+
+    await new Promise(r => setTimeout(r, 10));
+
+    const snapshot = plugin.getFleetHealth();
+    expect(snapshot.agents).toHaveLength(1);
+    const agent = snapshot.agents[0];
+    expect(agent.agentName).toBe("quinn");
+    expect(agent.successRate).toBe(0);
+    expect(agent.recentFailures).toHaveLength(1);
+    expect(agent.recentFailures[0].skill).toBe("sweep");
+  });
+
+  test("computes successRate across mixed outcomes", async () => {
+    for (let i = 0; i < 3; i++) {
+      bus.publish("autonomous.outcome.completed", makeOutcomeMsg({
+        systemActor: "ava",
+        skill: "plan",
+        success: true,
+        durationMs: 200,
+      }));
+    }
+    bus.publish("autonomous.outcome.failed", makeOutcomeMsg({
+      systemActor: "ava",
+      skill: "plan",
+      success: false,
+      durationMs: 100,
+    }));
+
+    await new Promise(r => setTimeout(r, 10));
+
+    const snapshot = plugin.getFleetHealth();
+    const agent = snapshot.agents.find(a => a.agentName === "ava")!;
+    expect(agent.totalOutcomes).toBe(4);
+    expect(agent.successRate).toBeCloseTo(0.75, 5);
+  });
+
+  test("computes p50 and p95 latency correctly", async () => {
+    const durations = [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000];
+    for (const d of durations) {
+      bus.publish("autonomous.outcome.completed", makeOutcomeMsg({
+        systemActor: "bot",
+        skill: "run",
+        success: true,
+        durationMs: d,
+      }));
+    }
+
+    await new Promise(r => setTimeout(r, 10));
+
+    const snapshot = plugin.getFleetHealth();
+    const agent = snapshot.agents.find(a => a.agentName === "bot")!;
+    // p50 = index floor(10 * 0.5) = 5 → 600 (0-indexed sorted)
+    expect(agent.p50LatencyMs).toBe(600);
+    // p95 = index floor(10 * 0.95) = 9 → 1000
+    expect(agent.p95LatencyMs).toBe(1000);
+  });
+
+  test("computes costPerSuccessfulOutcome from token usage", async () => {
+    bus.publish("autonomous.outcome.completed", makeOutcomeMsg({
+      systemActor: "ava",
+      skill: "plan",
+      success: true,
+      durationMs: 500,
+      usage: { input_tokens: 1000, output_tokens: 500 },
+    }));
+
+    await new Promise(r => setTimeout(r, 10));
+
+    const snapshot = plugin.getFleetHealth();
+    const agent = snapshot.agents.find(a => a.agentName === "ava")!;
+    // costPerSuccessfulOutcome > 0 when usage is provided
+    expect(agent.costPerSuccessfulOutcome).toBeGreaterThan(0);
+  });
+
+  test("costPerSuccessfulOutcome is 0 when all outcomes are failures", async () => {
+    bus.publish("autonomous.outcome.failed", makeOutcomeMsg({
+      systemActor: "ava",
+      skill: "plan",
+      success: false,
+      durationMs: 200,
+      usage: { input_tokens: 1000, output_tokens: 500 },
+    }));
+
+    await new Promise(r => setTimeout(r, 10));
+
+    const snapshot = plugin.getFleetHealth();
+    const agent = snapshot.agents.find(a => a.agentName === "ava")!;
+    expect(agent.costPerSuccessfulOutcome).toBe(0);
+  });
+
+  test("tracks multiple agents independently", async () => {
+    bus.publish("autonomous.outcome.completed", makeOutcomeMsg({ systemActor: "ava", skill: "plan", success: true, durationMs: 100 }));
+    bus.publish("autonomous.outcome.failed", makeOutcomeMsg({ systemActor: "quinn", skill: "sweep", success: false, durationMs: 200 }));
+
+    await new Promise(r => setTimeout(r, 10));
+
+    const snapshot = plugin.getFleetHealth();
+    expect(snapshot.agents).toHaveLength(2);
+    const ava = snapshot.agents.find(a => a.agentName === "ava")!;
+    const quinn = snapshot.agents.find(a => a.agentName === "quinn")!;
+    expect(ava.successRate).toBe(1);
+    expect(quinn.successRate).toBe(0);
+  });
+
+  test("recentFailures lists at most 10 entries, most recent first", async () => {
+    const timestamps: number[] = [];
+    for (let i = 0; i < 15; i++) {
+      const correlationId = `corr-${i}`;
+      bus.publish("autonomous.outcome.failed", makeOutcomeMsg({
+        systemActor: "bot",
+        skill: "run",
+        success: false,
+        correlationId,
+        durationMs: 100,
+      }));
+      timestamps.push(Date.now());
+      await new Promise(r => setTimeout(r, 1)); // ensure distinct timestamps
+    }
+
+    await new Promise(r => setTimeout(r, 10));
+
+    const snapshot = plugin.getFleetHealth();
+    const agent = snapshot.agents.find(a => a.agentName === "bot")!;
+    expect(agent.recentFailures).toHaveLength(10);
+    // most-recent first
+    for (let i = 0; i < agent.recentFailures.length - 1; i++) {
+      expect(agent.recentFailures[i].timestamp).toBeGreaterThanOrEqual(agent.recentFailures[i + 1].timestamp);
+    }
+  });
+
+  test("uninstall cleans up subscription", () => {
+    plugin.uninstall();
+    // After uninstall, publishing should not throw or add records
+    expect(() => {
+      bus.publish("autonomous.outcome.completed", makeOutcomeMsg({ systemActor: "ava", skill: "plan", success: true, durationMs: 100 }));
+    }).not.toThrow();
+    const snapshot = plugin.getFleetHealth();
+    expect(snapshot.agents).toHaveLength(0);
+  });
+});

--- a/src/plugins/agent-fleet-health-plugin.ts
+++ b/src/plugins/agent-fleet-health-plugin.ts
@@ -1,0 +1,185 @@
+/**
+ * AgentFleetHealthPlugin — Arc 8: Fleet-aware homeostasis.
+ *
+ * Aggregates `autonomous.outcome.#` events over a rolling 24h window into
+ * per-agent metrics: successRate, p50/p95 latency, costPerSuccessfulOutcome,
+ * and recentFailures.
+ *
+ * Exposes getFleetHealth() as the collector for the "agent_fleet_health"
+ * world state domain — called every 60s by WorldStateEngine.
+ *
+ * Inbound topics:
+ *   autonomous.outcome.#  — every autonomous task terminal state
+ */
+
+import type { Plugin, EventBus } from "../../lib/types.ts";
+import type { AutonomousOutcomePayload } from "../event-bus/payloads.ts";
+import { MODEL_RATES } from "../../lib/types/budget.ts";
+
+const WINDOW_MS = 24 * 60 * 60 * 1_000; // 24 hours
+const MAX_RECENT_FAILURES = 10;
+const DEFAULT_RATES = MODEL_RATES["default"];
+
+// ── Internal record ───────────────────────────────────────────────────────────
+
+interface OutcomeRecord {
+  timestamp: number;
+  success: boolean;
+  durationMs: number;
+  costUsd: number;
+  skill: string;
+  correlationId: string;
+  failureReason?: string;
+}
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+export interface AgentFleetMetrics {
+  agentName: string;
+  /** Fraction of outcomes that succeeded over the 24h window (0–1). */
+  successRate: number;
+  /** Median wall-clock duration across all outcomes in the window (ms). */
+  p50LatencyMs: number;
+  /** 95th-percentile wall-clock duration across all outcomes in the window (ms). */
+  p95LatencyMs: number;
+  /**
+   * Total LLM cost in USD for all outcomes in the window divided by
+   * the number of successful outcomes. 0 when successCount is 0 or
+   * no usage data is available.
+   */
+  costPerSuccessfulOutcome: number;
+  /** Most recent failures (up to 10), most-recent-first. */
+  recentFailures: Array<{
+    timestamp: number;
+    skill: string;
+    correlationId: string;
+    failureReason?: string;
+  }>;
+  /** Total outcome events counted in the 24h window. */
+  totalOutcomes: number;
+}
+
+export interface FleetHealthSnapshot {
+  agents: AgentFleetMetrics[];
+  /** Always 24 — documents the rolling window. */
+  windowHours: 24;
+  collectedAt: number;
+}
+
+// ── Plugin ────────────────────────────────────────────────────────────────────
+
+export class AgentFleetHealthPlugin implements Plugin {
+  readonly name = "agent-fleet-health";
+  readonly description =
+    "Aggregates autonomous.outcome.# over a rolling 24h window into per-agent fleet health metrics";
+  readonly capabilities = ["fleet-health"];
+
+  private bus?: EventBus;
+  private readonly subscriptionIds: string[] = [];
+  /** Per-agent rolling window. Keys are systemActor values. */
+  private readonly agentWindows = new Map<string, OutcomeRecord[]>();
+
+  install(bus: EventBus): void {
+    this.bus = bus;
+    this.subscriptionIds.push(
+      bus.subscribe("autonomous.outcome.#", this.name, (msg) => {
+        const p = msg.payload as AutonomousOutcomePayload | undefined;
+        if (!p?.systemActor) return;
+        this._record(p);
+      }),
+    );
+    console.log("[agent-fleet-health] Installed — aggregating autonomous.outcome.#");
+  }
+
+  uninstall(): void {
+    if (this.bus) {
+      for (const id of this.subscriptionIds) this.bus.unsubscribe(id);
+    }
+    this.subscriptionIds.length = 0;
+    this.bus = undefined;
+  }
+
+  /**
+   * Collector for WorldStateEngine — call every 60s to publish a domain snapshot.
+   * Prunes stale (>24h) records in-place on each call.
+   */
+  getFleetHealth(): FleetHealthSnapshot {
+    const now = Date.now();
+    const cutoff = now - WINDOW_MS;
+    const agents: AgentFleetMetrics[] = [];
+
+    for (const [agentName, records] of this.agentWindows) {
+      // Prune stale records
+      const fresh = records.filter(r => r.timestamp >= cutoff);
+      this.agentWindows.set(agentName, fresh);
+
+      if (fresh.length === 0) continue;
+
+      const successes = fresh.filter(r => r.success);
+      const failures = fresh.filter(r => !r.success);
+      const successRate = successes.length / fresh.length;
+
+      const durations = fresh.map(r => r.durationMs).sort((a, b) => a - b);
+      const p50LatencyMs = _percentile(durations, 0.5);
+      const p95LatencyMs = _percentile(durations, 0.95);
+
+      const totalCost = fresh.reduce((sum, r) => sum + r.costUsd, 0);
+      const costPerSuccessfulOutcome =
+        successes.length > 0 ? totalCost / successes.length : 0;
+
+      const recentFailures = failures
+        .sort((a, b) => b.timestamp - a.timestamp)
+        .slice(0, MAX_RECENT_FAILURES)
+        .map(r => ({
+          timestamp: r.timestamp,
+          skill: r.skill,
+          correlationId: r.correlationId,
+          failureReason: r.failureReason,
+        }));
+
+      agents.push({
+        agentName,
+        successRate,
+        p50LatencyMs,
+        p95LatencyMs,
+        costPerSuccessfulOutcome,
+        recentFailures,
+        totalOutcomes: fresh.length,
+      });
+    }
+
+    return { agents, windowHours: 24, collectedAt: now };
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────────
+
+  private _record(p: AutonomousOutcomePayload): void {
+    const costUsd = p.usage
+      ? (p.usage.input_tokens ?? 0) * DEFAULT_RATES.input +
+        (p.usage.output_tokens ?? 0) * DEFAULT_RATES.output
+      : 0;
+
+    const record: OutcomeRecord = {
+      timestamp: Date.now(),
+      success: p.success,
+      durationMs: p.durationMs,
+      costUsd,
+      skill: p.skill,
+      correlationId: p.correlationId,
+      failureReason: p.success ? undefined : (p.taskState ?? "failed"),
+    };
+
+    const existing = this.agentWindows.get(p.systemActor) ?? [];
+    existing.push(record);
+    this.agentWindows.set(p.systemActor, existing);
+  }
+}
+
+// ── Utility ───────────────────────────────────────────────────────────────────
+
+/** Returns the value at the given percentile p (0–1) from a sorted array. */
+function _percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(Math.floor(sorted.length * p), sorted.length - 1);
+  return sorted[idx];
+}


### PR DESCRIPTION
## Summary

**Arc 8: Fleet-aware homeostasis** (epic: Unified A2A + GOAP)

Domain source: aggregate `autonomous.outcome.#` over a rolling 24h window into per-agent metrics: successRate, p50/p95 latency, costPerSuccessfulOutcome, recentFailures. Published every 60s as a domain snapshot.

**Dependency**: Arc 2 (unified outcome) must ship first.

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-14T23:54:55.375Z -->