### PR TITLE
fix(a2a): graceful fallback to message/send on empty streaming result

### DIFF
--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -227,9 +227,24 @@ export class A2AExecutor implements IExecutor {
         },
       };
 
-      const result = this.config.streaming
+      let result = this.config.streaming
         ? await this._executeStream(client, params, req)
         : await this._executeBlocking(client, params, req);
+
+      // Graceful degradation: if the streaming path returned nothing usable
+      // (no taskId, no terminal text), the agent's SSE events likely don't
+      // match the @a2a-js/sdk discriminator shape (missing `kind` field or
+      // similar). Fall through to message/send so the dispatcher + TaskTracker
+      // still get a proper Task handle to work with. Logs the slip so we can
+      // spot agents that need a spec-compliance fix.
+      if (this.config.streaming && !result.isError
+        && !result.data?.taskId
+        && (!result.text || result.text.startsWith(`Skill "${req.skill}" completed by`))) {
+        console.warn(
+          `[a2a-executor] ${this.config.name}: streaming returned empty result — falling back to message/send (agent SSE events may be missing "kind" field)`,
+        );
+        result = await this._executeBlocking(client, params, req);
+      }
 
       // Run extension after-hooks — they read result.data (usage, confidence,
       // worldstate-delta) and emit observability events or record samples.


### PR DESCRIPTION
## Summary

If the SSE streaming path returns an empty result (no taskId, no terminal text, just the default placeholder), A2AExecutor now falls through to \`message/send\` so the dispatcher + TaskTracker still get a proper Task handle to work with.

## Why

Discovered during e2e Quinn testing: every Ava → Quinn dispatch was returning the placeholder "Skill X completed by Y" text and bypassing TaskTracker. Root cause: Quinn's SSE events lack the \`kind\` field that \`@a2a-js/sdk\` uses to discriminate Task / status-update / artifact-update events. The SDK silently filters out non-conforming events and the stream loop exits with empty state.

Filed as [protoLabsAI/quinn#40](https://github.com/protoLabsAI/quinn/issues/40) for Quinn-side spec compliance.

## Behavior

- When streaming returns a result with no \`taskId\` and only the default "completed by" text, the executor retries with \`message/send\`.
- Logs a warning (\`[a2a-executor] {name}: streaming returned empty result — falling back to message/send\`) so we can spot agents that need a spec fix.
- Agents that produce proper streaming results are unaffected — the fallback only kicks in when the stream yields nothing usable.

## Test plan

- [ ] CI green
- [ ] Post-deploy: Ava dispatches to Quinn — warning log appears once, then TaskTracker picks up the task via the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)