### PR TITLE
fix: webhook dedup + blast-v1 registry + suppress skill echo

### DIFF
--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -328,6 +328,7 @@ export class GitHubPlugin implements Plugin {
 
       const content = String((msg.payload as Record<string, unknown>).content ?? "").trim();
       if (!content) return;
+      if (/^Skill ".+" completed by \w+$/i.test(content)) return;
 
       await this._postComment(getToken, pending, content);
     });
@@ -552,6 +553,10 @@ export class GitHubPlugin implements Plugin {
     console.log(`[github] ${event} on ${ctx.owner}/${ctx.repo}#${ctx.number} → ${skillHint ?? "default"}`);
   }
 
+  /** Tracks recently-dispatched (owner/repo#number) to suppress duplicate webhook deliveries. */
+  private recentDispatches = new Map<string, number>();
+  private static readonly DEDUP_WINDOW_MS = 60_000;
+
   private _handleAutoTriage(
     event: string,
     payload: Record<string, unknown>,
@@ -560,6 +565,14 @@ export class GitHubPlugin implements Plugin {
     bus: EventBus,
     getToken: (owner: string, repo: string) => Promise<string>,
   ): void {
+    const dedupKey = `${ctx.owner}/${ctx.repo}#${ctx.number}`;
+    const lastDispatched = this.recentDispatches.get(dedupKey);
+    if (lastDispatched && Date.now() - lastDispatched < GitHubPlugin.DEDUP_WINDOW_MS) {
+      console.log(`[github] Auto-triage: skipping duplicate ${dedupKey} (dispatched ${Date.now() - lastDispatched}ms ago)`);
+      return;
+    }
+    this.recentDispatches.set(dedupKey, Date.now());
+
     (async () => {
       try {
         const token = await getToken(ctx.owner, ctx.repo);

--- a/src/executor/extensions/blast.ts
+++ b/src/executor/extensions/blast.ts
@@ -102,6 +102,13 @@ export class BlastRegistry {
     this.byKey.clear();
   }
 
+  clearAgent(agentName: string): void {
+    const prefix = `${agentName}::`;
+    for (const key of this.byKey.keys()) {
+      if (key.startsWith(prefix)) this.byKey.delete(key);
+    }
+  }
+
   get size(): number {
     return this.byKey.size;
   }

--- a/src/plugins/skill-broker-plugin.ts
+++ b/src/plugins/skill-broker-plugin.ts
@@ -31,6 +31,11 @@ import {
   HITL_MODE_URI,
   type HitlMode,
 } from "../executor/extensions/hitl-mode.ts";
+import {
+  defaultBlastRegistry,
+  BLAST_URI,
+  type BlastRadius,
+} from "../executor/extensions/blast.ts";
 
 interface AgentSkill {
   name: string;
@@ -269,6 +274,7 @@ export class SkillBrokerPlugin implements Plugin {
       }
 
       this._loadHitlModeDeclarations(agent.name, card);
+      this._loadBlastDeclarations(agent.name, card);
     } catch (err) {
       console.debug(`[skill-broker] ${agent.name}: card discovery skipped:`, err instanceof Error ? err.message : err);
     }
@@ -309,6 +315,36 @@ export class SkillBrokerPlugin implements Plugin {
 
     if (declared > 0) {
       console.log(`[skill-broker] ${agentName}: loaded ${declared} hitl-mode declaration(s)`);
+    }
+  }
+
+  private _loadBlastDeclarations(agentName: string, card: AgentCard): void {
+    defaultBlastRegistry.clearAgent(agentName);
+
+    const ext = (card.capabilities?.extensions ?? []).find(e => e?.uri === BLAST_URI);
+    if (!ext) return;
+
+    const params = (ext.params ?? {}) as { skills?: Record<string, unknown> };
+    const entries = params.skills && typeof params.skills === "object" ? params.skills : {};
+    const validRadii = new Set(["self", "project", "repo", "fleet", "public"]);
+    let declared = 0;
+
+    for (const [skill, rawEntry] of Object.entries(entries)) {
+      const entry = rawEntry as { radius?: unknown; note?: unknown } | undefined;
+      if (!entry || typeof entry !== "object") continue;
+      if (typeof entry.radius !== "string" || !validRadii.has(entry.radius)) continue;
+
+      defaultBlastRegistry.declare({
+        agentName,
+        skill,
+        radius: entry.radius as BlastRadius,
+        ...(typeof entry.note === "string" ? { note: entry.note } : {}),
+      });
+      declared++;
+    }
+
+    if (declared > 0) {
+      console.log(`[skill-broker] ${agentName}: loaded ${declared} blast declaration(s)`);
     }
   }
 


### PR DESCRIPTION
## Summary

Three low-complexity board items bundled — all in `lib/plugins/github.ts` and `src/plugins/skill-broker-plugin.ts`.

### 1. Webhook dedup (feature-1776307294155)

GitHub delivers duplicate \`issues.opened\` events. The webhook handler now tracks recently-dispatched \`(owner/repo#number)\` tuples with a 60s window. Duplicates are logged and skipped. Root cause of Quinn's 4x comment on issue #359.

### 2. Suppress skill-response echo

The outbound handler posted raw \`SkillResult.text\` (\`"Skill bug_triage completed by quinn"\`) as a GitHub comment alongside Quinn's own triage analysis. Now filters out single-line "completed by" stubs via regex guard.

### 3. Blast-v1 registry population (feature-1776303349701)

Same pre-existing bug as hitl-mode-v1 (fixed in #356): \`defaultBlastRegistry\` was never populated from agent cards. Now wired via \`SkillBrokerPlugin._loadBlastDeclarations()\` on the 10-min card refresh. Adds \`clearAgent()\` to \`BlastRegistry\` for refresh-time resets.

## Test plan

- [ ] CI green (946 pass / 0 fail locally)
- [ ] Post-deploy: file a test GitHub issue, verify single triage comment (no duplicates)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * GitHub plugin now filters skill completion notification messages and deduplicates auto-triage events within a 60-second window.

* **New Features**
  * Added agent-scoped deletion capability for blast declarations.
  * Skill discovery flow now includes blast declaration loading during card discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->