### PR TITLE
feat: per-agent API keys + ownership-scoped ceremony management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ workspace/projects.yaml
 workspace/discord.yaml
 workspace/github.yaml
 workspace/google.yaml
+workspace/agent-keys.yaml
 .automaker-lock
 .automaker/
 .worktrees/

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -26,6 +26,23 @@ A few endpoints return raw objects without the envelope (`/api/services`, `/api/
 
 Read endpoints are unauthenticated. Mutating endpoints (`/publish`, `/api/onboard`, `/api/ceremonies/:id/run`, `/api/incidents`, `/api/incidents/:id/resolve`) require `X-API-Key: $WORKSTACEAN_API_KEY`. If `WORKSTACEAN_API_KEY` is unset, authentication is skipped entirely.
 
+### Per-agent API keys (multi-tenant model)
+
+The ceremony endpoints (`GET /api/ceremonies`, `POST /api/ceremonies/create`, `POST /api/ceremonies/:id/update`, `POST /api/ceremonies/:id/delete`) additionally support per-agent identity resolution.
+
+- The legacy `WORKSTACEAN_API_KEY` is the **admin key** — sees all ceremonies, can create/update/delete any of them, can override `createdBy` on create.
+- Per-agent keys are declared in `workspace/agent-keys.yaml`:
+  ```yaml
+  keys:
+    quinn:
+      envKey: WORKSTACEAN_API_KEY_QUINN
+    jon:
+      envKey: WORKSTACEAN_API_KEY_JON
+  ```
+  Set the env var (via Infisical), the registry hot-reloads. When an agent calls with its own key, every ceremony it creates is stamped `createdBy: <agentName>` automatically. Update / delete are gated by `caller.agentName === ceremony.createdBy`. List filters to caller's own ceremonies (`?all=true` for admin-only fleet view).
+- Agents cannot override `createdBy` on create or transfer ownership on update — those are admin-only.
+- Backward-compatible: workspaces without `agent-keys.yaml` keep single-key admin behavior. Agents using the admin key bypass ownership checks.
+
 ---
 
 ## GET /health
@@ -184,9 +201,12 @@ For live goal evaluation, the dashboard's Goals page runs `src/lib/goal-evaluato
 
 ## GET /api/ceremonies
 
-List all ceremony definitions parsed from `workspace/ceremonies/*.yaml`.
+List ceremony definitions parsed from `workspace/ceremonies/*.yaml`.
 
-**Auth**: None
+**Auth**: API key. Agent-scoped callers see only their own ceremonies (`createdBy === caller.agentName`). Admin sees all.
+
+**Query params**:
+- `?all=true` — admin-only override: return every ceremony regardless of owner.
 
 **Response** (`200`):
 ```json
@@ -841,7 +861,7 @@ Returns `403` if the repo is not in `projects.yaml`.
 
 Create a new scheduled ceremony. Writes YAML to `workspace/ceremonies/` and registers with the hot-reload watcher.
 
-**Auth**: API key
+**Auth**: API key (admin or per-agent — see [Per-agent API keys](#per-agent-api-keys-multi-tenant-model))
 
 **Request body**:
 ```typescript
@@ -853,12 +873,17 @@ Create a new scheduled ceremony. Writes YAML to `workspace/ceremonies/` and regi
   targets?: string[];    // Agent targets (default: ["all"])
   enabled?: boolean;     // Default: true
   notifyChannel?: string; // Discord channel ID for notifications
+  createdBy?: string;    // Admin-only override (ignored from agent-scoped callers)
 }
 ```
 
+`createdBy` is **stamped server-side** from the caller's identity:
+- Agent-scoped key → `createdBy = <agentName>`, `createdBy` body field is ignored
+- Admin key → `createdBy` defaults to `"system"`; admins may set the body field to attribute the ceremony to a specific agent
+
 **Response** (`200`):
 ```json
