### PR TITLE
TR-1.1: LoggerPlugin: expose turn query capability

### DIFF
--- a/lib/plugins/logger.test.ts
+++ b/lib/plugins/logger.test.ts
@@ -1,20 +1,24 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { rmSync } from "node:fs";
 import { LoggerPlugin } from "./logger";
-import type { BusMessage } from "../types";
+import type { BusMessage, LoggerTurnQueryRequest, LoggerTurnQueryResponse } from "../types";
 
 const TEST_DATA_DIR = "/tmp/logger-test-" + process.pid;
 
 function makeBus() {
-  const subs: Array<(msg: BusMessage) => void> = [];
+  const subs: Array<{ pattern: string; handler: (msg: BusMessage) => void }> = [];
   return {
-    subscribe(_pattern: string, _name: string, handler: (msg: BusMessage) => void) {
-      subs.push(handler);
+    subscribe(pattern: string, _name: string, handler: (msg: BusMessage) => void) {
+      subs.push({ pattern, handler });
       return "sub-id";
     },
     unsubscribe() {},
-    publish(_topic: string, msg: BusMessage) {
-      for (const h of subs) h(msg);
+    publish(topic: string, msg: BusMessage) {
+      for (const sub of subs) {
+        if (sub.pattern === "#" || sub.pattern === topic) {
+          sub.handler(msg);
+        }
+      }
     },
     topics() { return []; },
     consumers() { return []; },
@@ -158,5 +162,85 @@ describe("LoggerPlugin.getRecentTurnsForUser", () => {
     const turns = plugin.getRecentTurnsForUser("user-abc", "", 2, 60_000);
     // 2 correlationIds * 1 user turn each = 2 turns
     expect(turns.length).toBe(2);
+  });
+});
+
+describe("LoggerPlugin bus-based logger.turn.query capability", () => {
+  let plugin: LoggerPlugin;
+  let bus: ReturnType<typeof makeBus>;
+
+  beforeEach(() => {
+    plugin = new LoggerPlugin(TEST_DATA_DIR);
+    bus = makeBus();
+    plugin.install(bus as never);
+  });
+
+  afterEach(() => {
+    plugin.uninstall();
+    try { rmSync(TEST_DATA_DIR, { recursive: true }); } catch {}
+  });
+
+  test("responds to logger.turn.query with turns published to replyTopic", () => {
+    const req = makeRequest();
+    const res = makeResponse();
+    bus.publish(req.topic, req);
+    bus.publish(res.topic, res);
+
+    let received: LoggerTurnQueryResponse | null = null;
+    bus.subscribe("logger.turn.query.response.test", "test", (msg: BusMessage) => {
+      received = msg.payload as LoggerTurnQueryResponse;
+    });
+
+    const queryRequest: LoggerTurnQueryRequest = {
+      type: "logger.turn.query",
+      userId: "user-abc",
+      agentName: "",
+      limit: 10,
+      maxAgeMs: 60_000,
+      replyTopic: "logger.turn.query.response.test",
+    };
+
+    bus.publish("logger.turn.query", {
+      id: "q-1",
+      correlationId: "corr-q-1",
+      topic: "logger.turn.query",
+      timestamp: Date.now(),
+      payload: queryRequest,
+    });
+
+    expect(received).not.toBeNull();
+    expect(received!.type).toBe("logger.turn.query.response");
+    expect(received!.turns.length).toBe(2);
+    expect(received!.turns[0].role).toBe("user");
+    expect(received!.turns[0].content).toBe("Hello agent");
+    expect(received!.turns[1].role).toBe("assistant");
+    expect(received!.turns[1].content).toBe("Hi there!");
+  });
+
+  test("responds with empty turns when no matching events", () => {
+    let received: LoggerTurnQueryResponse | null = null;
+    bus.subscribe("logger.turn.query.response.empty", "test", (msg: BusMessage) => {
+      received = msg.payload as LoggerTurnQueryResponse;
+    });
+
+    const queryRequest: LoggerTurnQueryRequest = {
+      type: "logger.turn.query",
+      userId: "nobody",
+      agentName: "",
+      limit: 10,
+      maxAgeMs: 60_000,
+      replyTopic: "logger.turn.query.response.empty",
+    };
+
+    bus.publish("logger.turn.query", {
+      id: "q-2",
+      correlationId: "corr-q-2",
+      topic: "logger.turn.query",
+      timestamp: Date.now(),
+      payload: queryRequest,
+    });
+
+    expect(received).not.toBeNull();
+    expect(received!.turns).toEqual([]);
   });
 });

--- a/lib/plugins/logger.ts
+++ b/lib/plugins/logger.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
-import type { Plugin, EventBus, BusMessage } from "../types";
+import type { Plugin, EventBus, BusMessage, LoggerTurnQueryRequest, LoggerTurnQueryResponse } from "../types";
 
 export interface ConversationTurn {
   role: "user" | "assistant";
@@ -18,6 +18,8 @@ export class LoggerPlugin implements Plugin {
 
   private db: Database | null = null;
   private subscriptionId: string | null = null;
+  private querySubscriptionId: string | null = null;
+  private bus: EventBus | null = null;
   private dataDir: string;
 
   constructor(dataDir: string) {
@@ -51,9 +53,25 @@ export class LoggerPlugin implements Plugin {
       this.db.exec("ALTER TABLE events ADD COLUMN parent_id TEXT");
     }
 
+    this.bus = bus;
+
     this.subscriptionId = bus.subscribe("#", this.name, (msg: BusMessage) => {
       if (msg.topic.startsWith("debug.")) return;
       this.log(msg);
+    });
+
+    this.querySubscriptionId = bus.subscribe("logger.turn.query", this.name, (msg: BusMessage) => {
+      const req = msg.payload as LoggerTurnQueryRequest;
+      const turns = this.getRecentTurnsForUser(req.userId, req.agentName, req.limit, req.maxAgeMs);
+      const response: LoggerTurnQueryResponse = { type: "logger.turn.query.response", turns };
+      bus.publish(req.replyTopic, {
+        id: crypto.randomUUID(),
+        correlationId: msg.correlationId,
+        parentId: msg.id,
+        topic: req.replyTopic,
+        timestamp: Date.now(),
+        payload: response,
+      });
     });
   }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -149,6 +149,37 @@ export interface ConfigChangeRenderer {
   onExpired?(request: ConfigChangeRequest, bus: EventBus): Promise<void>;
 }
 
+// ── Logger turn-query capability ──────────────────────────────────────────────
+// Topic: logger.turn.query
+// Any plugin may publish a LoggerTurnQueryRequest. LoggerPlugin subscribes to
+// "logger.turn.query", resolves the turns, and publishes a
+// LoggerTurnQueryResponse to the replyTopic.
+
+export interface LoggerTurnQueryRequest {
+  type: "logger.turn.query";
+  /** Canonical user ID (matches BusMessage.source.userId). */
+  userId: string;
+  /** Agent name to scope turns to. Pass empty string for any agent. */
+  agentName: string;
+  /** Maximum number of conversation turns (not pairs) to return. */
+  limit: number;
+  /** Only include turns within this many ms of now. */
+  maxAgeMs: number;
+  /** Topic where LoggerPlugin publishes the LoggerTurnQueryResponse. */
+  replyTopic: string;
+}
+
+export interface LoggerTurnQueryResponse {
+  type: "logger.turn.query.response";
+  turns: Array<{
+    role: "user" | "assistant";
+    content: string;
+    channel: string | undefined;
+    skill: string | undefined;
+    createdAt: number;
+  }>;
+}
+
 export type WidgetType = 'chart' | 'table' | 'status-card' | 'log-stream' | 'metric';
 
 export interface WidgetDescriptor {


### PR DESCRIPTION
## Summary

Promote LoggerPlugin.getRecentTurnsForUser() to a documented public capability.

---
*Recovered automatically by Automaker post-agent hook*