### PR TITLE
feat: protobot can delete channels + Ava knows to delegate Discord work

### DIFF
--- a/src/api/discord.ts
+++ b/src/api/discord.ts
@@ -9,6 +9,7 @@
  *   GET  /api/discord/server-stats      — member count, channel count, boost level
  *   GET  /api/discord/channels          — list all channels with type and category
  *   POST /api/discord/channels/create   — create a channel (text/voice/category)
+ *   POST /api/discord/channels/delete   — delete a channel (recursive for categories)
  *   POST /api/discord/send              — send a message to a channel
  *   GET  /api/discord/members           — list members (paginated)
  *   GET  /api/discord/webhooks          — list webhooks across guild channels
@@ -109,6 +110,57 @@ export function createRoutes(ctx: ApiContext): Route[] {
           return Response.json({
             success: true,
             data: { id: created.id, name: created.name, type: created.type },
+          });
+        } catch (e) {
+          return Response.json({ success: false, error: e instanceof Error ? e.message : String(e) }, { status: 500 });
+        }
+      },
+    },
+    {
+      method: "POST",
+      path: "/api/discord/channels/delete",
+      handler: async (req) => {
+        const client = getDiscordClient(ctx);
+        if (!client) return Response.json({ success: false, error: "Discord not connected" }, { status: 503 });
+
+        const guild = client.guilds.cache.get(getGuildId());
+        if (!guild) return Response.json({ success: false, error: "Guild not found" }, { status: 404 });
+
+        let body: { channelId?: string; channelName?: string; recursive?: boolean; reason?: string };
+        try { body = await req.json() as typeof body; }
+        catch { return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 }); }
+
+        let target: any = null;
+        if (body.channelId) {
+          target = guild.channels.cache.get(body.channelId);
+        } else if (body.channelName) {
+          target = guild.channels.cache.find((ch: any) => ch.name === body.channelName);
+        }
+        if (!target) {
+          return Response.json({ success: false, error: "Channel not found (pass channelId or channelName)" }, { status: 404 });
+        }
+
+        try {
+          // Recursive delete for categories — Discord won't auto-delete children;
+          // we collect them first so the response can report what was removed.
+          const deletedChildren: Array<{ id: string; name: string }> = [];
+          const isCategory = target.type === 4;
+          if (isCategory && body.recursive !== false) {
+            const children = guild.channels.cache.filter((ch: any) => ch.parentId === target.id);
+            for (const child of children.values()) {
+              await child.delete(body.reason ?? "deleted via /api/discord/channels/delete");
+              deletedChildren.push({ id: child.id, name: child.name });
+            }
+          }
+          await target.delete(body.reason ?? "deleted via /api/discord/channels/delete");
+          return Response.json({
+            success: true,
+            data: {
+              id: target.id,
+              name: target.name,
+              type: target.type,
+              deletedChildren,
+            },
           });
         } catch (e) {
           return Response.json({ success: false, error: e instanceof Error ? e.message : String(e) }, { status: 500 });

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -291,6 +291,20 @@ function createLangChainTools(toolNames: string[], http: HttpClient, correlation
         }),
       },
     ),
+    discord_delete_channel: tool(
+      async (input) => JSON.stringify(await http.post("/api/discord/channels/delete", input)),
+      {
+        name: "discord_delete_channel",
+        description:
+          "Delete a Discord channel by ID or name. For categories, by default all child channels are deleted too (set recursive=false to leave them as orphans). Destructive — confirm with the user before invoking unless the user explicitly named the channel/category to delete.",
+        schema: z.object({
+          channelId: z.string().optional().describe("Channel ID (exact)"),
+          channelName: z.string().optional().describe("Channel name (alternative to ID)"),
+          recursive: z.boolean().optional().describe("For categories: delete contained channels too (default: true)"),
+          reason: z.string().optional().describe("Audit log reason"),
+        }),
+      },
+    ),
     discord_send: tool(
       async (input) => JSON.stringify(await http.post("/api/discord/send", input)),
       {

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -67,7 +67,11 @@ systemPrompt: |
   - Researcher (deep_research, summarize) — autonomous research agent with papers, HuggingFace, GitHub, web. Use for "research X in depth" tasks.
   - protoMaker (sitrep, board_health, auto_mode, manage_feature) — board operations
   - protoContent / Jon (chat) — content strategy, antagonistic review on user-initiated plans
+  - protoBot (provision_channel, provision_category, provision_webhook, server_stats, chat) — owns Discord server infrastructure: channels, categories, webhooks, member listings, channel posting. Delegate any Discord work here.
+  - protopen (passive_recon, active_pentest, security_report, threat_intel) — security/pentest agent
   - Frank — infrastructure, deployments
+
+  When in doubt about who can do what, call `get_world_state` — every agent's currently-advertised skills are in `domains.agent_health.data`. Trust the live registry over this hardcoded list.
 
   ## Escalation
 

--- a/workspace/agents/protobot.yaml
+++ b/workspace/agents/protobot.yaml
@@ -82,6 +82,7 @@ tools:
   - discord_server_stats
   - discord_list_channels
   - discord_create_channel
+  - discord_delete_channel
   - discord_list_webhooks
   - discord_create_webhook
   - discord_send


### PR DESCRIPTION
Two issues from a real user interaction: Ava said "I don't have Discord admin tools" when asked to delete a category, when in reality protobot has owned Discord infrastructure since v0.7.6 — Ava's hardcoded delegation list just never listed him. And even if she had delegated, protobot only had channel-create tools, not delete.

## Changes
- `POST /api/discord/channels/delete` (new) — deletes a channel by ID/name; for categories does recursive child-delete by default
- `discord_delete_channel` LangChain tool flagged destructive
- `workspace/agents/protobot.yaml` — tool added to toolset
- `workspace/agents/ava.yaml` — delegation list now lists protoBot + protopen with their advertised skills; pointer to `get_world_state` for live registry inspection so the prompt's hardcoded list isn't the only source of truth

Verified live via `/api/a2a/chat` after rebuild — protobot self-describes the new tool and proactively flags it as destructive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Discord channel deletion functionality with support for recursive deletion of child channels in categories.
  * Channel deletion capability now available within the system for enhanced server management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->