### PR TITLE
TR-2.2: Context Assembly: build prompt context block

### DIFF
--- a/lib/conversation/context-assembler.ts
+++ b/lib/conversation/context-assembler.ts
@@ -1,0 +1,49 @@
+import type { ConversationTurn } from "../plugins/logger.ts";
+
+/**
+ * Assemble a structured context envelope for the agent prompt.
+ *
+ * Pure function — no side effects, suitable for unit testing.
+ *
+ * Sections emitted (in order, only when non-empty):
+ *   <recalled_memory>  — Graphiti facts retrieved for this user
+ *   <recent_conversation> — last N turns from LoggerPlugin
+ *   <current_message>  — the user's actual input (always emitted)
+ *
+ * When there is no history (no memory, no turns), only <current_message>
+ * is emitted — no empty XML tags.
+ */
+export function assembleContext(
+  recalledMemory: string | undefined,
+  recentTurns: ConversationTurn[],
+  currentMessage: string,
+): string {
+  const parts: string[] = [];
+
+  if (recalledMemory) {
+    parts.push(
+      `<recalled_memory>\n` +
+      `The following facts were retrieved from your memory about this user. ` +
+      `Use them as background context if relevant — do NOT repeat them back ` +
+      `to the user or reference them unless the user's message specifically ` +
+      `asks about something they relate to. Focus your response on what the ` +
+      `user is actually saying below.\n\n` +
+      `${recalledMemory}\n` +
+      `</recalled_memory>`,
+    );
+  }
+
+  if (recentTurns.length > 0) {
+    const turnLines = recentTurns.map(turn => {
+      const ts = new Date(turn.createdAt).toISOString();
+      const channelSuffix = turn.channel ? ` [${turn.channel}]` : "";
+      const label = turn.role === "user" ? "User" : "Assistant";
+      return `[${ts}${channelSuffix}] ${label}: ${turn.content}`;
+    });
+    parts.push(`<recent_conversation>\n${turnLines.join("\n")}\n</recent_conversation>`);
+  }
+
+  parts.push(`<current_message>\n${currentMessage}\n</current_message>`);
+
+  return parts.join("\n\n");
+}

--- a/src/executor/__tests__/skill-dispatcher-plugin.test.ts
+++ b/src/executor/__tests__/skill-dispatcher-plugin.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, mock, spyOn, beforeEach, afterEach } from "bun:test";
-import { SkillDispatcherPlugin, assembleContext } from "../skill-dispatcher-plugin.ts";
+import { SkillDispatcherPlugin } from "../skill-dispatcher-plugin.ts";
+import { assembleContext } from "../../../lib/conversation/context-assembler.ts";
 import { ExecutorRegistry } from "../executor-registry.ts";
 import { FunctionExecutor } from "../executors/function-executor.ts";
 import { ProtoSdkExecutor } from "../executors/proto-sdk-executor.ts";

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -20,60 +20,13 @@ import type { AgentSkillRequestPayload, AutonomousOutcomePayload, FlowItemPayloa
 import { GraphitiClient } from "../../lib/memory/graphiti-client.ts";
 import { IdentityRegistry } from "../../lib/identity/identity-registry.ts";
 import type { LoggerPlugin, ConversationTurn } from "../../lib/plugins/logger.ts";
+import { assembleContext } from "../../lib/conversation/context-assembler.ts";
 import { ContextMailbox } from "../../lib/dm/context-mailbox.ts";
 import type { TaskTracker } from "./task-tracker.ts";
 import type { A2AExecutor } from "./executors/a2a-executor.ts";
 import { SessionStore } from "../agent-runtime/session-context.ts";
 
 const WORKING_STATES = new Set(["submitted", "working"]);
-
-/**
- * Assemble a structured context envelope for the agent prompt.
- *
- * Pure function — no side effects, suitable for unit testing.
- *
- * Sections emitted (in order, only when non-empty):
- *   <recalled_memory>  — Graphiti facts retrieved for this user
- *   <recent_conversation> — last N turns from LoggerPlugin
- *   <current_message>  — the user's actual input (always emitted)
- *
- * When there is no history (no memory, no turns), only <current_message>
- * is emitted — no empty XML tags.
- */
-export function assembleContext(
-  recalledMemory: string | undefined,
-  recentTurns: ConversationTurn[],
-  currentMessage: string,
-): string {
-  const parts: string[] = [];
-
-  if (recalledMemory) {
-    parts.push(
-      `<recalled_memory>\n` +
-      `The following facts were retrieved from your memory about this user. ` +
-      `Use them as background context if relevant — do NOT repeat them back ` +
-      `to the user or reference them unless the user's message specifically ` +
-      `asks about something they relate to. Focus your response on what the ` +
-      `user is actually saying below.\n\n` +
-      `${recalledMemory}\n` +
-      `</recalled_memory>`,
-    );
-  }
-
-  if (recentTurns.length > 0) {
-    const turnLines = recentTurns.map(turn => {
-      const ts = new Date(turn.createdAt).toISOString();
-      const channelSuffix = turn.channel ? ` [${turn.channel}]` : "";
-      const label = turn.role === "user" ? "User" : "Assistant";
-      return `[${ts}${channelSuffix}] ${label}: ${turn.content}`;
-    });
-    parts.push(`<recent_conversation>\n${turnLines.join("\n")}\n</recent_conversation>`);
-  }
-
-  parts.push(`<current_message>\n${currentMessage}\n</current_message>`);
-
-  return parts.join("\n\n");
-}
 
 /**
  * Classify a skill name into a flow item type for distribution tracking.


### PR DESCRIPTION
## Summary

Extract context-formatting helper into lib/conversation/context-assembler.ts. Combines recalled facts plus recent turns into a single XML block injected before the user message.

---
*Recovered automatically by Automaker post-agent hook*