### PR TITLE
feat(hitl): caller-first reviewer chain — agent-in-the-loop

### DIFF
--- a/docs/extensions/hitl-mode-v1.md
+++ b/docs/extensions/hitl-mode-v1.md
@@ -136,7 +136,7 @@ if (decl && HITL_MODE_ORDER[decl.mode] >= HITL_MODE_ORDER.gated) {
 
 - ✅ `before` hook ships on every A2A call; metadata stamping live
 - ✅ Registry populated by `SkillBrokerPlugin` card-refresh path
-- ⏳ **Caller-first reviewer resolution is pending implementation** — today `input-required` routes directly to Discord (human operator). The sub-agent → caller fallback chain is documented here as the target design; follow-up ticket tracks the `TaskTracker` change to inspect `source.agentId` and hand HITL requests back through the dispatch chain before defaulting to the human renderer.
+- ✅ Caller-first reviewer resolution live — `TaskTracker` routes `input-required` back to the dispatching agent (via `meta.dispatcherAgent` on the originating `agent.skill.request`) before falling back to the human renderer chain. `reviewer: "operator"` on the declaration forces direct-to-human.
 
 ---
 

--- a/src/api/ava-tools.ts
+++ b/src/api/ava-tools.ts
@@ -37,6 +37,7 @@ export function createRoutes(ctx: ApiContext): Route[] {
     const contextId = body.contextId as string | undefined;
     const skill = (body.skill as string) || "chat";
     const done = body.done === true;
+    const dispatcherAgent = typeof body.dispatcherAgent === "string" ? body.dispatcherAgent : undefined;
 
     if (!agent || !message) {
       return Response.json(
@@ -67,6 +68,7 @@ export function createRoutes(ctx: ApiContext): Route[] {
         skill,
         content: message,
         targets: [agent],
+        ...(dispatcherAgent ? { meta: { dispatcherAgent } } : {}),
       },
     };
 
@@ -184,6 +186,7 @@ export function createRoutes(ctx: ApiContext): Route[] {
     const skill = body.skill as string | undefined;
     const message = body.message as string | undefined;
     const projectSlug = body.projectSlug as string | undefined;
+    const dispatcherAgent = typeof body.dispatcherAgent === "string" ? body.dispatcherAgent : undefined;
 
     if (!agent || !skill || !message) {
       return Response.json(
@@ -205,6 +208,7 @@ export function createRoutes(ctx: ApiContext): Route[] {
         content: message,
         targets: [agent],
         ...(projectSlug ? { projectSlug } : {}),
+        ...(dispatcherAgent ? { meta: { dispatcherAgent } } : {}),
       },
     });
 

--- a/src/event-bus/payloads.ts
+++ b/src/event-bus/payloads.ts
@@ -50,6 +50,14 @@ export interface AgentSkillRequestPayload {
     skillHint?: string;
     topic?: string;
     context?: Record<string, unknown>;
+    /**
+     * Name of the agent that dispatched this skill request (if any). Set when
+     * an agent tool like `chat_with_agent` or `delegate_task` fires the
+     * request. Carries through the A2A lifecycle so `TaskTracker` can route
+     * `input-required` prompts back to the dispatcher instead of directly to
+     * the human renderer.
+     */
+    dispatcherAgent?: string;
     [key: string]: unknown;
   };
   /** Allow additional forwarded payload fields from the originating message. */

--- a/src/executor/__tests__/task-tracker.test.ts
+++ b/src/executor/__tests__/task-tracker.test.ts
@@ -3,6 +3,7 @@ import { InMemoryEventBus } from "../../../lib/bus.ts";
 import { TaskTracker } from "../task-tracker.ts";
 import type { A2AExecutor } from "../executors/a2a-executor.ts";
 import type { SkillResult } from "../types.ts";
+import { defaultHitlModeRegistry } from "../extensions/hitl-mode.ts";
 
 /** Minimal fake executor that lets tests drive pollTask responses. */
 function makeFakeExecutor(responses: SkillResult[] | (() => SkillResult)): A2AExecutor {
@@ -257,6 +258,122 @@ describe("TaskTracker", () => {
       expect(first.checkpoint?.index).toBe(1);
       expect(first.title).toBe("Input needed from ava");
       expect(first.title).not.toContain("checkpoint");
+    });
+  });
+
+  // ── Dispatcher caller-first HITL chain ───────────────────────────────────
+  describe("dispatcher caller-first routing", () => {
+    afterEach(() => {
+      defaultHitlModeRegistry.clear();
+    });
+
+    function makeInputRequiredExecutor(): { executor: A2AExecutor; resumedWith: string[] } {
+      const resumedWith: string[] = [];
+      const fake = {
+        type: "a2a" as const,
+        execute: async () => ({ text: "", isError: false, correlationId: "" }),
+        pollTask: async (): Promise<SkillResult> => ({
+          text: "should I ship?", isError: false, correlationId: "c1",
+          data: { taskState: "input-required", taskId: "t1", contextId: "ctx1" },
+        }),
+        cancelTask: async () => ({ text: "", isError: false, correlationId: "c1" }),
+        resubscribeTask: async () => { throw new Error("not used"); },
+        resumeTask: async (_taskId: string, text: string) => { resumedWith.push(text); },
+      };
+      return { executor: fake as unknown as A2AExecutor, resumedWith };
+    }
+
+    test("routes input-required to dispatcher when dispatcherAgent set and no operator override", async () => {
+      const { executor, resumedWith } = makeInputRequiredExecutor();
+      const dispatcherRequests: Array<Record<string, unknown>> = [];
+      const hitlRequests: unknown[] = [];
+      bus.subscribe("agent.skill.request", "test-dispatcher", (msg) => {
+        dispatcherRequests.push(msg.payload as Record<string, unknown>);
+      });
+      bus.subscribe("hitl.request.#", "test-hitl", (msg) => { hitlRequests.push(msg.payload); });
+
+      tracker = new TaskTracker({ bus, sweepIntervalMs: 20, defaultPollIntervalMs: 10 });
+      tracker.track({
+        correlationId: "c1", taskId: "t1", agentName: "quinn", skillName: "pr_review",
+        dispatcherAgent: "ava",
+        replyTopic: "agent.skill.response.c1", executor,
+      });
+
+      await new Promise(r => setTimeout(r, 50));
+      expect(dispatcherRequests.length).toBe(1);
+      expect(dispatcherRequests[0].skill).toBe("chat");
+      expect(dispatcherRequests[0].targets).toEqual(["ava"]);
+      expect((dispatcherRequests[0].content as string)).toContain("should I ship?");
+      expect(hitlRequests).toHaveLength(0);
+
+      // Simulate Ava's chat reply
+      const replyTopic = dispatcherRequests[0].replyTopic as string;
+      bus.publish(replyTopic, {
+        id: "r1", correlationId: "x", topic: replyTopic, timestamp: Date.now(),
+        payload: { content: "yes, ship it", isError: false, correlationId: "x" },
+      });
+
+      await new Promise(r => setTimeout(r, 30));
+      expect(resumedWith).toHaveLength(1);
+      expect(resumedWith[0]).toContain("Dispatcher (ava)");
+      expect(resumedWith[0]).toContain("yes, ship it");
+      expect(hitlRequests).toHaveLength(0);
+    });
+
+    test("operator override forces hitl.request despite dispatcher being set", async () => {
+      defaultHitlModeRegistry.declare({
+        agentName: "quinn", skill: "security_triage",
+        mode: "gated", reviewer: "operator",
+      });
+
+      const { executor } = makeInputRequiredExecutor();
+      const dispatcherRequests: unknown[] = [];
+      const hitlRequests: unknown[] = [];
+      bus.subscribe("agent.skill.request", "test-dispatcher", (msg) => {
+        dispatcherRequests.push(msg.payload);
+      });
+      bus.subscribe("hitl.request.#", "test-hitl", (msg) => { hitlRequests.push(msg.payload); });
+
+      tracker = new TaskTracker({ bus, sweepIntervalMs: 20, defaultPollIntervalMs: 10 });
+      tracker.track({
+        correlationId: "c1", taskId: "t1", agentName: "quinn", skillName: "security_triage",
+        dispatcherAgent: "ava",
+        replyTopic: "agent.skill.response.c1", executor,
+      });
+
+      await new Promise(r => setTimeout(r, 50));
+      expect(dispatcherRequests).toHaveLength(0);
+      expect(hitlRequests).toHaveLength(1);
+    });
+
+    test("falls back to hitl.request when dispatcher reply is empty", async () => {
+      const { executor } = makeInputRequiredExecutor();
+      const dispatcherRequests: Array<Record<string, unknown>> = [];
+      const hitlRequests: unknown[] = [];
+      bus.subscribe("agent.skill.request", "test-dispatcher", (msg) => {
+        dispatcherRequests.push(msg.payload as Record<string, unknown>);
+      });
+      bus.subscribe("hitl.request.#", "test-hitl", (msg) => { hitlRequests.push(msg.payload); });
+
+      tracker = new TaskTracker({ bus, sweepIntervalMs: 20, defaultPollIntervalMs: 10 });
+      tracker.track({
+        correlationId: "c1", taskId: "t1", agentName: "quinn", skillName: "pr_review",
+        dispatcherAgent: "ava",
+        replyTopic: "agent.skill.response.c1", executor,
+      });
+
+      await new Promise(r => setTimeout(r, 40));
+      expect(dispatcherRequests).toHaveLength(1);
+
+      // Dispatcher replies with empty content — tracker should fall back
+      const replyTopic = dispatcherRequests[0].replyTopic as string;
+      bus.publish(replyTopic, {
+        id: "r1", correlationId: "x", topic: replyTopic, timestamp: Date.now(),
+        payload: { content: "", isError: false, correlationId: "x" },
+      });
+
+      await new Promise(r => setTimeout(r, 30));
+      expect(hitlRequests).toHaveLength(1);
     });
   });
 });

--- a/src/executor/__tests__/task-tracker.test.ts
+++ b/src/executor/__tests__/task-tracker.test.ts
@@ -278,7 +278,7 @@ describe("TaskTracker", () => {
         }),
         cancelTask: async () => ({ text: "", isError: false, correlationId: "c1" }),
         resubscribeTask: async () => { throw new Error("not used"); },
-        resumeTask: async (_taskId: string, text: string) => { resumedWith.push(text); },
+        resumeTask: async (_taskId: string, _contextId: string, text: string) => { resumedWith.push(text); },
       };
       return { executor: fake as unknown as A2AExecutor, resumedWith };
     }

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -102,14 +102,15 @@ const _worldCaches = new Map<string, WorldStateCache>();
 // These are all StructuredToolInterface at runtime, but TS can't unify them into a single
 // Record type because tool()'s zod v3/v4 interop overloads produce SchemaOutputT params
 // that don't widen back to the base interface defaults. Record stays loose; return is typed.
