### PR TITLE
feat(a2a): extract cost-v1 + confidence-v1 DataParts from Task responses

### DIFF
--- a/lib/types/confidence-v1.ts
+++ b/lib/types/confidence-v1.ts
@@ -1,0 +1,35 @@
+/**
+ * x-protolabs/confidence-v1 — artifact type for self-reported confidence.
+ *
+ * Agents emit a `kind: "data"` artifact part with this MIME type on their
+ * terminal Task to report how confident they are in the result. The
+ * confidence-v1 interceptor reads these fields off `result.data` (flattened
+ * by A2AExecutor), records a sample in `defaultConfidenceStore`, and emits
+ * calibration warnings when high-confidence tasks fail.
+ *
+ * MIME type: application/vnd.protolabs.confidence-v1+json
+ *
+ * Artifact part shape (A2A DataPart):
+ *   {
+ *     kind: "data",
+ *     data: ConfidenceArtifactData,
+ *     metadata: { mimeType: CONFIDENCE_V1_MIME_TYPE }
+ *   }
+ */
+
+/** Registered MIME type for confidence-v1 artifact parts. */
+export const CONFIDENCE_V1_MIME_TYPE =
+  "application/vnd.protolabs.confidence-v1+json";
+
+/**
+ * The `data` payload of an artifact part with
+ * `mimeType: CONFIDENCE_V1_MIME_TYPE`.
+ */
+export interface ConfidenceArtifactData {
+  /** Self-reported confidence in [0, 1]. Consumers defensively clamp out-of-range. */
+  confidence: number;
+  /** Free-text reasoning — surfaced in calibration views. */
+  explanation?: string;
+  /** Explicit success flag — overrides taskState when present. */
+  success?: boolean;
+}

--- a/lib/types/cost-v1.ts
+++ b/lib/types/cost-v1.ts
@@ -1,0 +1,44 @@
+/**
+ * x-protolabs/cost-v1 — artifact type for observed skill cost and duration.
+ *
+ * Agents emit a `kind: "data"` artifact part with this MIME type on their
+ * terminal Task to report what the skill actually cost (token usage, wall
+ * time, optional $USD). The cost-v1 interceptor reads these fields off
+ * `result.data` (flattened by A2AExecutor), records a sample in
+ * `defaultCostStore`, and publishes `autonomous.cost.*` for dashboards +
+ * planner ranking.
+ *
+ * MIME type: application/vnd.protolabs.cost-v1+json
+ *
+ * Artifact part shape (A2A DataPart):
+ *   {
+ *     kind: "data",
+ *     data: CostArtifactData,
+ *     metadata: { mimeType: COST_V1_MIME_TYPE }
+ *   }
+ */
+
+/** Registered MIME type for cost-v1 artifact parts. */
+export const COST_V1_MIME_TYPE = "application/vnd.protolabs.cost-v1+json";
+
+/** Token usage snapshot — Anthropic-shaped but framework-agnostic. */
+export interface CostArtifactUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+}
+
+/**
+ * The `data` payload of an artifact part with
+ * `mimeType: COST_V1_MIME_TYPE`.
+ */
+export interface CostArtifactData {
+  usage: CostArtifactUsage;
+  /** Wall-clock duration in milliseconds. */
+  durationMs?: number;
+  /** Dollar cost. If omitted, the consumer can compute from tokens + MODEL_RATES. */
+  costUsd?: number;
+  /** Explicit success flag — overrides taskState when present. */
+  success?: boolean;
+}

