### PR TITLE
DD-3.1: Migrate EventStreamPlugin to declare widgets

### DIFF
--- a/dashboard/src/components/renderers/LogStreamRenderer.tsx
+++ b/dashboard/src/components/renderers/LogStreamRenderer.tsx
@@ -1,0 +1,93 @@
+// LogStreamRenderer — renders a live event log stream for a log-stream WidgetDescriptor.
+//
+// Fetches initial events from the widget's query URL, then subscribes to the
+// WebSocket path in props.wsPath for real-time updates.
+
+import { useState, useEffect, useRef } from "preact/hooks";
+import { WebSocketManager } from "../../lib/websocket";
+import type { WsMessage } from "../../lib/websocket";
+import { EventRow } from "../EventRow";
+
+export interface LogStreamWidgetDescriptor {
+  id: string;
+  title: string;
+  type: "log-stream";
+  query: string;
+  props?: {
+    wsPath?: string;
+    limit?: number;
+  };
+}
+
+interface Props {
+  descriptor: LogStreamWidgetDescriptor;
+}
+
+export function LogStreamRenderer({ descriptor }: Props) {
+  const [events, setEvents] = useState<WsMessage[]>([]);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const queryUrl = descriptor.query;
+  const wsPath = descriptor.props?.wsPath;
+  const limit = descriptor.props?.limit ?? 100;
+
+  // Load history on mount
+  useEffect(() => {
+    fetch(`${queryUrl}?limit=${limit}`)
+      .then((r) => r.json())
+      .then((data: unknown) => {
+        const msgs = (Array.isArray(data) ? data : []) as WsMessage[];
+        setEvents(msgs.reverse());
+      })
+      .catch(() => {});
+  }, [queryUrl, limit]);
+
+  // WebSocket for live updates
+  useEffect(() => {
+    if (!wsPath) return;
+    const manager = new WebSocketManager(wsPath);
+    const off = manager.onMessage((msg) => {
+      setEvents((prev) => [...prev, msg]);
+    });
+    manager.connect();
+    return () => {
+      off();
+      manager.destroy();
+    };
+  }, [wsPath]);
+
+  // Auto-scroll to bottom
+  useEffect(() => {
+    const el = listRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [events]);
+
+  function toggleExpanded(id: string) {
+    setExpandedId((prev) => (prev === id ? null : id));
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "400px" }}>
+      <div
+        ref={listRef}
+        style={{ flex: 1, overflow: "auto", fontFamily: "'SF Mono', 'Fira Code', Consolas, monospace" }}
+      >
+        {events.length === 0 ? (
+          <div style={{ padding: "16px", color: "#484f58", fontSize: "13px" }}>
+            Waiting for events…
+          </div>
+        ) : (
+          events.map((msg) => (
+            <EventRow
+              key={msg.id ?? msg.timestamp}
+              msg={msg}
+              isExpanded={expandedId === (msg.id ?? msg.timestamp)}
+              onClick={() => toggleExpanded(msg.id ?? msg.timestamp)}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lib/plugins/event-viewer.ts
+++ b/lib/plugins/event-viewer.ts
@@ -3,7 +3,7 @@ import { readFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
 import type { ServerWebSocket } from "bun";
-import type { Plugin, EventBus, BusMessage } from "../types";
+import type { Plugin, EventBus, BusMessage, WidgetDescriptor } from "../types";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -68,6 +68,19 @@ export class EventViewerPlugin implements Plugin {
     });
 
     console.log(`Event viewer available at http://localhost:${this.port}`);
+  }
+
+  getWidgets(): WidgetDescriptor[] {
+    return [
+      {
+        pluginName: this.name,
+        id: "event-stream",
+        type: "log-stream",
+        title: "Event Stream",
+        query: "/api/events",
+        props: { wsPath: "/ws", limit: 500 },
+      },
+    ];
   }
 
   uninstall(): void {


### PR DESCRIPTION
## Summary

# Migrate EventStreamPlugin — Widget Declaration

Proof-of-concept: convert EventStreamPlugin's hardcoded event rendering to WidgetDescriptor.

## Acceptance Criteria
- [ ] EventStreamPlugin.getWidgets() returns log-stream widget descriptor
- [ ] Widget references /api/events as data source
- [ ] EventRow, EventDetail components become reusable renderers
- [ ] Stream updates via WebSocket (Astro Islands client-side)
- [ ] Test: verify event widget appears on discovery dashboard

## Files
- `lib/...

---
*Recovered automatically by Automaker post-agent hook*