### PR TITLE
DD-1.0: Plugin WidgetDescriptor contract

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -149,12 +149,23 @@ export interface ConfigChangeRenderer {
   onExpired?(request: ConfigChangeRequest, bus: EventBus): Promise<void>;
 }
 
+export type WidgetType = 'chart' | 'table' | 'status-card' | 'log-stream' | 'metric';
+
+export interface WidgetDescriptor {
+  id: string;
+  type: WidgetType;
+  title: string;
+  query?: string;
+  props?: Record<string, unknown>;
+}
+
 export interface Plugin {
   name: string;
   description: string;
   capabilities: string[];
   install(bus: EventBus): void;
   uninstall(): void;
+  getWidgets?(): WidgetDescriptor[];
 }
 
 export interface TopicInfo {

--- a/tests/widget-descriptor.test.ts
+++ b/tests/widget-descriptor.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "bun:test";
+import type { Plugin, WidgetDescriptor, WidgetType } from "../lib/types";
+
+// Minimal EventBus stub
+const stubBus: import("../lib/types").EventBus = {
+  publish: () => {},
+  subscribe: () => "id",
+  unsubscribe: () => {},
+  topics: () => [],
+  consumers: () => [],
+};
+
+describe("Plugin without getWidgets still works", () => {
+  it("installs and uninstalls without getWidgets", () => {
+    let installed = false;
+    const plugin: Plugin = {
+      name: "basic",
+      description: "no widgets",
+      capabilities: [],
+      install(_bus) { installed = true; },
+      uninstall() { installed = false; },
+    };
+    plugin.install(stubBus);
+    expect(installed).toBe(true);
+    plugin.uninstall();
+    expect(installed).toBe(false);
+    expect(plugin.getWidgets).toBeUndefined();
+  });
+});
+
+describe("WidgetDescriptor contract shape", () => {
+  it("accepts all widget types", () => {
+    const types: WidgetType[] = ["chart", "table", "status-card", "log-stream", "metric"];
+    for (const type of types) {
+      const w: WidgetDescriptor = { id: `w-${type}`, type, title: type };
+      expect(w.id).toBe(`w-${type}`);
+      expect(w.type).toBe(type);
+    }
+  });
+
+  it("allows optional query and props", () => {
+    const w: WidgetDescriptor = {
+      id: "w1",
+      type: "chart",
+      title: "My Chart",
+      query: "SELECT count FROM metrics",
+      props: { color: "blue" },
+    };
+    expect(w.query).toBe("SELECT count FROM metrics");
+    expect(w.props).toEqual({ color: "blue" });
+  });
+
+  it("plugin with getWidgets returns descriptors", () => {
+    const widget: WidgetDescriptor = { id: "status", type: "status-card", title: "Status" };
+    const plugin: Plugin = {
+      name: "widget-plugin",
+      description: "has widgets",
+      capabilities: [],
+      install() {},
+      uninstall() {},
+      getWidgets() { return [widget]; },
+    };
+    expect(plugin.getWidgets!()).toHaveLength(1);
+    expect(plugin.getWidgets!()[0]).toEqual(widget);
+  });
+});


### PR DESCRIPTION
## Summary

# Plugin WidgetDescriptor Contract

Add typed widget declaration to Plugin interface.

## Acceptance Criteria
- [ ] Extend Plugin with getWidgets?(): WidgetDescriptor[]
- [ ] Define WidgetDescriptor: { id, type, title, query?, props? }
- [ ] Define widget types: 'chart', 'table', 'status-card', 'log-stream', 'metric'
- [ ] Update lib/types.ts with full contract
- [ ] Types are backward compatible (optional method)

## Files
- `lib/types.ts` — add WidgetDescriptor, extend Plugin

## Test
- Unit t...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Plugins can now define and provide custom widgets to the application, including charts, tables, status cards, log streams, and metrics, enabling enhanced data visualization and monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->