### PR TITLE
Update docs after: Cross-Channel Conversational Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ bun run src/index.ts
 | `WORKSTACEAN_HTTP_PORT` | No | HTTP API port (default: `3000`) |
 | `WORKSTACEAN_API_KEY` | No | API key for `/publish` endpoint |
 | `WORKSTACEAN_BASE_URL` | For A2A push notifications | Externally-reachable URL of the workstacean API (e.g. `http://ava:8081`). Stamped into push-notification callback URLs registered with remote A2A agents that advertise `capabilities.pushNotifications: true`. Unset → silently falls back to task polling. |
-| `GRAPHITI_URL` | For memory enrichment | Base URL of the Graphiti knowledge-graph service (default: `http://graphiti:8000`). Skill dispatcher pulls `<recalled_memory>` context before every user-originated skill call and writes episodic memory on success. |
+| `GRAPHITI_URL` | For memory enrichment | Base URL of the Graphiti knowledge-graph service (default: `http://graphiti:8000`). Skill dispatcher pulls `<recalled_memory>` context before every user-originated skill call and writes episodic memory on success. Memory enrichment applies to all channels (Discord, GitHub, Plane, Slack, Signal) — not just Discord. |
+| `ROUTER_DM_DEFAULT_AGENT` | For DM conversations | Agent to route Discord DMs to when no keyword matches (e.g. `quinn`). Required to enable natural DM conversations. |
+| `ROUTER_DM_DEFAULT_SKILL` | For DM conversations | Skill used for DMs routed by `ROUTER_DM_DEFAULT_AGENT` (default: `chat`). |
+| `DM_CONVERSATION_TIMEOUT_MS` | For DM conversations | Idle timeout (ms) before a DM conversation session expires (default: `900000` = 15 min). |
 | `ANTHROPIC_API_KEY` | For in-process agents | Claude API key |
 
 Full list: see `.env.dist`.
@@ -79,7 +82,7 @@ Plugins are loaded in `src/index.ts`. Each implements `install(bus) / uninstall(
 | `ActionDispatcherPlugin` | always | Executes planned actions with WIP limit |
 | `AgentFleetHealthPlugin` | always | Aggregates `autonomous.outcome.#` over a rolling 24h window; exposes `agent_fleet_health` world-state domain for fleet goals |
 | `CeremonyPlugin` | always | Scheduled fleet rituals from `workspace/ceremonies/*.yaml` |
-| `DiscordPlugin` | `DISCORD_BOT_TOKEN` | Discord gateway |
+| `DiscordPlugin` | `DISCORD_BOT_TOKEN` | Discord gateway; multi-bot pool from `channels.yaml`; `ConversationManager` tracks per-user conversation sessions for multi-turn DMs and opted-in guild channels |
 | `GitHubPlugin` | `GITHUB_TOKEN` or `GITHUB_APP_ID` | GitHub webhooks |
 | `PlanePlugin` | always | Plane webhook adapter |
 | `EchoPlugin` | `ENABLED_PLUGINS=echo` | Test echo |

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -13,6 +13,7 @@ These docs explain the *why* behind protoWorkstacean's architecture. Read them w
 | [Self-improving loop](./self-improving-loop) | How A2A extensions feed observations into `PlannerPluginL0`'s candidate ranking, how episodic memory writes to Graphiti, and why the convergence loops don't diverge |
 | [Distributed tracing](./distributed-tracing) | How `correlationId` (trace-id) and `parentId` (span-id) flow from the bus through RouterPlugin, A2AExecutor, external agents (protoMaker team, Quinn), and back |
 | [Plugin system](./plugin-system) | The plugin lifecycle, core vs integration vs workspace plugins, ordering guarantees |
+| [Cross-channel conversations](../integrations/channels) | How `ChannelRegistry` maps channels → agents, how `ConversationManager` maintains stable `conversationId` across DM and guild turns, and how memory enrichment now applies to all channels |
 
 ## Design philosophy
 

