### PR TITLE
fix: streaming early-break + push-callback URL routing

### DIFF
--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -152,6 +152,11 @@ export class A2AExecutor implements IExecutor {
     return this.config.name;
   }
 
+  /** Expose the configured agent URL so the dispatcher can pick an appropriate callback base URL. */
+  get url(): string {
+    return this.config.url;
+  }
+
   /**
    * Update the streaming + pushNotifications capability flags from the agent
    * card. Called by SkillBrokerPlugin after every card discovery pass so the
@@ -457,6 +462,16 @@ export class A2AExecutor implements IExecutor {
           // Extract worldstate-delta parts from seeded task snapshot
           const delta = this._worldStateDeltaFromParts(artifact.parts);
           if (delta) streamDeltaData[WORLDSTATE_DELTA_MIME_TYPE] = delta;
+        }
+        // Non-terminal state (submitted / working / input-required) on the
+        // initial task event → stop consuming the SSE stream and let
+        // TaskTracker drive the task to completion via tasks/get polling.
+        // Holding the stream open longer forces slow agents to keep their
+        // SSE generator alive for minutes, which crashes them when the
+        // sync caller eventually times out and closes the connection.
+        if (taskState !== "completed" && taskState !== "failed"
+          && taskState !== "canceled" && taskState !== "rejected") {
+          break;
         }
         continue;
       }

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -361,7 +361,15 @@ export class SkillDispatcherPlugin implements Plugin {
         // burn a round-trip on every long-running task against every agent,
         // most of which reject. SkillBrokerPlugin refreshes the flag every
         // 10 min so capability changes land automatically.
-        const callbackBaseUrl = process.env.WORKSTACEAN_BASE_URL;
+        //
+        // Callback URL routing:
+        //   - Docker-internal agents (hostname like `http://quinn:7870`) use
+        //     WORKSTACEAN_INTERNAL_BASE_URL (default http://workstacean:3000)
+        //     which resolves inside the shared docker network.
+        //   - External agents reached over Tailscale / public networks
+        //     (hostname has a dot, e.g. `http://host.tailnet.ts.net:...`)
+        //     use WORKSTACEAN_BASE_URL — the operator-configured public URL.
+        const callbackBaseUrl = this._pickCallbackBaseUrl(a2aExecutor.url);
         if (callbackBaseUrl && a2aExecutor.pushNotifications) {
           const callbackUrl = `${callbackBaseUrl.replace(/\/$/, "")}/api/a2a/callback/${encodeURIComponent(taskId)}`;
           void a2aExecutor.registerPushNotification(taskId, callbackUrl, callbackToken, correlationId, parentId)
@@ -599,6 +607,29 @@ export class SkillDispatcherPlugin implements Plugin {
       timestamp: Date.now(),
       payload,
     });
+  }
+
+  /**
+   * Pick the callback base URL for push notifications based on whether the
+   * target agent is docker-internal or external. Docker service names are
+   * short hostnames (no dots); external hosts use FQDNs or IPs.
+   *
+   * Internal default: http://workstacean:3000 (resolves on shared docker net).
+   * External default: process.env.WORKSTACEAN_BASE_URL.
+   */
+  private _pickCallbackBaseUrl(agentUrl: string | undefined): string | undefined {
+    if (!agentUrl) return process.env.WORKSTACEAN_BASE_URL;
+    try {
+      const { hostname } = new URL(agentUrl);
+      // Docker service names are single-label (no dot, not an IP).
+      const isDockerInternal = !hostname.includes(".") && !hostname.includes(":");
+      if (isDockerInternal) {
+        return process.env.WORKSTACEAN_INTERNAL_BASE_URL ?? "http://workstacean:3000";
+      }
+      return process.env.WORKSTACEAN_BASE_URL;
+    } catch {
+      return process.env.WORKSTACEAN_BASE_URL;
+    }
   }
 
   private async _fileTriageOnBoard(


### PR DESCRIPTION
## Summary

Two fixes discovered during end-to-end Quinn testing via Ava.

### 1. Streaming early-break (closes feature-1776309307266)

\`A2AExecutor._executeStream\` held the SSE connection open after receiving a non-terminal \`task\` event, waiting for more stream events. Quinn (and agents like her) use the stream transport only for the initial \`submitted\` event, then do the work in the background. Holding the stream open for 2+ minutes until the sync caller times out was crashing her SSE generator with \`GeneratorExit\` (visible in Quinn's logs on every long-running task).

**Fix**: on non-terminal task events, break out of the SSE loop and let TaskTracker drive the task to completion via polling / resubscribe. Terminal states still flow through the stream end-to-end.

### 2. Push-callback URL routing (closes feature-1776309298112)

\`WORKSTACEAN_BASE_URL\` is set to \`http://ava:8081\` (the host's Tailscale MagicDNS name) so protoPen — running externally on steamdeck — can reach the callback. But internal docker agents resolve \`ava\` to their own 127.0.1.1, so the callback URL is unreachable from inside the shared docker network.

**Fix**: \`SkillDispatcherPlugin._pickCallbackBaseUrl\` inspects the target agent's URL. Single-label hostnames (docker service names like \`http://quinn:7870\`) get \`WORKSTACEAN_INTERNAL_BASE_URL\` (default \`http://workstacean:3000\`). FQDN/IP hosts get the existing \`WORKSTACEAN_BASE_URL\`.

Exposes \`A2AExecutor.url\` as a public getter so the dispatcher can see the agent URL without piercing config.

## Test plan

- [x] \`bun test\` — 946 pass / 0 fail
- [ ] CI green
- [ ] Post-deploy: Ava dispatches to Quinn, verify no \`GeneratorExit\` in Quinn's logs
- [ ] Post-deploy: verify push-notification callback URL is \`http://workstacean:3000/api/a2a/callback/...\` for Quinn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Streamlined task execution by optimizing SSE event handling for non-terminal states, reducing unnecessary event consumption during task processing
  * Improved push-notification reliability by enhancing callback URL routing to intelligently select endpoints based on agent deployment location and network configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->