### PR TITLE
DD-1.1: /api/widgets discovery endpoint

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -149,12 +149,21 @@ export interface ConfigChangeRenderer {
   onExpired?(request: ConfigChangeRequest, bus: EventBus): Promise<void>;
 }
 
+export interface WidgetDescriptor {
+  pluginName: string;
+  widgetId: string;
+  type: string;
+  title: string;
+  props: Record<string, unknown>;
+}
+
 export interface Plugin {
   name: string;
   description: string;
   capabilities: string[];
   install(bus: EventBus): void;
   uninstall(): void;
+  getWidgets?(): WidgetDescriptor[];
 }
 
 export interface TopicInfo {

--- a/src/api/__tests__/widgets.test.ts
+++ b/src/api/__tests__/widgets.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Integration test for GET /api/widgets
+ *
+ * Verifies:
+ * - Returns all WidgetDescriptors from plugins that implement getWidgets()
+ * - Plugins without getWidgets() are silently skipped
+ * - Response includes cache-control header
+ * - API key validation rejects unauthorized requests
+ * - Cache is returned on repeated requests within TTL
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { ExecutorRegistry } from "../../executor/executor-registry.ts";
+import { createRoutes } from "../widgets.ts";
+import type { ApiContext } from "../types.ts";
+import type { Plugin, WidgetDescriptor } from "../../../lib/types.ts";
+
+function makePlugin(name: string, widgets?: WidgetDescriptor[]): Plugin {
+  return {
+    name,
+    description: "test plugin",
+    capabilities: [],
+    install() {},
+    uninstall() {},
+    ...(widgets !== undefined ? { getWidgets: () => widgets } : {}),
+  };
+}
+
+function makeCtx(plugins: Plugin[], apiKey?: string): ApiContext {
+  return {
+    workspaceDir: "/tmp",
+    bus: new InMemoryEventBus(),
+    plugins,
+    executorRegistry: new ExecutorRegistry(),
+    apiKey,
+  };
+}
+
+describe("GET /api/widgets", () => {
+  test("returns empty array when no plugins have getWidgets", async () => {
+    const ctx = makeCtx([makePlugin("plain")]);
+    const [route] = createRoutes(ctx);
+    const resp = await route.handler(new Request("http://x/api/widgets"), {});
+    expect(resp.status).toBe(200);
+    const body = await resp.json();
+    expect(body).toEqual([]);
+  });
+
+  test("aggregates widgets from all plugins with getWidgets", async () => {
+    const w1: WidgetDescriptor = { pluginName: "a", widgetId: "w1", type: "chart", title: "Chart A", props: { color: "blue" } };
+    const w2: WidgetDescriptor = { pluginName: "b", widgetId: "w2", type: "table", title: "Table B", props: {} };
+    const ctx = makeCtx([
+      makePlugin("a", [w1]),
+      makePlugin("b", [w2]),
+      makePlugin("c"),
+    ]);
+    const [route] = createRoutes(ctx);
+    const resp = await route.handler(new Request("http://x/api/widgets"), {});
+    const body = await resp.json() as WidgetDescriptor[];
+    expect(body).toHaveLength(2);
+    expect(body.map(w => w.widgetId).sort()).toEqual(["w1", "w2"]);
+  });
+
+  test("skips plugins without getWidgets gracefully", async () => {
+    const w: WidgetDescriptor = { pluginName: "a", widgetId: "w1", type: "card", title: "Card", props: {} };
+    const ctx = makeCtx([makePlugin("noWidgets"), makePlugin("hasWidgets", [w])]);
+    const [route] = createRoutes(ctx);
+    const resp = await route.handler(new Request("http://x/api/widgets"), {});
+    const body = await resp.json() as WidgetDescriptor[];
+    expect(body).toHaveLength(1);
+    expect(body[0].widgetId).toBe("w1");
+  });
+
+  test("includes cache-control header with 5s max-age", async () => {
+    const ctx = makeCtx([]);
+    const [route] = createRoutes(ctx);
+    const resp = await route.handler(new Request("http://x/api/widgets"), {});
+    expect(resp.headers.get("cache-control")).toContain("max-age=5");
+  });
+
+  test("returns 401 when API key is required and missing", async () => {
+    const ctx = makeCtx([], "secret-key");
+    const [route] = createRoutes(ctx);
+    const resp = await route.handler(new Request("http://x/api/widgets"), {});
+    expect(resp.status).toBe(401);
+  });
+
+  test("returns 401 when API key is wrong", async () => {
+    const ctx = makeCtx([], "secret-key");
+    const [route] = createRoutes(ctx);
+    const resp = await route.handler(
+      new Request("http://x/api/widgets", { headers: { "X-API-Key": "wrong" } }),
+      {}
+    );
+    expect(resp.status).toBe(401);
+  });
+
+  test("succeeds with correct API key", async () => {
+    const ctx = makeCtx([], "secret-key");
+    const [route] = createRoutes(ctx);
+    const resp = await route.handler(
+      new Request("http://x/api/widgets", { headers: { "X-API-Key": "secret-key" } }),
+      {}
+    );
+    expect(resp.status).toBe(200);
+  });
+
+  test("cache returns same result on second request within TTL", async () => {
+    let callCount = 0;
+    const plugin = makePlugin("counter", []);
+    const origGetWidgets = plugin.getWidgets!;
+    plugin.getWidgets = () => {
+      callCount++;
+      return origGetWidgets();
+    };
+    const ctx = makeCtx([plugin]);
+    const [route] = createRoutes(ctx);
+    await route.handler(new Request("http://x/api/widgets"), {});
+    await route.handler(new Request("http://x/api/widgets"), {});
+    // getWidgets should only have been called once (cache hit on second request)
+    expect(callCount).toBe(1);
+  });
+});

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -19,6 +19,7 @@ import { createRoutes as discordRoutes } from "./discord.ts";
 import { createRoutes as a2aCallbackRoutes } from "./a2a-callback.ts";
 import { createRoutes as a2aServerRoutes } from "./a2a-server.ts";
 import { createRoutes as agentCardRoutes } from "./agent-card.ts";
+import { createRoutes as widgetsRoutes } from "./widgets.ts";
 
 export { matchPath } from "./types.ts";
 export type { Route, ApiContext } from "./types.ts";
@@ -37,5 +38,6 @@ export function createAllRoutes(ctx: ApiContext): Route[] {
     ...(ctx.taskTracker ? a2aCallbackRoutes(ctx.taskTracker, ctx) : []),
     ...agentCardRoutes(ctx),
     ...a2aServerRoutes(ctx),
+    ...widgetsRoutes(ctx),
   ];
 }

