### PR TITLE
TR-2.3: Graphiti: label episodes with turn metadata

### DIFF
--- a/lib/memory/__tests__/graphiti-client.test.ts
+++ b/lib/memory/__tests__/graphiti-client.test.ts
@@ -171,6 +171,52 @@ describe("GraphitiClient.addEpisode", () => {
       client.addEpisode({ groupId: "user_josh", userMessage: "x", agentMessage: "y" })
     ).rejects.toThrow("400");
   });
+
+  it("encodes turnNumber in source_description when provided", async () => {
+    spyFetch(null, 202);
+    const client = new GraphitiClient();
+    await client.addEpisode({
+      groupId: "user_josh",
+      userMessage: "hi",
+      agentMessage: "hello",
+      platform: "discord",
+      channelId: "99",
+      turnNumber: 3,
+    });
+    const body = lastFetchBody as { messages: Array<{ source_description: string }> };
+    expect(body.messages[0]!.source_description).toContain("| turn:3");
+    expect(body.messages[1]!.source_description).toContain("| turn:3");
+  });
+
+  it("encodes parentTurnId in source_description when provided", async () => {
+    spyFetch(null, 202);
+    const client = new GraphitiClient();
+    await client.addEpisode({
+      groupId: "user_josh",
+      userMessage: "hi",
+      agentMessage: "hello",
+      parentTurnId: "corr-abc-123",
+    });
+    const body = lastFetchBody as { messages: Array<{ source_description: string }> };
+    expect(body.messages[0]!.source_description).toContain("| parent:corr-abc-123");
+    expect(body.messages[1]!.source_description).toContain("| parent:corr-abc-123");
+  });
+
+  it("encodes both turnNumber and parentTurnId in source_description", async () => {
+    spyFetch(null, 202);
+    const client = new GraphitiClient();
+    await client.addEpisode({
+      groupId: "user_josh",
+      userMessage: "hi",
+      agentMessage: "hello",
+      platform: "slack",
+      channelId: "C01",
+      turnNumber: 7,
+      parentTurnId: "parent-xyz",
+    });
+    const body = lastFetchBody as { messages: Array<{ source_description: string }> };
+    expect(body.messages[0]!.source_description).toBe("slack channel C01 | turn:7 | parent:parent-xyz");
+  });
 });
 
 describe("GraphitiClient.search", () => {

--- a/lib/memory/graphiti-client.ts
+++ b/lib/memory/graphiti-client.ts
@@ -95,11 +95,17 @@ export class GraphitiClient {
     channelId?: string;
     platform?: string;
     timestamp?: Date;
+    /** Sequential turn number within the conversation — used to reconstruct threading. */
+    turnNumber?: number;
+    /** ID of the parent turn — used to reconstruct threading across correlated exchanges. */
+    parentTurnId?: string;
   }): Promise<void> {
     const ts = (params.timestamp ?? new Date()).toISOString();
-    const source = params.channelId && params.platform
+    let source = params.channelId && params.platform
       ? `${params.platform} channel ${params.channelId}`
       : (params.platform ?? "unknown");
+    if (params.turnNumber !== undefined) source += ` | turn:${params.turnNumber}`;
+    if (params.parentTurnId !== undefined) source += ` | parent:${params.parentTurnId}`;
 
     await this._post("/messages", {
       group_id: params.groupId,

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -512,6 +512,7 @@ export class SkillDispatcherPlugin implements Plugin {
           agentName: targets[0],
           channelId: sourceChannelId,
           platform: sourcePlatform ?? (systemActor ? "system" : undefined),
+          parentTurnId: correlationId,
         };
         this.graphiti.addEpisode({ groupId, ...episodeBase })
           .catch(err => console.debug("[skill-dispatcher] Graphiti addEpisode (shared) error:", err));


### PR DESCRIPTION
## Summary

Extend GraphitiClient.addEpisode payload with turnNumber + parentTurnId so future retrieval can reconstruct conversation threading.

---
*Recovered automatically by Automaker post-agent hook*