--- a/src/executor/__tests__/a2a-executor-cost-confidence.test.ts
+++ b/src/executor/__tests__/a2a-executor-cost-confidence.test.ts
@@ -1,0 +1,108 @@
+import { describe, test, expect } from "bun:test";
+import { A2AExecutor } from "../executors/a2a-executor.ts";
+import { COST_V1_MIME_TYPE } from "../../../lib/types/cost-v1.ts";
+import { CONFIDENCE_V1_MIME_TYPE } from "../../../lib/types/confidence-v1.ts";
+
+// Access the private extractors via `as any` — we're asserting pure-function
+// behavior on part arrays, not the full execute() plumbing.
+type PartsScan = {
+  _costFromParts(parts: unknown[]): unknown;
+  _confidenceFromParts(parts: unknown[]): unknown;
+  _flattenExtensionData(cost: unknown, confidence: unknown, taskState: string): Record<string, unknown>;
+};
+
+function makeExec(): PartsScan {
+  const exec = new A2AExecutor({
+    name: "quinn",
+    url: "http://quinn:7870/a2a",
+    streaming: false,
+    pushNotifications: false,
+  });
+  return exec as unknown as PartsScan;
+}
+
+describe("A2AExecutor cost-v1 / confidence-v1 extraction", () => {
+  test("_costFromParts returns the cost payload on match", () => {
+    const exec = makeExec();
+    const parts = [
+      { kind: "text", text: "ignored" },
+      {
+        kind: "data",
+        data: {
+          usage: { input_tokens: 1500, output_tokens: 420, cache_read_input_tokens: 120 },
+          durationMs: 4200,
+          costUsd: 0.0123,
+        },
+        metadata: { mimeType: COST_V1_MIME_TYPE },
+      },
+    ];
+    const cost = exec._costFromParts(parts) as { usage: { input_tokens: number }; durationMs: number; costUsd: number };
+    expect(cost).toBeDefined();
+    expect(cost.usage.input_tokens).toBe(1500);
+    expect(cost.durationMs).toBe(4200);
+    expect(cost.costUsd).toBe(0.0123);
+  });
+
+  test("_costFromParts returns undefined when no matching part", () => {
+    const exec = makeExec();
+    expect(exec._costFromParts([{ kind: "text", text: "hi" }])).toBeUndefined();
+    expect(exec._costFromParts([
+      { kind: "data", data: { foo: "bar" }, metadata: { mimeType: "application/other+json" } },
+    ])).toBeUndefined();
+  });
+
+  test("_confidenceFromParts returns payload with explanation", () => {
+    const exec = makeExec();
+    const parts = [
+      {
+        kind: "data",
+        data: { confidence: 0.88, explanation: "spec unambiguous; all tests pass" },
+        metadata: { mimeType: CONFIDENCE_V1_MIME_TYPE },
+      },
+    ];
+    const c = exec._confidenceFromParts(parts) as { confidence: number; explanation: string };
+    expect(c.confidence).toBe(0.88);
+    expect(c.explanation).toBe("spec unambiguous; all tests pass");
+  });
+
+  test("_flattenExtensionData merges cost + confidence onto result.data shape", () => {
+    const exec = makeExec();
+    const flattened = exec._flattenExtensionData(
+      { usage: { input_tokens: 100, output_tokens: 50 }, durationMs: 1000, costUsd: 0.001 },
+      { confidence: 0.75, explanation: "reasonable confidence" },
+      "completed",
+    );
+    expect(flattened.usage).toEqual({ input_tokens: 100, output_tokens: 50 });
+    expect(flattened.durationMs).toBe(1000);
+    expect(flattened.costUsd).toBe(0.001);
+    expect(flattened.success).toBe(true);
+    expect(flattened.confidence).toBe(0.75);
+    expect(flattened.confidenceExplanation).toBe("reasonable confidence");
+  });
+
+  test("_flattenExtensionData derives success=false from non-completed taskState when cost omits it", () => {
+    const exec = makeExec();
+    const flattened = exec._flattenExtensionData(
+      { usage: { input_tokens: 10, output_tokens: 5 } },
+      undefined,
+      "failed",
+    );
+    expect(flattened.success).toBe(false);
+    expect(flattened.confidence).toBeUndefined();
+  });
+
+  test("_flattenExtensionData respects explicit success flag even when taskState disagrees", () => {
+    const exec = makeExec();
+    const flattened = exec._flattenExtensionData(
+      { usage: { input_tokens: 10, output_tokens: 5 }, success: false },
+      undefined,
+      "completed",
+    );
+    expect(flattened.success).toBe(false);
+  });
+
+  test("_flattenExtensionData returns {} when neither payload present", () => {
+    const exec = makeExec();
+    expect(exec._flattenExtensionData(undefined, undefined, "completed")).toEqual({});
+  });
+});

--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -24,6 +24,14 @@ import {
   type WorldStateDeltaArtifactData,
 } from "../../../lib/types/worldstate-delta.ts";
 import {
+  COST_V1_MIME_TYPE,
+  type CostArtifactData,
+} from "../../../lib/types/cost-v1.ts";
+import {
+  CONFIDENCE_V1_MIME_TYPE,
+  type ConfidenceArtifactData,
+} from "../../../lib/types/confidence-v1.ts";
+import {
   defaultExtensionRegistry,
   type ExtensionContext,
   type ExtensionInterceptor,
@@ -427,6 +435,9 @@ export class A2AExecutor implements IExecutor {
     const taskState = task.status.state;
 
     const worldStateDelta = this._extractWorldStateDelta(task);
+    const allParts = (task.artifacts ?? []).flatMap(a => a.parts);
+    const cost = this._costFromParts(allParts);
+    const confidence = this._confidenceFromParts(allParts);
 
     return {
       text,
@@ -437,6 +448,7 @@ export class A2AExecutor implements IExecutor {
         contextId: task.contextId,
         taskState,
         ...(worldStateDelta ? { [WORLDSTATE_DELTA_MIME_TYPE]: worldStateDelta } : {}),
+        ...this._flattenExtensionData(cost, confidence, taskState),
       },
     };
   }
@@ -547,11 +559,23 @@ export class A2AExecutor implements IExecutor {
       .join("\n");
     const resultText = terminalMessage || artifactText;
 
+    // Scan accumulated artifact parts for cost-v1 + confidence-v1 payloads
+    // and flatten them onto result.data the same way the blocking path does.
+    const allStreamParts = Array.from(artifactBuffers.values()).flat();
+    const cost = this._costFromParts(allStreamParts);
+    const confidence = this._confidenceFromParts(allStreamParts);
+
     return {
       text: resultText || `Skill "${req.skill}" completed by ${this.config.name}`,
       isError: taskState === "failed" || taskState === "rejected",
       correlationId: req.correlationId,
-      data: { taskId, contextId, taskState, ...streamDeltaData },
+      data: {
+        taskId,
+        contextId,
+        taskState,
+        ...streamDeltaData,
+        ...this._flattenExtensionData(cost, confidence, taskState),
+      },
     };
   }
 
@@ -591,6 +615,64 @@ export class A2AExecutor implements IExecutor {
       }
     }
     return undefined;
