### PR TITLE
promote: v0.7.10 (Dynamic Dashboard + Turn Retrieval epics + protobot delete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ bun run src/index.ts
 | `WORKSTACEAN_HTTP_PORT` | No | HTTP API port (default: `3000`) |
 | `WORKSTACEAN_API_KEY` | No | API key for `/publish` endpoint |
 | `WORKSTACEAN_BASE_URL` | For A2A push notifications | Externally-reachable URL of the workstacean API (e.g. `http://ava:8081`). Stamped into push-notification callback URLs registered with remote A2A agents that advertise `capabilities.pushNotifications: true`. Unset → silently falls back to task polling. |
-| `GRAPHITI_URL` | For memory enrichment | Base URL of the Graphiti knowledge-graph service (default: `http://graphiti:8000`). Skill dispatcher pulls `<recalled_memory>` context before every user-originated skill call and writes episodic memory on success. |
+| `GRAPHITI_URL` | For memory enrichment | Base URL of the Graphiti knowledge-graph service (default: `http://graphiti:8000`). Skill dispatcher pulls `<recalled_memory>` context before every user-originated skill call and writes episodic memory on success. Memory enrichment applies to all channels (Discord, GitHub, Plane, Slack, Signal) — not just Discord. |
+| `ROUTER_DM_DEFAULT_AGENT` | For DM conversations | Agent to route Discord DMs to when no keyword matches (e.g. `quinn`). Required to enable natural DM conversations. |
+| `ROUTER_DM_DEFAULT_SKILL` | For DM conversations | Skill used for DMs routed by `ROUTER_DM_DEFAULT_AGENT` (default: `chat`). |
+| `DM_CONVERSATION_TIMEOUT_MS` | For DM conversations | Idle timeout (ms) before a DM conversation session expires (default: `900000` = 15 min). |
 | `ANTHROPIC_API_KEY` | For in-process agents | Claude API key |
 
 Full list: see `.env.dist`.
@@ -79,7 +82,7 @@ Plugins are loaded in `src/index.ts`. Each implements `install(bus) / uninstall(
 | `ActionDispatcherPlugin` | always | Executes planned actions with WIP limit |
 | `AgentFleetHealthPlugin` | always | Aggregates `autonomous.outcome.#` over a rolling 24h window; exposes `agent_fleet_health` world-state domain for fleet goals |
 | `CeremonyPlugin` | always | Scheduled fleet rituals from `workspace/ceremonies/*.yaml` |
-| `DiscordPlugin` | `DISCORD_BOT_TOKEN` | Discord gateway |
+| `DiscordPlugin` | `DISCORD_BOT_TOKEN` | Discord gateway; multi-bot pool from `channels.yaml`; `ConversationManager` tracks per-user conversation sessions for multi-turn DMs and opted-in guild channels |
 | `GitHubPlugin` | `GITHUB_TOKEN` or `GITHUB_APP_ID` | GitHub webhooks |
 | `PlanePlugin` | always | Plane webhook adapter |
 | `EchoPlugin` | `ENABLED_PLUGINS=echo` | Test echo |

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean-dashboard",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/dashboard/src/components/DiscoveryView.tsx
+++ b/dashboard/src/components/DiscoveryView.tsx
@@ -1,0 +1,301 @@
+// DiscoveryView — fetches /api/widgets and renders all plugin widgets grouped by plugin name.
+//
+// Maps the server-side WidgetDescriptor (lib/types.ts) to the dashboard-internal
+// renderer descriptor format (lib/widget-renderer.ts) at runtime.
+
+import { useState, useEffect } from "preact/hooks";
+import type {
+  ChartWidgetDescriptor,
+  TableWidgetDescriptor,
+  StatusCardWidgetDescriptor,
+  ChartConfig,
+  TableConfig,
+  StatusCardConfig,
+} from "../lib/widget-renderer";
+import ChartRenderer from "./renderers/ChartRenderer";
+import TableRenderer from "./renderers/TableRenderer";
+import StatusCardRenderer from "./renderers/StatusCardRenderer";
+
+// Shape returned by GET /api/widgets (matches lib/types.ts WidgetDescriptor)
+interface ApiWidget {
+  pluginName: string;
+  id: string;
+  type: string;
+  title: string;
+  query?: string;
+  props?: Record<string, unknown>;
+}
+
+type RendererDescriptor =
+  | ChartWidgetDescriptor
+  | TableWidgetDescriptor
+  | StatusCardWidgetDescriptor;
+
+function toRendererDescriptor(w: ApiWidget): RendererDescriptor | null {
+  const query = { url: w.query ?? "" };
+  switch (w.type) {
+    case "chart":
+      return {
+        id: w.id,
+        title: w.title,
+        type: "chart",
+        config: (w.props ?? {}) as ChartConfig,
+        query,
+      };
+    case "table":
+      return {
+        id: w.id,
+        title: w.title,
+        type: "table",
+        config: (w.props ?? {}) as TableConfig,
+        query,
+      };
+    case "status-card":
+      return {
+        id: w.id,
+        title: w.title,
+        type: "status-card",
+        config: (w.props ?? {}) as StatusCardConfig,
+        query,
+      };
+    default:
+      // log-stream, metric, unknown — no renderer yet
+      return null;
+  }
+}
+
+function groupByPlugin(widgets: ApiWidget[]): Map<string, ApiWidget[]> {
+  const groups = new Map<string, ApiWidget[]>();
+  for (const w of widgets) {
+    const existing = groups.get(w.pluginName) ?? [];
+    existing.push(w);
+    groups.set(w.pluginName, existing);
+  }
+  return groups;
+}
+
+interface WidgetCardProps {
+  widget: ApiWidget;
+}
+
+function WidgetCard({ widget }: WidgetCardProps) {
+  const descriptor = toRendererDescriptor(widget);
+
+  if (!descriptor) {
+    return (
+      <div class="discovery-widget discovery-widget--unsupported">
+        <div class="discovery-widget__title">{widget.title}</div>
+        <div class="discovery-widget__unsupported">
+          No renderer for type: {widget.type}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div class="discovery-widget">
+      {descriptor.type === "chart" && (
+        <ChartRenderer descriptor={descriptor} />
+      )}
+      {descriptor.type === "table" && (
+        <TableRenderer descriptor={descriptor} />
+      )}
+      {descriptor.type === "status-card" && (
+        <StatusCardRenderer descriptor={descriptor} />
+      )}
+    </div>
+  );
+}
+
+interface PluginSectionProps {
+  pluginName: string;
+  widgets: ApiWidget[];
+}
+
+function PluginSection({ pluginName, widgets }: PluginSectionProps) {
+  return (
+    <section class="discovery-plugin-section">
+      <h2 class="discovery-plugin-section__name">{pluginName}</h2>
+      <div class="discovery-widget-grid">
+        {widgets.map((w) => (
+          <WidgetCard key={w.id} widget={w} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+interface DiscoveryViewProps {
+  /** When set, only shows widgets for this plugin name. Null/undefined = show all. */
+  pluginFilter?: string | null;
+}
+
+export default function DiscoveryView({ pluginFilter }: DiscoveryViewProps) {
+  const [widgets, setWidgets] = useState<ApiWidget[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const res = await fetch("/api/widgets", {
+          headers: { Accept: "application/json" },
+        });
+        if (!res.ok) {
+          throw new Error(`/api/widgets returned ${res.status} ${res.statusText}`);
+        }
+        const data = await res.json();
+        if (cancelled) return;
+        // Handle both raw array and { success, data } envelope
+        const list: ApiWidget[] = Array.isArray(data)
+          ? data
+          : Array.isArray(data?.data)
+            ? data.data
+            : [];
+        setWidgets(list);
+        setError(null);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load widgets");
+      }
+    }
+
+    load();
+    // Refresh every 30s so new plugin registrations surface without a full reload
+    const id = setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  if (error) {
+    return (
+      <>
+        <style>{styles}</style>
+        <div class="discovery-error">
+          <div class="discovery-error__title">Failed to load widgets</div>
+          <div class="discovery-error__message">{error}</div>
+        </div>
+      </>
+    );
+  }
+
+  if (widgets === null) {
+    return (
+      <>
+        <style>{styles}</style>
+        <div class="discovery-loading">Loading widgets…</div>
+      </>
+    );
+  }
+
+  const filtered = pluginFilter
+    ? widgets.filter((w) => w.pluginName === pluginFilter)
+    : widgets;
+
+  if (filtered.length === 0) {
+    return (
+      <>
+        <style>{styles}</style>
+        <div class="discovery-empty">
+          {pluginFilter
+            ? `No widgets registered by "${pluginFilter}".`
+            : "No widgets registered. Plugins can contribute widgets via getWidgets()."}
+        </div>
+      </>
+    );
+  }
+
+  const groups = groupByPlugin(filtered);
+
+  return (
+    <>
+      <style>{styles}</style>
+      <div class="discovery-view">
+        {[...groups.entries()].map(([pluginName, pluginWidgets]) => (
+          <PluginSection
+            key={pluginName}
+            pluginName={pluginName}
+            widgets={pluginWidgets}
+          />
+        ))}
+      </div>
+    </>
+  );
+}
+
+const styles = `
+  .discovery-view {
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+  }
+
+  .discovery-plugin-section {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .discovery-plugin-section__name {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-secondary, #8b949e);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    border-bottom: 1px solid var(--border-default, #30363d);
+    padding-bottom: 8px;
+  }
+
+  .discovery-widget-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+    gap: 16px;
+  }
+
+  .discovery-widget {
+    background: var(--bg-card, #161b22);
+    border: 1px solid var(--border-default, #30363d);
+    border-radius: 8px;
+    padding: 16px;
+    min-width: 0;
+  }
+
+  .discovery-widget--unsupported {
+    opacity: 0.6;
+  }
+
+  .discovery-widget__title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary, #e6edf3);
+    margin-bottom: 8px;
+  }
+
+  .discovery-widget__unsupported {
+    font-size: 12px;
+    color: var(--text-muted, #8b949e);
+    font-style: italic;
+  }
+
+  .discovery-loading,
+  .discovery-empty,
+  .discovery-error {
+    padding: 48px 24px;
+    text-align: center;
+    color: var(--text-muted, #8b949e);
+    font-size: 14px;
+  }
+
+  .discovery-error__title {
+    font-weight: 600;
+    color: var(--text-danger, #f85149);
+    margin-bottom: 8px;
+  }
+
+  .discovery-error__message {
+    font-size: 12px;
+    font-family: monospace;
+  }
+`;

--- a/dashboard/src/components/WorldStateCard.tsx
+++ b/dashboard/src/components/WorldStateCard.tsx
@@ -1,0 +1,159 @@
+/**
+ * WorldStateCard — generic renderer for world-state domain widgets.
+ *
+ * Renders a single domain entry from /api/world-state as a status card.
+ * Used by the discovery-driven dashboard when a plugin declares a
+ * world-state-domain-card WidgetDescriptor.
+ */
+import { useState } from "preact/hooks";
+import JsonTree from "./JsonTree.tsx";
+
+export interface WorldStateCardProps {
+  name: string;
+  data: unknown;
+  metadata: {
+    collectedAt: number;
+    domain: string;
+    tickNumber: number;
+    failed?: boolean;
+    errorMessage?: string;
+  };
+}
+
+function relativeTime(ms: number): string {
+  const diffMs = Date.now() - ms;
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  return `${diffHr}h ago`;
+}
+
+export default function WorldStateCard({ name, data, metadata }: WorldStateCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const failed = metadata.failed === true;
+
+  return (
+    <div
+      class="ws-card"
+      style={{
+        borderColor: failed ? "rgba(248, 81, 73, 0.5)" : "var(--border-default)",
+        background: failed ? "rgba(248, 81, 73, 0.06)" : "var(--bg-default)",
+      }}
+    >
+      <div class="ws-card__header">
+        <div class="ws-card__title-row">
+          <span
+            class="ws-card__status-dot"
+            style={{ background: failed ? "var(--text-danger)" : "var(--text-success)" }}
+          />
+          <span class="ws-card__name">{name}</span>
+          {failed && (
+            <span class="badge badge-red" style={{ marginLeft: "8px" }}>
+              failed
+            </span>
+          )}
+        </div>
+        <div class="ws-card__meta">
+          <span title={new Date(metadata.collectedAt).toISOString()}>
+            {relativeTime(metadata.collectedAt)}
+          </span>
+          <span class="ws-card__sep">·</span>
+          <span>tick #{metadata.tickNumber}</span>
+        </div>
+      </div>
+
+      {failed && metadata.errorMessage && (
+        <div class="ws-card__error">{metadata.errorMessage}</div>
+      )}
+
+      <button class="ws-card__toggle" onClick={() => setExpanded(!expanded)}>
+        {expanded ? "Hide data ▲" : "Show data ▼"}
+      </button>
+
+      {expanded && (
+        <div class="ws-card__data">
+          <JsonTree value={data} />
+        </div>
+      )}
+
+      <style>{`
+        .ws-card {
+          display: flex;
+          flex-direction: column;
+          gap: 10px;
+          border: 1px solid var(--border-default);
+          border-radius: 8px;
+          padding: 14px 16px;
+          transition: border-color 0.2s;
+        }
+        .ws-card__header {
+          display: flex;
+          align-items: flex-start;
+          justify-content: space-between;
+          gap: 12px;
+        }
+        .ws-card__title-row {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+        }
+        .ws-card__status-dot {
+          width: 8px;
+          height: 8px;
+          border-radius: 50%;
+          flex-shrink: 0;
+        }
+        .ws-card__name {
+          font-size: 14px;
+          font-weight: 600;
+          color: var(--text-primary);
+          font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+        }
+        .ws-card__meta {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          font-size: 12px;
+          color: var(--text-secondary);
+          flex-shrink: 0;
+        }
+        .ws-card__sep {
+          color: var(--border-default);
+        }
+        .ws-card__error {
+          font-size: 12px;
+          color: var(--text-danger);
+          background: rgba(248, 81, 73, 0.1);
+          border: 1px solid rgba(248, 81, 73, 0.3);
+          border-radius: 4px;
+          padding: 6px 10px;
+        }
+        .ws-card__toggle {
+          align-self: flex-start;
+          background: none;
+          border: 1px solid var(--border-muted);
+          border-radius: 4px;
+          color: var(--text-secondary);
+          cursor: pointer;
+          font-size: 12px;
+          padding: 4px 10px;
+          transition: border-color 0.1s, color 0.1s;
+        }
+        .ws-card__toggle:hover {
+          border-color: var(--border-default);
+          color: var(--text-primary);
+        }
+        .ws-card__data {
+          background: var(--bg-inset);
+          border: 1px solid var(--border-default);
+          border-radius: 4px;
+          padding: 12px;
+          max-height: 400px;
+          overflow-y: auto;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/dashboard/src/components/renderers/ChartRenderer.tsx
+++ b/dashboard/src/components/renderers/ChartRenderer.tsx
@@ -1,0 +1,407 @@
+// ChartRenderer — renders a line, bar, or area chart from a ChartWidgetDescriptor.
+//
+// Uses inline SVG (no external charting library) for Preact compatibility.
+// Supports responsive layout, dark mode via CSS variables, and graceful
+// handling of missing or invalid data.
+
+import { useState, useEffect } from "preact/hooks";
+import type { ChartWidgetDescriptor } from "../../lib/widget-renderer";
+import { fetchWidgetData } from "../../lib/widget-renderer";
+
+const DEFAULT_COLORS = [
+  "#58a6ff",
+  "#3fb950",
+  "#d29922",
+  "#f85149",
+  "#bc8cff",
+  "#79c0ff",
+];
+
+// SVG viewBox dimensions
+const VB_WIDTH = 480;
+const PAD = { top: 16, right: 16, bottom: 36, left: 52 };
+
+type DataRow = Record<string, unknown>;
+
+function toNum(v: unknown): number {
+  if (typeof v === "number") return v;
+  if (typeof v === "string") {
+    const n = parseFloat(v);
+    return isNaN(n) ? 0 : n;
+  }
+  return 0;
+}
+
+function formatAxisLabel(v: unknown): string {
+  if (v === null || v === undefined) return "";
+  if (typeof v === "number") {
+    if (Math.abs(v) >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+    if (Math.abs(v) >= 1_000) return `${(v / 1_000).toFixed(0)}k`;
+    return v.toFixed(v % 1 === 0 ? 0 : 1);
+  }
+  const s = String(v);
+  return s.length > 8 ? s.slice(0, 8) + "…" : s;
+}
+
+interface PlotArea {
+  w: number;
+  h: number;
+}
+
+function computePlotArea(vbHeight: number): PlotArea {
+  return {
+    w: VB_WIDTH - PAD.left - PAD.right,
+    h: vbHeight - PAD.top - PAD.bottom,
+  };
+}
+
+function yRange(data: DataRow[], yKeys: string[]): { min: number; max: number } {
+  const allValues = data.flatMap((row) => yKeys.map((k) => toNum(row[k])));
+  if (allValues.length === 0) return { min: 0, max: 1 };
+  const min = Math.min(0, ...allValues);
+  const max = Math.max(...allValues);
+  return { min, max: max === min ? min + 1 : max };
+}
+
+function toX(i: number, count: number, plotW: number): number {
+  if (count <= 1) return PAD.left + plotW / 2;
+  return PAD.left + (i / (count - 1)) * plotW;
+}
+
+function toY(
+  value: number,
+  min: number,
+  max: number,
+  plotH: number,
+  vbHeight: number,
+): number {
+  const range = max - min || 1;
+  return PAD.top + plotH - ((value - min) / range) * plotH;
+}
+
+interface LineSeriesProps {
+  data: DataRow[];
+  xKey: string;
+  yKey: string;
+  color: string;
+  vbHeight: number;
+  min: number;
+  max: number;
+  area?: boolean;
+}
+
+function LineSeries({ data, yKey, color, vbHeight, min, max, area }: LineSeriesProps) {
+  const { w, h } = computePlotArea(vbHeight);
+  if (data.length === 0) return null;
+
+  const points = data.map((row, i) => ({
+    x: toX(i, data.length, w),
+    y: toY(toNum(row[yKey]), min, max, h, vbHeight),
+  }));
+
+  const linePath = points
+    .map((p, i) => `${i === 0 ? "M" : "L"}${p.x.toFixed(1)},${p.y.toFixed(1)}`)
+    .join(" ");
+
+  const areaPath = area
+    ? `${linePath} L${points[points.length - 1].x.toFixed(1)},${(PAD.top + h).toFixed(1)} L${points[0].x.toFixed(1)},${(PAD.top + h).toFixed(1)} Z`
+    : null;
+
+  return (
+    <g>
+      {areaPath && (
+        <path
+          d={areaPath}
+          fill={color}
+          fill-opacity="0.12"
+          stroke="none"
+        />
+      )}
+      <path d={linePath} fill="none" stroke={color} stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+      {data.length <= 20 &&
+        points.map((p, i) => (
+          <circle key={i} cx={p.x.toFixed(1)} cy={p.y.toFixed(1)} r="3" fill={color} />
+        ))}
+    </g>
+  );
+}
+
+interface BarSeriesProps {
+  data: DataRow[];
+  yKeys: string[];
+  colors: string[];
+  vbHeight: number;
+  max: number;
+}
+
+function BarSeries({ data, yKeys, colors, vbHeight, max }: BarSeriesProps) {
+  const { w, h } = computePlotArea(vbHeight);
+  if (data.length === 0) return null;
+
+  const groupW = w / data.length;
+  const barW = Math.max(2, (groupW / (yKeys.length + 1)) * 0.85);
+  const baseline = PAD.top + h;
+
+  return (
+    <g>
+      {data.map((row, i) => {
+        const groupX = PAD.left + i * groupW;
+        return yKeys.map((key, ki) => {
+          const value = toNum(row[key]);
+          const barH = Math.max(0, (value / (max || 1)) * h);
+          const x = groupX + (ki + 0.5) * (groupW / (yKeys.length + 1)) - barW / 2;
+          const y = baseline - barH;
+          return (
+            <rect
+              key={`${i}-${ki}`}
+              x={x.toFixed(1)}
+              y={y.toFixed(1)}
+              width={barW.toFixed(1)}
+              height={barH.toFixed(1)}
+              fill={colors[ki % colors.length]}
+              rx="2"
+            />
+          );
+        });
+      })}
+    </g>
+  );
+}
+
+interface AxesProps {
+  data: DataRow[];
+  xKey: string;
+  min: number;
+  max: number;
+  vbHeight: number;
+}
+
+function Axes({ data, xKey, min, max, vbHeight }: AxesProps) {
+  const { w, h } = computePlotArea(vbHeight);
+  const baseline = PAD.top + h;
+
+  // Y-axis tick count
+  const tickCount = 4;
+  const yTicks = Array.from({ length: tickCount + 1 }, (_, i) => {
+    const frac = i / tickCount;
+    return min + frac * (max - min);
+  });
+
+  // X labels — show at most 8 evenly spaced
+  const maxXLabels = 8;
+  const step = data.length <= maxXLabels ? 1 : Math.ceil(data.length / maxXLabels);
+  const xLabelIndices = data
+    .map((_, i) => i)
+    .filter((i) => i % step === 0 || i === data.length - 1);
+
+  return (
+    <g fill="var(--text-muted, #8b949e)" font-size="10" font-family="monospace">
+      {/* Y-axis line */}
+      <line
+        x1={PAD.left}
+        y1={PAD.top}
+        x2={PAD.left}
+        y2={baseline}
+        stroke="var(--border-default, #30363d)"
+        stroke-width="1"
+      />
+      {/* X-axis line */}
+      <line
+        x1={PAD.left}
+        y1={baseline}
+        x2={PAD.left + w}
+        y2={baseline}
+        stroke="var(--border-default, #30363d)"
+        stroke-width="1"
+      />
+      {/* Y gridlines + labels */}
+      {yTicks.map((tick, i) => {
+        const y = toY(tick, min, max, h, vbHeight);
+        return (
+          <g key={i}>
+            <line
+              x1={PAD.left}
+              y1={y.toFixed(1)}
+              x2={PAD.left + w}
+              y2={y.toFixed(1)}
+              stroke="var(--border-default, #30363d)"
+              stroke-width="0.5"
+              stroke-dasharray={i === 0 ? "none" : "3,3"}
+            />
+            <text x={(PAD.left - 4).toFixed(1)} y={(y + 3).toFixed(1)} text-anchor="end">
+              {formatAxisLabel(tick)}
+            </text>
+          </g>
+        );
+      })}
+      {/* X labels */}
+      {xLabelIndices.map((i) => {
+        const x = toX(i, data.length, w);
+        return (
+          <text
+            key={i}
+            x={x.toFixed(1)}
+            y={(baseline + 14).toFixed(1)}
+            text-anchor="middle"
+            transform={`rotate(-30, ${x.toFixed(1)}, ${(baseline + 14).toFixed(1)})`}
+          >
+            {formatAxisLabel(data[i][xKey])}
+          </text>
+        );
+      })}
+    </g>
+  );
+}
+
+interface ChartRendererProps {
+  descriptor: ChartWidgetDescriptor;
+}
+
+export default function ChartRenderer({ descriptor }: ChartRendererProps) {
+  const [data, setData] = useState<DataRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const { config } = descriptor;
+  const vbHeight = config.height ?? 220;
+  const colors = config.colors ?? DEFAULT_COLORS;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const result = await fetchWidgetData<unknown>(descriptor);
+        if (cancelled) return;
+        if (!Array.isArray(result)) {
+          setError("Expected array data for chart");
+          return;
+        }
+        setData(result as DataRow[]);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load");
+      }
+    }
+
+    load();
+    const ttl = descriptor.query.ttl ?? 30_000;
+    const id = setInterval(load, ttl);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [descriptor.id, descriptor.query.url]);
+
+  return (
+    <>
+      <style>{`
+        .chart-renderer {
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
+        }
+        .chart-renderer__title {
+          font-size: 13px;
+          font-weight: 600;
+          color: var(--text-primary, #e6edf3);
+          letter-spacing: 0.02em;
+        }
+        .chart-renderer__svg {
+          width: 100%;
+          height: auto;
+          display: block;
+        }
+        .chart-renderer__error {
+          font-size: 12px;
+          color: var(--text-muted, #8b949e);
+          padding: 24px 0;
+          text-align: center;
+        }
+        .chart-renderer__legend {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 12px;
+        }
+        .chart-renderer__legend-item {
+          display: flex;
+          align-items: center;
+          gap: 5px;
+          font-size: 11px;
+          color: var(--text-secondary, #8b949e);
+        }
+        .chart-renderer__legend-dot {
+          width: 8px;
+          height: 8px;
+          border-radius: 50%;
+          flex-shrink: 0;
+        }
+      `}</style>
+      <div class="chart-renderer">
+        <div class="chart-renderer__title">{descriptor.title}</div>
+
+        {error ? (
+          <div class="chart-renderer__error">{error}</div>
+        ) : data === null ? (
+          <div class="chart-renderer__error">Loading…</div>
+        ) : data.length === 0 ? (
+          <div class="chart-renderer__error">No data</div>
+        ) : (
+          <>
+            <svg
+              class="chart-renderer__svg"
+              viewBox={`0 0 ${VB_WIDTH} ${vbHeight}`}
+              aria-label={descriptor.title}
+            >
+              <Axes
+                data={data}
+                xKey={config.xKey}
+                min={config.type === "bar" ? 0 : yRange(data, config.yKeys).min}
+                max={yRange(data, config.yKeys).max}
+                vbHeight={vbHeight}
+              />
+              {config.type === "bar" ? (
+                <BarSeries
+                  data={data}
+                  yKeys={config.yKeys}
+                  colors={colors}
+                  vbHeight={vbHeight}
+                  max={yRange(data, config.yKeys).max}
+                />
+              ) : (
+                config.yKeys.map((yKey, ki) => {
+                  const { min, max } = yRange(data, config.yKeys);
+                  return (
+                    <LineSeries
+                      key={yKey}
+                      data={data}
+                      xKey={config.xKey}
+                      yKey={yKey}
+                      color={colors[ki % colors.length]}
+                      vbHeight={vbHeight}
+                      min={min}
+                      max={max}
+                      area={config.type === "area"}
+                    />
+                  );
+                })
+              )}
+            </svg>
+
+            {config.yKeys.length > 1 && (
+              <div class="chart-renderer__legend">
+                {config.yKeys.map((key, i) => (
+                  <div key={key} class="chart-renderer__legend-item">
+                    <span
+                      class="chart-renderer__legend-dot"
+                      style={{ background: colors[i % colors.length] }}
+                    />
+                    {key}
+                  </div>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/dashboard/src/components/renderers/LogStreamRenderer.tsx
+++ b/dashboard/src/components/renderers/LogStreamRenderer.tsx
@@ -1,0 +1,93 @@
+// LogStreamRenderer — renders a live event log stream for a log-stream WidgetDescriptor.
+//
+// Fetches initial events from the widget's query URL, then subscribes to the
+// WebSocket path in props.wsPath for real-time updates.
+
+import { useState, useEffect, useRef } from "preact/hooks";
+import { WebSocketManager } from "../../lib/websocket";
+import type { WsMessage } from "../../lib/websocket";
+import { EventRow } from "../EventRow";
+
+export interface LogStreamWidgetDescriptor {
+  id: string;
+  title: string;
+  type: "log-stream";
+  query: string;
+  props?: {
+    wsPath?: string;
+    limit?: number;
+  };
+}
+
+interface Props {
+  descriptor: LogStreamWidgetDescriptor;
+}
+
+export function LogStreamRenderer({ descriptor }: Props) {
+  const [events, setEvents] = useState<WsMessage[]>([]);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const queryUrl = descriptor.query;
+  const wsPath = descriptor.props?.wsPath;
+  const limit = descriptor.props?.limit ?? 100;
+
+  // Load history on mount
+  useEffect(() => {
+    fetch(`${queryUrl}?limit=${limit}`)
+      .then((r) => r.json())
+      .then((data: unknown) => {
+        const msgs = (Array.isArray(data) ? data : []) as WsMessage[];
+        setEvents(msgs.reverse());
+      })
+      .catch(() => {});
+  }, [queryUrl, limit]);
+
+  // WebSocket for live updates
+  useEffect(() => {
+    if (!wsPath) return;
+    const manager = new WebSocketManager(wsPath);
+    const off = manager.onMessage((msg) => {
+      setEvents((prev) => [...prev, msg]);
+    });
+    manager.connect();
+    return () => {
+      off();
+      manager.destroy();
+    };
+  }, [wsPath]);
+
+  // Auto-scroll to bottom
+  useEffect(() => {
+    const el = listRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [events]);
+
+  function toggleExpanded(id: string) {
+    setExpandedId((prev) => (prev === id ? null : id));
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "400px" }}>
+      <div
+        ref={listRef}
+        style={{ flex: 1, overflow: "auto", fontFamily: "'SF Mono', 'Fira Code', Consolas, monospace" }}
+      >
+        {events.length === 0 ? (
+          <div style={{ padding: "16px", color: "#484f58", fontSize: "13px" }}>
+            Waiting for events…
+          </div>
+        ) : (
+          events.map((msg) => (
+            <EventRow
+              key={msg.id ?? msg.timestamp}
+              msg={msg}
+              isExpanded={expandedId === (msg.id ?? msg.timestamp)}
+              onClick={() => toggleExpanded(msg.id ?? msg.timestamp)}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/renderers/StatusCardRenderer.tsx
+++ b/dashboard/src/components/renderers/StatusCardRenderer.tsx
@@ -1,0 +1,181 @@
+// StatusCardRenderer — renders a key-value status display from a StatusCardWidgetDescriptor.
+//
+// Each entry in config.entries maps a data key to a human-readable label.
+// An optional statusKey drives the card's border/accent color via statusMap.
+// Missing or invalid data is handled gracefully.
+
+import { useState, useEffect } from "preact/hooks";
+import type { StatusCardWidgetDescriptor, StatusLevel } from "../../lib/widget-renderer";
+import { fetchWidgetData, formatValue } from "../../lib/widget-renderer";
+
+const STATUS_COLORS: Record<StatusLevel, string> = {
+  healthy: "#3fb950",
+  degraded: "#d29922",
+  down: "#f85149",
+  unknown: "#8b949e",
+};
+
+const STATUS_BORDER: Record<StatusLevel, string> = {
+  healthy: "rgba(63, 185, 80, 0.3)",
+  degraded: "rgba(210, 153, 34, 0.3)",
+  down: "rgba(248, 81, 73, 0.3)",
+  unknown: "var(--border-default, #30363d)",
+};
+
+function deriveStatus(
+  data: Record<string, unknown>,
+  statusKey?: string,
+  statusMap?: Record<string, StatusLevel>,
+): StatusLevel {
+  if (!statusKey) return "unknown";
+  const raw = String(data[statusKey] ?? "");
+  return statusMap?.[raw] ?? "unknown";
+}
+
+interface StatusCardRendererProps {
+  descriptor: StatusCardWidgetDescriptor;
+}
+
+export default function StatusCardRenderer({ descriptor }: StatusCardRendererProps) {
+  const [data, setData] = useState<Record<string, unknown> | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const { config } = descriptor;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const result = await fetchWidgetData<unknown>(descriptor);
+        if (cancelled) return;
+        if (!result || typeof result !== "object" || Array.isArray(result)) {
+          setError("Expected object data for status card");
+          return;
+        }
+        setData(result as Record<string, unknown>);
+        setError(null);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load");
+      }
+    }
+
+    load();
+    const ttl = descriptor.query.ttl ?? 30_000;
+    const id = setInterval(load, ttl);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [descriptor.id, descriptor.query.url]);
+
+  const status = data ? deriveStatus(data, config.statusKey, config.statusMap) : "unknown";
+  const statusColor = STATUS_COLORS[status];
+  const borderColor = data ? STATUS_BORDER[status] : "var(--border-default, #30363d)";
+
+  return (
+    <>
+      <style>{`
+        .status-card {
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+          border: 1px solid var(--border-default, #30363d);
+          border-radius: 8px;
+          padding: 16px;
+          background: var(--bg-card, #0d1117);
+          transition: border-color 0.2s;
+        }
+        .status-card__header {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 8px;
+        }
+        .status-card__title {
+          font-size: 13px;
+          font-weight: 600;
+          color: var(--text-primary, #e6edf3);
+          letter-spacing: 0.02em;
+        }
+        .status-card__dot {
+          width: 10px;
+          height: 10px;
+          border-radius: 50%;
+          flex-shrink: 0;
+        }
+        .status-card__grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+          gap: 10px 16px;
+        }
+        .status-card__entry {
+          display: flex;
+          flex-direction: column;
+          gap: 2px;
+        }
+        .status-card__label {
+          font-size: 11px;
+          color: var(--text-muted, #8b949e);
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+        .status-card__value {
+          font-size: 15px;
+          font-weight: 600;
+          color: var(--text-primary, #e6edf3);
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+        .status-card__empty,
+        .status-card__error {
+          font-size: 12px;
+          color: var(--text-muted, #8b949e);
+          text-align: center;
+          padding: 12px 0;
+        }
+        .status-card__error {
+          color: var(--color-danger, #f85149);
+        }
+        @keyframes status-pulse {
+          0%, 100% { opacity: 0.4; }
+          50% { opacity: 1; }
+        }
+      `}</style>
+      <div class="status-card" style={{ borderColor }}>
+        <div class="status-card__header">
+          <div class="status-card__title">{descriptor.title}</div>
+          {data && (
+            <span
+              class="status-card__dot"
+              style={{
+                background: statusColor,
+                animation: status === "unknown" ? "status-pulse 1.4s ease-in-out infinite" : "none",
+              }}
+              aria-label={`Status: ${status}`}
+            />
+          )}
+        </div>
+
+        {error ? (
+          <div class="status-card__error">{error}</div>
+        ) : data === null ? (
+          <div class="status-card__empty">Loading…</div>
+        ) : (
+          <div class="status-card__grid">
+            {config.entries.map((entry) => (
+              <div key={entry.key} class="status-card__entry">
+                <div class="status-card__label">{entry.label}</div>
+                <div class="status-card__value" title={String(data[entry.key] ?? "—")}>
+                  {formatValue(data[entry.key], entry.format)}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/dashboard/src/components/renderers/TableRenderer.tsx
+++ b/dashboard/src/components/renderers/TableRenderer.tsx
@@ -1,0 +1,164 @@
+// TableRenderer — renders a dynamic columnar table from a TableWidgetDescriptor.
+//
+// Column definitions come from the descriptor config. Data is fetched via
+// widget.query and must be an array of objects. Missing or invalid data is
+// handled gracefully with empty-state and error views.
+
+import { useState, useEffect } from "preact/hooks";
+import type { TableWidgetDescriptor } from "../../lib/widget-renderer";
+import { fetchWidgetData } from "../../lib/widget-renderer";
+
+type DataRow = Record<string, unknown>;
+
+function cellValue(row: DataRow, key: string): string {
+  const v = row[key];
+  if (v === null || v === undefined) return "—";
+  if (typeof v === "object") return JSON.stringify(v);
+  return String(v);
+}
+
+interface TableRendererProps {
+  descriptor: TableWidgetDescriptor;
+}
+
+export default function TableRenderer({ descriptor }: TableRendererProps) {
+  const [rows, setRows] = useState<DataRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const { config } = descriptor;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const result = await fetchWidgetData<unknown>(descriptor);
+        if (cancelled) return;
+        if (!Array.isArray(result)) {
+          setError("Expected array data for table");
+          return;
+        }
+        setRows(result as DataRow[]);
+        setError(null);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load");
+      }
+    }
+
+    load();
+    const ttl = descriptor.query.ttl ?? 30_000;
+    const id = setInterval(load, ttl);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [descriptor.id, descriptor.query.url]);
+
+  return (
+    <>
+      <style>{`
+        .table-renderer {
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
+          min-width: 0;
+        }
+        .table-renderer__title {
+          font-size: 13px;
+          font-weight: 600;
+          color: var(--text-primary, #e6edf3);
+          letter-spacing: 0.02em;
+        }
+        .table-renderer__scroll {
+          overflow-x: auto;
+          border-radius: 6px;
+          border: 1px solid var(--border-default, #30363d);
+        }
+        .table-renderer__table {
+          width: 100%;
+          border-collapse: collapse;
+          font-size: 12px;
+        }
+        .table-renderer__table thead tr {
+          background: var(--bg-subtle, #161b22);
+        }
+        .table-renderer__table th {
+          padding: 8px 12px;
+          color: var(--text-muted, #8b949e);
+          font-weight: 500;
+          white-space: nowrap;
+          border-bottom: 1px solid var(--border-default, #30363d);
+        }
+        .table-renderer__table td {
+          padding: 7px 12px;
+          color: var(--text-primary, #e6edf3);
+          border-bottom: 1px solid var(--border-subtle, #21262d);
+          vertical-align: middle;
+          max-width: 240px;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+        .table-renderer__table tbody tr:last-child td {
+          border-bottom: none;
+        }
+        .table-renderer__table tbody tr:hover td {
+          background: var(--bg-subtle, #161b22);
+        }
+        .table-renderer__empty,
+        .table-renderer__error {
+          font-size: 12px;
+          color: var(--text-muted, #8b949e);
+          padding: 24px;
+          text-align: center;
+        }
+        .table-renderer__error {
+          color: var(--color-danger, #f85149);
+        }
+      `}</style>
+      <div class="table-renderer">
+        <div class="table-renderer__title">{descriptor.title}</div>
+
+        {error ? (
+          <div class="table-renderer__error">{error}</div>
+        ) : rows === null ? (
+          <div class="table-renderer__empty">Loading…</div>
+        ) : rows.length === 0 ? (
+          <div class="table-renderer__empty">No data</div>
+        ) : (
+          <div class="table-renderer__scroll">
+            <table class="table-renderer__table">
+              <thead>
+                <tr>
+                  {config.columns.map((col) => (
+                    <th
+                      key={col.key}
+                      style={{ textAlign: col.align ?? "left" }}
+                    >
+                      {col.label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row, i) => (
+                  <tr key={i}>
+                    {config.columns.map((col) => (
+                      <td
+                        key={col.key}
+                        style={{ textAlign: col.align ?? "left" }}
+                        title={cellValue(row, col.key)}
+                      >
+                        {cellValue(row, col.key)}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/dashboard/src/layouts/DashboardLayout.astro
+++ b/dashboard/src/layouts/DashboardLayout.astro
@@ -17,6 +17,7 @@ const navItems = [
   { href: "/outcomes", label: "Outcomes", id: "outcomes" },
   { href: "/projects", label: "Projects", id: "projects" },
   { href: "/fleet-cost", label: "Fleet Cost", id: "fleet-cost" },
+  { href: "/widgets", label: "Plugins", id: "discovery" },
 ];
 ---
 

--- a/dashboard/src/layouts/DiscoveryLayout.astro
+++ b/dashboard/src/layouts/DiscoveryLayout.astro
@@ -1,0 +1,17 @@
+---
+// DiscoveryLayout — wraps the standard dashboard shell for discovery-driven plugin pages.
+// Used by [dynamic].astro to render widgets fetched from /api/widgets.
+import DashboardLayout from "./DashboardLayout.astro";
+
+export interface Props {
+  title: string;
+  /** Sidebar nav item to highlight. Defaults to "discovery". */
+  activePage?: string;
+}
+
+const { title, activePage = "discovery" } = Astro.props;
+---
+
+<DashboardLayout title={title} activePage={activePage}>
+  <slot />
+</DashboardLayout>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -130,6 +130,9 @@ export const getCeremonies = () =>
 export const getHitlPending = () =>
   apiFetch<{ data: unknown[] }>("/api/hitl/pending", { ttl: 30_000 });
 
+export const getWidgets = (force = false) =>
+  apiFetch<unknown[]>("/api/widgets", { ttl: 30_000, force });
+
 // ── Response types (match actual API shapes after envelope unwrap) ─
 export interface WorldStateResponse {
   timestamp: number;

--- a/dashboard/src/lib/widget-renderer.ts
+++ b/dashboard/src/lib/widget-renderer.ts
@@ -1,0 +1,154 @@
+// WidgetDescriptor contract and data fetching utilities for generic widget renderers.
+//
+// Note: ChartRenderer uses SVG-based charts (inline, no external deps).
+// If Recharts is desired in future, enable preact/compat in astro.config.mjs
+// and add `recharts` to dashboard/package.json.
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type ChartType = "line" | "bar" | "area";
+
+export interface ChartConfig {
+  type: ChartType;
+  xKey: string;
+  yKeys: string[];
+  colors?: string[];
+  height?: number;
+}
+
+export interface TableConfig {
+  columns: Array<{
+    key: string;
+    label: string;
+    align?: "left" | "right" | "center";
+  }>;
+}
+
+export type StatusLevel = "healthy" | "degraded" | "down" | "unknown";
+
+export interface StatusCardConfig {
+  entries: Array<{
+    key: string;
+    label: string;
+    format?: "percent" | "bytes" | "ms" | "number" | "text";
+  }>;
+  /** Key in the data whose value is used to derive the card's overall status color. */
+  statusKey?: string;
+  /** Maps statusKey values to a StatusLevel. Falls back to "unknown". */
+  statusMap?: Record<string, StatusLevel>;
+}
+
+interface BaseWidgetDescriptor {
+  id: string;
+  title: string;
+  query: {
+    url: string;
+    ttl?: number;
+    /** Dot-path to extract from the response. E.g. "items" or "data.rows". */
+    dataPath?: string;
+  };
+}
+
+export interface ChartWidgetDescriptor extends BaseWidgetDescriptor {
+  type: "chart";
+  config: ChartConfig;
+}
+
+export interface TableWidgetDescriptor extends BaseWidgetDescriptor {
+  type: "table";
+  config: TableConfig;
+}
+
+export interface StatusCardWidgetDescriptor extends BaseWidgetDescriptor {
+  type: "status-card";
+  config: StatusCardConfig;
+}
+
+export type WidgetDescriptor =
+  | ChartWidgetDescriptor
+  | TableWidgetDescriptor
+  | StatusCardWidgetDescriptor;
+
+// ── Cache ─────────────────────────────────────────────────────────────────────
+
+const cache = new Map<string, { data: unknown; expiry: number }>();
+
+function unwrapEnvelope(raw: unknown): unknown {
+  if (
+    raw !== null &&
+    typeof raw === "object" &&
+    "success" in raw &&
+    "data" in (raw as Record<string, unknown>)
+  ) {
+    return (raw as { success: boolean; data: unknown }).data;
+  }
+  return raw;
+}
+
+function getByPath(obj: unknown, path: string): unknown {
+  return path.split(".").reduce((acc: unknown, key) => {
+    if (acc !== null && typeof acc === "object") {
+      return (acc as Record<string, unknown>)[key];
+    }
+    return undefined;
+  }, obj);
+}
+
+// ── Data fetching ─────────────────────────────────────────────────────────────
+
+export async function fetchWidgetData<T = unknown>(
+  descriptor: WidgetDescriptor,
+): Promise<T> {
+  const { url, ttl = 30_000, dataPath } = descriptor.query;
+  const cacheKey = `widget:${url}`;
+
+  const cached = cache.get(cacheKey);
+  if (cached && cached.expiry > Date.now()) {
+    return cached.data as T;
+  }
+
+  const res = await fetch(url, { headers: { Accept: "application/json" } });
+  if (!res.ok) {
+    throw new Error(
+      `Widget "${descriptor.id}" query failed: ${res.status} ${res.statusText}`,
+    );
+  }
+
+  const raw: unknown = await res.json();
+  let data = unwrapEnvelope(raw);
+
+  if (dataPath) {
+    data = getByPath(data, dataPath);
+  }
+
+  cache.set(cacheKey, { data, expiry: Date.now() + ttl });
+  return data as T;
+}
+
+// ── Format helpers ─────────────────────────────────────────────────────────────
+
+export function formatValue(
+  value: unknown,
+  format?: StatusCardConfig["entries"][number]["format"],
+): string {
+  if (value === null || value === undefined) return "—";
+  const n = typeof value === "number" ? value : parseFloat(String(value));
+
+  switch (format) {
+    case "percent":
+      return isNaN(n) ? String(value) : `${(n * 100).toFixed(1)}%`;
+    case "bytes": {
+      if (isNaN(n)) return String(value);
+      if (n >= 1_073_741_824) return `${(n / 1_073_741_824).toFixed(1)} GB`;
+      if (n >= 1_048_576) return `${(n / 1_048_576).toFixed(1)} MB`;
+      if (n >= 1_024) return `${(n / 1_024).toFixed(1)} KB`;
+      return `${n} B`;
+    }
+    case "ms":
+      return isNaN(n) ? String(value) : `${n.toFixed(0)}ms`;
+    case "number":
+      return isNaN(n) ? String(value) : n.toLocaleString();
+    default:
+      return String(value);
+  }
+}

--- a/dashboard/src/pages/[dynamic].astro
+++ b/dashboard/src/pages/[dynamic].astro
@@ -1,0 +1,55 @@
+---
+// [dynamic].astro — discovery-driven catch-all router.
+//
+// At build time, attempts to fetch /api/widgets to enumerate registered plugins
+// and pre-render one page per plugin. Falls back to a single "widgets" path
+// if the API is unavailable (server not running at build time).
+//
+// At runtime the DiscoveryView component re-fetches /api/widgets every 30s so
+// new plugin registrations surface without a rebuild (Astro ISR-compatible pattern).
+
+import DiscoveryLayout from "../layouts/DiscoveryLayout.astro";
+import DiscoveryView from "../components/DiscoveryView.tsx";
+
+export async function getStaticPaths() {
+  try {
+    const apiBase = import.meta.env.API_BASE_URL ?? "http://localhost:3000";
+    const res = await fetch(`${apiBase}/api/widgets`, {
+      signal: AbortSignal.timeout(3_000),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+    const raw = await res.json();
+    const list: Array<{ pluginName: string }> = Array.isArray(raw)
+      ? raw
+      : Array.isArray(raw?.data)
+        ? raw.data
+        : [];
+
+    const plugins = [...new Set(list.map((w) => w.pluginName))];
+    if (plugins.length === 0) {
+      return [{ params: { dynamic: "widgets" }, props: { pluginName: null } }];
+    }
+    return plugins.map((pluginName) => ({
+      params: {
+        dynamic: pluginName.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
+      },
+      props: { pluginName },
+    }));
+  } catch {
+    // Server not running at build time — fall back to generic "widgets" path.
+    return [{ params: { dynamic: "widgets" }, props: { pluginName: null } }];
+  }
+}
+
+interface Props {
+  pluginName: string | null;
+}
+
+const { pluginName } = Astro.props;
+const pageTitle = pluginName ? pluginName : "Plugins";
+---
+
+<DiscoveryLayout title={pageTitle}>
+  <DiscoveryView client:load pluginFilter={pluginName} />
+</DiscoveryLayout>

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -13,6 +13,7 @@ These docs explain the *why* behind protoWorkstacean's architecture. Read them w
 | [Self-improving loop](./self-improving-loop) | How A2A extensions feed observations into `PlannerPluginL0`'s candidate ranking, how episodic memory writes to Graphiti, and why the convergence loops don't diverge |
 | [Distributed tracing](./distributed-tracing) | How `correlationId` (trace-id) and `parentId` (span-id) flow from the bus through RouterPlugin, A2AExecutor, external agents (protoMaker team, Quinn), and back |
 | [Plugin system](./plugin-system) | The plugin lifecycle, core vs integration vs workspace plugins, ordering guarantees |
+| [Cross-channel conversations](../integrations/channels) | How `ChannelRegistry` maps channels → agents, how `ConversationManager` maintains stable `conversationId` across DM and guild turns, and how memory enrichment now applies to all channels |
 
 ## Design philosophy
 

--- a/docs/explanation/self-improving-loop.md
+++ b/docs/explanation/self-improving-loop.md
@@ -115,7 +115,7 @@ All three interceptors are registered once at startup (`src/index.ts`) and fire 
 
 Observations aren't the only thing captured on each dispatch. `SkillDispatcherPlugin` also writes a Graphiti episode for every successful skill completion:
 
-- **Human-originated** dispatches write to two groups: `user_{platform}_{userId}` (shared across agents — the user's common memory) and `agent_{agentName}__{user_...}` (this specific agent's relationship with this user).
+- **Human-originated** dispatches write to two groups: `user_{platform}_{userId}` (shared across agents — the user's common memory) and `agent_{agentName}__{user_...}` (this specific agent's relationship with this user). This applies to all channels — Discord, GitHub, Plane, Slack, Signal — wherever `msg.source.userId` and `msg.source.platform` are present.
 - **Bot-originated** dispatches (`meta.systemActor` set, e.g. `"goap"`) write to a single `system_{actor}` group — the autonomous loop's own episodic log of what it did.
 
 On the next turn, before the skill fires, the dispatcher reads back a `<recalled_memory>` block from Graphiti and injects it into the prompt. Ava and protoBot's system prompts explicitly tell them what the block is ("trusted background — prior commitments, workflow preferences, past provisioning decisions") so they use it silently.

--- a/docs/integrations/widget-declaration.md
+++ b/docs/integrations/widget-declaration.md
@@ -1,0 +1,179 @@
+---
+title: Declaring Dashboard Widgets
+description: How plugin authors add widgets to the discovery-driven dashboard
+---
+
+# Declaring Dashboard Widgets
+
+The protoWorkstacean dashboard is **discovery-driven**: plugins declare the widgets they contribute, and the dashboard renders them automatically. No hardcoded pages. No dashboard config files.
+
+## How it works
+
+1. A plugin implements `getWidgets(): WidgetDescriptor[]`
+2. The runtime calls `GET /api/widgets` to aggregate all declared widgets
+3. The dashboard fetches `/api/widgets` and renders each widget using its `type`
+
+---
+
+## Quick start
+
+### 1. Implement `getWidgets()` on your plugin
+
+```typescript
+import type { Plugin, EventBus, WidgetDescriptor } from "../types.ts";
+
+export class MyPlugin implements Plugin {
+  name = "my-plugin";
+  description = "Does something useful";
+  capabilities: string[] = [];
+
+  install(bus: EventBus): void { /* subscribe to topics */ }
+  uninstall(): void { /* cleanup */ }
+
+  getWidgets(): WidgetDescriptor[] {
+    return [
+      {
+        pluginName: this.name,
+        id: "my-status-card",
+        type: "status-card",
+        title: "My Service Status",
+        query: "/api/my-plugin/status",
+        props: {
+          refreshIntervalMs: 15_000,
+        },
+      },
+    ];
+  }
+}
+```
+
+That's it. The dashboard picks up your widget automatically on next render.
+
+### 2. Register your plugin
+
+Ensure your plugin instance is included in the `plugins` array passed to `ApiContext`. The runtime discovers plugins at startup — no additional wiring is needed.
+
+---
+
+## WidgetDescriptor fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `pluginName` | `string` | Yes | Set to `this.name`. Overwritten by `/api/widgets` stamping — used for attribution in the UI. |
+| `id` | `string` | Yes | Unique across all plugins. Use `kebab-case`. Example: `"world-state-domain-grid"`. |
+| `type` | `WidgetType` | Yes | Controls which renderer is used. See [Widget types](#widget-types). |
+| `title` | `string` | Yes | Human-readable label shown in the dashboard header. |
+| `query` | `string` | No | API endpoint the widget polls for data. Must be a path relative to the server root (e.g. `"/api/world-state"`). |
+| `props` | `Record<string, unknown>` | No | Renderer-specific options (chart type, refresh interval, limits, etc.). |
+
+### Widget types
+
+| Type | Renderer | Use when |
+|------|----------|----------|
+| `chart` | `ChartRenderer` | Time-series or categorical data (line, bar, area) |
+| `table` | `TableRenderer` | Tabular data with rows and columns |
+| `status-card` | `StatusCardRenderer` | Single-value health/status indicators |
+| `log-stream` | `EventStream` | Real-time event/log feeds (WebSocket-backed) |
+| `metric` | `MetricRenderer` | Single numeric KPI with optional trend |
+
+---
+
+## Rules for plugin authors
+
+### IDs must be globally unique
+
+Widget `id` is used as a React key and for URL routing. Namespace it with your plugin name:
+
+```
+my-plugin-status-card    ✅
+status-card              ❌  (collides with other plugins)
+```
+
+### `getWidgets()` must be pure and fast
+
+`getWidgets()` is called on every cache miss (every 5 seconds). It must:
+- Return a static array — do not fetch or await inside `getWidgets()`
+- Not throw — errors from `getWidgets()` propagate to `/api/widgets` callers
+- Return the same set of widgets for the lifetime of the plugin instance
+
+### `query` endpoints must exist
+
+If you declare `query: "/api/my-plugin/data"`, that route must exist in your plugin or the shared API layer. The dashboard does not validate `query` at discovery time — a broken query URL shows an error in the widget, not at startup.
+
+### `pluginName` is overwritten
+
+`/api/widgets` stamps `pluginName` from `plugin.name` regardless of what you set in the descriptor. You should still set it to `this.name` for clarity in tests and local usage.
+
+---
+
+## Example: multiple widget types from one plugin
+
+```typescript
+getWidgets(): WidgetDescriptor[] {
+  return [
+    {
+      pluginName: this.name,
+      id: "github-pr-table",
+      type: "table",
+      title: "Open Pull Requests",
+      query: "/api/github/prs",
+      props: { columns: ["title", "author", "status", "age"] },
+    },
+    {
+      pluginName: this.name,
+      id: "github-ci-status",
+      type: "status-card",
+      title: "CI Health",
+      query: "/api/github/ci-status",
+    },
+    {
+      pluginName: this.name,
+      id: "github-merge-rate",
+      type: "chart",
+      title: "Merge Rate (7d)",
+      query: "/api/github/merge-rate",
+      props: { chartType: "bar", unit: "PRs/day" },
+    },
+  ];
+}
+```
+
+---
+
+## Template plugin
+
+A copy-pasteable starting point lives at:
+
+```
+lib/plugins/example-template-plugin.ts
+```
+
+Copy it, rename the class and `name`, and replace the example widgets with your own.
+
+---
+
+## Testing your widgets
+
+Write a unit test that calls `getWidgets()` directly and asserts the returned descriptors:
+
+```typescript
+import { describe, test, expect } from "bun:test";
+import { MyPlugin } from "../../lib/plugins/my-plugin.ts";
+
+describe("MyPlugin.getWidgets()", () => {
+  test("returns expected widget ids", () => {
+    const plugin = new MyPlugin();
+    const widgets = plugin.getWidgets();
+
+    expect(widgets.length).toBeGreaterThan(0);
+    for (const w of widgets) {
+      expect(w.id).toContain("my-plugin");
+      expect(w.pluginName).toBe("my-plugin");
+      expect(w.type).toBeTruthy();
+      expect(w.title).toBeTruthy();
+    }
+  });
+});
+```
+
+For end-to-end verification, see `test/integration/widget-discovery.test.ts`.

--- a/docs/reference/bus-topics.md
+++ b/docs/reference/bus-topics.md
@@ -68,7 +68,7 @@ All bus topics published and subscribed across all plugins and subsystems. Topic
 
 | Topic | Direction | Publisher | Subscriber | Description |
 |-------|-----------|-----------|------------|-------------|
-| `message.inbound.discord.<channelId>` | Inbound | DiscordPlugin | RouterPlugin | @mention or DM received |
+| `message.inbound.discord.<channelId>` | Inbound | DiscordPlugin | RouterPlugin | @mention, guild channel message, or DM received |
 | `message.inbound.discord.slash.<interactionId>` | Inbound | DiscordPlugin | RouterPlugin | Slash command invoked |
 | `message.outbound.discord.<channelId>` | Outbound | Agents | DiscordPlugin | Reply to a specific channel |
 | `message.outbound.discord.push.<channelId>` | Outbound | CeremonyPlugin, ActionDispatcherPlugin | DiscordPlugin | Unprompted push (cron result, alert) |
@@ -76,15 +76,19 @@ All bus topics published and subscribed across all plugins and subsystems. Topic
 **Inbound payload**:
 ```typescript
 {
-  sender: string;       // Discord user ID
-  channel: string;      // Discord channel ID
-  content: string;      // Cleaned message (mentions stripped)
-  skillHint?: string;   // Set by slash commands and reaction handlers
+  sender: string;         // Discord user ID
+  channel: string;        // Discord channel ID
+  content: string;        // Cleaned message (mentions stripped)
+  skillHint?: string;     // Set by slash commands and reaction handlers
   isReaction?: boolean;
   isThread?: boolean;
   guildId?: string;
+  correlationId: string;  // Stable conversationId for multi-turn sessions — reused
+                          // across turns by ConversationManager, becomes the A2A contextId
 }
 ```
+
+**Multi-turn conversations**: when `conversation.enabled: true` is set for a channel in `workspace/channels.yaml`, `ConversationManager` assigns a stable `conversationId` to each `(channelId, userId)` pair. This ID flows as `correlationId` on every turn, becoming the A2A `contextId` so agents have full conversation memory. DMs are always conversation-enabled (no YAML needed). RouterPlugin applies DM conversation stickiness — once a skill/agent is matched, subsequent DM turns reuse the same target without re-running keyword matching.
 
 ---
 

--- a/lib/conversation/context-assembler.ts
+++ b/lib/conversation/context-assembler.ts
@@ -1,0 +1,49 @@
+import type { ConversationTurn } from "../types.ts";
+
+/**
+ * Assemble a structured context envelope for the agent prompt.
+ *
+ * Pure function — no side effects, suitable for unit testing.
+ *
+ * Sections emitted (in order, only when non-empty):
+ *   <recalled_memory>  — Graphiti facts retrieved for this user
+ *   <recent_conversation> — last N turns from LoggerPlugin
+ *   <current_message>  — the user's actual input (always emitted)
+ *
+ * When there is no history (no memory, no turns), only <current_message>
+ * is emitted — no empty XML tags.
+ */
+export function assembleContext(
+  recalledMemory: string | undefined,
+  recentTurns: ConversationTurn[],
+  currentMessage: string,
+): string {
+  const parts: string[] = [];
+
+  if (recalledMemory) {
+    parts.push(
+      `<recalled_memory>\n` +
+      `The following facts were retrieved from your memory about this user. ` +
+      `Use them as background context if relevant — do NOT repeat them back ` +
+      `to the user or reference them unless the user's message specifically ` +
+      `asks about something they relate to. Focus your response on what the ` +
+      `user is actually saying below.\n\n` +
+      `${recalledMemory}\n` +
+      `</recalled_memory>`,
+    );
+  }
+
+  if (recentTurns.length > 0) {
+    const turnLines = recentTurns.map(turn => {
+      const ts = new Date(turn.timestamp).toISOString();
+      const channelSuffix = turn.channelId ? ` [${turn.channelId}]` : "";
+      const label = turn.role === "user" ? "User" : "Assistant";
+      return `[${ts}${channelSuffix}] ${label}: ${turn.text}`;
+    });
+    parts.push(`<recent_conversation>\n${turnLines.join("\n")}\n</recent_conversation>`);
+  }
+
+  parts.push(`<current_message>\n${currentMessage}\n</current_message>`);
+
+  return parts.join("\n\n");
+}

--- a/lib/memory/__tests__/graphiti-client.test.ts
+++ b/lib/memory/__tests__/graphiti-client.test.ts
@@ -171,6 +171,52 @@ describe("GraphitiClient.addEpisode", () => {
       client.addEpisode({ groupId: "user_josh", userMessage: "x", agentMessage: "y" })
     ).rejects.toThrow("400");
   });
+
+  it("encodes turnNumber in source_description when provided", async () => {
+    spyFetch(null, 202);
+    const client = new GraphitiClient();
+    await client.addEpisode({
+      groupId: "user_josh",
+      userMessage: "hi",
+      agentMessage: "hello",
+      platform: "discord",
+      channelId: "99",
+      turnNumber: 3,
+    });
+    const body = lastFetchBody as { messages: Array<{ source_description: string }> };
+    expect(body.messages[0]!.source_description).toContain("| turn:3");
+    expect(body.messages[1]!.source_description).toContain("| turn:3");
+  });
+
+  it("encodes parentTurnId in source_description when provided", async () => {
+    spyFetch(null, 202);
+    const client = new GraphitiClient();
+    await client.addEpisode({
+      groupId: "user_josh",
+      userMessage: "hi",
+      agentMessage: "hello",
+      parentTurnId: "corr-abc-123",
+    });
+    const body = lastFetchBody as { messages: Array<{ source_description: string }> };
+    expect(body.messages[0]!.source_description).toContain("| parent:corr-abc-123");
+    expect(body.messages[1]!.source_description).toContain("| parent:corr-abc-123");
+  });
+
+  it("encodes both turnNumber and parentTurnId in source_description", async () => {
+    spyFetch(null, 202);
+    const client = new GraphitiClient();
+    await client.addEpisode({
+      groupId: "user_josh",
+      userMessage: "hi",
+      agentMessage: "hello",
+      platform: "slack",
+      channelId: "C01",
+      turnNumber: 7,
+      parentTurnId: "parent-xyz",
+    });
+    const body = lastFetchBody as { messages: Array<{ source_description: string }> };
+    expect(body.messages[0]!.source_description).toBe("slack channel C01 | turn:7 | parent:parent-xyz");
+  });
 });
 
 describe("GraphitiClient.search", () => {

--- a/lib/memory/graphiti-client.ts
+++ b/lib/memory/graphiti-client.ts
@@ -95,11 +95,17 @@ export class GraphitiClient {
     channelId?: string;
     platform?: string;
     timestamp?: Date;
+    /** Sequential turn number within the conversation — used to reconstruct threading. */
+    turnNumber?: number;
+    /** ID of the parent turn — used to reconstruct threading across correlated exchanges. */
+    parentTurnId?: string;
   }): Promise<void> {
     const ts = (params.timestamp ?? new Date()).toISOString();
-    const source = params.channelId && params.platform
+    let source = params.channelId && params.platform
       ? `${params.platform} channel ${params.channelId}`
       : (params.platform ?? "unknown");
+    if (params.turnNumber !== undefined) source += ` | turn:${params.turnNumber}`;
+    if (params.parentTurnId !== undefined) source += ` | parent:${params.parentTurnId}`;
 
     await this._post("/messages", {
       group_id: params.groupId,

--- a/lib/plugins/event-viewer.ts
+++ b/lib/plugins/event-viewer.ts
@@ -3,7 +3,7 @@ import { readFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
 import type { ServerWebSocket } from "bun";
-import type { Plugin, EventBus, BusMessage } from "../types";
+import type { Plugin, EventBus, BusMessage, WidgetDescriptor } from "../types";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -68,6 +68,19 @@ export class EventViewerPlugin implements Plugin {
     });
 
     console.log(`Event viewer available at http://localhost:${this.port}`);
+  }
+
+  getWidgets(): WidgetDescriptor[] {
+    return [
+      {
+        pluginName: this.name,
+        id: "event-stream",
+        type: "log-stream",
+        title: "Event Stream",
+        query: "/api/events",
+        props: { wsPath: "/ws", limit: 500 },
+      },
+    ];
   }
 
   uninstall(): void {

--- a/lib/plugins/example-template-plugin.ts
+++ b/lib/plugins/example-template-plugin.ts
@@ -1,0 +1,61 @@
+/**
+ * ExampleTemplatePlugin — starter template for plugin authors.
+ *
+ * Copy this file, rename the class, and fill in your own logic.
+ * The only required step to participate in widget discovery is
+ * implementing getWidgets() and returning one or more WidgetDescriptors.
+ *
+ * See docs/integrations/widget-declaration.md for full guidance.
+ */
+
+import type { Plugin, EventBus, WidgetDescriptor } from "../types.ts";
+
+export class ExampleTemplatePlugin implements Plugin {
+  name = "example-template";
+  description = "A minimal example plugin that declares widgets for the dashboard";
+  capabilities: string[] = ["dashboard"];
+
+  private bus: EventBus | null = null;
+
+  install(bus: EventBus): void {
+    this.bus = bus;
+    // Subscribe to relevant topics here, e.g.:
+    // bus.subscribe("some.topic", this.name, (msg) => this.handleMessage(msg));
+  }
+
+  uninstall(): void {
+    this.bus = null;
+  }
+
+  /**
+   * Declare the widgets this plugin contributes to the dashboard.
+   *
+   * Called by GET /api/widgets. Return an array of WidgetDescriptors.
+   * The runtime stamps pluginName from this.name — you don't need to set it.
+   */
+  getWidgets(): WidgetDescriptor[] {
+    return [
+      {
+        pluginName: this.name, // stamped automatically by /api/widgets, but set here for clarity
+        id: "example-status-card",
+        type: "status-card",
+        title: "Example Status",
+        query: "/api/example/status",
+        props: {
+          refreshIntervalMs: 10_000,
+        },
+      },
+      {
+        pluginName: this.name,
+        id: "example-metrics-chart",
+        type: "chart",
+        title: "Example Metrics",
+        query: "/api/example/metrics",
+        props: {
+          chartType: "line",
+          unit: "count",
+        },
+      },
+    ];
+  }
+}

--- a/lib/plugins/logger.test.ts
+++ b/lib/plugins/logger.test.ts
@@ -1,20 +1,24 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { rmSync } from "node:fs";
 import { LoggerPlugin } from "./logger";
-import type { BusMessage } from "../types";
+import type { BusMessage, LoggerTurnQueryRequest, LoggerTurnQueryResponse } from "../types";
 
 const TEST_DATA_DIR = "/tmp/logger-test-" + process.pid;
 
 function makeBus() {
-  const subs: Array<(msg: BusMessage) => void> = [];
+  const subs: Array<{ pattern: string; handler: (msg: BusMessage) => void }> = [];
   return {
-    subscribe(_pattern: string, _name: string, handler: (msg: BusMessage) => void) {
-      subs.push(handler);
+    subscribe(pattern: string, _name: string, handler: (msg: BusMessage) => void) {
+      subs.push({ pattern, handler });
       return "sub-id";
     },
     unsubscribe() {},
-    publish(_topic: string, msg: BusMessage) {
-      for (const h of subs) h(msg);
+    publish(topic: string, msg: BusMessage) {
+      for (const sub of subs) {
+        if (sub.pattern === "#" || sub.pattern === topic) {
+          sub.handler(msg);
+        }
+      }
     },
     topics() { return []; },
     consumers() { return []; },
@@ -158,5 +162,85 @@ describe("LoggerPlugin.getRecentTurnsForUser", () => {
     const turns = plugin.getRecentTurnsForUser("user-abc", "", 2, 60_000);
     // 2 correlationIds * 1 user turn each = 2 turns
     expect(turns.length).toBe(2);
+  });
+});
+
+describe("LoggerPlugin bus-based logger.turn.query capability", () => {
+  let plugin: LoggerPlugin;
+  let bus: ReturnType<typeof makeBus>;
+
+  beforeEach(() => {
+    plugin = new LoggerPlugin(TEST_DATA_DIR);
+    bus = makeBus();
+    plugin.install(bus as never);
+  });
+
+  afterEach(() => {
+    plugin.uninstall();
+    try { rmSync(TEST_DATA_DIR, { recursive: true }); } catch {}
+  });
+
+  test("responds to logger.turn.query with turns published to replyTopic", () => {
+    const req = makeRequest();
+    const res = makeResponse();
+    bus.publish(req.topic, req);
+    bus.publish(res.topic, res);
+
+    let received: LoggerTurnQueryResponse | null = null;
+    bus.subscribe("logger.turn.query.response.test", "test", (msg: BusMessage) => {
+      received = msg.payload as LoggerTurnQueryResponse;
+    });
+
+    const queryRequest: LoggerTurnQueryRequest = {
+      type: "logger.turn.query",
+      userId: "user-abc",
+      agentName: "",
+      limit: 10,
+      maxAgeMs: 60_000,
+      replyTopic: "logger.turn.query.response.test",
+    };
+
+    bus.publish("logger.turn.query", {
+      id: "q-1",
+      correlationId: "corr-q-1",
+      topic: "logger.turn.query",
+      timestamp: Date.now(),
+      payload: queryRequest,
+    });
+
+    expect(received).not.toBeNull();
+    expect(received!.type).toBe("logger.turn.query.response");
+    expect(received!.turns.length).toBe(2);
+    expect(received!.turns[0].role).toBe("user");
+    expect(received!.turns[0].content).toBe("Hello agent");
+    expect(received!.turns[1].role).toBe("assistant");
+    expect(received!.turns[1].content).toBe("Hi there!");
+  });
+
+  test("responds with empty turns when no matching events", () => {
+    let received: LoggerTurnQueryResponse | null = null;
+    bus.subscribe("logger.turn.query.response.empty", "test", (msg: BusMessage) => {
+      received = msg.payload as LoggerTurnQueryResponse;
+    });
+
+    const queryRequest: LoggerTurnQueryRequest = {
+      type: "logger.turn.query",
+      userId: "nobody",
+      agentName: "",
+      limit: 10,
+      maxAgeMs: 60_000,
+      replyTopic: "logger.turn.query.response.empty",
+    };
+
+    bus.publish("logger.turn.query", {
+      id: "q-2",
+      correlationId: "corr-q-2",
+      topic: "logger.turn.query",
+      timestamp: Date.now(),
+      payload: queryRequest,
+    });
+
+    expect(received).not.toBeNull();
+    expect(received!.turns).toEqual([]);
   });
 });

--- a/lib/plugins/logger.test.ts
+++ b/lib/plugins/logger.test.ts
@@ -80,15 +80,13 @@ describe("LoggerPlugin.getRecentTurnsForUser", () => {
 
     expect(turns.length).toBe(2);
     expect(turns[0].role).toBe("user");
-    expect(turns[0].content).toBe("Hello agent");
-    expect(turns[0].skill).toBe("chat");
-    expect(turns[0].channel).toBe("discord");
-    expect(turns[0].createdAt).toBe(req.timestamp);
+    expect(turns[0].text).toBe("Hello agent");
+    expect(turns[0].channelId).toBe("ch-1");
+    expect(turns[0].timestamp).toBe(req.timestamp);
 
     expect(turns[1].role).toBe("assistant");
-    expect(turns[1].content).toBe("Hi there!");
-    expect(turns[1].skill).toBe("chat");
-    expect(turns[1].channel).toBe("discord");
+    expect(turns[1].text).toBe("Hi there!");
+    expect(turns[1].channelId).toBe("ch-1");
   });
 
   test("returns only user turn when no response exists", () => {
@@ -134,7 +132,7 @@ describe("LoggerPlugin.getRecentTurnsForUser", () => {
     const turns = plugin.getRecentTurnsForUser("user-abc", "protomaker", 10, 60_000);
 
     expect(turns.length).toBe(1);
-    expect(turns[0].content).toBe("Hello protomaker");
+    expect(turns[0].text).toBe("Hello protomaker");
   });
 
   test("includes events with empty targets when agentName filter is set", () => {
@@ -212,9 +210,9 @@ describe("LoggerPlugin bus-based logger.turn.query capability", () => {
     expect(received!.type).toBe("logger.turn.query.response");
     expect(received!.turns.length).toBe(2);
     expect(received!.turns[0].role).toBe("user");
-    expect(received!.turns[0].content).toBe("Hello agent");
+    expect(received!.turns[0].text).toBe("Hello agent");
     expect(received!.turns[1].role).toBe("assistant");
-    expect(received!.turns[1].content).toBe("Hi there!");
+    expect(received!.turns[1].text).toBe("Hi there!");
   });
 
   test("responds with empty turns when no matching events", () => {

--- a/lib/plugins/logger.ts
+++ b/lib/plugins/logger.ts
@@ -1,15 +1,7 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
-import type { Plugin, EventBus, BusMessage, LoggerTurnQueryRequest, LoggerTurnQueryResponse } from "../types";
-
-export interface ConversationTurn {
-  role: "user" | "assistant";
-  content: string;
-  channel: string | undefined;
-  skill: string | undefined;
-  createdAt: number;
-}
+import type { Plugin, EventBus, BusMessage, LoggerTurnQueryRequest, LoggerTurnQueryResponse, ConversationTurn } from "../types";
 
 export class LoggerPlugin implements Plugin {
   name = "logger";
@@ -179,24 +171,25 @@ export class LoggerPlugin implements Plugin {
       if (!request) continue;
 
       const reqPayload = request.payload as { skill?: string; content?: string; targets?: string[] };
-      const channel = request.source?.interface;
+      const channelId = request.source?.channelId ?? "";
+      const agentName = reqPayload.targets?.[0] ?? "";
 
       turns.push({
         role: "user",
-        content: reqPayload.content ?? "",
-        channel,
-        skill: reqPayload.skill,
-        createdAt: request.timestamp,
+        text: reqPayload.content ?? "",
+        channelId,
+        agentName,
+        timestamp: request.timestamp,
       });
 
       if (response) {
         const resPayload = response.payload as { content?: string; error?: string };
         turns.push({
           role: "assistant",
-          content: resPayload.content ?? resPayload.error ?? "",
-          channel,
-          skill: reqPayload.skill,
-          createdAt: response.timestamp,
+          text: resPayload.content ?? resPayload.error ?? "",
+          channelId,
+          agentName,
+          timestamp: response.timestamp,
         });
       }
     }

--- a/lib/plugins/logger.ts
+++ b/lib/plugins/logger.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
-import type { Plugin, EventBus, BusMessage } from "../types";
+import type { Plugin, EventBus, BusMessage, LoggerTurnQueryRequest, LoggerTurnQueryResponse } from "../types";
 
 export interface ConversationTurn {
   role: "user" | "assistant";
@@ -18,6 +18,8 @@ export class LoggerPlugin implements Plugin {
 
   private db: Database | null = null;
   private subscriptionId: string | null = null;
+  private querySubscriptionId: string | null = null;
+  private bus: EventBus | null = null;
   private dataDir: string;
 
   constructor(dataDir: string) {
@@ -51,9 +53,25 @@ export class LoggerPlugin implements Plugin {
       this.db.exec("ALTER TABLE events ADD COLUMN parent_id TEXT");
     }
 
+    this.bus = bus;
+
     this.subscriptionId = bus.subscribe("#", this.name, (msg: BusMessage) => {
       if (msg.topic.startsWith("debug.")) return;
       this.log(msg);
+    });
+
+    this.querySubscriptionId = bus.subscribe("logger.turn.query", this.name, (msg: BusMessage) => {
+      const req = msg.payload as LoggerTurnQueryRequest;
+      const turns = this.getRecentTurnsForUser(req.userId, req.agentName, req.limit, req.maxAgeMs);
+      const response: LoggerTurnQueryResponse = { type: "logger.turn.query.response", turns };
+      bus.publish(req.replyTopic, {
+        id: crypto.randomUUID(),
+        correlationId: msg.correlationId,
+        parentId: msg.id,
+        topic: req.replyTopic,
+        timestamp: Date.now(),
+        payload: response,
+      });
     });
   }
 

--- a/lib/plugins/world-state-engine.ts
+++ b/lib/plugins/world-state-engine.ts
@@ -34,7 +34,7 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync, existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
-import type { Plugin, EventBus, BusMessage } from "../types.ts";
+import type { Plugin, EventBus, BusMessage, WidgetDescriptor } from "../types.ts";
 import type { WorldState, WorldStateDomain, WorldStateSnapshot } from "../types/world-state.ts";
 import { HttpClient } from "../../src/services/http-client.ts";
 
@@ -245,6 +245,27 @@ export class WorldStateEngine implements Plugin {
         `[world-state-engine] Pruned ${orphans.length} orphan domain(s) from restored snapshot: ${orphans.join(", ")}`,
       );
     }
+  }
+
+  getWidgets(): WidgetDescriptor[] {
+    return [
+      {
+        pluginName: this.name,
+        id: "world-state-domain-grid",
+        type: "table",
+        title: "Domain Grid",
+        query: "/api/world-state",
+        props: { layout: "grid" },
+      },
+      {
+        pluginName: this.name,
+        id: "world-state-domain-card",
+        type: "status-card",
+        title: "Domain Card",
+        query: "/api/world-state",
+        props: { layout: "card" },
+      },
+    ];
   }
 
   uninstall(): void {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -171,13 +171,7 @@ export interface LoggerTurnQueryRequest {
 
 export interface LoggerTurnQueryResponse {
   type: "logger.turn.query.response";
-  turns: Array<{
-    role: "user" | "assistant";
-    content: string;
-    channel: string | undefined;
-    skill: string | undefined;
-    createdAt: number;
-  }>;
+  turns: ConversationTurn[];
 }
 
 // ── ConversationTurn ──────────────────────────────────────────────────────────

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -152,6 +152,8 @@ export interface ConfigChangeRenderer {
 export type WidgetType = 'chart' | 'table' | 'status-card' | 'log-stream' | 'metric';
 
 export interface WidgetDescriptor {
+  /** Plugin that contributed this widget — stamped by /api/widgets discovery from plugin.name. */
+  pluginName: string;
   id: string;
   type: WidgetType;
   title: string;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -149,12 +149,23 @@ export interface ConfigChangeRenderer {
   onExpired?(request: ConfigChangeRequest, bus: EventBus): Promise<void>;
 }
 
+export type WidgetType = 'chart' | 'table' | 'status-card' | 'log-stream' | 'metric';
+
+export interface WidgetDescriptor {
+  id: string;
+  type: WidgetType;
+  title: string;
+  query?: string;
+  props?: Record<string, unknown>;
+}
+
 export interface Plugin {
   name: string;
   description: string;
   capabilities: string[];
   install(bus: EventBus): void;
   uninstall(): void;
+  getWidgets?(): WidgetDescriptor[];
 }
 
 export interface TopicInfo {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -149,6 +149,37 @@ export interface ConfigChangeRenderer {
   onExpired?(request: ConfigChangeRequest, bus: EventBus): Promise<void>;
 }
 
+// ── Logger turn-query capability ──────────────────────────────────────────────
+// Topic: logger.turn.query
+// Any plugin may publish a LoggerTurnQueryRequest. LoggerPlugin subscribes to
+// "logger.turn.query", resolves the turns, and publishes a
+// LoggerTurnQueryResponse to the replyTopic.
+
+export interface LoggerTurnQueryRequest {
+  type: "logger.turn.query";
+  /** Canonical user ID (matches BusMessage.source.userId). */
+  userId: string;
+  /** Agent name to scope turns to. Pass empty string for any agent. */
+  agentName: string;
+  /** Maximum number of conversation turns (not pairs) to return. */
+  limit: number;
+  /** Only include turns within this many ms of now. */
+  maxAgeMs: number;
+  /** Topic where LoggerPlugin publishes the LoggerTurnQueryResponse. */
+  replyTopic: string;
+}
+
+export interface LoggerTurnQueryResponse {
+  type: "logger.turn.query.response";
+  turns: Array<{
+    role: "user" | "assistant";
+    content: string;
+    channel: string | undefined;
+    skill: string | undefined;
+    createdAt: number;
+  }>;
+}
+
 export type WidgetType = 'chart' | 'table' | 'status-card' | 'log-stream' | 'metric';
 
 export interface WidgetDescriptor {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -180,6 +180,16 @@ export interface LoggerTurnQueryResponse {
   }>;
 }
 
+// ── ConversationTurn ──────────────────────────────────────────────────────────
+
+export interface ConversationTurn {
+  timestamp: number;
+  role: "user" | "assistant";
+  text: string;
+  agentName: string;
+  channelId: string;
+}
+
 export type WidgetType = 'chart' | 'table' | 'status-card' | 'log-stream' | 'metric';
 
 export interface WidgetDescriptor {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "type": "module",
   "scripts": {
     "start": "bun run src/index.ts",

--- a/src/api/__tests__/widgets.test.ts
+++ b/src/api/__tests__/widgets.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Integration test for GET /api/widgets
+ *
+ * Verifies:
+ * - Returns all WidgetDescriptors from plugins that implement getWidgets()
+ * - Plugins without getWidgets() are silently skipped
+ * - Response includes cache-control header
+ * - API key validation rejects unauthorized requests
+ * - Cache is returned on repeated requests within TTL
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { ExecutorRegistry } from "../../executor/executor-registry.ts";
+import { createRoutes } from "../widgets.ts";
+import type { ApiContext } from "../types.ts";
+import type { Plugin, WidgetDescriptor } from "../../../lib/types.ts";
+
+function makePlugin(name: string, widgets?: WidgetDescriptor[]): Plugin {
+  return {
+    name,
+    description: "test plugin",
+    capabilities: [],
+    install() {},
+    uninstall() {},
+    ...(widgets !== undefined ? { getWidgets: () => widgets } : {}),
+  };
+}
+
+function makeCtx(plugins: Plugin[], apiKey?: string): ApiContext {
+  return {
+    workspaceDir: "/tmp",
+    bus: new InMemoryEventBus(),
+    plugins,
+    executorRegistry: new ExecutorRegistry(),
+    apiKey,
+  };
+}
+
+describe("GET /api/widgets", () => {
+  test("returns empty array when no plugins have getWidgets", async () => {
+    const ctx = makeCtx([makePlugin("plain")]);
+    const [route] = createRoutes(ctx);
+    const resp = await route.handler(new Request("http://x/api/widgets"), {});
+    expect(resp.status).toBe(200);
+    const body = await resp.json();
+    expect(body).toEqual([]);
+  });
+
+  test("aggregates widgets from all plugins with getWidgets", async () => {
+    // Plugin-supplied widgets — pluginName is stamped by discovery from plugin.name
+    const w1: WidgetDescriptor = { pluginName: "", id: "w1", type: "chart", title: "Chart A", props: { color: "blue" } };
+    const w2: WidgetDescriptor = { pluginName: "", id: "w2", type: "table", title: "Table B" };
+    const ctx = makeCtx([
+      makePlugin("a", [w1]),
+      makePlugin("b", [w2]),
+      makePlugin("c"),
+    ]);
+    const [route] = createRoutes(ctx);
+    const resp = await route.handler(new Request("http://x/api/widgets"), {});
+    const body = await resp.json() as WidgetDescriptor[];
+    expect(body).toHaveLength(2);
+    expect(body.map(w => w.id).sort()).toEqual(["w1", "w2"]);
+    // Discovery stamps pluginName from plugin.name
+    expect(body.find(w => w.id === "w1")?.pluginName).toBe("a");
+    expect(body.find(w => w.id === "w2")?.pluginName).toBe("b");
+  });
+
+  test("skips plugins without getWidgets gracefully", async () => {
+    const w: WidgetDescriptor = { pluginName: "", id: "w1", type: "status-card", title: "Card" };
+    const ctx = makeCtx([makePlugin("noWidgets"), makePlugin("hasWidgets", [w])]);
+    const [route] = createRoutes(ctx);
+    const resp = await route.handler(new Request("http://x/api/widgets"), {});
+    const body = await resp.json() as WidgetDescriptor[];
+    expect(body).toHaveLength(1);
+    expect(body[0].id).toBe("w1");
+    expect(body[0].pluginName).toBe("hasWidgets");
+  });
+
+  test("includes cache-control header with 5s max-age", async () => {
+    const ctx = makeCtx([]);
+    const [route] = createRoutes(ctx);
+    const resp = await route.handler(new Request("http://x/api/widgets"), {});
+    expect(resp.headers.get("cache-control")).toContain("max-age=5");
+  });
+
+  test("returns 401 when API key is required and missing", async () => {
+    const ctx = makeCtx([], "secret-key");
+    const [route] = createRoutes(ctx);
+    const resp = await route.handler(new Request("http://x/api/widgets"), {});
+    expect(resp.status).toBe(401);
+  });
+
+  test("returns 401 when API key is wrong", async () => {
+    const ctx = makeCtx([], "secret-key");
+    const [route] = createRoutes(ctx);
+    const resp = await route.handler(
+      new Request("http://x/api/widgets", { headers: { "X-API-Key": "wrong" } }),
+      {}
+    );
+    expect(resp.status).toBe(401);
+  });
+
+  test("succeeds with correct API key", async () => {
+    const ctx = makeCtx([], "secret-key");
+    const [route] = createRoutes(ctx);
+    const resp = await route.handler(
+      new Request("http://x/api/widgets", { headers: { "X-API-Key": "secret-key" } }),
+      {}
+    );
+    expect(resp.status).toBe(200);
+  });
+
+  test("cache returns same result on second request within TTL", async () => {
+    let callCount = 0;
+    const plugin = makePlugin("counter", []);
+    const origGetWidgets = plugin.getWidgets!;
+    plugin.getWidgets = () => {
+      callCount++;
+      return origGetWidgets();
+    };
+    const ctx = makeCtx([plugin]);
+    const [route] = createRoutes(ctx);
+    await route.handler(new Request("http://x/api/widgets"), {});
+    await route.handler(new Request("http://x/api/widgets"), {});
+    // getWidgets should only have been called once (cache hit on second request)
+    expect(callCount).toBe(1);
+  });
+});

--- a/src/api/discord.ts
+++ b/src/api/discord.ts
@@ -9,6 +9,7 @@
  *   GET  /api/discord/server-stats      — member count, channel count, boost level
  *   GET  /api/discord/channels          — list all channels with type and category
  *   POST /api/discord/channels/create   — create a channel (text/voice/category)
+ *   POST /api/discord/channels/delete   — delete a channel (recursive for categories)
  *   POST /api/discord/send              — send a message to a channel
  *   GET  /api/discord/members           — list members (paginated)
  *   GET  /api/discord/webhooks          — list webhooks across guild channels
@@ -109,6 +110,57 @@ export function createRoutes(ctx: ApiContext): Route[] {
           return Response.json({
             success: true,
             data: { id: created.id, name: created.name, type: created.type },
+          });
+        } catch (e) {
+          return Response.json({ success: false, error: e instanceof Error ? e.message : String(e) }, { status: 500 });
+        }
+      },
+    },
+    {
+      method: "POST",
+      path: "/api/discord/channels/delete",
+      handler: async (req) => {
+        const client = getDiscordClient(ctx);
+        if (!client) return Response.json({ success: false, error: "Discord not connected" }, { status: 503 });
+
+        const guild = client.guilds.cache.get(getGuildId());
+        if (!guild) return Response.json({ success: false, error: "Guild not found" }, { status: 404 });
+
+        let body: { channelId?: string; channelName?: string; recursive?: boolean; reason?: string };
+        try { body = await req.json() as typeof body; }
+        catch { return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 }); }
+
+        let target: any = null;
+        if (body.channelId) {
+          target = guild.channels.cache.get(body.channelId);
+        } else if (body.channelName) {
+          target = guild.channels.cache.find((ch: any) => ch.name === body.channelName);
+        }
+        if (!target) {
+          return Response.json({ success: false, error: "Channel not found (pass channelId or channelName)" }, { status: 404 });
+        }
+
+        try {
+          // Recursive delete for categories — Discord won't auto-delete children;
+          // we collect them first so the response can report what was removed.
+          const deletedChildren: Array<{ id: string; name: string }> = [];
+          const isCategory = target.type === 4;
+          if (isCategory && body.recursive !== false) {
+            const children = guild.channels.cache.filter((ch: any) => ch.parentId === target.id);
+            for (const child of children.values()) {
+              await child.delete(body.reason ?? "deleted via /api/discord/channels/delete");
+              deletedChildren.push({ id: child.id, name: child.name });
+            }
+          }
+          await target.delete(body.reason ?? "deleted via /api/discord/channels/delete");
+          return Response.json({
+            success: true,
+            data: {
+              id: target.id,
+              name: target.name,
+              type: target.type,
+              deletedChildren,
+            },
           });
         } catch (e) {
           return Response.json({ success: false, error: e instanceof Error ? e.message : String(e) }, { status: 500 });

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -19,6 +19,7 @@ import { createRoutes as discordRoutes } from "./discord.ts";
 import { createRoutes as a2aCallbackRoutes } from "./a2a-callback.ts";
 import { createRoutes as a2aServerRoutes } from "./a2a-server.ts";
 import { createRoutes as agentCardRoutes } from "./agent-card.ts";
+import { createRoutes as widgetsRoutes } from "./widgets.ts";
 
 export { matchPath } from "./types.ts";
 export type { Route, ApiContext } from "./types.ts";
@@ -37,5 +38,6 @@ export function createAllRoutes(ctx: ApiContext): Route[] {
     ...(ctx.taskTracker ? a2aCallbackRoutes(ctx.taskTracker, ctx) : []),
     ...agentCardRoutes(ctx),
     ...a2aServerRoutes(ctx),
+    ...widgetsRoutes(ctx),
   ];
 }

--- a/src/api/widgets.ts
+++ b/src/api/widgets.ts
@@ -1,0 +1,54 @@
+/**
+ * Widget discovery endpoint — GET /api/widgets
+ *
+ * Aggregates WidgetDescriptor entries from every plugin that implements
+ * getWidgets(). Plugins without getWidgets() are silently skipped.
+ *
+ * Response is cached with a 5-second TTL since plugins are static per runtime.
+ * Requires X-API-Key header when ctx.apiKey is configured.
+ */
+
+import type { Route, ApiContext } from "./types.ts";
+import type { WidgetDescriptor } from "../../lib/types.ts";
+
+interface CacheEntry {
+  widgets: WidgetDescriptor[];
+  expiresAt: number;
+}
+
+const CACHE_TTL_MS = 5_000;
+
+export function createRoutes(ctx: ApiContext): Route[] {
+  let cache: CacheEntry | null = null;
+
+  return [
+    {
+      method: "GET",
+      path: "/api/widgets",
+      handler: (req) => {
+        if (ctx.apiKey && req.headers.get("X-API-Key") !== ctx.apiKey) {
+          return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+        }
+
+        const now = Date.now();
+        if (!cache || now >= cache.expiresAt) {
+          const widgets: WidgetDescriptor[] = [];
+          for (const plugin of ctx.plugins) {
+            if (typeof plugin.getWidgets === "function") {
+              // Stamp pluginName from plugin.name so plugins don't have to
+              // duplicate their own name on every widget descriptor.
+              for (const w of plugin.getWidgets()) {
+                widgets.push({ ...w, pluginName: plugin.name });
+              }
+            }
+          }
+          cache = { widgets, expiresAt: now + CACHE_TTL_MS };
+        }
+
+        return Response.json(cache.widgets, {
+          headers: { "cache-control": `public, max-age=${CACHE_TTL_MS / 1000}` },
+        });
+      },
+    },
+  ];
+}

--- a/src/executor/__tests__/skill-dispatcher-plugin.test.ts
+++ b/src/executor/__tests__/skill-dispatcher-plugin.test.ts
@@ -9,7 +9,7 @@ import type { BusMessage } from "../../../lib/types.ts";
 import type { SkillRequest, SkillResult } from "../types.ts";
 import type { AgentDefinition } from "../../agent-runtime/types.ts";
 import type { GraphitiClient } from "../../../lib/memory/graphiti-client.ts";
-import type { ConversationTurn } from "../../../lib/plugins/logger.ts";
+import type { ConversationTurn } from "../../../lib/types.ts";
 
 // Minimal in-memory event bus for tests
 function makeBus() {
@@ -352,10 +352,10 @@ describe("SkillDispatcherPlugin — memory enrichment", () => {
 function makeTurn(overrides: Partial<ConversationTurn> = {}): ConversationTurn {
   return {
     role: "user",
-    content: "Hello",
-    channel: "discord",
-    skill: "chat",
-    createdAt: new Date("2024-01-01T12:00:00.000Z").getTime(),
+    text: "Hello",
+    channelId: "discord",
+    agentName: "chat",
+    timestamp: new Date("2024-01-01T12:00:00.000Z").getTime(),
     ...overrides,
   };
 }
@@ -380,8 +380,8 @@ describe("assembleContext", () => {
 
   it("includes <recent_conversation> when turns are provided", () => {
     const turns = [
-      makeTurn({ role: "user", content: "What time is it?", channel: "discord" }),
-      makeTurn({ role: "assistant", content: "It is noon.", channel: "discord" }),
+      makeTurn({ role: "user", text: "What time is it?", channelId: "discord" }),
+      makeTurn({ role: "assistant", text: "It is noon.", channelId: "discord" }),
     ];
     const result = assembleContext(undefined, turns, "Thanks");
     expect(result).toContain("<recent_conversation>");
@@ -392,10 +392,10 @@ describe("assembleContext", () => {
     expect(result).toContain("<current_message>");
   });
 
-  it("labels turns with ISO timestamp, channel, and role", () => {
+  it("labels turns with ISO timestamp, channelId, and role", () => {
     const ts = new Date("2024-06-15T09:30:00.000Z").getTime();
     const turns = [
-      makeTurn({ role: "user", content: "Hi", channel: "slack", createdAt: ts }),
+      makeTurn({ role: "user", text: "Hi", channelId: "slack", timestamp: ts }),
     ];
     const result = assembleContext(undefined, turns, "Next");
     expect(result).toContain("2024-06-15T09:30:00.000Z");
@@ -403,21 +403,21 @@ describe("assembleContext", () => {
     expect(result).toContain("User:");
   });
 
-  it("omits channel suffix when channel is undefined", () => {
-    const turns = [makeTurn({ channel: undefined })];
+  it("omits channel suffix when channelId is empty", () => {
+    const turns = [makeTurn({ channelId: "" })];
     const result = assembleContext(undefined, turns, "Next");
-    expect(result).not.toMatch(/\[undefined\]/);
+    expect(result).not.toMatch(/\[\]/);
     expect(result).toContain("User:");
   });
 
   it("labels assistant turns correctly", () => {
-    const turns = [makeTurn({ role: "assistant", content: "Hello!" })];
+    const turns = [makeTurn({ role: "assistant", text: "Hello!" })];
     const result = assembleContext(undefined, turns, "Next");
     expect(result).toContain("Assistant:");
   });
 
   it("emits all three sections in correct order when all data present", () => {
-    const turns = [makeTurn({ content: "Previous question" })];
+    const turns = [makeTurn({ text: "Previous question" })];
     const result = assembleContext("Some facts", turns, "Current question");
 
     const rmPos = result.indexOf("<recalled_memory>");

--- a/src/executor/__tests__/skill-dispatcher-plugin.test.ts
+++ b/src/executor/__tests__/skill-dispatcher-plugin.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, mock, spyOn, beforeEach, afterEach } from "bun:test";
-import { SkillDispatcherPlugin, assembleContext } from "../skill-dispatcher-plugin.ts";
+import { SkillDispatcherPlugin } from "../skill-dispatcher-plugin.ts";
+import { assembleContext } from "../../../lib/conversation/context-assembler.ts";
 import { ExecutorRegistry } from "../executor-registry.ts";
 import { FunctionExecutor } from "../executors/function-executor.ts";
 import { ProtoSdkExecutor } from "../executors/proto-sdk-executor.ts";

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -291,6 +291,20 @@ function createLangChainTools(toolNames: string[], http: HttpClient, correlation
         }),
       },
     ),
+    discord_delete_channel: tool(
+      async (input) => JSON.stringify(await http.post("/api/discord/channels/delete", input)),
+      {
+        name: "discord_delete_channel",
+        description:
+          "Delete a Discord channel by ID or name. For categories, by default all child channels are deleted too (set recursive=false to leave them as orphans). Destructive — confirm with the user before invoking unless the user explicitly named the channel/category to delete.",
+        schema: z.object({
+          channelId: z.string().optional().describe("Channel ID (exact)"),
+          channelName: z.string().optional().describe("Channel name (alternative to ID)"),
+          recursive: z.boolean().optional().describe("For categories: delete contained channels too (default: true)"),
+          reason: z.string().optional().describe("Audit log reason"),
+        }),
+      },
+    ),
     discord_send: tool(
       async (input) => JSON.stringify(await http.post("/api/discord/send", input)),
       {

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -19,60 +19,13 @@ import type { SkillRequest } from "./types.ts";
 import type { AgentSkillRequestPayload, AutonomousOutcomePayload, FlowItemPayload } from "../event-bus/payloads.ts";
 import { GraphitiClient } from "../../lib/memory/graphiti-client.ts";
 import { IdentityRegistry } from "../../lib/identity/identity-registry.ts";
+import { assembleContext } from "../../lib/conversation/context-assembler.ts";
 import { ContextMailbox } from "../../lib/dm/context-mailbox.ts";
 import type { TaskTracker } from "./task-tracker.ts";
 import type { A2AExecutor } from "./executors/a2a-executor.ts";
 import { SessionStore } from "../agent-runtime/session-context.ts";
 
 const WORKING_STATES = new Set(["submitted", "working"]);
-
-/**
- * Assemble a structured context envelope for the agent prompt.
- *
- * Pure function — no side effects, suitable for unit testing.
- *
- * Sections emitted (in order, only when non-empty):
- *   <recalled_memory>  — Graphiti facts retrieved for this user
- *   <recent_conversation> — last N turns from LoggerPlugin
- *   <current_message>  — the user's actual input (always emitted)
- *
- * When there is no history (no memory, no turns), only <current_message>
- * is emitted — no empty XML tags.
- */
-export function assembleContext(
-  recalledMemory: string | undefined,
-  recentTurns: ConversationTurn[],
-  currentMessage: string,
-): string {
-  const parts: string[] = [];
-
-  if (recalledMemory) {
-    parts.push(
-      `<recalled_memory>\n` +
-      `The following facts were retrieved from your memory about this user. ` +
-      `Use them as background context if relevant — do NOT repeat them back ` +
-      `to the user or reference them unless the user's message specifically ` +
-      `asks about something they relate to. Focus your response on what the ` +
-      `user is actually saying below.\n\n` +
-      `${recalledMemory}\n` +
-      `</recalled_memory>`,
-    );
-  }
-
-  if (recentTurns.length > 0) {
-    const turnLines = recentTurns.map(turn => {
-      const ts = new Date(turn.timestamp).toISOString();
-      const channelSuffix = turn.channelId ? ` [${turn.channelId}]` : "";
-      const label = turn.role === "user" ? "User" : "Assistant";
-      return `[${ts}${channelSuffix}] ${label}: ${turn.text}`;
-    });
-    parts.push(`<recent_conversation>\n${turnLines.join("\n")}\n</recent_conversation>`);
-  }
-
-  parts.push(`<current_message>\n${currentMessage}\n</current_message>`);
-
-  return parts.join("\n\n");
-}
 
 /**
  * Classify a skill name into a flow item type for distribution tracking.

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -13,13 +13,12 @@
  * Outbound: {replyTopic}  (from msg.reply.topic or agent.skill.response.{correlationId})
  */
 
-import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
+import type { Plugin, EventBus, BusMessage, ConversationTurn, LoggerTurnQueryRequest, LoggerTurnQueryResponse } from "../../lib/types.ts";
 import type { ExecutorRegistry } from "./executor-registry.ts";
 import type { SkillRequest } from "./types.ts";
 import type { AgentSkillRequestPayload, AutonomousOutcomePayload, FlowItemPayload } from "../event-bus/payloads.ts";
 import { GraphitiClient } from "../../lib/memory/graphiti-client.ts";
 import { IdentityRegistry } from "../../lib/identity/identity-registry.ts";
-import type { LoggerPlugin, ConversationTurn } from "../../lib/plugins/logger.ts";
 import { ContextMailbox } from "../../lib/dm/context-mailbox.ts";
 import type { TaskTracker } from "./task-tracker.ts";
 import type { A2AExecutor } from "./executors/a2a-executor.ts";
@@ -62,10 +61,10 @@ export function assembleContext(
 
   if (recentTurns.length > 0) {
     const turnLines = recentTurns.map(turn => {
-      const ts = new Date(turn.createdAt).toISOString();
-      const channelSuffix = turn.channel ? ` [${turn.channel}]` : "";
+      const ts = new Date(turn.timestamp).toISOString();
+      const channelSuffix = turn.channelId ? ` [${turn.channelId}]` : "";
       const label = turn.role === "user" ? "User" : "Assistant";
-      return `[${ts}${channelSuffix}] ${label}: ${turn.content}`;
+      return `[${ts}${channelSuffix}] ${label}: ${turn.text}`;
     });
     parts.push(`<recent_conversation>\n${turnLines.join("\n")}\n</recent_conversation>`);
   }
@@ -98,7 +97,6 @@ export class SkillDispatcherPlugin implements Plugin {
   private readonly subscriptionIds: string[] = [];
   private readonly graphiti: GraphitiClient;
   private readonly identityRegistry: IdentityRegistry;
-  private readonly loggerPlugin: LoggerPlugin | undefined;
   private readonly mailbox: ContextMailbox | undefined;
   private readonly taskTracker: TaskTracker | undefined;
   private readonly sessionStore: SessionStore;
@@ -116,8 +114,6 @@ export class SkillDispatcherPlugin implements Plugin {
     workspaceDir: string,
     /** Injectable for testing — defaults to a real GraphitiClient. */
     graphiti?: GraphitiClient,
-    /** Injectable for testing — provides recent conversation turns. */
-    loggerPlugin?: LoggerPlugin,
     /** Optional mailbox for mid-execution DM queuing. */
     mailbox?: ContextMailbox,
     /** Optional tracker for long-running A2A tasks. */
@@ -127,7 +123,6 @@ export class SkillDispatcherPlugin implements Plugin {
   ) {
     this.graphiti = graphiti ?? new GraphitiClient();
     this.identityRegistry = new IdentityRegistry(workspaceDir);
-    this.loggerPlugin = loggerPlugin;
     this.mailbox = mailbox;
     this.taskTracker = taskTracker;
     this.sessionStore = sessionStore ?? new SessionStore();
@@ -136,6 +131,51 @@ export class SkillDispatcherPlugin implements Plugin {
   /** Check if an execution is currently active for a given correlationId. */
   isActive(correlationId: string): boolean {
     return this.activeExecutions.has(correlationId);
+  }
+
+  /**
+   * Query LoggerPlugin for recent conversation turns via the bus.
+   * Resolves with [] if LoggerPlugin is not installed (timeout) or on any error.
+   */
+  private _queryRecentTurns(userId: string, agentName: string): Promise<ConversationTurn[]> {
+    if (!this.bus) return Promise.resolve([]);
+
+    return new Promise<ConversationTurn[]>((resolve) => {
+      const replyTopic = `logger.turn.query.response.${crypto.randomUUID()}`;
+      let settled = false;
+
+      const subId = this.bus!.subscribe(replyTopic, this.name, (msg: BusMessage) => {
+        if (settled) return;
+        settled = true;
+        this.bus!.unsubscribe(subId);
+        resolve((msg.payload as LoggerTurnQueryResponse).turns);
+      });
+
+      this.bus!.publish("logger.turn.query", {
+        id: crypto.randomUUID(),
+        correlationId: crypto.randomUUID(),
+        topic: "logger.turn.query",
+        timestamp: Date.now(),
+        payload: {
+          type: "logger.turn.query",
+          userId,
+          agentName,
+          limit: 8,
+          maxAgeMs: 24 * 60 * 60 * 1000,
+          replyTopic,
+        } satisfies LoggerTurnQueryRequest,
+      });
+
+      // Fallback: LoggerPlugin responds synchronously, so if not installed
+      // the timeout fires at next tick and we continue without turns.
+      setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          this.bus?.unsubscribe(subId);
+          resolve([]);
+        }
+      }, 0);
+    });
   }
 
   install(bus: EventBus): void {
@@ -266,14 +306,9 @@ export class SkillDispatcherPlugin implements Plugin {
       ]);
       const combined = [sharedCtx, agentCtx].filter(Boolean).join("\n");
 
-      // Retrieve recent turns for human-originated messages only
-      const recentTurns: ConversationTurn[] = (this.loggerPlugin && sourceUserId)
-        ? this.loggerPlugin.getRecentTurnsForUser(
-            sourceUserId,
-            targets[0] ?? "",
-            8,
-            24 * 60 * 60 * 1000,
-          )
+      // Retrieve recent turns for human-originated messages only via bus query
+      const recentTurns: ConversationTurn[] = sourceUserId
+        ? await this._queryRecentTurns(sourceUserId, targets[0] ?? "")
         : [];
 
       rawContent = assembleContext(combined || undefined, recentTurns, rawContent);

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -512,6 +512,7 @@ export class SkillDispatcherPlugin implements Plugin {
           agentName: targets[0],
           channelId: sourceChannelId,
           platform: sourcePlatform ?? (systemActor ? "system" : undefined),
+          parentTurnId: correlationId,
         };
         this.graphiti.addEpisode({ groupId, ...episodeBase })
           .catch(err => console.debug("[skill-dispatcher] Graphiti addEpisode (shared) error:", err));

--- a/src/index.ts
+++ b/src/index.ts
@@ -289,7 +289,7 @@ const pluginRegistry: PluginRegistryEntry[] = [
     condition: () => true,
     factory: async () => {
       const { SkillDispatcherPlugin } = await import("./executor/skill-dispatcher-plugin.js");
-      return new SkillDispatcherPlugin(executorRegistry, workspaceDir, undefined, loggerPlugin, contextMailbox, taskTracker);
+      return new SkillDispatcherPlugin(executorRegistry, workspaceDir, undefined, contextMailbox, taskTracker);
     },
   },
   {

--- a/test/integration/widget-discovery.test.ts
+++ b/test/integration/widget-discovery.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Integration test: widget discovery full flow.
+ *
+ * Verifies end-to-end behaviour of the /api/widgets discovery pipeline:
+ * - 3+ plugins loaded, all declared widgets discovered
+ * - Dashboard receives all widgets (simulated via route response)
+ * - Performance: response assembles <50ms with 10 plugins
+ * - Plugins without getWidgets() are silently skipped (backward compat)
+ */
+
+import { describe, test, expect } from "bun:test";
+import { InMemoryEventBus } from "../../lib/bus.ts";
+import { ExecutorRegistry } from "../../src/executor/executor-registry.ts";
+import { createRoutes } from "../../src/api/widgets.ts";
+import type { ApiContext } from "../../src/api/types.ts";
+import type { Plugin, WidgetDescriptor, EventBus } from "../../lib/types.ts";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makePlugin(name: string, widgets?: WidgetDescriptor[]): Plugin {
+  return {
+    name,
+    description: `${name} plugin`,
+    capabilities: [],
+    install(_bus: EventBus) {},
+    uninstall() {},
+    ...(widgets !== undefined ? { getWidgets: () => widgets } : {}),
+  };
+}
+
+function makeCtx(plugins: Plugin[]): ApiContext {
+  return {
+    workspaceDir: "/tmp",
+    bus: new InMemoryEventBus(),
+    plugins,
+    executorRegistry: new ExecutorRegistry(),
+  };
+}
+
+// ── Widget fixture factories ──────────────────────────────────────────────────
+
+function worldStateWidgets(): WidgetDescriptor[] {
+  return [
+    {
+      pluginName: "",
+      id: "world-state-domain-grid",
+      type: "table",
+      title: "Domain Grid",
+      query: "/api/world-state",
+      props: { layout: "grid" },
+    },
+    {
+      pluginName: "",
+      id: "world-state-domain-card",
+      type: "status-card",
+      title: "Domain Card",
+      query: "/api/world-state",
+      props: { layout: "card" },
+    },
+  ];
+}
+
+function eventStreamWidgets(): WidgetDescriptor[] {
+  return [
+    {
+      pluginName: "",
+      id: "event-stream",
+      type: "log-stream",
+      title: "Event Stream",
+      query: "/api/events",
+      props: { wsPath: "/ws", limit: 500 },
+    },
+  ];
+}
+
+function metricsWidgets(): WidgetDescriptor[] {
+  return [
+    {
+      pluginName: "",
+      id: "fleet-cost-chart",
+      type: "chart",
+      title: "Fleet Cost",
+      query: "/api/fleet-cost",
+      props: { unit: "USD" },
+    },
+    {
+      pluginName: "",
+      id: "agent-status-table",
+      type: "table",
+      title: "Agent Status",
+      query: "/api/agents",
+    },
+  ];
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("Widget discovery integration", () => {
+  test("discovers all widgets from 3+ plugins", async () => {
+    const plugins: Plugin[] = [
+      makePlugin("world-state-engine", worldStateWidgets()),
+      makePlugin("event-viewer", eventStreamWidgets()),
+      makePlugin("fleet-metrics", metricsWidgets()),
+    ];
+
+    const ctx = makeCtx(plugins);
+    const [route] = createRoutes(ctx);
+    const resp = await route.handler(new Request("http://localhost/api/widgets"), {});
+
+    expect(resp.status).toBe(200);
+
+    const body = (await resp.json()) as WidgetDescriptor[];
+
+    // All 5 widgets discovered
+    expect(body).toHaveLength(5);
+
+    // Every widget has pluginName stamped
+    for (const w of body) {
+      expect(w.pluginName).toBeTruthy();
+      expect(w.id).toBeTruthy();
+      expect(w.type).toBeTruthy();
+      expect(w.title).toBeTruthy();
+    }
+
+    // Correct plugin attribution
+    const worldWidgets = body.filter((w) => w.pluginName === "world-state-engine");
+    expect(worldWidgets).toHaveLength(2);
+    expect(worldWidgets.map((w) => w.id).sort()).toEqual([
+      "world-state-domain-card",
+      "world-state-domain-grid",
+    ]);
+
+    const eventWidgets = body.filter((w) => w.pluginName === "event-viewer");
+    expect(eventWidgets).toHaveLength(1);
+    expect(eventWidgets[0].id).toBe("event-stream");
+    expect(eventWidgets[0].type).toBe("log-stream");
+
+    const metricsWidgets_ = body.filter((w) => w.pluginName === "fleet-metrics");
+    expect(metricsWidgets_).toHaveLength(2);
+  });
+
+  test("dashboard widget set covers all expected widget types", async () => {
+    const plugins: Plugin[] = [
+      makePlugin("world-state-engine", worldStateWidgets()),
+      makePlugin("event-viewer", eventStreamWidgets()),
+      makePlugin("fleet-metrics", metricsWidgets()),
+    ];
+
+    const ctx = makeCtx(plugins);
+    const [route] = createRoutes(ctx);
+    const resp = await route.handler(new Request("http://localhost/api/widgets"), {});
+    const body = (await resp.json()) as WidgetDescriptor[];
+
+    const types = new Set(body.map((w) => w.type));
+    expect(types.has("table")).toBe(true);
+    expect(types.has("status-card")).toBe(true);
+    expect(types.has("log-stream")).toBe(true);
+    expect(types.has("chart")).toBe(true);
+  });
+
+  test("performance: /api/widgets assembles <50ms with 10 plugins", async () => {
+    const plugins: Plugin[] = Array.from({ length: 10 }, (_, i) =>
+      makePlugin(`plugin-${i}`, [
+        {
+          pluginName: "",
+          id: `widget-${i}-a`,
+          type: "chart",
+          title: `Chart ${i}A`,
+          query: `/api/data-${i}`,
+        },
+        {
+          pluginName: "",
+          id: `widget-${i}-b`,
+          type: "status-card",
+          title: `Status ${i}B`,
+        },
+      ])
+    );
+
+    const ctx = makeCtx(plugins);
+    const [route] = createRoutes(ctx);
+
+    const start = performance.now();
+    const resp = await route.handler(new Request("http://localhost/api/widgets"), {});
+    const elapsed = performance.now() - start;
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as WidgetDescriptor[];
+    expect(body).toHaveLength(20);
+
+    // Assembly must be fast — well under 50ms
+    expect(elapsed).toBeLessThan(50);
+  });
+
+  test("backward compat: plugins without getWidgets() are skipped", async () => {
+    const plugins: Plugin[] = [
+      // Older plugin with no getWidgets
+      makePlugin("legacy-discord"),
+      makePlugin("legacy-github"),
+      // New plugin with getWidgets
+      makePlugin("world-state-engine", worldStateWidgets()),
+    ];
+
+    const ctx = makeCtx(plugins);
+    const [route] = createRoutes(ctx);
+    const resp = await route.handler(new Request("http://localhost/api/widgets"), {});
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as WidgetDescriptor[];
+
+    // Only widgets from the new plugin appear
+    expect(body).toHaveLength(2);
+    expect(body.every((w) => w.pluginName === "world-state-engine")).toBe(true);
+  });
+
+  test("backward compat: empty plugin list returns empty array", async () => {
+    const ctx = makeCtx([]);
+    const [route] = createRoutes(ctx);
+    const resp = await route.handler(new Request("http://localhost/api/widgets"), {});
+
+    expect(resp.status).toBe(200);
+    const body = await resp.json();
+    expect(body).toEqual([]);
+  });
+
+  test("response includes cache-control header", async () => {
+    const ctx = makeCtx([makePlugin("world-state-engine", worldStateWidgets())]);
+    const [route] = createRoutes(ctx);
+    const resp = await route.handler(new Request("http://localhost/api/widgets"), {});
+
+    const cc = resp.headers.get("cache-control");
+    expect(cc).toBeTruthy();
+    expect(cc).toContain("max-age=5");
+  });
+
+  test("widget ids are unique across plugins", async () => {
+    const plugins: Plugin[] = [
+      makePlugin("world-state-engine", worldStateWidgets()),
+      makePlugin("event-viewer", eventStreamWidgets()),
+      makePlugin("fleet-metrics", metricsWidgets()),
+    ];
+
+    const ctx = makeCtx(plugins);
+    const [route] = createRoutes(ctx);
+    const resp = await route.handler(new Request("http://localhost/api/widgets"), {});
+    const body = (await resp.json()) as WidgetDescriptor[];
+
+    const ids = body.map((w) => w.id);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+  });
+});

--- a/tests/widget-descriptor.test.ts
+++ b/tests/widget-descriptor.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "bun:test";
+import type { Plugin, WidgetDescriptor, WidgetType } from "../lib/types";
+
+// Minimal EventBus stub
+const stubBus: import("../lib/types").EventBus = {
+  publish: () => {},
+  subscribe: () => "id",
+  unsubscribe: () => {},
+  topics: () => [],
+  consumers: () => [],
+};
+
+describe("Plugin without getWidgets still works", () => {
+  it("installs and uninstalls without getWidgets", () => {
+    let installed = false;
+    const plugin: Plugin = {
+      name: "basic",
+      description: "no widgets",
+      capabilities: [],
+      install(_bus) { installed = true; },
+      uninstall() { installed = false; },
+    };
+    plugin.install(stubBus);
+    expect(installed).toBe(true);
+    plugin.uninstall();
+    expect(installed).toBe(false);
+    expect(plugin.getWidgets).toBeUndefined();
+  });
+});
+
+describe("WidgetDescriptor contract shape", () => {
+  it("accepts all widget types", () => {
+    const types: WidgetType[] = ["chart", "table", "status-card", "log-stream", "metric"];
+    for (const type of types) {
+      const w: WidgetDescriptor = { id: `w-${type}`, type, title: type };
+      expect(w.id).toBe(`w-${type}`);
+      expect(w.type).toBe(type);
+    }
+  });
+
+  it("allows optional query and props", () => {
+    const w: WidgetDescriptor = {
+      id: "w1",
+      type: "chart",
+      title: "My Chart",
+      query: "SELECT count FROM metrics",
+      props: { color: "blue" },
+    };
+    expect(w.query).toBe("SELECT count FROM metrics");
+    expect(w.props).toEqual({ color: "blue" });
+  });
+
+  it("plugin with getWidgets returns descriptors", () => {
+    const widget: WidgetDescriptor = { id: "status", type: "status-card", title: "Status" };
+    const plugin: Plugin = {
+      name: "widget-plugin",
+      description: "has widgets",
+      capabilities: [],
+      install() {},
+      uninstall() {},
+      getWidgets() { return [widget]; },
+    };
+    expect(plugin.getWidgets!()).toHaveLength(1);
+    expect(plugin.getWidgets!()[0]).toEqual(widget);
+  });
+});

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -67,7 +67,11 @@ systemPrompt: |
   - Researcher (deep_research, summarize) — autonomous research agent with papers, HuggingFace, GitHub, web. Use for "research X in depth" tasks.
   - protoMaker (sitrep, board_health, auto_mode, manage_feature) — board operations
   - protoContent / Jon (chat) — content strategy, antagonistic review on user-initiated plans
+  - protoBot (provision_channel, provision_category, provision_webhook, server_stats, chat) — owns Discord server infrastructure: channels, categories, webhooks, member listings, channel posting. Delegate any Discord work here.
+  - protopen (passive_recon, active_pentest, security_report, threat_intel) — security/pentest agent
   - Frank — infrastructure, deployments
+
+  When in doubt about who can do what, call `get_world_state` — every agent's currently-advertised skills are in `domains.agent_health.data`. Trust the live registry over this hardcoded list.
 
   ## Escalation
 

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -78,15 +78,24 @@ systemPrompt: |
 
   ## Memory
 
-  Before each turn the system may inject a `<recalled_memory>` block into
-  your context — facts, past decisions, and user preferences pulled from
-  Graphiti's knowledge graph. Treat it as trusted background: prior
-  commitments the user made, their workflow preferences, things they've
-  told you to remember. Use it silently to inform your response; don't
-  quote it back verbatim unless the user asks what you remember. When
-  `<recalled_memory>` is empty or absent, respond based on the current
-  turn alone. The episodic log is written automatically after each
-  successful reply — you don't need to call a tool to "save" anything.
+  Before each turn the system may inject two context blocks:
+
+  **`<recalled_memory>`** — facts, past decisions, and user preferences
+  pulled from Graphiti's knowledge graph. Treat it as trusted background:
+  prior commitments the user made, their workflow preferences, things
+  they've told you to remember. Use it silently to inform your response;
+  don't quote it back verbatim unless the user asks what you remember.
+  When `<recalled_memory>` is empty or absent, ignore it.
+
+  **`<recent_conversation>`** — the last few turns of this conversation,
+  reconstructed from the episodic log. This is your short-term memory:
+  what was said, what you did, what the user asked. Use it to maintain
+  continuity across turns — don't repeat yourself, don't re-ask what
+  you already know. When `<recent_conversation>` is empty or absent,
+  treat this as the start of a fresh conversation.
+
+  The episodic log is written automatically after each successful reply —
+  you don't need to call a tool to "save" anything.
 
   ## Verification
 

--- a/workspace/agents/protobot.yaml
+++ b/workspace/agents/protobot.yaml
@@ -45,15 +45,24 @@ systemPrompt: |
 
   ## Memory
 
-  Before each turn the system may inject a `<recalled_memory>` block into
-  your context — prior Discord operations, what channels already exist,
-  past provisioning decisions, and user preferences pulled from Graphiti.
-  Treat it as trusted background: if memory says you already created
-  #ci-alerts last week, don't create it again. Use it silently to inform
-  your response; don't quote it back verbatim unless asked. When
-  `<recalled_memory>` is empty or absent, respond based on the current
-  turn alone. Episodic memory is written automatically after each
-  successful action — no explicit save needed.
+  Before each turn the system may inject two context blocks:
+
+  **`<recalled_memory>`** — prior Discord operations, what channels already
+  exist, past provisioning decisions, and user preferences pulled from
+  Graphiti. Treat it as trusted background: if memory says you already
+  created #ci-alerts last week, don't create it again. Use it silently
+  to inform your response; don't quote it back verbatim unless asked.
+  When `<recalled_memory>` is empty or absent, ignore it.
+
+  **`<recent_conversation>`** — the last few turns of this conversation,
+  reconstructed from the episodic log. This is your short-term memory:
+  what was provisioned, what the user asked, what actions you took. Use
+  it to maintain continuity — don't re-ask for context you already have,
+  don't provision things you've already reported creating. When
+  `<recent_conversation>` is empty or absent, treat this as a fresh start.
+
+  Episodic memory is written automatically after each successful action —
+  no explicit save needed.
 
   ## Personality
 

--- a/workspace/agents/protobot.yaml
+++ b/workspace/agents/protobot.yaml
@@ -82,6 +82,7 @@ tools:
   - discord_server_stats
   - discord_list_channels
   - discord_create_channel
+  - discord_delete_channel
   - discord_list_webhooks
   - discord_create_webhook
   - discord_send


### PR DESCRIPTION
Promotes v0.7.10 from dev → main.

## Shipped this release

**Dynamic plugin-contributed dashboard epic (DD-x.y)** — 7 features: WidgetDescriptor contract, /api/widgets discovery endpoint, generic renderers, dashboard refactor to discovery-driven layout, WorldStatePlugin + EventStreamPlugin migrations, integration tests + docs.

**Turn Retrieval + Context Assembly epic (TR-x.y)** — 6 features: LoggerPlugin turn query capability, ConversationTurn schema, dispatcher integration, context-assembler module, Graphiti turn metadata (parentTurnId), system-prompt framing for recent_conversation block.

**Discord operations** — protobot can now delete channels/categories (recursive by default), and Ava's delegation list explicitly includes him + protopen so user requests for Discord work get routed correctly instead of bouncing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)