-function createLangChainTools(toolNames: string[], http: HttpClient, correlationId?: string): StructuredToolInterface[] {
+function createLangChainTools(toolNames: string[], http: HttpClient, correlationId?: string, agentName?: string): StructuredToolInterface[] {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const all: Record<string, any> = {
     chat_with_agent: tool(
       async (input) => {
         console.log(`[deep-agent:tool] chat_with_agent called: agent=${input.agent}, skill=${input.skill ?? "auto"}, msg="${input.message.slice(0, 80)}"`);
         try {
-          const result = await http.post("/api/a2a/chat", input);
+          const body = agentName ? { ...input, dispatcherAgent: agentName } : input;
+          const result = await http.post("/api/a2a/chat", body);
           console.log(`[deep-agent:tool] chat_with_agent returned: ${JSON.stringify(result).slice(0, 200)}`);
           return JSON.stringify(result);
         } catch (e) {
@@ -134,7 +135,10 @@ function createLangChainTools(toolNames: string[], http: HttpClient, correlation
       },
     ),
     delegate_task: tool(
-      async (input) => JSON.stringify(await http.post("/api/a2a/delegate", input)),
+      async (input) => {
+        const body = agentName ? { ...input, dispatcherAgent: agentName } : input;
+        return JSON.stringify(await http.post("/api/a2a/delegate", body));
+      },
       {
         name: "delegate_task",
         description: "Fire-and-forget: dispatch work to an agent.",
@@ -417,7 +421,7 @@ export class DeepAgentExecutor implements IExecutor {
 
   async execute(req: SkillRequest): Promise<SkillResult> {
     const prompt = req.content ?? req.prompt ?? this._buildPrompt(req);
-    const tools = createLangChainTools(this.agentDef.tools, this.http, req.correlationId);
+    const tools = createLangChainTools(this.agentDef.tools, this.http, req.correlationId, this.agentDef.name);
 
     const callbacks = LANGFUSE_ENABLED
       ? [new LangfuseCallbackHandler({

--- a/src/executor/extensions/hitl-mode.ts
+++ b/src/executor/extensions/hitl-mode.ts
@@ -57,6 +57,15 @@ export interface HitlModeDeclaration {
   mode: HitlMode;
   /** Per-skill TTL for veto mode, in ms. Ignored for other modes. */
   vetoTtlMs?: number;
+  /**
+   * Who answers `input-required` prompts. `"operator"` forces the prompt
+   * straight to the human renderer chain (Discord, etc.), bypassing the
+   * dispatching-agent caller-first chain. Absent means caller-first (the
+   * default): the dispatching agent gets the first shot via a chat skill
+   * invocation, and only falls back to the human if the dispatcher can't
+   * answer or doesn't reply within a TTL.
+   */
+  reviewer?: "operator";
   /** Optional human-readable reason for the declared mode. */
   note?: string;
 }
@@ -100,6 +109,14 @@ export class HitlModeRegistry {
 
   clear(): void {
     this.byKey.clear();
+  }
+
+  /** Drop every declaration for a given agent. Used on card-refresh so deletions propagate. */
+  clearAgent(agentName: string): void {
+    const prefix = `${agentName}::`;
+    for (const key of this.byKey.keys()) {
+      if (key.startsWith(prefix)) this.byKey.delete(key);
+    }
   }
 
   get size(): number {

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -231,6 +231,11 @@ export class SkillDispatcherPlugin implements Plugin {
     const goapGoalId: string | undefined =
       typeof payload.meta?.goalId === "string" ? payload.meta.goalId
       : (typeof payload.goalId === "string" ? payload.goalId : undefined);
+    // Name of the agent that issued this skill request (via chat_with_agent /
+    // delegate_task). Carried forward to TaskTracker so input-required prompts
+    // can route back to the dispatcher instead of straight to the operator.
+    const dispatcherAgent: string | undefined =
+      typeof payload.meta?.dispatcherAgent === "string" ? payload.meta.dispatcherAgent : undefined;
 
     let rawContent = typeof payload.content === "string" ? payload.content : undefined;
     const originalContent = rawContent; // preserved for episode storage — never includes context prefix
@@ -321,6 +326,7 @@ export class SkillDispatcherPlugin implements Plugin {
           correlationId,
           taskId,
           agentName: targets[0] ?? "unknown",
+          skillName: skill,
           replyTopic,
           executor: a2aExecutor,
           parentId,
@@ -328,6 +334,7 @@ export class SkillDispatcherPlugin implements Plugin {
           sourceInterface: sourcePlatform,
           sourceChannelId: sourceChannelId,
           sourceUserId: sourceUserId,
+          ...(dispatcherAgent ? { dispatcherAgent } : {}),
           onTerminal: (content, isError, taskState) => {
             this._publishAutonomousOutcome({
               correlationId,

--- a/src/executor/task-tracker.ts
+++ b/src/executor/task-tracker.ts
@@ -330,7 +330,7 @@ export class TaskTracker {
 
       const resp = msg.payload as AgentSkillResponsePayload | undefined;
       const answer = typeof resp?.content === "string" ? resp.content.trim() : "";
-      if (resp?.isError || !answer) {
+      if (resp?.error || !answer) {
         console.log(
           `[task-tracker] dispatcher ${dispatcher} returned empty/error reply — falling back to renderer chain`,
         );
@@ -379,7 +379,10 @@ export class TaskTracker {
     try {
       await task.executor.resumeTask(
         task.taskId,
+        task.taskId,
         `Dispatcher (${dispatcher}) response:\n${answerText}`,
+        task.correlationId,
+        task.parentId,
       );
       task.awaitingHuman = false;
       task.lastPolledAt = Date.now();

--- a/src/executor/task-tracker.ts
+++ b/src/executor/task-tracker.ts
@@ -15,9 +15,12 @@
 import type { EventBus, BusMessage, HITLRequest, HITLResponse } from "../../lib/types.ts";
 import type { A2AExecutor } from "./executors/a2a-executor.ts";
 import type { AgentSkillResponsePayload } from "../event-bus/payloads.ts";
+import { defaultHitlModeRegistry } from "./extensions/hitl-mode.ts";
 
 const TERMINAL_STATES = new Set(["completed", "failed", "canceled", "rejected"]);
 const HITL_TTL_MS = 30 * 60_000; // 30 min default input-required window
+/** Per-prompt deadline for the dispatching-agent caller-first chain. On timeout, fall back to Discord. */
+const DISPATCHER_REPLY_TIMEOUT_MS = 5 * 60_000; // 5 min
 
 /** Extension URI for worldstate-delta-v1 artifacts. */
 const WORLDSTATE_DELTA_URI = "https://protolabs.ai/a2a/ext/worldstate-delta-v1";
@@ -26,6 +29,10 @@ export interface TrackedTask {
   correlationId: string;
   taskId: string;
   agentName: string;
+  /** Skill name the sub-agent is running — needed for hitl-mode registry lookup. */
+  skillName?: string;
+  /** Name of the agent that dispatched this task (if any). Enables caller-first HITL routing. */
+  dispatcherAgent?: string;
   replyTopic: string;
   executor: A2AExecutor;
   parentId?: string;
@@ -99,6 +106,10 @@ export class TaskTracker {
     correlationId: string;
     taskId: string;
     agentName: string;
+    /** Skill name — enables hitl-mode registry lookup for input-required routing. */
+    skillName?: string;
+    /** Dispatching agent — enables caller-first HITL chain (agent answers before human). */
+    dispatcherAgent?: string;
     replyTopic: string;
     executor: A2AExecutor;
     parentId?: string;
@@ -117,6 +128,8 @@ export class TaskTracker {
       correlationId: params.correlationId,
       taskId: params.taskId,
       agentName: params.agentName,
+      skillName: params.skillName,
+      dispatcherAgent: params.dispatcherAgent,
       replyTopic: params.replyTopic,
       executor: params.executor,
       parentId: params.parentId,
@@ -258,9 +271,16 @@ export class TaskTracker {
   }
 
   /**
-   * Emit a HITL request for a task that hit input-required. HITLPlugin will
-   * route to the registered renderer (Discord approval buttons, etc). The
-   * response flows back via hitl.response.# which we subscribe to.
+   * Decide who answers an `input-required` prompt and route accordingly.
+   *
+   * Caller-first chain (the default when a dispatching agent is known):
+   *   1. hitl-mode-v1 declaration says `reviewer: "operator"` → skip to step 3
+   *   2. dispatcherAgent present → publish a chat skill-request to the
+   *      dispatcher; on reply within the deadline, resume the sub-agent's
+   *      task with the dispatcher's answer. No Discord prompt is raised
+   *      unless this path fails.
+   *   3. Fallback: emit the traditional `hitl.request.*` event so the
+   *      registered renderer (Discord, Plane) asks a human.
    */
   private _raiseHitl(task: TrackedTask, question: string | undefined): void {
     if (task.awaitingHuman) return; // already raised, avoid duplicate
@@ -269,16 +289,127 @@ export class TaskTracker {
     // input-required) surface which prompt this is in the sequence. 1-based.
     task.checkpointCount = (task.checkpointCount ?? 0) + 1;
 
+    const decl = task.skillName
+      ? defaultHitlModeRegistry.get(task.agentName, task.skillName)
+      : undefined;
+    const forceOperator = decl?.reviewer === "operator";
+
+    if (task.dispatcherAgent && !forceOperator) {
+      this._askDispatcher(task, question);
+      return;
+    }
+
+    this._emitHitlRequest(task, question);
+  }
+
+  /**
+   * Ask the dispatching agent to answer an `input-required` prompt from one
+   * of its sub-agents. Publishes a `chat` skill-request to the dispatcher,
+   * waits up to DISPATCHER_REPLY_TIMEOUT_MS for a reply, and resumes the
+   * sub-agent's task with the answer. Falls back to the human renderer path
+   * on timeout, empty reply, or error.
+   */
+  private _askDispatcher(task: TrackedTask, question: string | undefined): void {
+    const dispatcher = task.dispatcherAgent!;
+    const promptCorrelationId = crypto.randomUUID();
+    const promptReplyTopic = `agent.skill.response.${promptCorrelationId}`;
+    const promptText = [
+      `${task.agentName} is asking for input on the "${task.skillName ?? "current"}" task:`,
+      "",
+      question || "(no question text provided)",
+      "",
+      "Reply with the decision or context needed for the task to continue. Keep it concise.",
+    ].join("\n");
+
+    let settled = false;
+    const subId = this.bus.subscribe(promptReplyTopic, "task-tracker-hitl-reply", (msg: BusMessage) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      this.bus.unsubscribe(subId);
+
+      const resp = msg.payload as AgentSkillResponsePayload | undefined;
+      const answer = typeof resp?.content === "string" ? resp.content.trim() : "";
+      if (resp?.isError || !answer) {
+        console.log(
+          `[task-tracker] dispatcher ${dispatcher} returned empty/error reply — falling back to renderer chain`,
+        );
+        this._emitHitlRequest(task, question);
+        return;
+      }
+
+      void this._resumeFromDispatcher(task, answer, dispatcher);
+    });
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      this.bus.unsubscribe(subId);
+      console.log(
+        `[task-tracker] dispatcher ${dispatcher} did not reply within ${DISPATCHER_REPLY_TIMEOUT_MS}ms — falling back to renderer chain`,
+      );
+      this._emitHitlRequest(task, question);
+    }, DISPATCHER_REPLY_TIMEOUT_MS);
+    (timer as { unref?: () => void }).unref?.();
+
+    this.bus.publish("agent.skill.request", {
+      id: crypto.randomUUID(),
+      correlationId: promptCorrelationId,
+      topic: "agent.skill.request",
+      timestamp: Date.now(),
+      payload: {
+        skill: "chat",
+        content: promptText,
+        targets: [dispatcher],
+        replyTopic: promptReplyTopic,
+      },
+    });
+
+    console.log(
+      `[task-tracker] input-required from ${task.agentName} — routing to dispatcher ${dispatcher} (correlationId: ${task.correlationId.slice(0, 8)}…)`,
+    );
+  }
+
+  /**
+   * Resume the sub-agent's task after the dispatching agent has supplied an
+   * answer to an `input-required` prompt. Mirrors _resumeFromHitl but carries
+   * agent-sourced text instead of a structured human decision.
+   */
+  private async _resumeFromDispatcher(task: TrackedTask, answerText: string, dispatcher: string): Promise<void> {
+    try {
+      await task.executor.resumeTask(
+        task.taskId,
+        `Dispatcher (${dispatcher}) response:\n${answerText}`,
+      );
+      task.awaitingHuman = false;
+      task.lastPolledAt = Date.now();
+      console.log(
+        `[task-tracker] Resumed ${task.agentName} task ${task.taskId.slice(0, 8)}… with dispatcher answer`,
+      );
+    } catch (err) {
+      console.error(`[task-tracker] resumeTask after dispatcher reply failed:`, err);
+      // Fall back to human path so the task doesn't hang
+      this._emitHitlRequest(task, answerText);
+    }
+  }
+
+  /**
+   * Publish the traditional `hitl.request.{correlationId}` event for the
+   * HITL plugin to render (Discord button, Plane comment, etc.). Used both
+   * as the direct operator-only path and as a fallback from the dispatcher
+   * caller-first chain.
+   */
+  private _emitHitlRequest(task: TrackedTask, question: string | undefined): void {
     const req: HITLRequest = {
       type: "hitl_request",
       correlationId: task.correlationId,
-      title: task.checkpointCount > 1
+      title: (task.checkpointCount ?? 1) > 1
         ? `Input needed from ${task.agentName} (checkpoint ${task.checkpointCount})`
         : `Input needed from ${task.agentName}`,
       summary: question || "The agent is requesting input to continue.",
       options: ["approve", "reject"],
       expiresAt: new Date(Date.now() + HITL_TTL_MS).toISOString(),
-      checkpoint: { index: task.checkpointCount },
+      checkpoint: { index: task.checkpointCount ?? 1 },
       replyTopic: `hitl.response.${task.correlationId}`,
       sourceMeta: {
         interface: task.sourceInterface ?? "discord",

--- a/src/plugins/skill-broker-plugin.ts
+++ b/src/plugins/skill-broker-plugin.ts
@@ -26,6 +26,11 @@ import type { Plugin, EventBus } from "../../lib/types.ts";
 import type { ExecutorRegistry } from "../executor/executor-registry.ts";
 import { A2AExecutor } from "../executor/executors/a2a-executor.ts";
 import { resolveEnvVars } from "../utils/env-interpolation.ts";
+import {
+  defaultHitlModeRegistry,
+  HITL_MODE_URI,
+  type HitlMode,
+} from "../executor/extensions/hitl-mode.ts";
 
 interface AgentSkill {
   name: string;
@@ -262,8 +267,48 @@ export class SkillBrokerPlugin implements Plugin {
       if (added > 0) {
         console.log(`[skill-broker] ${agent.name}: discovered ${added} new skill(s) from agent card (${Array.from(registered).join(", ")})`);
       }
+
+      this._loadHitlModeDeclarations(agent.name, card);
     } catch (err) {
       console.debug(`[skill-broker] ${agent.name}: card discovery skipped:`, err instanceof Error ? err.message : err);
+    }
+  }
+
+  /**
+   * Parse `capabilities.extensions[hitl-mode-v1].params.skills` and populate
+   * the shared HITL-mode registry. Clears the agent's prior entries first so
+   * deletions on the agent's card propagate through.
+   */
+  private _loadHitlModeDeclarations(agentName: string, card: AgentCard): void {
+    defaultHitlModeRegistry.clearAgent(agentName);
+
+    const ext = (card.capabilities?.extensions ?? []).find(e => e?.uri === HITL_MODE_URI);
+    if (!ext) return;
+
+    const params = (ext.params ?? {}) as { skills?: Record<string, unknown> };
+    const entries = params.skills && typeof params.skills === "object" ? params.skills : {};
+    let declared = 0;
+
+    for (const [skill, rawEntry] of Object.entries(entries)) {
+      const entry = rawEntry as { mode?: unknown; vetoTtlMs?: unknown; reviewer?: unknown; note?: unknown } | undefined;
+      if (!entry || typeof entry !== "object") continue;
+      const mode = entry.mode;
+      if (typeof mode !== "string") continue;
+      if (!["autonomous", "notification", "veto", "gated", "compound"].includes(mode)) continue;
+
+      defaultHitlModeRegistry.declare({
+        agentName,
+        skill,
+        mode: mode as HitlMode,
+        ...(typeof entry.vetoTtlMs === "number" ? { vetoTtlMs: entry.vetoTtlMs } : {}),
+        ...(entry.reviewer === "operator" ? { reviewer: "operator" as const } : {}),
+        ...(typeof entry.note === "string" ? { note: entry.note } : {}),
+      });
+      declared++;
+    }
+
+    if (declared > 0) {
+      console.log(`[skill-broker] ${agentName}: loaded ${declared} hitl-mode declaration(s)`);
     }
   }
 


### PR DESCRIPTION
## Summary

Closes board feature \`feature-1776289055472-whkki7rm3\` — routes \`input-required\` prompts back to the dispatching agent before falling back to the human renderer.

**Before:** sub-agent input-required → Discord button → human is the only reviewer (context-blind).
**After:** sub-agent input-required → dispatching agent (e.g. Ava) answers from context → sub-agent resumes. Human is the fallback on timeout, empty reply, or explicit \`reviewer: "operator"\` override.

## End-to-end flow

\`\`\`
Ava.chat_with_agent(quinn, pr_review)
  ↓   stamps meta.dispatcherAgent: "ava" on agent.skill.request
Quinn.pr_review returns input-required("Should I mark ready to merge?")
  ↓   TaskTracker sees dispatcherAgent + no operator override
TaskTracker → agent.skill.request { skill: "chat", targets: ["ava"], content: "<question>" }
  ↓   Ava answers from LangGraph context
TaskTracker.resumeTask(quinn.taskId, "Dispatcher (ava) response: …")
  ↓   Quinn continues the task with Ava's input
No Discord prompt fired.
\`\`\`

## Files changed

| File | Change |
|---|---|
| \`src/executor/task-tracker.ts\` | Split \`_raiseHitl\` into branching \`_askDispatcher\` + \`_emitHitlRequest\` + \`_resumeFromDispatcher\`; add 5-min dispatcher reply TTL with Discord fallback |
| \`src/plugins/skill-broker-plugin.ts\` | New \`_loadHitlModeDeclarations\` — parses \`capabilities.extensions[hitl-mode-v1].params.skills\` on card refresh (fixes pre-existing bug: registry was never populated) |
| \`src/executor/extensions/hitl-mode.ts\` | Add \`reviewer?: "operator"\` field; add \`clearAgent(name)\` helper for refresh-time resets |
| \`src/event-bus/payloads.ts\` | Add \`meta.dispatcherAgent\` on \`AgentSkillRequestPayload\` |
| \`src/executor/executors/deep-agent-executor.ts\` | \`createLangChainTools\` accepts \`agentName\`; \`chat_with_agent\` + \`delegate_task\` stamp \`dispatcherAgent\` on HTTP body |
| \`src/api/ava-tools.ts\` | \`/api/a2a/chat\` + \`/api/a2a/delegate\` forward \`dispatcherAgent\` into \`SkillRequest.payload.meta\` |
| \`src/executor/skill-dispatcher-plugin.ts\` | Extract \`payload.meta.dispatcherAgent\` and pass to \`tracker.track()\` along with \`skillName\` |
| \`src/executor/__tests__/task-tracker.test.ts\` | +3 tests: dispatcher-first, operator-override, empty-reply fallback |
| \`docs/extensions/hitl-mode-v1.md\` | Flip status from "pending" to "live" for caller-first |

## Pre-existing bug fixed in-scope

The hitl-mode-v1 registry was never populated from agent cards — the interceptor ran on every A2A call but always hit an empty map, so \`x-hitl-mode\` metadata stamping was dead code. Now wired correctly via \`SkillBrokerPlugin._loadHitlModeDeclarations\` on each 10-min card refresh. Same gap exists for \`blast-v1\` — filed as follow-up \`feature-1776303349701-g7olxwk09\`.

## Verification

- \`bun test\` — 946 pass / 0 fail (+3 new task-tracker cases)
- Operator-override test confirms \`reviewer: "operator"\` short-circuits to Discord even when dispatcher is set
- Empty-reply test confirms graceful fallback to Discord on empty dispatcher answer

## Test plan

- [ ] CI green
- [ ] Smoke test (post-deploy): Ava delegates \`pr_review\` to Quinn with a deliberately ambiguous PR. Logs should show \`routing to dispatcher ava\`, then Quinn resumes without a Discord prompt.
- [ ] Operator-override smoke: declare \`security_triage: { mode: "gated", reviewer: "operator" }\` on Quinn's card, force input-required, verify Discord prompt fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented caller-first reviewer resolution: when an agent requests human input, the system now routes the request back to the originating agent before escalating to a human operator.
  * Added `reviewer: "operator"` option to force direct human routing, bypassing agent-to-agent escalation.

* **Documentation**
  * Updated HITL mode documentation to reflect live implementation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->