### PR TITLE
fix(a2a): surface push-notification registration failures visibly

### DIFF
--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -310,8 +310,11 @@ export class A2AExecutor implements IExecutor {
         pushNotificationConfig: { url: callbackUrl, token },
       });
       return true;
-    } catch {
+    } catch (err) {
       // Agent doesn't support push notifications — tracker falls back to polling
+      console.log(
+        `[a2a-executor] ${this.config.name}: push-notification register failed for ${taskId.slice(0, 8)}… — ${err instanceof Error ? err.message : String(err)}`,
+      );
       return false;
     }
   }

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -374,9 +374,10 @@ export class SkillDispatcherPlugin implements Plugin {
           const callbackUrl = `${callbackBaseUrl.replace(/\/$/, "")}/api/a2a/callback/${encodeURIComponent(taskId)}`;
           void a2aExecutor.registerPushNotification(taskId, callbackUrl, callbackToken, correlationId, parentId)
             .then(ok => {
-              if (ok) console.log(`[skill-dispatcher] Push-notification registered for ${taskId.slice(0, 8)}…`);
+              if (ok) console.log(`[skill-dispatcher] Push-notification registered for ${taskId.slice(0, 8)}… at ${callbackUrl}`);
+              // Failure path is logged by A2AExecutor.registerPushNotification with agent + reason.
             })
-            .catch(err => console.debug("[skill-dispatcher] push-notification register failed:", err));
+            .catch(err => console.log("[skill-dispatcher] push-notification register failed:", err));
         } else if (callbackBaseUrl) {
           console.log(
             `[skill-dispatcher] ${a2aExecutor.name}: card.capabilities.pushNotifications=false — using polling for ${taskId.slice(0, 8)}…`,


### PR DESCRIPTION
## Summary

Small but material diagnostic fix discovered during e2e Quinn testing.

Previously \`A2AExecutor.registerPushNotification\` swallowed any JSON-RPC error from the agent silently and returned \`false\`, which meant push-notification failures were invisible in logs. The bug that hid behind this: Quinn's SSRF guard was rejecting every workstacean callback URL as RFC1918, and we only saw "no push log" — not "push was rejected for reason X".

## Changes

- \`A2AExecutor.registerPushNotification\` logs the rejection reason on catch before returning \`false\`. Boolean contract preserved so \`TaskTracker\`'s polling fallback still kicks in.
- \`SkillDispatcherPlugin\` push-registered log now includes the full callback URL — useful for cross-network routing verification.
- Dispatcher \`.catch\` elevated from \`console.debug\` to \`console.log\`.

## Verification

Live post-deploy (v0.7.13 + Quinn v0.1.5 with SSRF allowlist):

\`\`\`
[task-tracker] Tracking quinn task 9073f267…
[skill-dispatcher] Push-notification registered for 9073f267… at http://workstacean:3000/api/a2a/callback/9073f267-c9ea-4ec1-8d3f-86972e9201a4
\`\`\`

Before this PR the same flow produced only the "Tracking" line; registration failures were silent.

## Test plan

- [ ] CI green
- [ ] Post-deploy: next Quinn dispatch logs either a registered URL or a visible reject reason

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error logging for push notification registration failures, providing more detailed diagnostic information when issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->