### PR TITLE
DD-2.0: Dashboard refactor — discovery-driven layout

### DIFF
--- a/dashboard/src/components/DiscoveryView.tsx
+++ b/dashboard/src/components/DiscoveryView.tsx
@@ -1,0 +1,301 @@
+// DiscoveryView — fetches /api/widgets and renders all plugin widgets grouped by plugin name.
+//
+// Maps the server-side WidgetDescriptor (lib/types.ts) to the dashboard-internal
+// renderer descriptor format (lib/widget-renderer.ts) at runtime.
+
+import { useState, useEffect } from "preact/hooks";
+import type {
+  ChartWidgetDescriptor,
+  TableWidgetDescriptor,
+  StatusCardWidgetDescriptor,
+  ChartConfig,
+  TableConfig,
+  StatusCardConfig,
+} from "../lib/widget-renderer";
+import ChartRenderer from "./renderers/ChartRenderer";
+import TableRenderer from "./renderers/TableRenderer";
+import StatusCardRenderer from "./renderers/StatusCardRenderer";
+
+// Shape returned by GET /api/widgets (matches lib/types.ts WidgetDescriptor)
+interface ApiWidget {
+  pluginName: string;
+  id: string;
+  type: string;
+  title: string;
+  query?: string;
+  props?: Record<string, unknown>;
+}
+
+type RendererDescriptor =
+  | ChartWidgetDescriptor
+  | TableWidgetDescriptor
+  | StatusCardWidgetDescriptor;
+
+function toRendererDescriptor(w: ApiWidget): RendererDescriptor | null {
+  const query = { url: w.query ?? "" };
+  switch (w.type) {
+    case "chart":
+      return {
+        id: w.id,
+        title: w.title,
+        type: "chart",
+        config: (w.props ?? {}) as ChartConfig,
+        query,
+      };
+    case "table":
+      return {
+        id: w.id,
+        title: w.title,
+        type: "table",
+        config: (w.props ?? {}) as TableConfig,
+        query,
+      };
+    case "status-card":
+      return {
+        id: w.id,
+        title: w.title,
+        type: "status-card",
+        config: (w.props ?? {}) as StatusCardConfig,
+        query,
+      };
+    default:
+      // log-stream, metric, unknown — no renderer yet
+      return null;
+  }
+}
+
+function groupByPlugin(widgets: ApiWidget[]): Map<string, ApiWidget[]> {
+  const groups = new Map<string, ApiWidget[]>();
+  for (const w of widgets) {
+    const existing = groups.get(w.pluginName) ?? [];
+    existing.push(w);
+    groups.set(w.pluginName, existing);
+  }
+  return groups;
+}
+
+interface WidgetCardProps {
+  widget: ApiWidget;
+}
+
+function WidgetCard({ widget }: WidgetCardProps) {
+  const descriptor = toRendererDescriptor(widget);
+
+  if (!descriptor) {
+    return (
+      <div class="discovery-widget discovery-widget--unsupported">
+        <div class="discovery-widget__title">{widget.title}</div>
+        <div class="discovery-widget__unsupported">
+          No renderer for type: {widget.type}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div class="discovery-widget">
+      {descriptor.type === "chart" && (
+        <ChartRenderer descriptor={descriptor} />
+      )}
+      {descriptor.type === "table" && (
+        <TableRenderer descriptor={descriptor} />
+      )}
+      {descriptor.type === "status-card" && (
+        <StatusCardRenderer descriptor={descriptor} />
+      )}
+    </div>
+  );
+}
+
+interface PluginSectionProps {
+  pluginName: string;
+  widgets: ApiWidget[];
+}
+
+function PluginSection({ pluginName, widgets }: PluginSectionProps) {
+  return (
+    <section class="discovery-plugin-section">
+      <h2 class="discovery-plugin-section__name">{pluginName}</h2>
+      <div class="discovery-widget-grid">
+        {widgets.map((w) => (
+          <WidgetCard key={w.id} widget={w} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+interface DiscoveryViewProps {
+  /** When set, only shows widgets for this plugin name. Null/undefined = show all. */
+  pluginFilter?: string | null;
+}
+
+export default function DiscoveryView({ pluginFilter }: DiscoveryViewProps) {
+  const [widgets, setWidgets] = useState<ApiWidget[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const res = await fetch("/api/widgets", {
+          headers: { Accept: "application/json" },
+        });
+        if (!res.ok) {
+          throw new Error(`/api/widgets returned ${res.status} ${res.statusText}`);
+        }
+        const data = await res.json();
+        if (cancelled) return;
+        // Handle both raw array and { success, data } envelope
+        const list: ApiWidget[] = Array.isArray(data)
+          ? data
+          : Array.isArray(data?.data)
+            ? data.data
+            : [];
+        setWidgets(list);
+        setError(null);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load widgets");
+      }
+    }
+
+    load();
+    // Refresh every 30s so new plugin registrations surface without a full reload
+    const id = setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  if (error) {
+    return (
+      <>
+        <style>{styles}</style>
+        <div class="discovery-error">
+          <div class="discovery-error__title">Failed to load widgets</div>
+          <div class="discovery-error__message">{error}</div>
+        </div>
+      </>
+    );
+  }
+
+  if (widgets === null) {
+    return (
+      <>
+        <style>{styles}</style>
+        <div class="discovery-loading">Loading widgets…</div>
+      </>
+    );
+  }
+
+  const filtered = pluginFilter
+    ? widgets.filter((w) => w.pluginName === pluginFilter)
+    : widgets;
+
+  if (filtered.length === 0) {
+    return (
+      <>
+        <style>{styles}</style>
+        <div class="discovery-empty">
+          {pluginFilter
+            ? `No widgets registered by "${pluginFilter}".`
+            : "No widgets registered. Plugins can contribute widgets via getWidgets()."}
+        </div>
+      </>
+    );
+  }
+
+  const groups = groupByPlugin(filtered);
+
+  return (
+    <>
+      <style>{styles}</style>
+      <div class="discovery-view">
+        {[...groups.entries()].map(([pluginName, pluginWidgets]) => (
+          <PluginSection
+            key={pluginName}
+            pluginName={pluginName}
+            widgets={pluginWidgets}
+          />
+        ))}
+      </div>
+    </>
+  );
+}
+
+const styles = `
+  .discovery-view {
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+  }
+
+  .discovery-plugin-section {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .discovery-plugin-section__name {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-secondary, #8b949e);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    border-bottom: 1px solid var(--border-default, #30363d);
+    padding-bottom: 8px;
+  }
+
+  .discovery-widget-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+    gap: 16px;
+  }
+
+  .discovery-widget {
+    background: var(--bg-card, #161b22);
+    border: 1px solid var(--border-default, #30363d);
+    border-radius: 8px;
+    padding: 16px;
+    min-width: 0;
+  }
+
+  .discovery-widget--unsupported {
+    opacity: 0.6;
+  }
+
+  .discovery-widget__title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary, #e6edf3);
+    margin-bottom: 8px;
+  }
+
+  .discovery-widget__unsupported {
+    font-size: 12px;
+    color: var(--text-muted, #8b949e);
+    font-style: italic;
+  }
+
+  .discovery-loading,
+  .discovery-empty,
+  .discovery-error {
+    padding: 48px 24px;
+    text-align: center;
+    color: var(--text-muted, #8b949e);
+    font-size: 14px;
+  }
+
+  .discovery-error__title {
+    font-weight: 600;
+    color: var(--text-danger, #f85149);
+    margin-bottom: 8px;
+  }
+
+  .discovery-error__message {
+    font-size: 12px;
+    font-family: monospace;
+  }
+`;

--- a/dashboard/src/layouts/DashboardLayout.astro
+++ b/dashboard/src/layouts/DashboardLayout.astro
@@ -17,6 +17,7 @@ const navItems = [
   { href: "/outcomes", label: "Outcomes", id: "outcomes" },
   { href: "/projects", label: "Projects", id: "projects" },
   { href: "/fleet-cost", label: "Fleet Cost", id: "fleet-cost" },
+  { href: "/widgets", label: "Plugins", id: "discovery" },
 ];
 ---
 

--- a/dashboard/src/layouts/DiscoveryLayout.astro
+++ b/dashboard/src/layouts/DiscoveryLayout.astro
@@ -1,0 +1,17 @@
+---
+// DiscoveryLayout — wraps the standard dashboard shell for discovery-driven plugin pages.
+// Used by [dynamic].astro to render widgets fetched from /api/widgets.
+import DashboardLayout from "./DashboardLayout.astro";
+
+export interface Props {
+  title: string;
+  /** Sidebar nav item to highlight. Defaults to "discovery". */
+  activePage?: string;
+}
+
+const { title, activePage = "discovery" } = Astro.props;
+---
+
+<DashboardLayout title={title} activePage={activePage}>
+  <slot />
+</DashboardLayout>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -130,6 +130,9 @@ export const getCeremonies = () =>
 export const getHitlPending = () =>
   apiFetch<{ data: unknown[] }>("/api/hitl/pending", { ttl: 30_000 });
 
+export const getWidgets = (force = false) =>
+  apiFetch<unknown[]>("/api/widgets", { ttl: 30_000, force });
+
 // ── Response types (match actual API shapes after envelope unwrap) ─
 export interface WorldStateResponse {
   timestamp: number;

--- a/dashboard/src/pages/[dynamic].astro
+++ b/dashboard/src/pages/[dynamic].astro
@@ -1,0 +1,55 @@
+---
+// [dynamic].astro — discovery-driven catch-all router.
+//
+// At build time, attempts to fetch /api/widgets to enumerate registered plugins
+// and pre-render one page per plugin. Falls back to a single "widgets" path
+// if the API is unavailable (server not running at build time).
+//
+// At runtime the DiscoveryView component re-fetches /api/widgets every 30s so
+// new plugin registrations surface without a rebuild (Astro ISR-compatible pattern).
+
+import DiscoveryLayout from "../layouts/DiscoveryLayout.astro";
+import DiscoveryView from "../components/DiscoveryView.tsx";
+
+export async function getStaticPaths() {
+  try {
+    const apiBase = import.meta.env.API_BASE_URL ?? "http://localhost:3000";
+    const res = await fetch(`${apiBase}/api/widgets`, {
+      signal: AbortSignal.timeout(3_000),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+    const raw = await res.json();
+    const list: Array<{ pluginName: string }> = Array.isArray(raw)
+      ? raw
+      : Array.isArray(raw?.data)
+        ? raw.data
+        : [];
+
+    const plugins = [...new Set(list.map((w) => w.pluginName))];
+    if (plugins.length === 0) {
+      return [{ params: { dynamic: "widgets" }, props: { pluginName: null } }];
+    }
+    return plugins.map((pluginName) => ({
+      params: {
+        dynamic: pluginName.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
+      },
+      props: { pluginName },
+    }));
+  } catch {
+    // Server not running at build time — fall back to generic "widgets" path.
+    return [{ params: { dynamic: "widgets" }, props: { pluginName: null } }];
+  }
+}
+
+interface Props {
+  pluginName: string | null;
+}
+
+const { pluginName } = Astro.props;
+const pageTitle = pluginName ? pluginName : "Plugins";
+---
+
+<DiscoveryLayout title={pageTitle}>
+  <DiscoveryView client:load pluginFilter={pluginName} />
+</DiscoveryLayout>


### PR DESCRIPTION
## Summary

# Dashboard Refactor to Discovery-Driven Layout

Replace hardcoded pages with dynamic discovery. Dashboard fetches /api/widgets and renders using generic renderers.

## Acceptance Criteria
- [ ] Remove hardcoded pages (projects.astro, fleet-cost.astro, etc.)
- [ ] New unified dashboard page that calls /api/widgets at build + runtime
- [ ] Organizes widgets by plugin name (cards in a grid)
- [ ] Falls back to static pages for backward compat during transition
- [ ] Astro ISR compatible (revalidat...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Plugins" section to the dashboard navigation menu.
  * Introduced a discovery view that fetches and displays available widgets grouped by plugin name, with automatic refresh every 30 seconds.
  * Added dynamic routing to generate dedicated pages for each plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->