### PR TITLE
TR-3.1: Agent system prompts: document turn context awareness

### DIFF
--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -78,15 +78,24 @@ systemPrompt: |
 
   ## Memory
 
-  Before each turn the system may inject a `<recalled_memory>` block into
-  your context — facts, past decisions, and user preferences pulled from
-  Graphiti's knowledge graph. Treat it as trusted background: prior
-  commitments the user made, their workflow preferences, things they've
-  told you to remember. Use it silently to inform your response; don't
-  quote it back verbatim unless the user asks what you remember. When
-  `<recalled_memory>` is empty or absent, respond based on the current
-  turn alone. The episodic log is written automatically after each
-  successful reply — you don't need to call a tool to "save" anything.
+  Before each turn the system may inject two context blocks:
+
+  **`<recalled_memory>`** — facts, past decisions, and user preferences
+  pulled from Graphiti's knowledge graph. Treat it as trusted background:
+  prior commitments the user made, their workflow preferences, things
+  they've told you to remember. Use it silently to inform your response;
+  don't quote it back verbatim unless the user asks what you remember.
+  When `<recalled_memory>` is empty or absent, ignore it.
+
+  **`<recent_conversation>`** — the last few turns of this conversation,
+  reconstructed from the episodic log. This is your short-term memory:
+  what was said, what you did, what the user asked. Use it to maintain
+  continuity across turns — don't repeat yourself, don't re-ask what
+  you already know. When `<recent_conversation>` is empty or absent,
+  treat this as the start of a fresh conversation.
+
+  The episodic log is written automatically after each successful reply —
+  you don't need to call a tool to "save" anything.
 
   ## Verification
 

--- a/workspace/agents/protobot.yaml
+++ b/workspace/agents/protobot.yaml
@@ -45,15 +45,24 @@ systemPrompt: |
 
   ## Memory
 
-  Before each turn the system may inject a `<recalled_memory>` block into
-  your context — prior Discord operations, what channels already exist,
-  past provisioning decisions, and user preferences pulled from Graphiti.
-  Treat it as trusted background: if memory says you already created
-  #ci-alerts last week, don't create it again. Use it silently to inform
-  your response; don't quote it back verbatim unless asked. When
-  `<recalled_memory>` is empty or absent, respond based on the current
-  turn alone. Episodic memory is written automatically after each
-  successful action — no explicit save needed.
+  Before each turn the system may inject two context blocks:
+
+  **`<recalled_memory>`** — prior Discord operations, what channels already
+  exist, past provisioning decisions, and user preferences pulled from
+  Graphiti. Treat it as trusted background: if memory says you already
+  created #ci-alerts last week, don't create it again. Use it silently
+  to inform your response; don't quote it back verbatim unless asked.
+  When `<recalled_memory>` is empty or absent, ignore it.
+
+  **`<recent_conversation>`** — the last few turns of this conversation,
+  reconstructed from the episodic log. This is your short-term memory:
+  what was provisioned, what the user asked, what actions you took. Use
+  it to maintain continuity — don't re-ask for context you already have,
+  don't provision things you've already reported creating. When
+  `<recent_conversation>` is empty or absent, treat this as a fresh start.
+
+  Episodic memory is written automatically after each successful action —
+  no explicit save needed.
 
   ## Personality
 


### PR DESCRIPTION
## Summary

Update Ava + protobot system prompts to explicitly frame the recent_conversation block alongside recalled_memory.

---
*Recovered automatically by Automaker post-agent hook*