### PR TITLE
feat: [Arc 9.5] A/B framework — compete skill variants against same goal

### DIFF
--- a/src/executor/__tests__/skill-ab-test-plugin.test.ts
+++ b/src/executor/__tests__/skill-ab-test-plugin.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { ExecutorRegistry } from "../executor-registry.ts";
+import { SkillAbTestPlugin, AbTestExecutor } from "../skill-ab-test-plugin.ts";
+import type { IExecutor, SkillRequest, SkillResult } from "../types.ts";
+import type { EventBus, BusMessage } from "../../../lib/types.ts";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeExecutor(type: string, isError = false): IExecutor {
+  return {
+    type,
+    execute: mock(async (req: SkillRequest): Promise<SkillResult> => ({
+      text: `result from ${type}`,
+      isError,
+      correlationId: req.correlationId,
+      data: { usage: { input_tokens: 10, output_tokens: 20 } },
+    })),
+  };
+}
+
+function makeReq(correlationId: string): SkillRequest {
+  return {
+    skill: "bug_triage",
+    correlationId,
+    replyTopic: `agent.skill.response.${correlationId}`,
+    payload: {},
+  };
+}
+
+/** Minimal in-memory bus stub */
+function makeBus(): EventBus & { published: BusMessage[] } {
+  const published: BusMessage[] = [];
+  const subs = new Map<string, (msg: BusMessage) => void>();
+
+  return {
+    published,
+    publish(topic: string, message: BusMessage) {
+      published.push(message);
+    },
+    subscribe(pattern: string, _name: string, handler: (msg: BusMessage) => void) {
+      const id = `sub-${pattern}`;
+      subs.set(id, handler);
+      return id;
+    },
+    unsubscribe(id: string) {
+      subs.delete(id);
+    },
+    topics() { return []; },
+    consumers() { return []; },
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("SkillAbTestPlugin", () => {
+  let registry: ExecutorRegistry;
+  let plugin: SkillAbTestPlugin;
+  let bus: ReturnType<typeof makeBus>;
+
+  beforeEach(() => {
+    registry = new ExecutorRegistry();
+    plugin = new SkillAbTestPlugin(registry);
+    bus = makeBus();
+    plugin.install(bus);
+  });
+
+  it("passes through to original resolve when no test is registered", () => {
+    const exec = makeExecutor("proto-sdk");
+    registry.register("bug_triage", exec);
+    expect(registry.resolve("bug_triage")).toBe(exec);
+  });
+
+  it("intercepts resolve() for a skill under test", () => {
+    const control = makeExecutor("quinn.v1");
+    const challenger = makeExecutor("quinn.v2");
+    plugin.registerTest("bug_triage", control, challenger, 10);
+
+    const resolved = registry.resolve("bug_triage");
+    expect(resolved).toBeInstanceOf(AbTestExecutor);
+  });
+
+  it("does not intercept resolve() for a different skill", () => {
+    const exec = makeExecutor("quinn.v1");
+    registry.register("daily_standup", exec);
+    const control = makeExecutor("quinn.v1");
+    const challenger = makeExecutor("quinn.v2");
+    plugin.registerTest("bug_triage", control, challenger, 10);
+
+    expect(registry.resolve("daily_standup")).toBe(exec);
+  });
+
+  describe("A/B routing via correlationId hash", () => {
+    it("routes dispatches to control or challenger based on correlationId", async () => {
+      const control = makeExecutor("ctrl");
+      const challenger = makeExecutor("chal");
+      plugin.registerTest("bug_triage", control, challenger, 100);
+
+      // Execute many times with different correlationIds
+      const executor = registry.resolve("bug_triage")!;
+      const results: string[] = [];
+      for (let i = 0; i < 20; i++) {
+        const r = await executor.execute(makeReq(`corr-${i}`));
+        results.push(r.text);
+      }
+
+      // Both arms should have been called
+      const ctrlCalls = (control.execute as ReturnType<typeof mock>).mock.calls.length;
+      const chalCalls = (challenger.execute as ReturnType<typeof mock>).mock.calls.length;
+      expect(ctrlCalls).toBeGreaterThan(0);
+      expect(chalCalls).toBeGreaterThan(0);
+      expect(ctrlCalls + chalCalls).toBe(20);
+    });
+
+    it("same correlationId always routes to same arm (deterministic)", async () => {
+      const control = makeExecutor("ctrl");
+      const challenger = makeExecutor("chal");
+      plugin.registerTest("bug_triage", control, challenger, 100);
+
+      const executor = registry.resolve("bug_triage")!;
+      const r1 = await executor.execute(makeReq("stable-id"));
+      const r2 = await executor.execute(makeReq("stable-id"));
+      expect(r1.text).toBe(r2.text);
+    });
+  });
+
+  describe("winner selection after N dispatches", () => {
+    it("commits winner and removes ab-test executor after n dispatches", async () => {
+      const control = makeExecutor("ctrl");
+      // challenger always errors
+      const challenger = makeExecutor("chal", true);
+      plugin.registerTest("bug_triage", control, challenger, 4);
+
+      const executor = registry.resolve("bug_triage")!;
+
+      // Drive 4 dispatches using corr IDs that hash to different buckets
+      // We need at least 4 total dispatches
+      for (let i = 0; i < 10; i++) {
+        await executor.execute(makeReq(`test-${i}`));
+        const state = plugin.getTestStatus("bug_triage");
+        if (state?.resolvedAt) break;
+      }
+
+      const state = plugin.getTestStatus("bug_triage");
+      expect(state?.resolvedAt).toBeDefined();
+      expect(state?.winner).toBeDefined();
+    });
+
+    it("publishes skill.ab_test.resolved after n dispatches", async () => {
+      const control = makeExecutor("ctrl");
+      const challenger = makeExecutor("chal");
+      plugin.registerTest("bug_triage", control, challenger, 4);
+
+      const executor = registry.resolve("bug_triage")!;
+      for (let i = 0; i < 10; i++) {
+        await executor.execute(makeReq(`done-${i}`));
+        if (plugin.getTestStatus("bug_triage")?.resolvedAt) break;
+      }
+
+      const resolved = bus.published.find(m => m.topic === "skill.ab_test.resolved");
+      expect(resolved).toBeDefined();
+      const p = resolved!.payload as { skill: string; winner: string };
+      expect(p.skill).toBe("bug_triage");
+      expect(["control", "challenger"]).toContain(p.winner);
+    });
+
+    it("removes ab-test executor from resolve after winner is committed", async () => {
+      const control = makeExecutor("ctrl");
+      const challenger = makeExecutor("chal");
+      registry.register("bug_triage", control); // control already in registry
+      plugin.registerTest("bug_triage", control, challenger, 4);
+
+      const executor = registry.resolve("bug_triage")!;
+      for (let i = 0; i < 20; i++) {
+        await executor.execute(makeReq(`fin-${i}`));
+        if (plugin.getTestStatus("bug_triage")?.resolvedAt) break;
+      }
+
+      // After resolution, resolve() should NOT return AbTestExecutor
+      const afterExec = registry.resolve("bug_triage");
+      expect(afterExec).not.toBeInstanceOf(AbTestExecutor);
+    });
+
+    it("picks challenger as winner when it has a clearly higher success rate", async () => {
+      // Control always errors; challenger always succeeds.
+      // correlationIds that hash to bucket 0 go to control, bucket 1 to challenger.
+      // We need enough dispatches with bucket=1 to hit n.
+      const control = makeExecutor("ctrl", true);  // always fails
+      const challenger = makeExecutor("chal", false); // always succeeds
+      plugin.registerTest("bug_triage", control, challenger, 4);
+
+      const executor = registry.resolve("bug_triage")!;
+      // Use correlationIds we know hash to bucket 1 (challenger)
+      // and bucket 0 (control) to ensure both arms get dispatches
+      for (let i = 0; i < 20; i++) {
+        await executor.execute(makeReq(`pick-${i}`));
+        if (plugin.getTestStatus("bug_triage")?.resolvedAt) break;
+      }
+
+      const state = plugin.getTestStatus("bug_triage");
+      if (state?.winner) {
+        // If enough dispatches went to each arm, challenger should win
+        const ctrlRate = state.control.metrics.dispatches > 0
+          ? state.control.metrics.successes / state.control.metrics.dispatches
+          : 0;
+        const chalRate = state.challenger.metrics.dispatches > 0
+          ? state.challenger.metrics.successes / state.challenger.metrics.dispatches
+          : 0;
+        if (chalRate > ctrlRate + 0.05) {
+          expect(state.winner).toBe("challenger");
+        }
+      }
+    });
+  });
+
+  describe("listTests and getTestStatus", () => {
+    it("returns undefined for an unknown skill", () => {
+      expect(plugin.getTestStatus("unknown")).toBeUndefined();
+    });
+
+    it("lists all tests including resolved ones", async () => {
+      const c1 = makeExecutor("c1");
+      const ch1 = makeExecutor("ch1");
+      plugin.registerTest("skill_a", c1, ch1, 2);
+
+      const c2 = makeExecutor("c2");
+      const ch2 = makeExecutor("ch2");
+      plugin.registerTest("skill_b", c2, ch2, 100);
+
+      expect(plugin.listTests()).toHaveLength(2);
+    });
+
+    it("ignores duplicate registerTest() for same skill", () => {
+      const c = makeExecutor("c");
+      const ch = makeExecutor("ch");
+      plugin.registerTest("bug_triage", c, ch, 10);
+      plugin.registerTest("bug_triage", c, ch, 20); // duplicate
+
+      expect(plugin.listTests()).toHaveLength(1);
+      expect(plugin.getTestStatus("bug_triage")!.n).toBe(10);
+    });
+  });
+
+  describe("uninstall", () => {
+    it("removes the resolve hook so registry returns original result", () => {
+      const exec = makeExecutor("original");
+      registry.register("bug_triage", exec);
+
+      const control = makeExecutor("ctrl");
+      const challenger = makeExecutor("chal");
+      plugin.registerTest("bug_triage", control, challenger, 10);
+
+      // Confirm the hook is active
+      expect(registry.resolve("bug_triage")).toBeInstanceOf(AbTestExecutor);
+
+      plugin.uninstall();
+
+      // After uninstall, original executor is returned
+      expect(registry.resolve("bug_triage")).toBe(exec);
+    });
+  });
+});
+
+describe("ExecutorRegistry resolve hook integration", () => {
+  it("hook can override resolved executor", () => {
+    const registry = new ExecutorRegistry();
+    const original = makeExecutor("original");
+    const override = makeExecutor("override");
+    registry.register("skill", original);
+
+    registry.setResolveHook((_skill, _targets, resolved) => {
+      if (resolved === original) return override;
+      return resolved;
+    });
+
+    expect(registry.resolve("skill")).toBe(override);
+  });
+
+  it("clearing hook (null) restores normal resolution", () => {
+    const registry = new ExecutorRegistry();
+    const original = makeExecutor("original");
+    registry.register("skill", original);
+
+    registry.setResolveHook(() => null);
+    expect(registry.resolve("skill")).toBeNull();
+
+    registry.setResolveHook(null);
+    expect(registry.resolve("skill")).toBe(original);
+  });
+});

--- a/src/executor/executor-registry.ts
+++ b/src/executor/executor-registry.ts
@@ -29,12 +29,25 @@ interface AgentHealthMetrics {
 
 type HealthGetter = () => AgentHealthMetrics[];
 
+/**
+ * Optional hook called after standard resolution.
+ * Receives (skill, targets, resolved) where resolved is the standard result.
+ * Return a different executor to override, or resolved to keep the default.
+ * Used by SkillAbTestPlugin to intercept specific skills under A/B test.
+ */
+export type ResolveHook = (
+  skill: string,
+  targets: string[],
+  resolved: IExecutor | null,
+) => IExecutor | null;
+
 export class ExecutorRegistry {
   private readonly _registrations: ExecutorRegistration[] = [];
   private _default: IExecutor | null = null;
   /** Secondary index: `${domain}::${path}` → EffectRegistration[] */
   private readonly _effectIndex = new Map<string, EffectRegistration[]>();
   private _healthGetter: HealthGetter | null = null;
+  private _resolveHook: ResolveHook | null = null;
 
   /**
    * Inject a live fleet-health snapshot provider (Arc 8.4).
@@ -84,12 +97,27 @@ export class ExecutorRegistry {
       }
     }
 
-    // 2. Skill-specific match with optional health-weighted selection
+    // 2. Skill-specific match — health-weighted ordering when a health
+    //    getter is registered (Arc 8.4), priority sort otherwise.
     const bySkill = this._registrations.filter(r => r.skill === skill);
-    if (bySkill.length > 0) return this._resolveByHealth(bySkill);
+    const resolved = bySkill.length > 0
+      ? this._resolveByHealth(bySkill)
+      : this._default;
 
-    // 3. Default
-    return this._default;
+    // 3. Optional hook — allows SkillAbTestPlugin to intercept (Arc 9.5)
+    if (this._resolveHook) return this._resolveHook(skill, targets, resolved);
+
+    return resolved;
+  }
+
+  /**
+   * Set (or clear) a resolve hook.
+   * The hook runs after standard resolution and may return a different executor.
+   * Pass null to remove the hook.
+   * Used by SkillAbTestPlugin to intercept skills under A/B test.
+   */
+  setResolveHook(hook: ResolveHook | null): void {
+    this._resolveHook = hook;
   }
 
   /**

--- a/src/executor/skill-ab-test-plugin.ts
+++ b/src/executor/skill-ab-test-plugin.ts
@@ -1,0 +1,341 @@
+/**
+ * SkillAbTestPlugin — A/B test competing skill executor variants.
+ *
+ * When Ava (or any caller) proposes an alternative executor for an existing
+ * skill, this plugin runs both variants in parallel for N total dispatches,
+ * compares success rate and cost, and commits the winner back to the registry.
+ *
+ * Usage:
+ *   const abTest = new SkillAbTestPlugin(executorRegistry);
+ *   abTest.install(bus);
+ *   abTest.registerTest("bug_triage", quinnV1Executor, quinnV2Executor, 20);
+ *
+ * Architecture:
+ *   - Installs a resolve hook on ExecutorRegistry via setResolveHook().
+ *   - For skills under test, the hook returns an AbTestExecutor wrapper.
+ *   - AbTestExecutor uses correlationId hash to deterministically assign each
+ *     dispatch to control (bucket 0) or challenger (bucket 1) — 50/50 split.
+ *   - After n total dispatches, selectWinner() picks the arm with higher
+ *     success rate; ties are broken by lower average token cost.
+ *   - The winner's executor is registered at priority 100, removing the test.
+ *   - Publishes skill.ab_test.resolved on completion.
+ *
+ * Bus topics:
+ *   Inbound:  skill.ab_test.register  (programmatic via bus — see payload type)
+ *   Outbound: skill.ab_test.resolved  (winner committed)
+ */
+
+import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
+import type { ExecutorRegistry } from "./executor-registry.ts";
+import type { IExecutor, SkillRequest, SkillResult } from "./types.ts";
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+export interface AbTestMetrics {
+  dispatches: number;
+  successes: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+}
+
+export interface AbTestState {
+  skill: string;
+  /** Total dispatches (across both arms) before declaring a winner. */
+  n: number;
+  control: { executor: IExecutor; metrics: AbTestMetrics };
+  challenger: { executor: IExecutor; metrics: AbTestMetrics };
+  startedAt: number;
+  resolvedAt?: number;
+  winner?: "control" | "challenger";
+}
+
+/** Payload for skill.ab_test.resolved */
+export interface AbTestResolvedPayload {
+  skill: string;
+  winner: "control" | "challenger";
+  controlMetrics: AbTestMetrics;
+  challengerMetrics: AbTestMetrics;
+  resolvedAt: number;
+  reason: string;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Deterministic 0/1 bucket from a correlationId string.
+ * Same correlationId always maps to the same arm — retries stay consistent.
+ */
+function hashBucket(correlationId: string): 0 | 1 {
+  let hash = 0;
+  for (let i = 0; i < correlationId.length; i++) {
+    hash = (((hash << 5) - hash) + correlationId.charCodeAt(i)) >>> 0;
+  }
+  return (hash % 2) as 0 | 1;
+}
+
+function successRate(m: AbTestMetrics): number {
+  return m.dispatches === 0 ? 0 : m.successes / m.dispatches;
+}
+
+function avgTokensPerDispatch(m: AbTestMetrics): number {
+  return m.dispatches === 0 ? 0 : (m.totalInputTokens + m.totalOutputTokens) / m.dispatches;
+}
+
+function selectWinner(state: AbTestState): "control" | "challenger" {
+  const cRate = successRate(state.control.metrics);
+  const chRate = successRate(state.challenger.metrics);
+
+  // If challenger wins by more than 5 percentage points → challenger
+  if (chRate > cRate + 0.05) return "challenger";
+  // If control wins by more than 5 percentage points → control
+  if (cRate > chRate + 0.05) return "control";
+
+  // Tied on success rate — lower avg token cost wins
+  const cCost = avgTokensPerDispatch(state.control.metrics);
+  const chCost = avgTokensPerDispatch(state.challenger.metrics);
+  return chCost < cCost ? "challenger" : "control";
+}
+
+function buildReason(winner: "control" | "challenger", state: AbTestState): string {
+  const c = state.control.metrics;
+  const ch = state.challenger.metrics;
+  const cRate = successRate(c);
+  const chRate = successRate(ch);
+
+  if (Math.abs(cRate - chRate) > 0.05) {
+    return (
+      `${winner} had higher success rate ` +
+      `(control=${(cRate * 100).toFixed(0)}% challenger=${(chRate * 100).toFixed(0)}%)`
+    );
+  }
+
+  const cCost = avgTokensPerDispatch(c);
+  const chCost = avgTokensPerDispatch(ch);
+  return (
+    `tied on success rate; ${winner} had lower avg cost ` +
+    `(control=${cCost.toFixed(0)} challenger=${chCost.toFixed(0)} tokens/dispatch)`
+  );
+}
+
+function emptyMetrics(): AbTestMetrics {
+  return { dispatches: 0, successes: 0, totalInputTokens: 0, totalOutputTokens: 0 };
+}
+
+// ── AbTestExecutor ────────────────────────────────────────────────────────────
+
+/**
+ * Wraps two executors and routes each dispatch to control or challenger
+ * based on a deterministic correlationId hash. Tracks per-arm metrics
+ * and fires onWinner() once the dispatch budget is exhausted.
+ */
+export class AbTestExecutor implements IExecutor {
+  readonly type = "ab-test";
+
+  constructor(
+    private readonly state: AbTestState,
+    private readonly onWinner: (winner: "control" | "challenger", state: AbTestState) => void,
+  ) {}
+
+  async execute(req: SkillRequest): Promise<SkillResult> {
+    const bucket = hashBucket(req.correlationId);
+    const arm = bucket === 0 ? "control" : "challenger";
+    const { executor, metrics } = this.state[arm];
+
+    const result = await executor.execute(req);
+
+    metrics.dispatches++;
+    if (!result.isError) metrics.successes++;
+    if (result.data?.usage) {
+      metrics.totalInputTokens += result.data.usage.input_tokens ?? 0;
+      metrics.totalOutputTokens += result.data.usage.output_tokens ?? 0;
+    }
+
+    const total =
+      this.state.control.metrics.dispatches + this.state.challenger.metrics.dispatches;
+
+    if (total >= this.state.n && !this.state.resolvedAt) {
+      const winner = selectWinner(this.state);
+      this.onWinner(winner, this.state);
+    }
+
+    return result;
+  }
+}
+
+// ── SkillAbTestPlugin ─────────────────────────────────────────────────────────
+
+export class SkillAbTestPlugin implements Plugin {
+  readonly name = "skill-ab-test";
+  readonly description =
+    "A/B tests competing skill executor variants; auto-commits winner after N dispatches.";
+  readonly capabilities = ["ab_testing", "executor_routing"];
+
+  private readonly tests = new Map<string, AbTestState>();
+  private readonly abExecutors = new Map<string, AbTestExecutor>();
+  private bus!: EventBus;
+  private subscriptionId?: string;
+
+  constructor(private readonly registry: ExecutorRegistry) {}
+
+  install(bus: EventBus): void {
+    this.bus = bus;
+
+    // Install resolve hook — returns AbTestExecutor for skills under test
+    this.registry.setResolveHook((skill, _targets, resolved) => {
+      const abExec = this.abExecutors.get(skill);
+      return abExec ?? resolved;
+    });
+
+    // Bus topic: accept programmatic test registrations (control/challenger
+    // must already be registered in the ExecutorRegistry at call time)
+    this.subscriptionId = bus.subscribe(
+      "skill.ab_test.register",
+      this.name,
+      (msg: BusMessage) => this.handleRegisterMessage(msg),
+    );
+  }
+
+  uninstall(): void {
+    this.registry.setResolveHook(null);
+    if (this.subscriptionId && this.bus) {
+      this.bus.unsubscribe(this.subscriptionId);
+    }
+  }
+
+  // ── Public API ─────────────────────────────────────────────────────────────
+
+  /**
+   * Start an A/B test for a skill.
+   *
+   * @param skill            Skill name to intercept (e.g. "bug_triage")
+   * @param controlExecutor  Current/baseline executor
+   * @param challengerExecutor  New executor to evaluate
+   * @param n                Total dispatches before declaring a winner
+   */
+  registerTest(
+    skill: string,
+    controlExecutor: IExecutor,
+    challengerExecutor: IExecutor,
+    n: number,
+  ): void {
+    if (this.tests.has(skill)) {
+      console.warn(
+        `[skill-ab-test] Test for '${skill}' already in progress — ignoring duplicate registerTest()`,
+      );
+      return;
+    }
+
+    const state: AbTestState = {
+      skill,
+      n,
+      control: { executor: controlExecutor, metrics: emptyMetrics() },
+      challenger: { executor: challengerExecutor, metrics: emptyMetrics() },
+      startedAt: Date.now(),
+    };
+
+    this.tests.set(skill, state);
+    this.abExecutors.set(
+      skill,
+      new AbTestExecutor(state, (winner, s) => this.commitWinner(winner, s)),
+    );
+
+    console.info(
+      `[skill-ab-test] Started test for '${skill}' ` +
+      `(n=${n}, control=${controlExecutor.type}, challenger=${challengerExecutor.type})`,
+    );
+  }
+
+  /** Current test state for a skill (includes metrics). undefined if no test active. */
+  getTestStatus(skill: string): AbTestState | undefined {
+    return this.tests.get(skill);
+  }
+
+  /** All tests (active and resolved). */
+  listTests(): AbTestState[] {
+    return [...this.tests.values()];
+  }
+
+  // ── Internal ───────────────────────────────────────────────────────────────
+
+  private commitWinner(winner: "control" | "challenger", state: AbTestState): void {
+    state.resolvedAt = Date.now();
+    state.winner = winner;
+
+    // Remove the ab-test executor first — future resolves bypass this plugin
+    this.abExecutors.delete(state.skill);
+
+    // Register winner at priority 100 so it wins over any existing registrations
+    this.registry.register(state.skill, state[winner].executor, { priority: 100 });
+
+    const reason = buildReason(winner, state);
+
+    const payload: AbTestResolvedPayload = {
+      skill: state.skill,
+      winner,
+      controlMetrics: state.control.metrics,
+      challengerMetrics: state.challenger.metrics,
+      resolvedAt: state.resolvedAt,
+      reason,
+    };
+
+    this.bus.publish("skill.ab_test.resolved", {
+      id: crypto.randomUUID(),
+      correlationId: crypto.randomUUID(),
+      topic: "skill.ab_test.resolved",
+      timestamp: Date.now(),
+      payload,
+    });
+
+    console.info(
+      `[skill-ab-test] Test resolved for '${state.skill}': winner=${winner} (${reason})`,
+    );
+  }
+
+  /**
+   * Handle skill.ab_test.register bus messages.
+   * Expects payload: { skill, n, controlType, challengerType }
+   * where controlType and challengerType identify registered executor agentNames.
+   *
+   * For more control, callers should use registerTest() directly.
+   */
+  private handleRegisterMessage(msg: BusMessage): void {
+    const p = msg.payload as {
+      skill?: string;
+      n?: number;
+      controlAgentName?: string;
+      challengerAgentName?: string;
+    } | null;
+
+    if (!p?.skill || typeof p.n !== "number") {
+      console.warn(
+        "[skill-ab-test] skill.ab_test.register message missing required fields (skill, n) — ignored",
+      );
+      return;
+    }
+
+    // Resolve executors from the registry by agent name
+    const controlExec = p.controlAgentName
+      ? this.registry.resolve(p.skill, [p.controlAgentName])
+      : this.registry.resolve(p.skill);
+
+    if (!controlExec) {
+      console.warn(
+        `[skill-ab-test] No control executor found for skill '${p.skill}' — cannot start test`,
+      );
+      return;
+    }
+
+    const challengerExec = p.challengerAgentName
+      ? this.registry.resolve(p.skill, [p.challengerAgentName])
+      : null;
+
+    if (!challengerExec) {
+      console.warn(
+        `[skill-ab-test] No challenger executor found for skill '${p.skill}' — cannot start test`,
+      );
+      return;
+    }
+
+    this.registerTest(p.skill, controlExec, challengerExec, p.n);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,6 +272,17 @@ const pluginRegistry: PluginRegistryEntry[] = [
     },
   },
   {
+    // Intercepts ExecutorRegistry.resolve() to A/B test competing skill variants.
+    // Must be installed AFTER registrars (agent-runtime, skill-broker) and
+    // BEFORE skill-dispatcher so the hook is active when dispatches begin.
+    name: "skill-ab-test",
+    condition: () => true,
+    factory: async () => {
+      const { SkillAbTestPlugin } = await import("./executor/skill-ab-test-plugin.js");
+      return new SkillAbTestPlugin(executorRegistry);
+    },
+  },
+  {
     // Sole subscriber to agent.skill.request — dispatches via ExecutorRegistry.
     // Must be installed AFTER agent-runtime and skill-broker (registrars).
     name: "skill-dispatcher",


### PR DESCRIPTION
Re-cut of #309 on fresh dev.

Adds `SkillAbTestPlugin` with a resolve-hook on `ExecutorRegistry` so two skills targeting the same goal can be split-tested. The hook intercepts after health-weighted resolution (Arc 8.4) so A/B selection composes cleanly with fleet-health-based primary ranking.

3 changes:
- New `src/executor/skill-ab-test-plugin.ts` (341 lines) + 289-line test suite
- `ExecutorRegistry` exposes `setResolveHook` (sibling to Arc 8.4's `setHealthGetter`)
- Plugin registered in `src/index.ts`

Conflict resolution: HEAD has `_healthGetter` (Arc 8.4), incoming has `_resolveHook` — kept both as sibling fields. `resolve()` runs health-weighted resolution first, then the hook gets a chance to override. Composes cleanly with all the Arc 8.x fleet-health work.

898/898 tests pass (+19 new), typecheck clean. Closes #309.