### PR TITLE
docs: restore Build an A2A agent entry in guides index

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -9,6 +9,7 @@ Task-oriented guides for common operations in protoWorkstacean.
 | Guide | Description |
 |-------|-------------|
 | [Add an agent](./add-an-agent) | Register an in-process agent (YAML + ProtoSdkExecutor) or an external A2A agent |
+| [Build an A2A agent](./build-an-a2a-agent) | Agent-author recipe: the endpoint, task lifecycle, hardening, automatic health, and scheduled work |
 | [Extend an A2A agent](./extend-an-a2a-agent) | Opt in to the x-protolabs extensions pack (cost, confidence, effect-domain, blast, hitl-mode) — smarter planner + HITL with minimal card changes |
 | [Add a domain](./add-a-domain) | Poll a custom HTTP endpoint and expose it as a world-state domain |
 | [Add goals and actions](./add-goals-and-actions) | Write goal definitions (Invariant, Threshold, Distribution) and matching actions with preconditions and effects |


### PR DESCRIPTION
#340 + #342 both touched docs/guides/index.md. #340 landed second via squash merge and overwrote #342's `Extend` row with its pre-#342 snapshot. Dev ended up with `Extend` but missing `Build`. Both files exist on disk; this restores the missing index entry so both show up in the docs nav.