### PR TITLE
feat: [Arc 8.5] Goal fleet.no_skill_orphaned

### DIFF
--- a/src/plugins/agent-fleet-health-plugin.test.ts
+++ b/src/plugins/agent-fleet-health-plugin.test.ts
@@ -203,7 +203,6 @@ describe("AgentFleetHealthPlugin", () => {
   });
 
   test("failureRate1h reflects only outcomes within the last 1h", async () => {
-    // All failures — failureRate1h should be 1
     bus.publish("autonomous.outcome.failed", makeOutcomeMsg({
       systemActor: "ava",
       skill: "plan",
@@ -236,15 +235,50 @@ describe("AgentFleetHealthPlugin", () => {
   });
 
   test("maxFailureRate1h is the max failureRate1h across all agents", async () => {
-    // ava: 1 success, 0 failures → failureRate1h = 0
     bus.publish("autonomous.outcome.completed", makeOutcomeMsg({ systemActor: "ava", skill: "plan", success: true, durationMs: 100 }));
-    // quinn: 0 successes, 1 failure → failureRate1h = 1
     bus.publish("autonomous.outcome.failed", makeOutcomeMsg({ systemActor: "quinn", skill: "sweep", success: false, durationMs: 100 }));
 
     await new Promise(r => setTimeout(r, 10));
 
     const snapshot = plugin.getFleetHealth();
     expect(snapshot.maxFailureRate1h).toBe(1);
+  });
+
+  // ── Arc 8.5: orphanedSkillCount ───────────────────────────────────────────
+  test("orphanedSkillCount is 0 when all skills have at least one success", async () => {
+    bus.publish("autonomous.outcome.completed", makeOutcomeMsg({ systemActor: "ava", skill: "plan", success: true, durationMs: 100 }));
+    bus.publish("autonomous.outcome.failed", makeOutcomeMsg({ systemActor: "ava", skill: "plan", success: false, durationMs: 100 }));
+
+    await new Promise(r => setTimeout(r, 10));
+
+    const snapshot = plugin.getFleetHealth();
+    expect(snapshot.orphanedSkillCount).toBe(0);
+  });
+
+  test("orphanedSkillCount counts skills with no success in window", async () => {
+    bus.publish("autonomous.outcome.failed", makeOutcomeMsg({ systemActor: "ava", skill: "sweep", success: false, durationMs: 100 }));
+    bus.publish("autonomous.outcome.failed", makeOutcomeMsg({ systemActor: "quinn", skill: "review", success: false, durationMs: 200 }));
+    bus.publish("autonomous.outcome.completed", makeOutcomeMsg({ systemActor: "ava", skill: "plan", success: true, durationMs: 100 }));
+
+    await new Promise(r => setTimeout(r, 10));
+
+    const snapshot = plugin.getFleetHealth();
+    expect(snapshot.orphanedSkillCount).toBe(2);
+  });
+
+  test("orphanedSkillCount is 0 when no outcomes recorded", () => {
+    const snapshot = plugin.getFleetHealth();
+    expect(snapshot.orphanedSkillCount).toBe(0);
+  });
+
+  test("same skill across agents — counts as not orphaned if any agent succeeded", async () => {
+    bus.publish("autonomous.outcome.failed", makeOutcomeMsg({ systemActor: "ava", skill: "plan", success: false, durationMs: 100 }));
+    bus.publish("autonomous.outcome.completed", makeOutcomeMsg({ systemActor: "quinn", skill: "plan", success: true, durationMs: 100 }));
+
+    await new Promise(r => setTimeout(r, 10));
+
+    const snapshot = plugin.getFleetHealth();
+    expect(snapshot.orphanedSkillCount).toBe(0);
   });
 
   test("uninstall cleans up subscription", () => {

--- a/src/plugins/agent-fleet-health-plugin.ts
+++ b/src/plugins/agent-fleet-health-plugin.ts
@@ -78,6 +78,13 @@ export interface FleetHealthSnapshot {
   maxFailureRate1h: number;
   /** Sum of all LLM costs across all agents over the 24h window (USD). Used by fleet.cost_under_budget (Arc 8.3). */
   totalCostUsd1d: number;
+  /**
+   * Count of skills seen in any outcome in the 24h window that have had
+   * no successful execution during that window. > 0 signals capability
+   * regression — a skill is active but consistently failing.
+   * Used by fleet.no_skill_orphaned (Arc 8.5).
+   */
+  orphanedSkillCount: number;
   collectedAt: number;
 }
 
@@ -124,12 +131,21 @@ export class AgentFleetHealthPlugin implements Plugin {
     const cutoff1h = now - WINDOW_1H_MS;
     const agents: AgentFleetMetrics[] = [];
 
+    // Per-skill: track whether any success exists in the window.
+    const skillSeenInWindow = new Set<string>();
+    const skillHasSuccessInWindow = new Set<string>();
+
     for (const [agentName, records] of this.agentWindows) {
       // Prune stale records
       const fresh = records.filter(r => r.timestamp >= cutoff);
       this.agentWindows.set(agentName, fresh);
 
       if (fresh.length === 0) continue;
+
+      for (const r of fresh) {
+        skillSeenInWindow.add(r.skill);
+        if (r.success) skillHasSuccessInWindow.add(r.skill);
+      }
 
       const successes = fresh.filter(r => r.success);
       const failures = fresh.filter(r => !r.success);
@@ -175,7 +191,12 @@ export class AgentFleetHealthPlugin implements Plugin {
       : 0;
     const totalCostUsd1d = agents.reduce((sum, a) => sum + a.totalCostUsd, 0);
 
-    return { agents, windowHours: 24, maxFailureRate1h, totalCostUsd1d, collectedAt: now };
+    let orphanedSkillCount = 0;
+    for (const skill of skillSeenInWindow) {
+      if (!skillHasSuccessInWindow.has(skill)) orphanedSkillCount++;
+    }
+
+    return { agents, windowHours: 24, maxFailureRate1h, totalCostUsd1d, orphanedSkillCount, collectedAt: now };
   }
 
   // ── Private ─────────────────────────────────────────────────────────────────

--- a/workspace/actions.yaml
+++ b/workspace/actions.yaml
@@ -593,3 +593,41 @@ actions:
     meta:
       skillHint: downshift_models
       fireAndForget: true
+
+  # ── Skill orphan detection (Arc 8.5) ──────────────────────────────
+
+  - id: alert.fleet_skill_orphaned
+    goalId: fleet.no_skill_orphaned
+    tier: tier_0
+    priority: 10
+    cost: 0
+    name: "Alert on orphaned skills — active skills with no success in 24h window"
+    preconditions:
+      - path: "extensions.agent_fleet_health_available"
+        operator: eq
+        value: true
+      - path: "domains.agent_fleet_health.data.orphanedSkillCount"
+        operator: gt
+        value: 0
+    effects: []
+    meta:
+      fireAndForget: true
+
+  - id: action.fleet_investigate_orphaned_skills
+    goalId: fleet.no_skill_orphaned
+    tier: tier_0
+    priority: 30
+    cost: 1
+    name: "Dispatch Ava to investigate orphaned skills and diagnose capability regression"
+    preconditions:
+      - path: "extensions.agent_fleet_health_available"
+        operator: eq
+        value: true
+      - path: "domains.agent_fleet_health.data.orphanedSkillCount"
+        operator: gt
+        value: 0
+    effects: []
+    meta:
+      skillHint: investigate_orphaned_skills
+      agentId: ava
+      fireAndForget: true

--- a/workspace/goals.yaml
+++ b/workspace/goals.yaml
@@ -213,15 +213,18 @@ goals:
     max: 10
     description: "HITL pending queue should not exceed 10 — escalations are piling up faster than humans can clear them"
 
-  # ── Fleet cost homeostasis ───────────────────────────────────────
-  #
-  # Fires when the sum of all agent LLM costs over the rolling 24h window
-  # exceeds the daily fleet budget ($50). Triggers model downshifting on
-  # low-blast skills and alerts the operator.
-
+  # ── Fleet cost homeostasis (Arc 8.3) ─────────────────────────────
   - id: fleet.cost_under_budget
     type: Threshold
     severity: high
     selector: "domains.agent_fleet_health.data.totalCostUsd1d"
     max: 50
     description: "Total fleet LLM spend over the rolling 24h window must not exceed $50"
+
+  # ── Skill orphan detection (Arc 8.5) ─────────────────────────────
+  - id: fleet.no_skill_orphaned
+    type: Threshold
+    severity: high
+    selector: "domains.agent_fleet_health.data.orphanedSkillCount"
+    max: 0
+    description: "Every skill seen in the 24h window must have at least one successful execution — orphaned skills (active but never succeeding) signal capability regression"


### PR DESCRIPTION
Re-cut of #305 on fresh dev (after #306 batch landed Arc 8.2/8.3/8.4).

Adds:
- `orphanedSkillCount` field on `FleetHealthSnapshot` — counts skills seen in the 24h outcome window with no successful execution
- `fleet.no_skill_orphaned` goal (max=0)
- `alert.fleet_skill_orphaned` + `action.fleet_investigate_orphaned_skills` actions (the latter dispatches Ava to diagnose capability regression)
- 4 new tests (zero, count, empty, cross-agent)

Conflicts resolved by merging additively — `FleetHealthSnapshot` keeps `maxFailureRate1h`, `totalCostUsd1d`, AND `orphanedSkillCount`. New goals/actions appended cleanly under labelled section headers in the YAMLs.

883/883 tests pass (+4 new), typecheck clean. Closes #305.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Fleet health monitoring now includes orphaned skill detection, tracking skills with no successful executions in the 24-hour window
  * Added automatic alert triggering when orphaned skills are detected
  * Added investigation action to diagnose and address orphaned skills
  * New monitoring goal to maintain zero orphaned skills in the fleet

* **Tests**
  * Added test coverage for orphaned skill count validation under various scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->