+  }
+
+  /** Scan artifact parts for a cost-v1 DataPart and return the first match. */
+  private _costFromParts(
+    parts: Array<{ kind: string; data?: Record<string, unknown>; metadata?: Record<string, unknown> }>,
+  ): CostArtifactData | undefined {
+    for (const part of parts) {
+      if (
+        part.kind === "data" &&
+        part.metadata?.["mimeType"] === COST_V1_MIME_TYPE &&
+        part.data
+      ) {
+        return part.data as unknown as CostArtifactData;
+      }
+    }
+    return undefined;
+  }
+
+  /** Scan artifact parts for a confidence-v1 DataPart and return the first match. */
+  private _confidenceFromParts(
+    parts: Array<{ kind: string; data?: Record<string, unknown>; metadata?: Record<string, unknown> }>,
+  ): ConfidenceArtifactData | undefined {
+    for (const part of parts) {
+      if (
+        part.kind === "data" &&
+        part.metadata?.["mimeType"] === CONFIDENCE_V1_MIME_TYPE &&
+        part.data
+      ) {
+        return part.data as unknown as ConfidenceArtifactData;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Flatten cost-v1 + confidence-v1 DataPart payloads onto the fields the
+   * extension interceptors already read off `result.data`. Call sites merge
+   * the returned object into their `data` spread.
+   */
+  private _flattenExtensionData(
+    cost: CostArtifactData | undefined,
+    confidence: ConfidenceArtifactData | undefined,
+    taskState: string,
+  ): Record<string, unknown> {
+    return {
+      ...(cost && {
+        usage: cost.usage,
+        ...(typeof cost.durationMs === "number" ? { durationMs: cost.durationMs } : {}),
+        ...(typeof cost.costUsd === "number" ? { costUsd: cost.costUsd } : {}),
+        success: cost.success ?? (taskState === "completed"),
+      }),
+      ...(confidence && {
+        confidence: confidence.confidence,
+        ...(typeof confidence.explanation === "string"
+          ? { confidenceExplanation: confidence.explanation }
+          : {}),
+      }),
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes #341. Extends \`A2AExecutor\` to extract the two missing extension MIMEs from terminal Task artifact parts and flatten their payloads onto \`result.data\` — parallel to the existing \`worldstate-delta-v1\` pattern.

Unblocks the external-agent half of Quinn #27 (cost-v1 / confidence-v1 / blast-v1 / hitl-mode-v1).

## Before → after

**Before**: \`cost.ts\` + \`confidence.ts\` interceptors were registered and their stores + bus publishers wired end-to-end, but they read \`result.data.usage\` / \`.durationMs\` / \`.costUsd\` / \`.confidence\` — fields that were never populated for A2A agents because nothing extracted them from Task artifacts. Extensions effectively worked only for in-process DeepAgentExecutor.

**After**: A2AExecutor scans artifact parts for the two MIMEs, flattens onto \`result.data\`, extensions record samples exactly as they do for in-process agents.

## New MIMEs + types

- \`application/vnd.protolabs.cost-v1+json\` → \`CostArtifactData\` (usage + durationMs + costUsd + optional success)
- \`application/vnd.protolabs.confidence-v1+json\` → \`ConfidenceArtifactData\` (confidence + explanation + optional success)

## Agent-side recipe (unchanged)

Agents emit DataParts on terminal Task artifacts:

\`\`\`json
{
  "artifacts": [{
    "parts": [
      { "kind": "text", "text": "…" },
      {
        "kind": "data",
        "data": { "usage": { "input_tokens": 1500, "output_tokens": 420 }, "durationMs": 4200, "costUsd": 0.012 },
        "metadata": { "mimeType": "application/vnd.protolabs.cost-v1+json" }
      },
      {
        "kind": "data",
        "data": { "confidence": 0.88, "explanation": "spec unambiguous" },
        "metadata": { "mimeType": "application/vnd.protolabs.confidence-v1+json" }
      }
    ]
  }]
}
\`\`\`

\`docs/guides/extend-an-a2a-agent.md\` already documents the shape; it just works now.

## Test plan

- [x] \`bun test\` — 953 pass / 0 fail (+7 new a2a-executor tests)
- [ ] CI green
- [ ] Post-deploy: once Quinn emits the parts, verify \`defaultCostStore\` + \`defaultConfidenceStore\` populate samples and \`autonomous.cost.quinn.pr_review\` fires

## Related

- [Quinn #27](https://github.com/protoLabsAI/quinn/issues/27) — extension opt-ins (this unblocks cost + confidence halves)
- \`docs/extensions/cost-v1.md\`, \`docs/extensions/confidence-v1.md\` — reference pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)