--- a/src/api/widgets.ts
+++ b/src/api/widgets.ts
@@ -1,0 +1,50 @@
+/**
+ * Widget discovery endpoint — GET /api/widgets
+ *
+ * Aggregates WidgetDescriptor entries from every plugin that implements
+ * getWidgets(). Plugins without getWidgets() are silently skipped.
+ *
+ * Response is cached with a 5-second TTL since plugins are static per runtime.
+ * Requires X-API-Key header when ctx.apiKey is configured.
+ */
+
+import type { Route, ApiContext } from "./types.ts";
+import type { WidgetDescriptor } from "../../lib/types.ts";
+
+interface CacheEntry {
+  widgets: WidgetDescriptor[];
+  expiresAt: number;
+}
+
+const CACHE_TTL_MS = 5_000;
+
+export function createRoutes(ctx: ApiContext): Route[] {
+  let cache: CacheEntry | null = null;
+
+  return [
+    {
+      method: "GET",
+      path: "/api/widgets",
+      handler: (req) => {
+        if (ctx.apiKey && req.headers.get("X-API-Key") !== ctx.apiKey) {
+          return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+        }
+
+        const now = Date.now();
+        if (!cache || now >= cache.expiresAt) {
+          const widgets: WidgetDescriptor[] = [];
+          for (const plugin of ctx.plugins) {
+            if (typeof plugin.getWidgets === "function") {
+              widgets.push(...plugin.getWidgets());
+            }
+          }
+          cache = { widgets, expiresAt: now + CACHE_TTL_MS };
+        }
+
+        return Response.json(cache.widgets, {
+          headers: { "cache-control": `public, max-age=${CACHE_TTL_MS / 1000}` },
+        });
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

# /api/widgets Discovery Endpoint

Expose plugin-contributed widgets at runtime.

## Acceptance Criteria
- [ ] GET /api/widgets returns array of all WidgetDescriptor from all plugins
- [ ] Descriptor includes plugin name, widget id, type, title, props
- [ ] Handles plugins without getWidgets() gracefully (empty array)
- [ ] Response cached with 5s TTL (plugins are static per runtime)
- [ ] API key validated

## Files
- `src/api/widgets.ts` — new module
- `src/api/index.ts` — import and mount wid...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-15T01:45:30.880Z -->