-{ "success": true, "data": { "id": "my.ceremony", "name": "...", "schedule": "...", "..." } }
+{ "success": true, "data": { "id": "...", "createdBy": "quinn", "..." } }
 ```
 
 ---
@@ -867,11 +892,15 @@ Create a new scheduled ceremony. Writes YAML to `workspace/ceremonies/` and regi
 
 Update an existing ceremony. Merges fields into the existing YAML.
 
-**Auth**: API key
+**Auth**: API key. Agent-scoped callers may only update ceremonies where `createdBy === caller.agentName`. Admin can update any.
 
 **Path params**: `id` — ceremony ID
 
-**Request body**: Same fields as create (all optional except `id`).
+**Request body**: Same fields as create (all optional except `id`). `createdBy` is **stripped from the body** — ownership transfers are not supported via update.
+
+**Errors**:
+- `404` — ceremony not found
+- `403` — agent-scoped caller is not the owner
 
 ---
 
@@ -879,9 +908,12 @@ Update an existing ceremony. Merges fields into the existing YAML.
 
 Delete a ceremony. Removes the YAML file and unregisters from the scheduler.
 
-**Auth**: API key
+**Auth**: API key. Agent-scoped callers may only delete their own ceremonies. Admin can delete any.
 
 **Path params**: `id` — ceremony ID
+
+**Errors**:
+- `403` — agent-scoped caller is not the owner
 
 ---
 

--- a/lib/auth/__tests__/agent-keys.test.ts
+++ b/lib/auth/__tests__/agent-keys.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for AgentKeyRegistry — the per-agent X-API-Key resolver.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AgentKeyRegistry } from "../agent-keys.ts";
+
+let workspace: string;
+const ENV_KEYS = ["WORKSTACEAN_API_KEY_QUINN", "WORKSTACEAN_API_KEY_AVA", "WORKSTACEAN_API_KEY_JON"];
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), "agent-keys-test-"));
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+function writeYaml(content: string): void {
+  writeFileSync(join(workspace, "agent-keys.yaml"), content);
+}
+
+describe("AgentKeyRegistry.resolve", () => {
+  test("admin key returns isAdmin true with no agentName", () => {
+    const reg = new AgentKeyRegistry(workspace, "admin-secret");
+    expect(reg.resolve("admin-secret")).toEqual({ isAdmin: true });
+  });
+
+  test("agent-scoped key returns the right agentName", () => {
+    process.env.WORKSTACEAN_API_KEY_QUINN = "quinn-secret-xyz";
+    writeYaml("keys:\n  quinn:\n    envKey: WORKSTACEAN_API_KEY_QUINN");
+    const reg = new AgentKeyRegistry(workspace, "admin-secret");
+    expect(reg.resolve("quinn-secret-xyz")).toEqual({ agentName: "quinn", isAdmin: false });
+  });
+
+  test("unknown key returns null", () => {
+    const reg = new AgentKeyRegistry(workspace, "admin-secret");
+    expect(reg.resolve("not-a-real-key")).toBeNull();
+  });
+
+  test("missing key returns null", () => {
+    const reg = new AgentKeyRegistry(workspace, "admin-secret");
+    expect(reg.resolve(null)).toBeNull();
+    expect(reg.resolve(undefined)).toBeNull();
+    expect(reg.resolve("")).toBeNull();
+  });
+
+  test("admin always wins over agent — same key value would be admin-resolved", () => {
+    // Edge case: env var is set to the same value as the admin key. Admin
+    // path is checked first so the caller is treated as admin.
+    process.env.WORKSTACEAN_API_KEY_QUINN = "shared-key";
+    writeYaml("keys:\n  quinn:\n    envKey: WORKSTACEAN_API_KEY_QUINN");
+    const reg = new AgentKeyRegistry(workspace, "shared-key");
+    expect(reg.resolve("shared-key")).toEqual({ isAdmin: true });
+  });
+
+  test("missing yaml file → no agent keys, admin still works", () => {
+    const reg = new AgentKeyRegistry(workspace, "admin-secret");
+    expect(reg.hasAgentKeys).toBe(false);
+    expect(reg.agentNames()).toEqual([]);
+    expect(reg.resolve("admin-secret")).toEqual({ isAdmin: true });
+  });
+
+  test("yaml entry whose envKey is unset is silently skipped", () => {
+    writeYaml("keys:\n  quinn:\n    envKey: WORKSTACEAN_API_KEY_QUINN_NOT_SET");
+    const reg = new AgentKeyRegistry(workspace, "admin-secret");
+    expect(reg.hasAgentKeys).toBe(false);
+  });
+
+  test("multiple agents from one yaml", () => {
+    process.env.WORKSTACEAN_API_KEY_QUINN = "quinn-key";
+    process.env.WORKSTACEAN_API_KEY_AVA = "ava-key";
+    process.env.WORKSTACEAN_API_KEY_JON = "jon-key";
+    writeYaml(`keys:
+  quinn:
+    envKey: WORKSTACEAN_API_KEY_QUINN
+  ava:
+    envKey: WORKSTACEAN_API_KEY_AVA
+  jon:
+    envKey: WORKSTACEAN_API_KEY_JON`);
+    const reg = new AgentKeyRegistry(workspace, "admin-secret");
+    expect(reg.hasAgentKeys).toBe(true);
+    expect(reg.agentNames().sort()).toEqual(["ava", "jon", "quinn"]);
+    expect(reg.resolve("quinn-key")?.agentName).toBe("quinn");
+    expect(reg.resolve("ava-key")?.agentName).toBe("ava");
+    expect(reg.resolve("jon-key")?.agentName).toBe("jon");
+  });
+
+  test("admin key undefined — admin path disabled but agents still work", () => {
+    process.env.WORKSTACEAN_API_KEY_QUINN = "quinn-key";
+    writeYaml("keys:\n  quinn:\n    envKey: WORKSTACEAN_API_KEY_QUINN");
+    const reg = new AgentKeyRegistry(workspace, undefined);
+    expect(reg.resolve("any-admin-attempt")).toBeNull();
+    expect(reg.resolve("quinn-key")?.agentName).toBe("quinn");
+  });
+
+  test("malformed yaml is logged + treated as no-keys (graceful degradation)", () => {
+    writeYaml("not: valid: yaml: structure: ::");
+    const reg = new AgentKeyRegistry(workspace, "admin-secret");
+    expect(reg.hasAgentKeys).toBe(false);
+    expect(reg.resolve("admin-secret")).toEqual({ isAdmin: true });
+  });
+});

--- a/lib/auth/agent-keys.ts
+++ b/lib/auth/agent-keys.ts
@@ -1,0 +1,134 @@
+/**
+ * Per-agent API key resolver — backs the multi-tenant cron / ceremony
+ * scoping and any future operator-vs-agent permission gates.
+ *
+ * Two key tiers exist on workstacean:
+ *
+ *   - **admin**: the legacy `WORKSTACEAN_API_KEY` env var. Holds full
+ *     read/write across all resources; used by Ava (in-process), the
+ *     dashboard, and out-of-band operator scripts. Backward-compatible
+ *     with every endpoint that already calls `ctx.apiKey === <header>`.
+ *
+ *   - **agent-scoped**: per-agent keys declared in
+ *     `workspace/agent-keys.yaml` (env-resolved). Each entry binds a
+ *     friendly `agentName` to an env var holding the secret. Used by
+ *     external A2A agents (Quinn, Jon, Researcher, protopen) and by any
+ *     in-process agent that wants to be subject to ownership checks.
+ *
+ * The resolver returns `{ agentName?, isAdmin }`. `agentName` is only
+ * set for agent-scoped keys; admin callers are agentless and bypass all
+ * ownership checks.
+ *
+ * Yaml shape:
+ *
+ *   keys:
+ *     quinn:
+ *       envKey: WORKSTACEAN_API_KEY_QUINN
+ *     jon:
+ *       envKey: WORKSTACEAN_API_KEY_JON
+ *     researcher:
+ *       envKey: WORKSTACEAN_API_KEY_RESEARCHER
+ *
+ * Missing file or unset env vars are treated as absent — the resolver
+ * falls back to admin-only auth (current behavior). This means rolling
+ * out per-agent keys is incremental: deploy the yaml, set env vars per
+ * agent at your own pace.
+ */
+
+import { existsSync, readFileSync, watchFile } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+
+export interface CallerIdentity {
+  /** Set when the request was authenticated via an agent-scoped key. */
+  agentName?: string;
+  /** True for the legacy WORKSTACEAN_API_KEY (operator / Ava / dashboard). */
+  isAdmin: boolean;
+}
+
+interface AgentKeyEntry {
+  envKey: string;
+}
+
+interface AgentKeysFile {
+  keys?: Record<string, AgentKeyEntry>;
+}
+
+export class AgentKeyRegistry {
+  /** Map of API-key value → agent name. Rebuilt on yaml change. */
+  private keyToAgent = new Map<string, string>();
+  private adminKey: string | undefined;
+  private readonly yamlPath: string;
+
+  constructor(workspaceDir: string, adminKey: string | undefined) {
+    this.adminKey = adminKey;
+    this.yamlPath = join(workspaceDir, "agent-keys.yaml");
+    this.reload();
+    if (existsSync(this.yamlPath)) {
+      // Hot-reload — operator can rotate / add keys without restart.
+      watchFile(this.yamlPath, { interval: 5_000 }, () => this.reload());
+    }
+  }
+
+  /**
+   * Resolve a request's `X-API-Key` header (or `Authorization: Bearer ...`)
+   * to a CallerIdentity. Returns null when no key matches — caller decides
+   * whether to 401 or fall through (e.g. `ctx.apiKey` not configured at all).
+   */
+  resolve(apiKey: string | null | undefined): CallerIdentity | null {
+    if (!apiKey) return null;
+    if (this.adminKey && apiKey === this.adminKey) {
+      return { isAdmin: true };
+    }
+    const agentName = this.keyToAgent.get(apiKey);
+    if (agentName) {
+      return { agentName, isAdmin: false };
+    }
+    return null;
+  }
+
+  /** True if any per-agent keys are configured (used to gate strict mode). */
+  get hasAgentKeys(): boolean {
+    return this.keyToAgent.size > 0;
+  }
+
+  /** All known agent names (for diagnostics + dashboard). */
+  agentNames(): string[] {
+    return Array.from(new Set(this.keyToAgent.values()));
+  }
+
+  private reload(): void {
+    const next = new Map<string, string>();
+    if (!existsSync(this.yamlPath)) {
+      this.keyToAgent = next;
+      return;
+    }
+    try {
+      const parsed = parseYaml(readFileSync(this.yamlPath, "utf8")) as AgentKeysFile;
+      for (const [agentName, entry] of Object.entries(parsed.keys ?? {})) {
+        if (!entry?.envKey) continue;
+        const value = process.env[entry.envKey];
+        if (!value) {
+          console.warn(
+            `[agent-keys] ${agentName}: env var "${entry.envKey}" is unset — skipping`,
+          );
+          continue;
+        }
+        if (next.has(value)) {
+          console.warn(
+            `[agent-keys] duplicate key value detected — multiple agents share the same secret. Last write wins.`,
+          );
+        }
+        next.set(value, agentName);
+      }
+      this.keyToAgent = next;
+      if (next.size > 0) {
+        console.log(
+          `[agent-keys] Loaded ${next.size} per-agent key(s): ${this.agentNames().join(", ")}`,
+        );
+      }
+    } catch (err) {
+      console.error(`[agent-keys] Failed to parse ${this.yamlPath}:`, err);
+    }
+  }
+}

--- a/src/api/__tests__/ceremony-ownership.test.ts
+++ b/src/api/__tests__/ceremony-ownership.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Integration tests for ceremony ownership enforcement.
+ *
+ * Verifies:
+ *   - createCeremony stamps createdBy from the caller's identity
+ *   - update / delete are gated by createdBy === caller.agentName (or admin)
+ *   - list filters to caller's own ceremonies (admin sees all; ?all=true is admin-only)
+ *   - createdBy in update body is stripped (immutable from caller side)
+ *   - admin keeps full access for backward compatibility
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { ExecutorRegistry } from "../../executor/executor-registry.ts";
+import { AgentKeyRegistry } from "../../../lib/auth/agent-keys.ts";
+import { createRoutes } from "../operations.ts";
+import type { ApiContext, Route } from "../types.ts";
+
+const ADMIN_KEY = "admin-secret";
+const QUINN_KEY = "quinn-secret";
+const AVA_KEY = "ava-secret";
+
+let workspace: string;
+let routes: Route[];
+
+function findRoute(method: string, path: string): Route {
+  const r = routes.find(rt => rt.method === method && rt.path === path);
+  if (!r) throw new Error(`Route ${method} ${path} not found`);
+  return r;
+}
+
+function makeReq(headers: Record<string, string> = {}, body?: unknown, url = "http://x/api/ceremonies"): Request {
+  return new Request(url, {
+    method: body ? "POST" : "GET",
+    headers,
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+function ceremonyOnDisk(id: string): Record<string, unknown> | null {
+  const p = join(workspace, "ceremonies", `${id}.yaml`);
+  if (!existsSync(p)) return null;
+  return parseYaml(readFileSync(p, "utf8")) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), "ceremony-test-"));
+  process.env.WORKSTACEAN_API_KEY_QUINN = QUINN_KEY;
+  process.env.WORKSTACEAN_API_KEY_AVA = AVA_KEY;
+  writeFileSync(
+    join(workspace, "agent-keys.yaml"),
+    `keys:\n  quinn:\n    envKey: WORKSTACEAN_API_KEY_QUINN\n  ava:\n    envKey: WORKSTACEAN_API_KEY_AVA\n`,
+  );
+
+  const ctx: ApiContext = {
+    workspaceDir: workspace,
+    bus: new InMemoryEventBus(),
+    plugins: [],
+    executorRegistry: new ExecutorRegistry(),
+    apiKey: ADMIN_KEY,
+    agentKeys: new AgentKeyRegistry(workspace, ADMIN_KEY),
+  };
+  routes = createRoutes(ctx);
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+  delete process.env.WORKSTACEAN_API_KEY_QUINN;
+  delete process.env.WORKSTACEAN_API_KEY_AVA;
+});
+
+describe("ceremony ownership", () => {
+  test("create stamps createdBy from agent-scoped caller", async () => {
+    const create = findRoute("POST", "/api/ceremonies/create");
+    const resp = await create.handler(
+      makeReq(
+        { "X-API-Key": QUINN_KEY, "Content-Type": "application/json" },
+        { id: "quinn.daily-digest", name: "Daily QA digest", schedule: "0 14 * * *", skill: "qa_report" },
+      ),
+      {},
+    );
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { success: boolean; data: Record<string, unknown> };
+    expect(body.success).toBe(true);
+    expect(body.data.createdBy).toBe("quinn");
+    expect(ceremonyOnDisk("quinn.daily-digest")?.createdBy).toBe("quinn");
+  });
+
+  test("create by admin defaults createdBy to 'system' (or accepts override)", async () => {
+    const create = findRoute("POST", "/api/ceremonies/create");
+    const resp = await create.handler(
+      makeReq(
+        { "X-API-Key": ADMIN_KEY, "Content-Type": "application/json" },
+        { id: "system.cleanup", name: "Cleanup", schedule: "0 4 * * *", skill: "cleanup", createdBy: "ava" },
+      ),
+      {},
+    );
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { success: boolean; data: Record<string, unknown> };
+    expect(body.data.createdBy).toBe("ava");
+
+    // No override → defaults to system
+    const resp2 = await create.handler(
+      makeReq(
+        { "X-API-Key": ADMIN_KEY, "Content-Type": "application/json" },
+        { id: "system.bare", name: "Bare", schedule: "0 5 * * *", skill: "noop" },
+      ),
+      {},
+    );
+    expect(((await resp2.json()) as { data: { createdBy: string } }).data.createdBy).toBe("system");
+  });
+
+  test("agent cannot override createdBy on create", async () => {
+    const create = findRoute("POST", "/api/ceremonies/create");
+    const resp = await create.handler(
+      makeReq(
+        { "X-API-Key": QUINN_KEY, "Content-Type": "application/json" },
+        { id: "quinn.spoof", name: "Spoof", schedule: "0 6 * * *", skill: "report", createdBy: "ava" },
+      ),
+      {},
+    );
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { success: boolean; data: Record<string, unknown> };
+    // createdBy from quinn's call must be "quinn", not the body's "ava" claim
+    expect(body.data.createdBy).toBe("quinn");
+  });
+
+  test("update by owner succeeds", async () => {
+    const create = findRoute("POST", "/api/ceremonies/create");
+    await create.handler(
+      makeReq(
+        { "X-API-Key": QUINN_KEY, "Content-Type": "application/json" },
+        { id: "quinn.task1", name: "T1", schedule: "0 9 * * *", skill: "qa_report" },
+      ),
+      {},
+    );
+
+    const update = findRoute("POST", "/api/ceremonies/:id/update");
+    const resp = await update.handler(
+      makeReq({ "X-API-Key": QUINN_KEY, "Content-Type": "application/json" }, { schedule: "0 10 * * *" }),
+      { id: "quinn.task1" },
+    );
+    expect(resp.status).toBe(200);
+    expect(ceremonyOnDisk("quinn.task1")?.schedule).toBe("0 10 * * *");
+  });
+
+  test("update by non-owner returns 403", async () => {
+    const create = findRoute("POST", "/api/ceremonies/create");
+    await create.handler(
+      makeReq(
+        { "X-API-Key": QUINN_KEY, "Content-Type": "application/json" },
+        { id: "quinn.task2", name: "T2", schedule: "0 9 * * *", skill: "qa_report" },
+      ),
+      {},
+    );
+
+    const update = findRoute("POST", "/api/ceremonies/:id/update");
+    const resp = await update.handler(
+      makeReq({ "X-API-Key": AVA_KEY, "Content-Type": "application/json" }, { schedule: "0 11 * * *" }),
+      { id: "quinn.task2" },
+    );
+    expect(resp.status).toBe(403);
+    // Schedule unchanged on disk
+    expect(ceremonyOnDisk("quinn.task2")?.schedule).toBe("0 9 * * *");
+  });
+
+  test("update by admin always succeeds (backward compat)", async () => {
+    const create = findRoute("POST", "/api/ceremonies/create");
+    await create.handler(
+      makeReq(
+        { "X-API-Key": QUINN_KEY, "Content-Type": "application/json" },
+        { id: "quinn.task3", name: "T3", schedule: "0 9 * * *", skill: "qa_report" },
+      ),
+      {},
+    );
+    const update = findRoute("POST", "/api/ceremonies/:id/update");
+    const resp = await update.handler(
+      makeReq({ "X-API-Key": ADMIN_KEY, "Content-Type": "application/json" }, { schedule: "0 12 * * *" }),
+      { id: "quinn.task3" },
+    );
+    expect(resp.status).toBe(200);
+    expect(ceremonyOnDisk("quinn.task3")?.schedule).toBe("0 12 * * *");
+  });
+
+  test("update strips createdBy from body — owner can't transfer", async () => {
+    const create = findRoute("POST", "/api/ceremonies/create");
+    await create.handler(
+      makeReq(
+        { "X-API-Key": QUINN_KEY, "Content-Type": "application/json" },
+        { id: "quinn.task4", name: "T4", schedule: "0 9 * * *", skill: "qa_report" },
+      ),
+      {},
+    );
+    const update = findRoute("POST", "/api/ceremonies/:id/update");
+    await update.handler(
+      makeReq({ "X-API-Key": QUINN_KEY, "Content-Type": "application/json" }, { createdBy: "ava", name: "renamed" }),
+      { id: "quinn.task4" },
+    );
+    const updated = ceremonyOnDisk("quinn.task4");
+    expect(updated?.createdBy).toBe("quinn"); // unchanged
+    expect(updated?.name).toBe("renamed"); // other fields applied
+  });
+
+  test("delete by non-owner returns 403", async () => {
+    const create = findRoute("POST", "/api/ceremonies/create");
+    await create.handler(
+      makeReq(
+        { "X-API-Key": QUINN_KEY, "Content-Type": "application/json" },
+        { id: "quinn.task5", name: "T5", schedule: "0 9 * * *", skill: "qa_report" },
+      ),
+      {},
+    );
+    const del = findRoute("POST", "/api/ceremonies/:id/delete");
+    const resp = await del.handler(
+      makeReq({ "X-API-Key": AVA_KEY }, undefined),
+      { id: "quinn.task5" },
+    );
+    expect(resp.status).toBe(403);
+    expect(ceremonyOnDisk("quinn.task5")).not.toBeNull();
+  });
+
+  test("list filters to caller's own; admin sees all", async () => {
+    const create = findRoute("POST", "/api/ceremonies/create");
+    for (const [key, id] of [[QUINN_KEY, "quinn.q1"], [QUINN_KEY, "quinn.q2"], [AVA_KEY, "ava.a1"]]) {
+      await create.handler(
+        makeReq({ "X-API-Key": key, "Content-Type": "application/json" }, { id, name: id, schedule: "0 1 * * *", skill: "noop" }),
+        {},
+      );
+    }
+
+    const list = findRoute("GET", "/api/ceremonies");
+
+    const quinnResp = await list.handler(makeReq({ "X-API-Key": QUINN_KEY }), {});
+    const quinnList = ((await quinnResp.json()) as { data: Array<{ id: string }> }).data;
+    expect(quinnList.map(c => c.id).sort()).toEqual(["quinn.q1", "quinn.q2"]);
+
+    const adminResp = await list.handler(makeReq({ "X-API-Key": ADMIN_KEY }), {});
+    const adminList = ((await adminResp.json()) as { data: Array<{ id: string }> }).data;
+    expect(adminList.map(c => c.id).sort()).toEqual(["ava.a1", "quinn.q1", "quinn.q2"]);
+  });
+
+  test("?all=true requires admin", async () => {
+    const list = findRoute("GET", "/api/ceremonies");
+    const resp = await list.handler(
+      makeReq({ "X-API-Key": QUINN_KEY }, undefined, "http://x/api/ceremonies?all=true"),
+      {},
+    );
+    expect(resp.status).toBe(401);
+  });
+
+  test("unauthenticated request returns 401", async () => {
+    const list = findRoute("GET", "/api/ceremonies");
+    const resp = await list.handler(makeReq({}), {});
+    expect(resp.status).toBe(401);
+  });
+});

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -7,19 +7,63 @@ import { join } from "node:path";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import type { Route, ApiContext } from "./types.ts";
 import { serveWorkspaceYaml } from "./types.ts";
+import type { CallerIdentity } from "../../lib/auth/agent-keys.ts";
 
 export function createRoutes(ctx: ApiContext): Route[] {
   const hitlPlugin = ctx.plugins.find(p => p.name === "hitl") as { getPendingRequests(): unknown } | undefined;
 
-  function handleGetCeremonies(): Response {
+  /**
+   * Resolve a request to a CallerIdentity. Returns null when auth fails:
+   *   - If ctx.apiKey is unset, all requests are allowed as admin (legacy).
+   *   - With ctx.apiKey set, the X-API-Key (or Bearer) header must match
+   *     either the admin key OR a per-agent key registered in ctx.agentKeys.
+   *   - With ctx.agentKeys configured, agent-scoped callers get
+   *     {agentName, isAdmin: false}; admin callers get {isAdmin: true}.
+   */
+  function authenticateCaller(req: Request): CallerIdentity | null {
+    if (!ctx.apiKey) return { isAdmin: true };
+    const headerKey = req.headers.get("X-API-Key");
+    const bearer = req.headers.get("Authorization");
+    const apiKey = headerKey ?? (bearer?.startsWith("Bearer ") ? bearer.slice(7) : null);
+    if (ctx.agentKeys) {
+      const resolved = ctx.agentKeys.resolve(apiKey);
+      if (resolved) return resolved;
+    }
+    // Fallback: ctx.apiKey direct comparison (single-key legacy mode when
+    // agentKeys isn't configured).
+    if (apiKey === ctx.apiKey) return { isAdmin: true };
+    return null;
+  }
+
+  /** Standard 401 response. */
+  function unauthorized(): Response {
+    return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  function handleGetCeremonies(req: Request): Response {
+    const caller = authenticateCaller(req);
+    if (!caller) return unauthorized();
+
+    // ?all=true returns every ceremony regardless of owner. Admin-only.
+    // Default behavior:
+    //   - admin caller (no agentName) → sees all
+    //   - agent-scoped caller → sees only own ceremonies
+    // Check is BEFORE the dir-existence early-return so unauthorized callers
+    // can't probe state by passing the flag.
+    const allRequested = new URL(req.url).searchParams.get("all") === "true";
+    if (allRequested && !caller.isAdmin) return unauthorized();
+
     const ceremoniesDir = join(ctx.workspaceDir, "ceremonies");
     if (!existsSync(ceremoniesDir)) return Response.json({ success: true, data: [] });
+
     const files = readdirSync(ceremoniesDir).filter(f => f.endsWith(".yaml") || f.endsWith(".yml"));
-    const ceremonies: unknown[] = [];
+    const ceremonies: Record<string, unknown>[] = [];
     for (const file of files) {
       try {
         const parsed = parseYaml(readFileSync(join(ceremoniesDir, file), "utf8")) as Record<string, unknown>;
-        ceremonies.push(parsed);
+        if (caller.isAdmin || caller.agentName === parsed.createdBy) {
+          ceremonies.push(parsed);
+        }
       } catch { /* skip malformed */ }
     }
     return Response.json({ success: true, data: ceremonies });
@@ -97,9 +141,9 @@ export function createRoutes(ctx: ApiContext): Route[] {
   }
 
   async function handleCreateCeremony(req: Request): Promise<Response> {
-    if (ctx.apiKey && req.headers.get("X-API-Key") !== ctx.apiKey) {
-      return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
-    }
+    const caller = authenticateCaller(req);
+    if (!caller) return unauthorized();
+
     let body: Record<string, unknown>;
     try { body = (await req.json()) as Record<string, unknown>; }
     catch { return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 }); }
@@ -116,6 +160,13 @@ export function createRoutes(ctx: ApiContext): Route[] {
       return Response.json({ success: false, error: "Invalid ceremony id (alphanumeric, dots, dashes only)" }, { status: 400 });
     }
 
+    // Stamp createdBy from the caller. Admin callers may override via the
+    // body (so an operator can create on behalf of an agent); agent-scoped
+    // callers always own what they create.
+    const createdBy = caller.isAdmin
+      ? ((body.createdBy as string | undefined) ?? "system")
+      : caller.agentName!;
+
     const ceremony = {
       id,
       name,
@@ -124,6 +175,7 @@ export function createRoutes(ctx: ApiContext): Route[] {
       targets: (body.targets as string[]) ?? ["all"],
       notifyChannel: (body.notifyChannel as string) ?? "",
       enabled: body.enabled !== false,
+      createdBy,
     };
 
     const ceremoniesDir = join(ctx.workspaceDir, "ceremonies");
@@ -133,10 +185,27 @@ export function createRoutes(ctx: ApiContext): Route[] {
     return Response.json({ success: true, data: ceremony });
   }
 
+  /**
+   * Ownership check shared by update + delete. Admin always passes;
+   * agent-scoped caller must equal the ceremony's createdBy.
+   * Returns null on success, a Response on failure (caller returns it).
+   */
+  function checkOwnership(caller: CallerIdentity, ceremony: Record<string, unknown>, id: string): Response | null {
+    if (caller.isAdmin) return null;
+    if (caller.agentName && ceremony.createdBy === caller.agentName) return null;
+    return Response.json(
+      {
+        success: false,
+        error: `Forbidden — ceremony "${id}" is owned by "${ceremony.createdBy ?? "system"}", not "${caller.agentName}"`,
+      },
+      { status: 403 },
+    );
+  }
+
   async function handleUpdateCeremony(req: Request, id: string): Promise<Response> {
-    if (ctx.apiKey && req.headers.get("X-API-Key") !== ctx.apiKey) {
-      return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
-    }
+    const caller = authenticateCaller(req);
+    if (!caller) return unauthorized();
+
     const filePath = join(ctx.workspaceDir, "ceremonies", `${id}.yaml`);
     if (!existsSync(filePath)) {
       return Response.json({ success: false, error: `Ceremony "${id}" not found` }, { status: 404 });
@@ -147,18 +216,29 @@ export function createRoutes(ctx: ApiContext): Route[] {
     catch { return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 }); }
 
     const existing = parseYaml(readFileSync(filePath, "utf8")) as Record<string, unknown>;
-    const updated = { ...existing, ...body, id };
+    const ownershipFail = checkOwnership(caller, existing, id);
+    if (ownershipFail) return ownershipFail;
+
+    // createdBy is immutable from the body — only admins can rotate ownership
+    // and only via a dedicated transfer endpoint (not built yet). Strip it.
+    const { createdBy: _ignore, ...mutable } = body;
+    const updated = { ...existing, ...mutable, id };
     writeFileSync(filePath, stringifyYaml(updated));
 
     return Response.json({ success: true, data: updated });
   }
 
   async function handleDeleteCeremony(req: Request, id: string): Promise<Response> {
-    if (ctx.apiKey && req.headers.get("X-API-Key") !== ctx.apiKey) {
-      return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
-    }
+    const caller = authenticateCaller(req);
+    if (!caller) return unauthorized();
+
     const filePath = join(ctx.workspaceDir, "ceremonies", `${id}.yaml`);
-    if (existsSync(filePath)) unlinkSync(filePath);
+    if (existsSync(filePath)) {
+      const existing = parseYaml(readFileSync(filePath, "utf8")) as Record<string, unknown>;
+      const ownershipFail = checkOwnership(caller, existing, id);
+      if (ownershipFail) return ownershipFail;
+      unlinkSync(filePath);
+    }
     return Response.json({ success: true, message: `Ceremony "${id}" deleted` });
   }
 
@@ -169,7 +249,7 @@ export function createRoutes(ctx: ApiContext): Route[] {
     { method: "GET",  path: "/api/projects",            handler: () => serveWorkspaceYaml(ctx.workspaceDir, "projects.yaml", "projects") },
     { method: "GET",  path: "/api/agents",              handler: () => serveWorkspaceYaml(ctx.workspaceDir, "agents.yaml", "agents") },
     { method: "GET",  path: "/api/goals",               handler: () => serveWorkspaceYaml(ctx.workspaceDir, "goals.yaml", "goals") },
-    { method: "GET",  path: "/api/ceremonies",          handler: () => handleGetCeremonies() },
+    { method: "GET",  path: "/api/ceremonies",          handler: (req) => handleGetCeremonies(req) },
     { method: "POST", path: "/api/ceremonies/create",   handler: (req) => handleCreateCeremony(req) },
     { method: "POST", path: "/api/ceremonies/:id/run",  handler: (req, p) => handleRunCeremony(req, p.id) },
     { method: "POST", path: "/api/ceremonies/:id/update", handler: (req, p) => handleUpdateCeremony(req, p.id) },

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -13,6 +13,7 @@ import type { ExecutorRegistry } from "../executor/executor-registry.ts";
 import type { TelemetryService } from "../telemetry/telemetry-service.ts";
 import type { ContextMailbox } from "../../lib/dm/context-mailbox.ts";
 import type { TaskTracker } from "../executor/task-tracker.ts";
+import type { AgentKeyRegistry } from "../../lib/auth/agent-keys.ts";
 
 export type Params = Record<string, string>;
 export type RouteHandler = (req: Request, params: Params) => Response | Promise<Response>;
@@ -34,6 +35,12 @@ export interface ApiContext {
   executorRegistry: ExecutorRegistry;
   telemetry?: TelemetryService;
   apiKey?: string;
+  /**
+   * Per-agent API key registry — resolves request `X-API-Key` headers to a
+   * CallerIdentity. When unset, endpoints fall back to the legacy single-key
+   * model (admin-only via ctx.apiKey).
+   */
+  agentKeys?: AgentKeyRegistry;
   mailbox?: ContextMailbox;
   taskTracker?: TaskTracker;
 }

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -189,13 +189,17 @@ function createLangChainTools(toolNames: string[], http: HttpClient, correlation
         if (input.action === "list") return JSON.stringify(await http.get("/api/ceremonies"));
         if (input.action === "create") return JSON.stringify(await http.post("/api/ceremonies/create", input));
         if (input.action === "update") return JSON.stringify(await http.post(`/api/ceremonies/${input.id}/update`, input));
+        if (input.action === "run") return JSON.stringify(await http.post(`/api/ceremonies/${input.id}/run`, {}));
         return JSON.stringify(await http.post(`/api/ceremonies/${input.id}/delete`, {}));
       },
       {
         name: "manage_cron",
-        description: "CRUD scheduled ceremonies.",
+        description:
+          "CRUD scheduled ceremonies (cron jobs). Actions: list, create, update, delete, run (manual fire — ignores schedule). " +
+          "Naming convention: prefix ids with the agent's name (e.g. ava.weekly-rollup) so the dashboard groups by owner. " +
+          "Per-agent ownership is enforced server-side via X-API-Key — agent-scoped keys can only update/delete their own ceremonies; admin keys see all.",
         schema: z.object({
-          action: z.enum(["create", "update", "delete", "list"]),
+          action: z.enum(["create", "update", "delete", "list", "run"]),
           id: z.string().optional(),
           name: z.string().optional(),
           schedule: z.string().optional(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,13 @@ const contextMailbox = new ContextMailbox();
 import { TaskTracker } from "./executor/task-tracker.ts";
 const taskTracker = new TaskTracker({ bus });
 
+// --- Agent key registry — resolves per-agent X-API-Key headers to identities
+//     so ceremony / cron endpoints (and any future per-agent permission gates)
+//     can enforce ownership. Falls back to admin-only mode when
+//     workspace/agent-keys.yaml is absent.
+import { AgentKeyRegistry } from "../lib/auth/agent-keys.ts";
+const agentKeys = new AgentKeyRegistry(workspaceDir, process.env.WORKSTACEAN_API_KEY);
+
 // --- A2A extensions — register observability interceptors (cost, confidence,
 //     effect-domain, blast, hitl-mode, worldstate-delta). A2AExecutor.execute()
 //     runs the before/after hooks on every skill call; the extensions
@@ -585,6 +592,7 @@ const apiContext: ApiContext = {
   executorRegistry,
   telemetry,
   apiKey: API_KEY,
+  agentKeys,
   mailbox: contextMailbox,
   taskTracker,
 };

--- a/workspace/agent-keys.yaml.example
+++ b/workspace/agent-keys.yaml.example
@@ -1,0 +1,36 @@
+# Per-agent API key registry — backs the multi-tenant ceremony / cron model.
+#
+# Each entry binds an agent name to an environment variable holding that
+# agent's secret. Workstacean reads X-API-Key headers on /api/ceremonies/*
+# (and any future per-agent-permissioned endpoint), looks up the key value
+# here, and stamps the resolved agentName on every ceremony that agent
+# creates. Update / delete / list filtering enforce caller === createdBy.
+#
+# The legacy WORKSTACEAN_API_KEY remains the admin / operator key with
+# full read/write across all ceremonies. Listing it here is unnecessary.
+#
+# Rollout:
+#   1. Copy this file to workspace/agent-keys.yaml
+#   2. For each agent, generate a long random secret and set the env var
+#      via Infisical (or your container's environment).
+#   3. Restart workstacean — keys hot-reload from the yaml every 5s, but
+#      env vars are read once at process start.
+#   4. In each agent's container, set WORKSTACEAN_API_KEY to the
+#      agent-scoped secret instead of the admin key.
+#
+# Hot-reload: the file is watched at 5s interval. Adding / removing
+# agents takes effect without a restart; rotating an env var requires
+# a workstacean restart.
+
+keys:
+  quinn:
+    envKey: WORKSTACEAN_API_KEY_QUINN
+  jon:
+    envKey: WORKSTACEAN_API_KEY_JON
+  researcher:
+    envKey: WORKSTACEAN_API_KEY_RESEARCHER
+  protopen:
+    envKey: WORKSTACEAN_API_KEY_PROTOPEN
+  # ava and protobot run in-process and use the admin key directly,
+  # so they don't appear here. Add them only if you want to subject
+  # them to the per-agent ownership model too.


### PR DESCRIPTION
Adds per-agent identity to workstacean's HTTP API so each agent owns its own cron jobs. Pairs with Quinn PR #12 (ManageCronTool) — both can land independently, but together they give the fleet a single source of truth for cron with per-tenant isolation.

## Highlights
- New `AgentKeyRegistry` (`lib/auth/agent-keys.ts`) — maps X-API-Key → `{agentName, isAdmin}`
- Ceremony API stamps `createdBy` from caller; update / delete enforce ownership; list filters by owner
- Admin key (`WORKSTACEAN_API_KEY`) keeps full bypass for backward compat
- Hot-reload yaml; agents can be onboarded incrementally
- `manage_cron` deep-agent tool gains `run` action for parity with Quinn's tool

## Tests
- 10 unit tests on AgentKeyRegistry
- 11 integration tests on ceremony ownership
- 943/943 total green, typecheck clean

## Docs
- `workspace/agent-keys.yaml.example` template
- `docs/reference/http-api.md` updated with multi-tenant section + per-endpoint clarifications

## Rollout

1. Merge this PR
2. Copy `workspace/agent-keys.yaml.example` → `workspace/agent-keys.yaml` on the host
3. Generate per-agent secrets in Infisical (e.g. `WORKSTACEAN_API_KEY_QUINN`)
4. Update each agent's container env to use its own key
5. Existing ceremonies (no `createdBy` on disk) become admin-only manageable until manually transferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-agent API key support for multi-tenant isolation on the ceremonies API
  * Implemented ceremony ownership tracking and access control—agents can only access/modify their own ceremonies
  * Added "run" action to manually trigger ceremonies

* **Documentation**
  * Updated API reference with per-agent key configuration and ownership enforcement details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->