--- a/docs/explanation/self-improving-loop.md
+++ b/docs/explanation/self-improving-loop.md
@@ -115,7 +115,7 @@ All three interceptors are registered once at startup (`src/index.ts`) and fire 
 
 Observations aren't the only thing captured on each dispatch. `SkillDispatcherPlugin` also writes a Graphiti episode for every successful skill completion:
 
-- **Human-originated** dispatches write to two groups: `user_{platform}_{userId}` (shared across agents — the user's common memory) and `agent_{agentName}__{user_...}` (this specific agent's relationship with this user).
+- **Human-originated** dispatches write to two groups: `user_{platform}_{userId}` (shared across agents — the user's common memory) and `agent_{agentName}__{user_...}` (this specific agent's relationship with this user). This applies to all channels — Discord, GitHub, Plane, Slack, Signal — wherever `msg.source.userId` and `msg.source.platform` are present.
 - **Bot-originated** dispatches (`meta.systemActor` set, e.g. `"goap"`) write to a single `system_{actor}` group — the autonomous loop's own episodic log of what it did.
 
 On the next turn, before the skill fires, the dispatcher reads back a `<recalled_memory>` block from Graphiti and injects it into the prompt. Ava and protoBot's system prompts explicitly tell them what the block is ("trusted background — prior commitments, workflow preferences, past provisioning decisions") so they use it silently.

--- a/docs/reference/bus-topics.md
+++ b/docs/reference/bus-topics.md
@@ -68,7 +68,7 @@ All bus topics published and subscribed across all plugins and subsystems. Topic
 
 | Topic | Direction | Publisher | Subscriber | Description |
 |-------|-----------|-----------|------------|-------------|
-| `message.inbound.discord.<channelId>` | Inbound | DiscordPlugin | RouterPlugin | @mention or DM received |
+| `message.inbound.discord.<channelId>` | Inbound | DiscordPlugin | RouterPlugin | @mention, guild channel message, or DM received |
 | `message.inbound.discord.slash.<interactionId>` | Inbound | DiscordPlugin | RouterPlugin | Slash command invoked |
 | `message.outbound.discord.<channelId>` | Outbound | Agents | DiscordPlugin | Reply to a specific channel |
 | `message.outbound.discord.push.<channelId>` | Outbound | CeremonyPlugin, ActionDispatcherPlugin | DiscordPlugin | Unprompted push (cron result, alert) |
@@ -76,15 +76,19 @@ All bus topics published and subscribed across all plugins and subsystems. Topic
 **Inbound payload**:
 ```typescript
 {
-  sender: string;       // Discord user ID
-  channel: string;      // Discord channel ID
-  content: string;      // Cleaned message (mentions stripped)
-  skillHint?: string;   // Set by slash commands and reaction handlers
+  sender: string;         // Discord user ID
+  channel: string;        // Discord channel ID
+  content: string;        // Cleaned message (mentions stripped)
+  skillHint?: string;     // Set by slash commands and reaction handlers
   isReaction?: boolean;
   isThread?: boolean;
   guildId?: string;
+  correlationId: string;  // Stable conversationId for multi-turn sessions — reused
+                          // across turns by ConversationManager, becomes the A2A contextId
 }
 ```
+
+**Multi-turn conversations**: when `conversation.enabled: true` is set for a channel in `workspace/channels.yaml`, `ConversationManager` assigns a stable `conversationId` to each `(channelId, userId)` pair. This ID flows as `correlationId` on every turn, becoming the A2A `contextId` so agents have full conversation memory. DMs are always conversation-enabled (no YAML needed). RouterPlugin applies DM conversation stickiness — once a skill/agent is matched, subsequent DM turns reuse the same target without re-running keyword matching.
 
 ---
 


### PR DESCRIPTION
## Summary

4 doc-relevant files changed recently.

Changed files requiring docs review:
- README.md
- docs/explanation/index.md
- docs/explanation/self-improving-loop.md
- docs/reference/bus-topics.md


---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-15T02:09:26.454Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced documentation for multi-channel conversation support, including direct messaging configuration options.
  * Clarified that memory enrichment now applies across all communication channels (Discord, GitHub, Plane, Slack, Signal).
  * Updated reference documentation for message handling and conversation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->