### PR TITLE
feat(extensions): wire blast-v1 + hitl-mode-v1 + full extension docs pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,11 +200,13 @@ protoWorkstacean is a first-class [A2A](https://a2a-protocol.org) client **and**
   - [`cost-v1`](docs/extensions/cost-v1.md) — records per-(agent, skill) token + wall-time actuals, publishes `autonomous.cost.*`
   - [`confidence-v1`](docs/extensions/confidence-v1.md) — captures agent-reported confidence (0.0–1.0), flags high-confidence failures
   - [`effect-domain-v1`](docs/extensions/effect-domain-v1.md) — parses worldstate-delta artifacts, publishes `world.state.delta`
+  - [`blast-v1`](docs/extensions/blast-v1.md) — per-skill scope-of-effect declaration (self/project/repo/fleet/public); planner + HITL policy read from it
+  - [`hitl-mode-v1`](docs/extensions/hitl-mode-v1.md) — per-skill approval policy (autonomous / notification / veto / gated / compound); sub-agent `input-required` routes back to the dispatching agent by default, human operator as final fallback
   - [`worldstate-delta-v1`](docs/extensions/worldstate-delta-v1.md) — DataPart content type for observed domain mutations
 
   Observations from cost-v1 + confidence-v1 feed `PlannerPluginL0`'s candidate ranking ([Arc 6.4](docs/explanation/self-improving-loop.md)): once a candidate has ≥5 samples the planner ranks by observed success rate × confidence × wall-time penalty; cold candidates fall back to the card's self-declared confidence.
 
-See [`docs/guides/add-an-agent.md`](docs/guides/add-an-agent.md) for the full agent-onboarding flow.
+Agent authors: see [Build an A2A agent](docs/guides/build-an-a2a-agent.md) for the spec-side recipe and [Extend an A2A agent](docs/guides/extend-an-a2a-agent.md) for the x-protolabs extension pack (all 5 above, complete example agent card, response-field conventions).
 
 ---
 

--- a/docs/explanation/self-improving-loop.md
+++ b/docs/explanation/self-improving-loop.md
@@ -51,6 +51,8 @@ world state change
 │   before hooks:     │    - cost-v1 stamps x-cost-skill metadata
 │                     │    - confidence-v1 stamps x-confidence-skill
 │                     │    - effect-domain-v1 stamps x-effect-domain-skill
+│                     │    - blast-v1 stamps x-blast-radius (from card)
+│                     │    - hitl-mode-v1 stamps x-hitl-mode (from card)
 │   after hooks:      │    - cost-v1 records tokens + wall-time → CostStore
 │                     │    - confidence-v1 records self-assessment → ConfidenceStore
 │                     │    - effect-domain-v1 publishes world.state.delta
@@ -101,13 +103,15 @@ When two candidates score identically (common in the cold regime with matching c
 
 ## What each extension contributes
 
-| Extension | Reads from response | Writes to | Consumer |
+| Extension | Reads from | Writes to | Consumer |
 |---|---|---|---|
 | [`cost-v1`](../extensions/cost-v1.md) | `result.data.usage`, `durationMs`, `costUsd`, `success` | `defaultCostStore` + `autonomous.cost.*` topic | Planner ranking, dashboard, `OutcomeAnalysis` action-quality alerts |
 | [`confidence-v1`](../extensions/confidence-v1.md) | `result.data.confidence`, `confidenceExplanation`, `success` | `defaultConfidenceStore` + `autonomous.confidence.*` topic | Planner ranking, calibration dashboard |
 | [`effect-domain-v1`](../extensions/effect-domain-v1.md) | `worldstate-delta-v1` artifact DataPart | `world.state.delta` bus event | `WorldStateEngine` applies deltas, planner sees fresh state faster |
+| [`blast-v1`](../extensions/blast-v1.md) | `capabilities.extensions[].params.skills` on the agent card | `defaultBlastRegistry` + stamps `x-blast-radius` on outbound metadata | HITL policy + planner tiebreaker + dashboard severity coloring |
+| [`hitl-mode-v1`](../extensions/hitl-mode-v1.md) | `capabilities.extensions[].params.skills` on the agent card | `defaultHitlModeRegistry` + stamps `x-hitl-mode` on outbound metadata | `HITLPlugin` flow selection (autonomous / notification / veto / gated / compound); sub-agent `input-required` routes back to dispatching agent, human fallback |
 
-All three interceptors are registered once at startup (`src/index.ts`) and fire on every A2A dispatch regardless of whether the agent's card opts in — they self-gate by checking for their expected response fields. Agents that don't implement an extension just produce no samples; agents that do get their samples counted. No config change needed on either side when a new agent joins the fleet.
+All five interceptors are registered once at startup (`src/index.ts`) and fire on every A2A dispatch regardless of whether the agent's card opts in — they self-gate by checking for their expected response fields or card declarations. Agents that don't opt in produce no samples and no metadata stamps; agents that do get their samples counted. No config change needed on either side when a new agent joins the fleet.
 
 ---
 

--- a/docs/extensions/blast-v1.md
+++ b/docs/extensions/blast-v1.md
@@ -1,0 +1,106 @@
+---
+title: "Extension: x-protolabs/blast-v1"
+---
+
+`x-protolabs/blast-v1` lets agents declare the **scope of effect** for each skill so the planner, HITL policy, and dashboards can apply stricter gates to higher-impact work — independent of goal-level config.
+
+**Extension URI**: `https://protolabs.ai/a2a/ext/blast-v1`
+
+---
+
+## The five radii
+
+Ordered from narrowest to widest impact. One value per skill:
+
+| Radius | What it affects | Typical skills |
+|---|---|---|
+| `self` | Only the agent's own internal state | `sitrep`, `status_report` |
+| `project` | A single project's state | `manage_feature`, `board_audit` |
+| `repo` | A single git repository | `open_pr`, `rebase_pr`, `pr_review` |
+| `fleet` | Multiple repos or agents | `bulk_migration`, `cross_repo_bump` |
+| `public` | Externally-visible state | `production_deploy`, `public_post` |
+
+`BLAST_ORDER` assigns `self=0` through `public=4` for numeric comparisons. Consumers (e.g. HITL policy) can say "require human approval for anything ≥ `repo`".
+
+---
+
+## What the extension does
+
+A **read-side** declaration — blast-v1 does NOT mutate outbound traffic or collect observations. It's policy metadata that downstream consumers look up by `(agentName, skill)`.
+
+- **`before(ctx)`** — if the agent advertised a blast radius for this skill in their card, the interceptor stamps `x-blast-radius: <radius>` onto the outbound JSON-RPC metadata so any consumer in the execution chain can see it without a second lookup.
+- **`after(ctx)`** — no-op. Blast is policy, not observation.
+
+Registration at startup in `src/index.ts`:
+
+```ts
+import { registerBlastExtension } from "./executor/extensions/blast.ts";
+registerBlastExtension();
+```
+
+---
+
+## Declaring it on your agent card
+
+Add to your agent card's `capabilities.extensions` list:
+
+```json
+{
+  "capabilities": {
+    "extensions": [
+      {
+        "uri": "https://protolabs.ai/a2a/ext/blast-v1",
+        "params": {
+          "skills": {
+            "sitrep":              { "radius": "self" },
+            "pr_review":           { "radius": "repo" },
+            "bulk_migration":      { "radius": "fleet", "note": "Rewrites every repo in the org" },
+            "production_deploy":   { "radius": "public" }
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+`skills` is a map of `skill_id` → `{ radius, note? }`. `note` is a human-readable explanation shown in dashboards and HITL prompts.
+
+When `SkillBrokerPlugin` refreshes your card (every 10 min), declarations are parsed into `defaultBlastRegistry` so the planner and HITL policy can query them without re-fetching.
+
+---
+
+## Consumers
+
+Blast is useful whenever "this action is big" needs to affect routing or gating:
+
+- **HITL policy** — the [hitl-mode-v1](hitl-mode-v1.md) extension can say `mode: gated` only for skills with `radius >= repo`, leaving smaller-blast work fully autonomous. The two extensions compose.
+- **Planner tiebreaker** — `PlannerL0` can prefer lower-blast options when two skills produce the same effect (Arc 6.4 ranking).
+- **Dashboard** — the fleet view colors skills by blast radius so operators see at a glance which work needs attention vs. which runs quietly.
+- **Ops alerts** — `ops.alert.action_quality` on a `public`-radius skill is a much bigger signal than one on a `self` skill. Alert severity can scale.
+
+---
+
+## Registry API
+
+```ts
+import { defaultBlastRegistry, BLAST_ORDER, type BlastRadius } from "../executor/extensions/blast.ts";
+
+const decl = defaultBlastRegistry.get("quinn", "pr_review");
+// → { agentName: "quinn", skill: "pr_review", radius: "repo", note?: "..." }
+
+// Numeric comparison for policy thresholds
+if (decl && BLAST_ORDER[decl.radius] >= BLAST_ORDER["repo"]) {
+  // Require human approval, stricter timeouts, etc.
+}
+```
+
+Registry is populated by `SkillBrokerPlugin` on every card refresh. Missing declarations return `undefined` — consumers should treat "no declaration" as "unknown, assume worst case" or "none, proceed."
+
+---
+
+## Related
+
+- [hitl-mode-v1](hitl-mode-v1.md) — per-skill approval policy; composes with blast to gate high-impact skills
+- [cost-v1](cost-v1.md) — per-skill cost observations; planner tiebreaker alongside blast
+- [Build an A2A Agent](../guides/build-an-a2a-agent.md) — agent-author recipe (task store, webhooks, health)

--- a/docs/extensions/hitl-mode-v1.md
+++ b/docs/extensions/hitl-mode-v1.md
@@ -1,0 +1,147 @@
+---
+title: "Extension: x-protolabs/hitl-mode-v1"
+---
+
+`x-protolabs/hitl-mode-v1` lets agents declare the **approval policy** for each skill on their agent card. HITL is a gradient, not a binary — this extension lets the dispatcher + HITL plugin route each skill invocation through the right flow without goal-level config.
+
+**Extension URI**: `https://protolabs.ai/a2a/ext/hitl-mode-v1`
+
+---
+
+## The five modes
+
+Ordered from least-gated to most-gated:
+
+| Mode | Semantics |
+|---|---|
+| `autonomous` | No human in the loop. Task runs, outcome is what it is. |
+| `notification` | Runs autonomously. A read-only notification is rendered on the originating surface (Discord, Plane) for awareness. |
+| `veto` | Short TTL window after dispatch where a human can cancel via `tasks/cancel` before side effects complete. Auto-approved on TTL expiry. |
+| `gated` | Blocking `input-required` **before** any side effect. No auto-approve; execution halts until a decision. |
+| `compound` | Multi-checkpoint gated. The agent emits multiple `input-required` states across the task lifecycle (draft → review → publish); each requires its own decision. |
+
+`HITL_MODE_ORDER` ranks them `autonomous=0` through `compound=4` for numeric comparisons.
+
+---
+
+## Reviewer resolution — sub-agent → caller
+
+**This is the part agent-authors most often get wrong.** HITL doesn't always mean "human in the loop" — it can mean "dispatching agent in the loop."
+
+Picture the chain: Ava dispatches `pr_review` to Quinn. Quinn needs the user's intent clarified on an ambiguous change. The `input-required` state should route back to **Ava** (the dispatcher), not straight to the human operator. Ava then chooses:
+
+1. Answer autonomously from context she already has, or
+2. Bubble up to the human if she genuinely needs their input
+
+The reviewer precedence is:
+
+```
+input-required
+  → dispatching agent (if present; agent-scoped resolution)
+  → renderer chain (Discord, Plane, etc.) as final fallback
+```
+
+`TaskTracker` reads the original dispatch's `source.agentId` to decide the first hop. Sub-agent chains (Ava → Quinn → protoMaker) walk the chain back until a resolver wants the question or the chain terminates at the operator.
+
+A declaration can override this via `reviewer`:
+
+```json
+{ "mode": "gated", "reviewer": "operator" }
+```
+
+Forces the prompt straight to the human for skills where the dispatching agent's judgment isn't sufficient (e.g. production deploys). Default without this field is the caller-first chain.
+
+---
+
+## What the extension does
+
+A **read-side** declaration — hitl-mode-v1 does NOT mutate outbound traffic or collect observations. It's policy metadata.
+
+- **`before(ctx)`** — stamps `x-hitl-mode: <mode>` (and `x-hitl-veto-ttl-ms: <N>` if set) on outbound metadata. Downstream consumers read these to decide how to render the prompt.
+- **`after(ctx)`** — no-op. Mode is policy, not observation.
+
+Registration at startup in `src/index.ts`:
+
+```ts
+import { registerHitlModeExtension } from "./executor/extensions/hitl-mode.ts";
+registerHitlModeExtension();
+```
+
+---
+
+## Declaring it on your agent card
+
+```json
+{
+  "capabilities": {
+    "extensions": [
+      {
+        "uri": "https://protolabs.ai/a2a/ext/hitl-mode-v1",
+        "params": {
+          "skills": {
+            "sitrep":              { "mode": "autonomous" },
+            "open_pr":             { "mode": "notification" },
+            "merge_pr":            { "mode": "veto", "vetoTtlMs": 300000 },
+            "rebase_pr":           { "mode": "gated" },
+            "production_deploy":   { "mode": "gated", "reviewer": "operator" },
+            "publish_post":        { "mode": "compound" }
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+Keys:
+
+- `mode` (required) — one of the five values above
+- `vetoTtlMs` (optional) — veto-window length in ms, only meaningful for `veto` mode. Default: 60_000 (1 minute)
+- `reviewer` (optional) — `"operator"` forces the HITL prompt to the human; absent means caller-first chain (the default)
+- `note` (optional) — human-readable reason, shown in the HITL prompt
+
+`SkillBrokerPlugin` parses the declarations into `defaultHitlModeRegistry` on every card refresh (every 10 min).
+
+---
+
+## Consumers
+
+- **`HITLPlugin`** — reads `x-hitl-mode` from the metadata on `input-required` and selects the rendering path: Discord button, resume-prompt, or auto-approve-on-TTL. Without the extension, falls back to legacy HITL config.
+- **`TaskTracker`** — honors `vetoTtlMs` for veto-mode skills; auto-resumes the task on timeout if no cancel arrived.
+- **Planner** — can compose with [blast-v1](blast-v1.md) to require `gated` only for skills with `radius >= repo`.
+- **Dashboard** — fleet view shows which skills are gated vs. autonomous, how often each mode fires.
+
+---
+
+## Registry API
+
+```ts
+import {
+  defaultHitlModeRegistry,
+  HITL_MODE_ORDER,
+  type HitlMode,
+} from "../executor/extensions/hitl-mode.ts";
+
+const decl = defaultHitlModeRegistry.get("quinn", "merge_pr");
+// → { agentName: "quinn", skill: "merge_pr", mode: "veto", vetoTtlMs: 300000 }
+
+if (decl && HITL_MODE_ORDER[decl.mode] >= HITL_MODE_ORDER.gated) {
+  // Halt execution until human decides
+}
+```
+
+---
+
+## Status
+
+- ✅ `before` hook ships on every A2A call; metadata stamping live
+- ✅ Registry populated by `SkillBrokerPlugin` card-refresh path
+- ⏳ **Caller-first reviewer resolution is pending implementation** — today `input-required` routes directly to Discord (human operator). The sub-agent → caller fallback chain is documented here as the target design; follow-up ticket tracks the `TaskTracker` change to inspect `source.agentId` and hand HITL requests back through the dispatch chain before defaulting to the human renderer.
+
+---
+
+## Related
+
+- [blast-v1](blast-v1.md) — per-skill scope declaration; compose with hitl-mode to gate high-impact skills
+- [Build an A2A Agent](../guides/build-an-a2a-agent.md) — agent-author recipe for the A2A spec surface
+- [self-improving-loop](../explanation/self-improving-loop.md) — how observations feed back into planner + goal proposals

--- a/docs/guides/extend-an-a2a-agent.md
+++ b/docs/guides/extend-an-a2a-agent.md
@@ -1,0 +1,191 @@
+---
+title: Extend an A2A Agent — the x-protolabs extensions pack
+---
+
+Once you've built the A2A spec surface ([Build an A2A Agent](./build-an-a2a-agent.md)) your agent works as a plain A2A responder — workstacean discovers skills, dispatches, tracks tasks, reports to fleet health. But five additional capabilities let the dispatcher, planner, and HITL policy make smarter decisions about each skill:
+
+| Extension | Purpose | Direction |
+|---|---|---|
+| [cost-v1](../extensions/cost-v1.md) | Token + wall-time observations → planner tiebreaker | workstacean → stores → planner |
+| [confidence-v1](../extensions/confidence-v1.md) | Agent self-reported confidence → calibration + ranking | your agent → stores → planner |
+| [effect-domain-v1](../extensions/effect-domain-v1.md) | Declared world-state deltas → faster planner convergence | your agent's card + response artifacts |
+| [blast-v1](../extensions/blast-v1.md) | Scope-of-effect declaration → HITL/policy routing | your agent's card |
+| [hitl-mode-v1](../extensions/hitl-mode-v1.md) | Per-skill approval policy → HITL flow selection | your agent's card |
+
+You don't have to implement any of them. You keep working as a plain A2A agent. But each extension unlocks behavior on the workstacean side that only fires when you opt in.
+
+## How workstacean picks them up
+
+All five interceptors are **registered unconditionally** at workstacean startup (`src/index.ts`). They run on every outbound A2A call, but **self-gate** on whether you advertised the URI in your agent card. Workstacean never forces behavior on agents that don't opt in.
+
+Two concrete consequences:
+
+1. **Card-only extensions** (blast-v1, hitl-mode-v1, effect-domain-v1's declarations): the `before` hook reads `defaultXxxRegistry` — populated when `SkillBrokerPlugin` refreshes your card every 10 min. If you don't declare, the registry miss is a no-op; nothing is stamped on the outbound request.
+2. **Observation extensions** (cost-v1, confidence-v1): the `after` hook reads the response's `data` field. If your agent doesn't include `usage` / `confidence` fields, the interceptor early-returns without recording.
+
+This means extensions are a **zero-risk gradient**. Ship your agent, observe fleet health, decide one extension at a time whether it's worth declaring.
+
+## A complete example — Quinn's card
+
+Here's what it looks like when an agent opts in to all five:
+
+```json
+{
+  "name": "quinn",
+  "description": "QA engineer — PR review, bug triage, board audit",
+  "url": "http://quinn:7870/a2a",
+  "version": "1.0.0",
+  "provider": { "organization": "protoLabsAI" },
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": true,
+    "stateTransitionHistory": false,
+    "extensions": [
+      { "uri": "https://protolabs.ai/a2a/ext/cost-v1" },
+      { "uri": "https://protolabs.ai/a2a/ext/confidence-v1" },
+
+      {
+        "uri": "https://protolabs.ai/a2a/ext/effect-domain-v1",
+        "params": {
+          "skills": {
+            "pr_review":     { "effects": [{ "domain": "pr_pipeline", "path": "data.conflicting", "delta": -1, "confidence": 0.7 }] },
+            "bug_triage":    { "effects": [{ "domain": "board", "path": "data.openBugs",   "delta": -1, "confidence": 0.8 }] },
+            "board_audit":   { "effects": [] }
+          }
+        }
+      },
+
+      {
+        "uri": "https://protolabs.ai/a2a/ext/blast-v1",
+        "params": {
+          "skills": {
+            "sitrep":          { "radius": "self" },
+            "board_audit":     { "radius": "project" },
+            "pr_review":       { "radius": "repo" },
+            "bug_triage":      { "radius": "project" },
+            "security_triage": { "radius": "fleet",  "note": "Can affect the entire fleet's security posture" }
+          }
+        }
+      },
+
+      {
+        "uri": "https://protolabs.ai/a2a/ext/hitl-mode-v1",
+        "params": {
+          "skills": {
+            "sitrep":          { "mode": "autonomous" },
+            "board_audit":     { "mode": "notification" },
+            "pr_review":       { "mode": "veto", "vetoTtlMs": 300000 },
+            "bug_triage":      { "mode": "notification" },
+            "security_triage": { "mode": "gated", "reviewer": "operator" }
+          }
+        }
+      }
+    ]
+  },
+
+  "defaultInputModes": ["text/plain"],
+  "defaultOutputModes": ["text/markdown"],
+  "skills": [
+    { "id": "sitrep",          "name": "Situation Report",  "description": "…" },
+    { "id": "board_audit",     "name": "Board Audit",       "description": "…" },
+    { "id": "pr_review",       "name": "PR Review",         "description": "…" },
+    { "id": "bug_triage",      "name": "Bug Triage",        "description": "…" },
+    { "id": "security_triage", "name": "Security Triage",   "description": "…" }
+  ],
+  "securitySchemes": {
+    "apiKey": { "type": "apiKey", "in": "header", "name": "X-API-Key" }
+  },
+  "security": [{ "apiKey": [] }]
+}
+```
+
+Notice:
+
+- cost-v1 + confidence-v1 have **no params** — declaring the URI is enough to opt in. Your agent still has to include `usage` / `confidence` fields on terminal-task `data` for samples to be recorded.
+- effect-domain-v1, blast-v1, hitl-mode-v1 carry `params.skills` — a map keyed by skill id.
+- You don't declare every skill. Only the ones where the default (no declaration → no-op) isn't what you want.
+
+## Response-side requirements
+
+For the **observation extensions** (cost-v1, confidence-v1), you also need to include the expected fields on your terminal `Task.data`. None of these are required by the A2A spec itself — they're extension-specific conventions:
+
+```json
+{
+  "status": { "state": "completed" },
+  "artifacts": [{ "parts": [{ "kind": "text", "text": "…" }] }],
+  "data": {
+    "usage": {
+      "input_tokens": 3421,
+      "output_tokens": 890,
+      "cache_read_input_tokens": 0
+    },
+    "durationMs": 4823,
+    "costUsd": 0.0187,
+    "confidence": 0.88,
+    "confidenceExplanation": "Spec was unambiguous; all tests pass.",
+    "success": true
+  }
+}
+```
+
+- `usage.input_tokens` / `output_tokens` — Anthropic-shaped token counts. Cached tokens are optional but tracked when provided.
+- `durationMs` / `costUsd` — wall-time + dollar cost. `costUsd` is optional; the cost-v1 consumer can compute from tokens + `MODEL_RATES` if missing.
+- `confidence` — float in `[0, 1]`. Required for confidence-v1 sample recording; the extension defensively clamps out-of-range values.
+- `confidenceExplanation` — free-text, surfaced in calibration views.
+- `success` — `false` explicitly marks a failure even when `state: completed`. Use this when your skill returns a textual failure message rather than throwing.
+
+For **effect-domain-v1** (the response side of it), attach a `worldstate-delta` DataPart to your terminal task's artifacts when you've mutated shared state:
+
+```json
+{
+  "artifacts": [
+    {
+      "parts": [
+        { "kind": "text", "text": "Closed 3 stale PRs" },
+        {
+          "kind": "data",
+          "data": {
+            "deltas": [
+              { "domain": "pr_pipeline", "path": "data.staleOpen", "op": "inc", "value": -3 }
+            ]
+          },
+          "metadata": { "mimeType": "application/vnd.protolabs.worldstate-delta+json" }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Workstacean's effect-domain-v1 after-hook extracts this and publishes `world.state.delta` — the planner picks up the mutation immediately instead of waiting for the next full domain poll.
+
+## Registration at workstacean side
+
+For reference — you don't need to do anything here; this is what workstacean runs at startup:
+
+```ts
+// src/index.ts
+registerCostExtension(bus);
+registerConfidenceExtension(bus);
+registerEffectDomainExtension(bus);
+registerBlastExtension();
+registerHitlModeExtension();
+```
+
+All five interceptors live in `defaultExtensionRegistry` and fire on every `A2AExecutor.execute()` call. Self-gating keeps them safe for non-opt-in agents.
+
+## Adoption order — recommended
+
+1. **cost-v1** — zero card changes, just emit `usage` + `durationMs` in your terminal data. Gets you dashboard visibility + planner ranking for your agent.
+2. **confidence-v1** — add `confidence` to your terminal data. Gets your agent into calibration views and unblocks the "high-confidence failure" signal for OutcomeAnalysis.
+3. **blast-v1** — declare scope per skill on the card. Unlocks policy-driven HITL gating without code changes.
+4. **hitl-mode-v1** — declare per-skill approval policy. Now your skills route through the right HITL flow by default (autonomous / notification / veto / gated / compound).
+5. **effect-domain-v1** — the most involved: declare expected deltas on the card, include observed deltas in your response artifacts. Lets the planner react to your actions in ~1s instead of one poll cycle.
+
+Each step is independently useful. The pack composes — e.g. blast-v1 + hitl-mode-v1 together let you say "anything `fleet` or `public` radius is `gated`, reviewer: operator."
+
+## Related
+
+- [Build an A2A Agent](./build-an-a2a-agent.md) — the spec-side recipe (task store, webhooks, health)
+- [Self-improving loop](../explanation/self-improving-loop.md) — how extension observations feed the planner + goal proposals
+- Extension reference pages — [cost-v1](../extensions/cost-v1.md), [confidence-v1](../extensions/confidence-v1.md), [effect-domain-v1](../extensions/effect-domain-v1.md), [blast-v1](../extensions/blast-v1.md), [hitl-mode-v1](../extensions/hitl-mode-v1.md)

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -9,6 +9,7 @@ Task-oriented guides for common operations in protoWorkstacean.
 | Guide | Description |
 |-------|-------------|
 | [Add an agent](./add-an-agent) | Register an in-process agent (YAML + ProtoSdkExecutor) or an external A2A agent |
+| [Extend an A2A agent](./extend-an-a2a-agent) | Opt in to the x-protolabs extensions pack (cost, confidence, effect-domain, blast, hitl-mode) — smarter planner + HITL with minimal card changes |
 | [Add a domain](./add-a-domain) | Poll a custom HTTP endpoint and expose it as a world-state domain |
 | [Add goals and actions](./add-goals-and-actions) | Write goal definitions (Invariant, Threshold, Distribution) and matching actions with preconditions and effects |
 | [Create a ceremony](./create-a-ceremony) | Schedule a recurring fleet ritual — a skill dispatched on a cron expression |

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,9 +50,13 @@ const agentKeys = new AgentKeyRegistry(workspaceDir, process.env.WORKSTACEAN_API
 import { registerCostExtension } from "./executor/extensions/cost.ts";
 import { registerConfidenceExtension } from "./executor/extensions/confidence.ts";
 import { registerEffectDomainExtension } from "./executor/extensions/effect-domain.ts";
+import { registerBlastExtension } from "./executor/extensions/blast.ts";
+import { registerHitlModeExtension } from "./executor/extensions/hitl-mode.ts";
 registerCostExtension(bus);
 registerConfidenceExtension(bus);
 registerEffectDomainExtension(bus);
+registerBlastExtension();
+registerHitlModeExtension();
 
 // --- ChannelRegistry — loaded from workspace/channels.yaml, shared by RouterPlugin + DiscordPlugin ---
 import { ChannelRegistry } from "../lib/channels/channel-registry.js";


### PR DESCRIPTION
Two follow-ups from the recent extensions audit:

**1. The registered-but-inert bug I fixed for cost/confidence/effect-domain in #265 was also hiding on `blast-v1` and `hitl-mode-v1`.** Code shipped in Arc 7.x but the `registerBlastExtension()` / `registerHitlModeExtension()` calls were never added to `src/index.ts`. Their before-hooks therefore never stamped `x-blast-radius` / `x-hitl-mode` on outbound A2A requests — downstream consumers (HITL policy selection, planner tiebreaker, dashboard severity coloring) saw the registries populated from card refreshes but never the live per-request metadata.

4-line fix in `src/index.ts`. Self-gating by `(agentName, skill)` registry lookup means it's safe for agents that haven't declared — they keep getting no metadata stamped, identical to today.

**2. Docs pack for agent authors** — no reference docs existed for blast-v1 or hitl-mode-v1, and the five extensions weren't consolidated into one place for agent builders:

- `docs/extensions/blast-v1.md` + `docs/extensions/hitl-mode-v1.md` — reference pages mirroring the cost-v1 / confidence-v1 structure
- `docs/guides/extend-an-a2a-agent.md` — new agent-builder guide showing all 5 x-protolabs extensions on a single example card (Quinn's shape), response-side field conventions, recommended adoption order. Complements `docs/guides/build-an-a2a-agent.md` (#340): that one covers the spec-side recipe (task store, webhooks, health); this one covers the extension pack.
- README.md extensions list grows to 5; `self-improving-loop.md` extension table + ASCII flow diagram updated.

**3. The HITL reviewer-chain design the hitl-mode doc describes is intentional but not yet implemented** — sub-agent `input-required` should route back to the dispatching agent (Ava) before defaulting to the human operator. Doc calls this out as the target; TaskTracker implementation filed as a board feature.

Tests: 943/943 pass. Typecheck clean.