### PR TITLE
feat: [TR-2.2] Context Assembly: extract assembleContext to lib/conversation

### DIFF
--- a/lib/conversation/context-assembler.ts
+++ b/lib/conversation/context-assembler.ts
@@ -1,0 +1,49 @@
+import type { ConversationTurn } from "../types.ts";
+
+/**
+ * Assemble a structured context envelope for the agent prompt.
+ *
+ * Pure function — no side effects, suitable for unit testing.
+ *
+ * Sections emitted (in order, only when non-empty):
+ *   <recalled_memory>  — Graphiti facts retrieved for this user
+ *   <recent_conversation> — last N turns from LoggerPlugin
+ *   <current_message>  — the user's actual input (always emitted)
+ *
+ * When there is no history (no memory, no turns), only <current_message>
+ * is emitted — no empty XML tags.
+ */
+export function assembleContext(
+  recalledMemory: string | undefined,
+  recentTurns: ConversationTurn[],
+  currentMessage: string,
+): string {
+  const parts: string[] = [];
+
+  if (recalledMemory) {
+    parts.push(
+      `<recalled_memory>\n` +
+      `The following facts were retrieved from your memory about this user. ` +
+      `Use them as background context if relevant — do NOT repeat them back ` +
+      `to the user or reference them unless the user's message specifically ` +
+      `asks about something they relate to. Focus your response on what the ` +
+      `user is actually saying below.\n\n` +
+      `${recalledMemory}\n` +
+      `</recalled_memory>`,
+    );
+  }
+
+  if (recentTurns.length > 0) {
+    const turnLines = recentTurns.map(turn => {
+      const ts = new Date(turn.timestamp).toISOString();
+      const channelSuffix = turn.channelId ? ` [${turn.channelId}]` : "";
+      const label = turn.role === "user" ? "User" : "Assistant";
+      return `[${ts}${channelSuffix}] ${label}: ${turn.text}`;
+    });
+    parts.push(`<recent_conversation>\n${turnLines.join("\n")}\n</recent_conversation>`);
+  }
+
+  parts.push(`<current_message>\n${currentMessage}\n</current_message>`);
+
+  return parts.join("\n\n");
+}

--- a/src/executor/__tests__/skill-dispatcher-plugin.test.ts
+++ b/src/executor/__tests__/skill-dispatcher-plugin.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, mock, spyOn, beforeEach, afterEach } from "bun:test";
-import { SkillDispatcherPlugin, assembleContext } from "../skill-dispatcher-plugin.ts";
+import { SkillDispatcherPlugin } from "../skill-dispatcher-plugin.ts";
+import { assembleContext } from "../../../lib/conversation/context-assembler.ts";
 import { ExecutorRegistry } from "../executor-registry.ts";
 import { FunctionExecutor } from "../executors/function-executor.ts";
 import { ProtoSdkExecutor } from "../executors/proto-sdk-executor.ts";

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -19,60 +19,13 @@ import type { SkillRequest } from "./types.ts";
 import type { AgentSkillRequestPayload, AutonomousOutcomePayload, FlowItemPayload } from "../event-bus/payloads.ts";
 import { GraphitiClient } from "../../lib/memory/graphiti-client.ts";
 import { IdentityRegistry } from "../../lib/identity/identity-registry.ts";
+import { assembleContext } from "../../lib/conversation/context-assembler.ts";
 import { ContextMailbox } from "../../lib/dm/context-mailbox.ts";
 import type { TaskTracker } from "./task-tracker.ts";
 import type { A2AExecutor } from "./executors/a2a-executor.ts";
 import { SessionStore } from "../agent-runtime/session-context.ts";
 
 const WORKING_STATES = new Set(["submitted", "working"]);
-
-/**
- * Assemble a structured context envelope for the agent prompt.
- *
- * Pure function — no side effects, suitable for unit testing.
- *
- * Sections emitted (in order, only when non-empty):
- *   <recalled_memory>  — Graphiti facts retrieved for this user
- *   <recent_conversation> — last N turns from LoggerPlugin
- *   <current_message>  — the user's actual input (always emitted)
- *
- * When there is no history (no memory, no turns), only <current_message>
- * is emitted — no empty XML tags.
- */
-export function assembleContext(
-  recalledMemory: string | undefined,
-  recentTurns: ConversationTurn[],
-  currentMessage: string,
-): string {
-  const parts: string[] = [];
-
-  if (recalledMemory) {
-    parts.push(
-      `<recalled_memory>\n` +
-      `The following facts were retrieved from your memory about this user. ` +
-      `Use them as background context if relevant — do NOT repeat them back ` +
-      `to the user or reference them unless the user's message specifically ` +
-      `asks about something they relate to. Focus your response on what the ` +
-      `user is actually saying below.\n\n` +
-      `${recalledMemory}\n` +
-      `</recalled_memory>`,
-    );
-  }
-
-  if (recentTurns.length > 0) {
-    const turnLines = recentTurns.map(turn => {
-      const ts = new Date(turn.timestamp).toISOString();
-      const channelSuffix = turn.channelId ? ` [${turn.channelId}]` : "";
-      const label = turn.role === "user" ? "User" : "Assistant";
-      return `[${ts}${channelSuffix}] ${label}: ${turn.text}`;
-    });
-    parts.push(`<recent_conversation>\n${turnLines.join("\n")}\n</recent_conversation>`);
-  }
-
-  parts.push(`<current_message>\n${currentMessage}\n</current_message>`);
-
-  return parts.join("\n\n");
-}
 
 /**
  * Classify a skill name into a flow item type for distribution tracking.


### PR DESCRIPTION
Re-cut of #327 on fresh dev. Extracts `assembleContext()` from skill-dispatcher-plugin.ts to a dedicated module.

Conflict resolution:
- Original was built when ConversationTurn lived at `lib/plugins/logger.ts` with fields `createdAt/channel/content`. TR-1.1 (already merged) moved ConversationTurn to `lib/types.ts` with the canonical fields `timestamp/channelId/text`.
- Updated the extracted assembler to import from `lib/types` and use the canonical field names.
- Removed the inline definition from skill-dispatcher-plugin.ts (now just imports + uses).

919/919 tests pass, typecheck clean. Closes #327.