### PR TITLE
DD-3.0: Migrate WorldStatePlugin to declare widgets

### DIFF
--- a/dashboard/src/components/WorldStateCard.tsx
+++ b/dashboard/src/components/WorldStateCard.tsx
@@ -1,0 +1,159 @@
+/**
+ * WorldStateCard — generic renderer for world-state domain widgets.
+ *
+ * Renders a single domain entry from /api/world-state as a status card.
+ * Used by the discovery-driven dashboard when a plugin declares a
+ * world-state-domain-card WidgetDescriptor.
+ */
+import { useState } from "preact/hooks";
+import JsonTree from "./JsonTree.tsx";
+
+export interface WorldStateCardProps {
+  name: string;
+  data: unknown;
+  metadata: {
+    collectedAt: number;
+    domain: string;
+    tickNumber: number;
+    failed?: boolean;
+    errorMessage?: string;
+  };
+}
+
+function relativeTime(ms: number): string {
+  const diffMs = Date.now() - ms;
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  return `${diffHr}h ago`;
+}
+
+export default function WorldStateCard({ name, data, metadata }: WorldStateCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const failed = metadata.failed === true;
+
+  return (
+    <div
+      class="ws-card"
+      style={{
+        borderColor: failed ? "rgba(248, 81, 73, 0.5)" : "var(--border-default)",
+        background: failed ? "rgba(248, 81, 73, 0.06)" : "var(--bg-default)",
+      }}
+    >
+      <div class="ws-card__header">
+        <div class="ws-card__title-row">
+          <span
+            class="ws-card__status-dot"
+            style={{ background: failed ? "var(--text-danger)" : "var(--text-success)" }}
+          />
+          <span class="ws-card__name">{name}</span>
+          {failed && (
+            <span class="badge badge-red" style={{ marginLeft: "8px" }}>
+              failed
+            </span>
+          )}
+        </div>
+        <div class="ws-card__meta">
+          <span title={new Date(metadata.collectedAt).toISOString()}>
+            {relativeTime(metadata.collectedAt)}
+          </span>
+          <span class="ws-card__sep">·</span>
+          <span>tick #{metadata.tickNumber}</span>
+        </div>
+      </div>
+
+      {failed && metadata.errorMessage && (
+        <div class="ws-card__error">{metadata.errorMessage}</div>
+      )}
+
+      <button class="ws-card__toggle" onClick={() => setExpanded(!expanded)}>
+        {expanded ? "Hide data ▲" : "Show data ▼"}
+      </button>
+
+      {expanded && (
+        <div class="ws-card__data">
+          <JsonTree value={data} />
+        </div>
+      )}
+
+      <style>{`
+        .ws-card {
+          display: flex;
+          flex-direction: column;
+          gap: 10px;
+          border: 1px solid var(--border-default);
+          border-radius: 8px;
+          padding: 14px 16px;
+          transition: border-color 0.2s;
+        }
+        .ws-card__header {
+          display: flex;
+          align-items: flex-start;
+          justify-content: space-between;
+          gap: 12px;
+        }
+        .ws-card__title-row {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+        }
+        .ws-card__status-dot {
+          width: 8px;
+          height: 8px;
+          border-radius: 50%;
+          flex-shrink: 0;
+        }
+        .ws-card__name {
+          font-size: 14px;
+          font-weight: 600;
+          color: var(--text-primary);
+          font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+        }
+        .ws-card__meta {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          font-size: 12px;
+          color: var(--text-secondary);
+          flex-shrink: 0;
+        }
+        .ws-card__sep {
+          color: var(--border-default);
+        }
+        .ws-card__error {
+          font-size: 12px;
+          color: var(--text-danger);
+          background: rgba(248, 81, 73, 0.1);
+          border: 1px solid rgba(248, 81, 73, 0.3);
+          border-radius: 4px;
+          padding: 6px 10px;
+        }
+        .ws-card__toggle {
+          align-self: flex-start;
+          background: none;
+          border: 1px solid var(--border-muted);
+          border-radius: 4px;
+          color: var(--text-secondary);
+          cursor: pointer;
+          font-size: 12px;
+          padding: 4px 10px;
+          transition: border-color 0.1s, color 0.1s;
+        }
+        .ws-card__toggle:hover {
+          border-color: var(--border-default);
+          color: var(--text-primary);
+        }
+        .ws-card__data {
+          background: var(--bg-inset);
+          border: 1px solid var(--border-default);
+          border-radius: 4px;
+          padding: 12px;
+          max-height: 400px;
+          overflow-y: auto;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/lib/plugins/world-state-engine.ts
+++ b/lib/plugins/world-state-engine.ts
@@ -34,7 +34,7 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync, existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
-import type { Plugin, EventBus, BusMessage } from "../types.ts";
+import type { Plugin, EventBus, BusMessage, WidgetDescriptor } from "../types.ts";
 import type { WorldState, WorldStateDomain, WorldStateSnapshot } from "../types/world-state.ts";
 import { HttpClient } from "../../src/services/http-client.ts";
 
@@ -245,6 +245,27 @@ export class WorldStateEngine implements Plugin {
         `[world-state-engine] Pruned ${orphans.length} orphan domain(s) from restored snapshot: ${orphans.join(", ")}`,
       );
     }
+  }
+
+  getWidgets(): WidgetDescriptor[] {
+    return [
+      {
+        pluginName: this.name,
+        id: "world-state-domain-grid",
+        type: "table",
+        title: "Domain Grid",
+        query: "/api/world-state",
+        props: { layout: "grid" },
+      },
+      {
+        pluginName: this.name,
+        id: "world-state-domain-card",
+        type: "status-card",
+        title: "Domain Card",
+        query: "/api/world-state",
+        props: { layout: "card" },
+      },
+    ];
   }
 
   uninstall(): void {


### PR DESCRIPTION
## Summary

# Migrate WorldStatePlugin — Widget Declaration

Proof-of-concept: convert WorldStatePlugin's hardcoded components to WidgetDescriptor declarations.

## Acceptance Criteria
- [ ] WorldStatePlugin.getWidgets() returns DomainCard, DomainGrid descriptors
- [ ] Widgets use /api/world-state as data source (query endpoint)
- [ ] No changes to world-state API needed
- [ ] dashboard/src/components/DomainCard.tsx becomes generic CardRenderer component
- [ ] Test: verify plugin widgets appear on discovery...

---
*Recovered automatically by Automaker post-agent hook*