### PR TITLE
TR-2.1: Types: ConversationTurn schema definition

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -180,6 +180,16 @@ export interface LoggerTurnQueryResponse {
   }>;
 }
 
+// ── ConversationTurn ──────────────────────────────────────────────────────────
+
+export interface ConversationTurn {
+  timestamp: number;
+  role: "user" | "assistant";
+  text: string;
+  agentName: string;
+  channelId: string;
+}
+
 export type WidgetType = 'chart' | 'table' | 'status-card' | 'log-stream' | 'metric';
 
 export interface WidgetDescriptor {


### PR DESCRIPTION
## Summary

Define and export ConversationTurn type in lib/types.ts (timestamp, role, text, agentName, channelId).

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-15T02:10:36.723Z -->