### PR TITLE
TR-1.2: SkillDispatcher: integrate LoggerPlugin turn retrieval

### DIFF
--- a/lib/plugins/logger.test.ts
+++ b/lib/plugins/logger.test.ts
@@ -80,15 +80,13 @@ describe("LoggerPlugin.getRecentTurnsForUser", () => {
 
     expect(turns.length).toBe(2);
     expect(turns[0].role).toBe("user");
-    expect(turns[0].content).toBe("Hello agent");
-    expect(turns[0].skill).toBe("chat");
-    expect(turns[0].channel).toBe("discord");
-    expect(turns[0].createdAt).toBe(req.timestamp);
+    expect(turns[0].text).toBe("Hello agent");
+    expect(turns[0].channelId).toBe("ch-1");
+    expect(turns[0].timestamp).toBe(req.timestamp);
 
     expect(turns[1].role).toBe("assistant");
-    expect(turns[1].content).toBe("Hi there!");
-    expect(turns[1].skill).toBe("chat");
-    expect(turns[1].channel).toBe("discord");
+    expect(turns[1].text).toBe("Hi there!");
+    expect(turns[1].channelId).toBe("ch-1");
   });
 
   test("returns only user turn when no response exists", () => {
@@ -134,7 +132,7 @@ describe("LoggerPlugin.getRecentTurnsForUser", () => {
     const turns = plugin.getRecentTurnsForUser("user-abc", "protomaker", 10, 60_000);
 
     expect(turns.length).toBe(1);
-    expect(turns[0].content).toBe("Hello protomaker");
+    expect(turns[0].text).toBe("Hello protomaker");
   });
 
   test("includes events with empty targets when agentName filter is set", () => {
@@ -212,9 +210,9 @@ describe("LoggerPlugin bus-based logger.turn.query capability", () => {
     expect(received!.type).toBe("logger.turn.query.response");
     expect(received!.turns.length).toBe(2);
     expect(received!.turns[0].role).toBe("user");
-    expect(received!.turns[0].content).toBe("Hello agent");
+    expect(received!.turns[0].text).toBe("Hello agent");
     expect(received!.turns[1].role).toBe("assistant");
-    expect(received!.turns[1].content).toBe("Hi there!");
+    expect(received!.turns[1].text).toBe("Hi there!");
   });
 
   test("responds with empty turns when no matching events", () => {

--- a/lib/plugins/logger.ts
+++ b/lib/plugins/logger.ts
@@ -1,15 +1,7 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
-import type { Plugin, EventBus, BusMessage, LoggerTurnQueryRequest, LoggerTurnQueryResponse } from "../types";
-
-export interface ConversationTurn {
-  role: "user" | "assistant";
-  content: string;
-  channel: string | undefined;
-  skill: string | undefined;
-  createdAt: number;
-}
+import type { Plugin, EventBus, BusMessage, LoggerTurnQueryRequest, LoggerTurnQueryResponse, ConversationTurn } from "../types";
 
 export class LoggerPlugin implements Plugin {
   name = "logger";
@@ -179,24 +171,25 @@ export class LoggerPlugin implements Plugin {
       if (!request) continue;
 
       const reqPayload = request.payload as { skill?: string; content?: string; targets?: string[] };
-      const channel = request.source?.interface;
+      const channelId = request.source?.channelId ?? "";
+      const agentName = reqPayload.targets?.[0] ?? "";
 
       turns.push({
         role: "user",
-        content: reqPayload.content ?? "",
-        channel,
-        skill: reqPayload.skill,
-        createdAt: request.timestamp,
+        text: reqPayload.content ?? "",
+        channelId,
+        agentName,
+        timestamp: request.timestamp,
       });
 
       if (response) {
         const resPayload = response.payload as { content?: string; error?: string };
         turns.push({
           role: "assistant",
-          content: resPayload.content ?? resPayload.error ?? "",
-          channel,
-          skill: reqPayload.skill,
-          createdAt: response.timestamp,
+          text: resPayload.content ?? resPayload.error ?? "",
+          channelId,
+          agentName,
+          timestamp: response.timestamp,
         });
       }
     }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -171,13 +171,7 @@ export interface LoggerTurnQueryRequest {
 
 export interface LoggerTurnQueryResponse {
   type: "logger.turn.query.response";
-  turns: Array<{
-    role: "user" | "assistant";
-    content: string;
-    channel: string | undefined;
-    skill: string | undefined;
-    createdAt: number;
-  }>;
+  turns: ConversationTurn[];
 }
 
 // ── ConversationTurn ──────────────────────────────────────────────────────────

--- a/src/executor/__tests__/skill-dispatcher-plugin.test.ts
+++ b/src/executor/__tests__/skill-dispatcher-plugin.test.ts
@@ -9,7 +9,7 @@ import type { BusMessage } from "../../../lib/types.ts";
 import type { SkillRequest, SkillResult } from "../types.ts";
 import type { AgentDefinition } from "../../agent-runtime/types.ts";
 import type { GraphitiClient } from "../../../lib/memory/graphiti-client.ts";
-import type { ConversationTurn } from "../../../lib/plugins/logger.ts";
+import type { ConversationTurn } from "../../../lib/types.ts";
 
 // Minimal in-memory event bus for tests
 function makeBus() {
@@ -352,10 +352,10 @@ describe("SkillDispatcherPlugin — memory enrichment", () => {
 function makeTurn(overrides: Partial<ConversationTurn> = {}): ConversationTurn {
   return {
     role: "user",
-    content: "Hello",
-    channel: "discord",
-    skill: "chat",
-    createdAt: new Date("2024-01-01T12:00:00.000Z").getTime(),
+    text: "Hello",
+    channelId: "discord",
+    agentName: "chat",
+    timestamp: new Date("2024-01-01T12:00:00.000Z").getTime(),
     ...overrides,
   };
 }
@@ -380,8 +380,8 @@ describe("assembleContext", () => {
 
   it("includes <recent_conversation> when turns are provided", () => {
     const turns = [
-      makeTurn({ role: "user", content: "What time is it?", channel: "discord" }),
-      makeTurn({ role: "assistant", content: "It is noon.", channel: "discord" }),
+      makeTurn({ role: "user", text: "What time is it?", channelId: "discord" }),
+      makeTurn({ role: "assistant", text: "It is noon.", channelId: "discord" }),
     ];
     const result = assembleContext(undefined, turns, "Thanks");
     expect(result).toContain("<recent_conversation>");
@@ -392,10 +392,10 @@ describe("assembleContext", () => {
     expect(result).toContain("<current_message>");
   });
 
-  it("labels turns with ISO timestamp, channel, and role", () => {
+  it("labels turns with ISO timestamp, channelId, and role", () => {
     const ts = new Date("2024-06-15T09:30:00.000Z").getTime();
     const turns = [
-      makeTurn({ role: "user", content: "Hi", channel: "slack", createdAt: ts }),
+      makeTurn({ role: "user", text: "Hi", channelId: "slack", timestamp: ts }),
     ];
     const result = assembleContext(undefined, turns, "Next");
     expect(result).toContain("2024-06-15T09:30:00.000Z");
@@ -403,21 +403,21 @@ describe("assembleContext", () => {
     expect(result).toContain("User:");
   });
 
-  it("omits channel suffix when channel is undefined", () => {
-    const turns = [makeTurn({ channel: undefined })];
+  it("omits channel suffix when channelId is empty", () => {
+    const turns = [makeTurn({ channelId: "" })];
     const result = assembleContext(undefined, turns, "Next");
-    expect(result).not.toMatch(/\[undefined\]/);
+    expect(result).not.toMatch(/\[\]/);
     expect(result).toContain("User:");
   });
 
   it("labels assistant turns correctly", () => {
-    const turns = [makeTurn({ role: "assistant", content: "Hello!" })];
+    const turns = [makeTurn({ role: "assistant", text: "Hello!" })];
     const result = assembleContext(undefined, turns, "Next");
     expect(result).toContain("Assistant:");
   });
 
   it("emits all three sections in correct order when all data present", () => {
-    const turns = [makeTurn({ content: "Previous question" })];
+    const turns = [makeTurn({ text: "Previous question" })];
     const result = assembleContext("Some facts", turns, "Current question");
 
     const rmPos = result.indexOf("<recalled_memory>");

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -13,13 +13,12 @@
  * Outbound: {replyTopic}  (from msg.reply.topic or agent.skill.response.{correlationId})
  */
 
-import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
+import type { Plugin, EventBus, BusMessage, ConversationTurn, LoggerTurnQueryRequest, LoggerTurnQueryResponse } from "../../lib/types.ts";
 import type { ExecutorRegistry } from "./executor-registry.ts";
 import type { SkillRequest } from "./types.ts";
 import type { AgentSkillRequestPayload, AutonomousOutcomePayload, FlowItemPayload } from "../event-bus/payloads.ts";
 import { GraphitiClient } from "../../lib/memory/graphiti-client.ts";
 import { IdentityRegistry } from "../../lib/identity/identity-registry.ts";
-import type { LoggerPlugin, ConversationTurn } from "../../lib/plugins/logger.ts";
 import { ContextMailbox } from "../../lib/dm/context-mailbox.ts";
 import type { TaskTracker } from "./task-tracker.ts";
 import type { A2AExecutor } from "./executors/a2a-executor.ts";
@@ -62,10 +61,10 @@ export function assembleContext(
 
   if (recentTurns.length > 0) {
     const turnLines = recentTurns.map(turn => {
-      const ts = new Date(turn.createdAt).toISOString();
-      const channelSuffix = turn.channel ? ` [${turn.channel}]` : "";
+      const ts = new Date(turn.timestamp).toISOString();
+      const channelSuffix = turn.channelId ? ` [${turn.channelId}]` : "";
       const label = turn.role === "user" ? "User" : "Assistant";
-      return `[${ts}${channelSuffix}] ${label}: ${turn.content}`;
+      return `[${ts}${channelSuffix}] ${label}: ${turn.text}`;
     });
     parts.push(`<recent_conversation>\n${turnLines.join("\n")}\n</recent_conversation>`);
   }
@@ -98,7 +97,6 @@ export class SkillDispatcherPlugin implements Plugin {
   private readonly subscriptionIds: string[] = [];
   private readonly graphiti: GraphitiClient;
   private readonly identityRegistry: IdentityRegistry;
-  private readonly loggerPlugin: LoggerPlugin | undefined;
   private readonly mailbox: ContextMailbox | undefined;
   private readonly taskTracker: TaskTracker | undefined;
   private readonly sessionStore: SessionStore;
@@ -116,8 +114,6 @@ export class SkillDispatcherPlugin implements Plugin {
     workspaceDir: string,
     /** Injectable for testing — defaults to a real GraphitiClient. */
     graphiti?: GraphitiClient,
-    /** Injectable for testing — provides recent conversation turns. */
-    loggerPlugin?: LoggerPlugin,
     /** Optional mailbox for mid-execution DM queuing. */
     mailbox?: ContextMailbox,
     /** Optional tracker for long-running A2A tasks. */
@@ -127,7 +123,6 @@ export class SkillDispatcherPlugin implements Plugin {
   ) {
     this.graphiti = graphiti ?? new GraphitiClient();
     this.identityRegistry = new IdentityRegistry(workspaceDir);
-    this.loggerPlugin = loggerPlugin;
     this.mailbox = mailbox;
     this.taskTracker = taskTracker;
     this.sessionStore = sessionStore ?? new SessionStore();
@@ -136,6 +131,51 @@ export class SkillDispatcherPlugin implements Plugin {
   /** Check if an execution is currently active for a given correlationId. */
   isActive(correlationId: string): boolean {
     return this.activeExecutions.has(correlationId);
+  }
+
+  /**
+   * Query LoggerPlugin for recent conversation turns via the bus.
+   * Resolves with [] if LoggerPlugin is not installed (timeout) or on any error.
+   */
+  private _queryRecentTurns(userId: string, agentName: string): Promise<ConversationTurn[]> {
+    if (!this.bus) return Promise.resolve([]);
+
+    return new Promise<ConversationTurn[]>((resolve) => {
+      const replyTopic = `logger.turn.query.response.${crypto.randomUUID()}`;
+      let settled = false;
+
+      const subId = this.bus!.subscribe(replyTopic, this.name, (msg: BusMessage) => {
+        if (settled) return;
+        settled = true;
+        this.bus!.unsubscribe(subId);
+        resolve((msg.payload as LoggerTurnQueryResponse).turns);
+      });
+
+      this.bus!.publish("logger.turn.query", {
+        id: crypto.randomUUID(),
+        correlationId: crypto.randomUUID(),
+        topic: "logger.turn.query",
+        timestamp: Date.now(),
+        payload: {
+          type: "logger.turn.query",
+          userId,
+          agentName,
+          limit: 8,
+          maxAgeMs: 24 * 60 * 60 * 1000,
+          replyTopic,
+        } satisfies LoggerTurnQueryRequest,
+      });
+
+      // Fallback: LoggerPlugin responds synchronously, so if not installed
+      // the timeout fires at next tick and we continue without turns.
+      setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          this.bus?.unsubscribe(subId);
+          resolve([]);
+        }
+      }, 0);
+    });
   }
 
   install(bus: EventBus): void {
@@ -266,14 +306,9 @@ export class SkillDispatcherPlugin implements Plugin {
       ]);
       const combined = [sharedCtx, agentCtx].filter(Boolean).join("\n");
 
-      // Retrieve recent turns for human-originated messages only
-      const recentTurns: ConversationTurn[] = (this.loggerPlugin && sourceUserId)
-        ? this.loggerPlugin.getRecentTurnsForUser(
-            sourceUserId,
-            targets[0] ?? "",
-            8,
-            24 * 60 * 60 * 1000,
-          )
+      // Retrieve recent turns for human-originated messages only via bus query
+      const recentTurns: ConversationTurn[] = sourceUserId
+        ? await this._queryRecentTurns(sourceUserId, targets[0] ?? "")
         : [];
 
       rawContent = assembleContext(combined || undefined, recentTurns, rawContent);

--- a/src/index.ts
+++ b/src/index.ts
@@ -289,7 +289,7 @@ const pluginRegistry: PluginRegistryEntry[] = [
     condition: () => true,
     factory: async () => {
       const { SkillDispatcherPlugin } = await import("./executor/skill-dispatcher-plugin.js");
-      return new SkillDispatcherPlugin(executorRegistry, workspaceDir, undefined, loggerPlugin, contextMailbox, taskTracker);
+      return new SkillDispatcherPlugin(executorRegistry, workspaceDir, undefined, contextMailbox, taskTracker);
     },
   },
   {


### PR DESCRIPTION
## Summary

Refactor skill-dispatcher-plugin.ts (lines 265-272) to use the new public capability + unified ConversationTurn type.

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized conversation turn data structure across the codebase with updated field names.
  * Changed skill dispatcher to query conversation history through the message bus instead of direct plugin dependency.

* **Tests**
  * Updated test assertions to validate the revised conversation turn data format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->