### PR TITLE
docs: update docs after Arc 8 agent runtime SDK hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ External surfaces (GitHub, Discord, Plane, HTTP)
 World engine loop (parallel):
   WorldStateEngine (domain pollers)
     → GoalEvaluatorPlugin → world.goal.violated
-      → PlannerPluginL0 → world.action.plan
+      → PlannerPluginL0 → world.action.dispatch
         → ActionDispatcherPlugin → agent.skill.request
 ```
 
@@ -77,6 +77,7 @@ Plugins are loaded in `src/index.ts`. Each implements `install(bus) / uninstall(
 | `GoalEvaluatorPlugin` | always | Evaluates `workspace/goals.yaml` against world state |
 | `PlannerPluginL0` | always | Maps violated goals → actions from `ActionRegistry` |
 | `ActionDispatcherPlugin` | always | Executes planned actions with WIP limit |
+| `AgentFleetHealthPlugin` | always | Aggregates `autonomous.outcome.#` over a rolling 24h window; exposes `agent_fleet_health` world-state domain for fleet goals |
 | `CeremonyPlugin` | always | Scheduled fleet rituals from `workspace/ceremonies/*.yaml` |
 | `DiscordPlugin` | `DISCORD_BOT_TOKEN` | Discord gateway |
 | `GitHubPlugin` | `GITHUB_TOKEN` or `GITHUB_APP_ID` | GitHub webhooks |
@@ -95,6 +96,9 @@ The executor layer is the unified dispatch path for all agent skill calls.
 ExecutorRegistry.resolve(skill, targets?)
   1. Named target match — any registration whose agentName is in targets[]
   2. Skill-specific match — sorted by priority desc
+     └─ If multiple agents qualify: health-weighted random selection (Arc 8.4)
+        weight = successRate × (1 / (1 + costPerSuccessfulOutcome))
+        New agents with no data get neutral weight 1.0
   3. Default executor
   4. null → SkillDispatcherPlugin logs and publishes error response
 ```

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -8,7 +8,7 @@ These docs explain the *why* behind protoWorkstacean's architecture. Read them w
 
 | Document | What it explains |
 |----------|-----------------|
-| [Executor layer](../integrations/runtimes/) | Why the executor layer exists, how resolution works, the registrar pattern, and why `SkillDispatcherPlugin` is the sole `agent.skill.request` subscriber |
+| [Executor layer](../integrations/runtimes/) | Why the executor layer exists, how resolution works, the registrar pattern, health-weighted multi-agent selection (Arc 8.4), and why `SkillDispatcherPlugin` is the sole `agent.skill.request` subscriber |
 | [World engine](./world-engine) | Why `WorldState` is a generic record, the GOAP loop design, domain discovery rationale |
 | [Self-improving loop](./self-improving-loop) | How A2A extensions feed observations into `PlannerPluginL0`'s candidate ranking, how episodic memory writes to Graphiti, and why the convergence loops don't diverge |
 | [Distributed tracing](./distributed-tracing) | How `correlationId` (trace-id) and `parentId` (span-id) flow from the bus through RouterPlugin, A2AExecutor, external agents (protoMaker team, Quinn), and back |

--- a/docs/explanation/self-improving-loop.md
+++ b/docs/explanation/self-improving-loop.md
@@ -137,14 +137,33 @@ An earlier attempt to close `outcome → state` by republishing `world.state.upd
 
 ## Fleet-level rollups — `agent_fleet_health`
 
-`AgentFleetHealthPlugin` (Arc 8.1) subscribes to `autonomous.outcome.#` and keeps a rolling 24-hour window of every autonomous dispatch. For each agent it exposes:
+`AgentFleetHealthPlugin` (Arc 8.1) subscribes to `autonomous.outcome.#` and keeps a rolling 24-hour window of every autonomous dispatch. For each agent (`AgentFleetMetrics`) it exposes:
 
 - `successRate` — fraction of the window's outcomes that succeeded
 - `p50LatencyMs` / `p95LatencyMs` — wall-clock distribution
-- `costPerSuccessfulOutcome` — USD / success (from `cost-v1` usage samples when available, falling back to `MODEL_RATES["default"]` token pricing)
-- `recentFailures` — last 10 failure correlation IDs for drill-down
+- `costPerSuccessfulOutcome` — total window cost ÷ success count (from `cost-v1` usage samples when available, falling back to `MODEL_RATES["default"]` token pricing); 0 when no successes
+- `totalCostUsd` — raw LLM spend for all outcomes in the window
+- `failureRate1h` — failure fraction over the last 1h (a sub-window of the 24h window)
+- `recentFailures` — last 10 failure correlation IDs + reasons for drill-down
+- `totalOutcomes` — total outcome events in the window
 
-Exposed as the `agent_fleet_health` world-state domain via a 60-second collector. Goals can target `domains.agent_fleet_health.data.<agent>.successRate < 0.5` to fire when a specific agent degrades, or `costPerSuccessfulOutcome > X` to catch runaway spend.
+The `FleetHealthSnapshot` also exposes fleet-level aggregates:
+
+- `maxFailureRate1h` — max `failureRate1h` across all agents; used by `fleet.no_agent_stuck` (Arc 8.2) to fire when any agent's 1h failure rate exceeds 50%
+- `totalCostUsd1d` — sum of all agent costs in the window; used by `fleet.cost_under_budget` (Arc 8.3) to fire when fleet LLM spend exceeds $50/day
+- `orphanedSkillCount` — skills seen in any outcome in the 24h window that have had zero successful executions; > 0 signals capability regression; used by `fleet.no_skill_orphaned` (Arc 8.5)
+
+Exposed as the `agent_fleet_health` world-state domain via a 60-second collector. Goals target `domains.agent_fleet_health.data.*` selectors — no custom domain code required.
+
+### Health-weighted executor selection (Arc 8.4)
+
+When multiple agents can serve the same skill, `ExecutorRegistry` uses fleet health data to pick probabilistically rather than greedily:
+
+```
+weight = successRate × (1 / (1 + costPerSuccessfulOutcome))
+```
+
+Agents with no data (`totalOutcomes === 0`) get weight 1.0 so new agents still receive traffic. `AgentFleetHealthPlugin.getFleetHealth()` is the data source; `ExecutorRegistry.setHealthGetter()` wires it at startup.
 
 ---
 

--- a/docs/reference/bus-topics.md
+++ b/docs/reference/bus-topics.md
@@ -242,7 +242,7 @@ message.outbound.<dest>.<...context>    — messages to deliver to external inte
 agent.skill.request / response.<id>     — skill dispatch pipeline
 world.state.updated                     — domain poll results
 world.goal.violated                     — GOAP goal breach
-world.action.plan                       — GOAP action plan
+world.action.dispatch                   — GOAP action ready to execute
 ceremony.<id>.execute                   — ceremony trigger
 cron.<id>                               — scheduled event
 security.incident.reported              — incident lifecycle


### PR DESCRIPTION
## Summary

- Fixes stale `world.action.plan` reference → `world.action.dispatch` in README and bus-topics naming conventions
- Adds `AgentFleetHealthPlugin` to the integration plugins table in README
- Documents health-weighted executor resolution (Arc 8.4) with weight formula in README and explanation/index.md
- Expands `agent_fleet_health` fleet rollups section in `self-improving-loop.md` with complete `AgentFleetMetrics` fields, `FleetHealthSnapshot` aggregates, and the three fleet goals (Arc 8.2/8.3/8.5)

## Test plan

- [ ] Docs site builds without errors
- [ ] All links in updated pages resolve correctly
- [ ] Self-improving-loop fleet section matches `AgentFleetHealthPlugin` source types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated world engine action dispatch flow documentation
  * Documented new fleet health monitoring capability tracking 24-hour agent performance metrics
  * Enhanced executor selection to incorporate agent health weighting for multi-agent scenarios
  * Updated reference documentation for event routing standards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->