### PR TITLE
docs: cite Quinn as cost-v1 producer reference impl + emission notes

### DIFF
--- a/docs/extensions/cost-v1.md
+++ b/docs/extensions/cost-v1.md
@@ -106,6 +106,17 @@ Payload is the raw `CostSample` above. Used for:
 
 ---
 
+## Reference implementations
+
+| Side | Where | Notes |
+|---|---|---|
+| **Extraction** (consumer) | [`src/executor/executors/a2a-executor.ts`](https://github.com/protoLabsAI/protoWorkstacean/blob/main/src/executor/executors/a2a-executor.ts) — added in #372 | Scans terminal Task artifact parts for `application/vnd.protolabs.cost-v1+json`, flattens onto `result.data` so the cost interceptor records the sample |
+| **Emission** (producer) | [`Quinn/a2a_handler.py::_terminal_artifact_parts`](https://github.com/protoLabsAI/quinn/blob/main/a2a_handler.py) + [`Quinn/server.py::_chat_langgraph_stream`](https://github.com/protoLabsAI/quinn/blob/main/server.py) — added in Quinn #56 | Captures `on_chat_model_end` events from LangGraph for `usage_metadata`, accumulates onto `TaskRecord.usage`, emits the DataPart on COMPLETED |
+
+Quinn currently emits `usage` + `durationMs` only — `costUsd` capture from the LiteLLM gateway response is a follow-up. Consumers tolerate missing `costUsd` and can derive it from per-model rates if needed.
+
+---
+
 ## Related
 
 - [`confidence-v1`](confidence-v1.md) — companion extension for agent-reported confidence, read alongside cost in the same planner ranking

--- a/docs/guides/a2a-langfuse-trace-propagation.md
+++ b/docs/guides/a2a-langfuse-trace-propagation.md
@@ -1,0 +1,86 @@
+---
+title: A2A Langfuse Trace Propagation
+---
+
+How distributed Langfuse tracing works across the protoLabs agent fleet. One Langfuse project, per-agent tags, cross-referenced trace IDs.
+
+## Architecture decision
+
+**One Langfuse project for the entire fleet**, not one per agent.
+
+When Workstacean dispatches Quinn via A2A, and Quinn dispatches a subagent, the full chain should be visible in Langfuse without jumping between projects. Per-agent isolation is achieved with tags (`["quinn"]`, `["ava"]`, `["workstacean"]`), not project boundaries.
+
+## The `a2a.trace` metadata convention
+
+Every A2A `message/send` or `message/stream` call can carry the caller's Langfuse trace context in `params.metadata["a2a.trace"]`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "message/send",
+  "params": {
+    "message": {
+      "role": "user",
+      "parts": [{ "kind": "text", "text": "Run a board audit" }]
+    },
+    "metadata": {
+      "a2a.trace": {
+        "traceId": "abc-123-langfuse-trace-uuid",
+        "spanId": "def-456-current-span-uuid",
+        "project": "protolabs"
+      }
+    }
+  }
+}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `traceId` | yes | The Langfuse trace UUID from the caller's current scope |
+| `spanId` | no | The specific span that dispatched this A2A call |
+| `project` | no | Langfuse project name (future-proofing for multi-project setups) |
+
+## How agents use it
+
+### Receiving side (implemented in Quinn)
+
+Quinn reads `params.metadata["a2a.trace"]` in `a2a_handler.py` and forwards it through:
+
+```
+a2a_handler → _submit_task(caller_trace=) → chat_stream_fn_factory(caller_trace=)
+            → server._chat_langgraph_stream(caller_trace=)
+            → tracing.trace_session(metadata={caller_trace_id, caller_span_id})
+```
+
+Quinn's Langfuse trace now carries `caller_trace_id` and `caller_span_id` in its metadata. An operator can filter Langfuse by `metadata.caller_trace_id = <uuid>` to find all agent traces spawned from a single Workstacean dispatch.
+
+### Sending side (Workstacean — TODO)
+
+`a2a-executor.ts` needs to stamp the current Langfuse trace context into outbound `params.metadata["a2a.trace"]`. The extension interceptor hook at line 221 is the natural injection point — extensions' metadata is already merged into outbound params.
+
+## Cross-referencing in Langfuse
+
+With this convention, a single Workstacean dispatch produces:
+
+1. **Workstacean trace** — tagged `["workstacean"]`, spans: `a2a-dispatch → task-tracker-poll → ...`
+2. **Quinn trace** — tagged `["quinn"]`, metadata: `caller_trace_id = <workstacean-trace-uuid>`
+
+Search Langfuse by `metadata.caller_trace_id` to see all agent traces spawned from one orchestration run.
+
+## Future: true parent-child nesting
+
+The current implementation uses metadata cross-referencing. True nesting (Quinn's spans appear as children of Workstacean's span in one trace tree) requires:
+
+1. Validate that `langfuse.trace(id=parent_trace_id)` followed by `trace.span(name=...)` nests correctly when called from a different process
+2. If it works: Quinn calls `_langfuse.trace(id=caller_trace_id)` instead of creating a new trace, and her observations land directly in the caller's trace tree
+
+This is tracked in [quinn#31](https://github.com/protoLabsAI/quinn/issues/31) (the OTel context cleanup issue is related).
+
+## Adopting in a new agent
+
+If you're building a new A2A agent per the [Build an A2A Agent](./build-an-a2a-agent) guide:
+
+1. Read `params.metadata["a2a.trace"]` when parsing incoming `message/send` / `message/stream`
+2. Forward `traceId` and `spanId` into your tracing system's metadata on the session/trace you open for this task
+3. Tag your traces with your agent name (e.g. `["myagent"]`)
+4. That's it — Langfuse cross-referencing works automatically

--- a/docs/guides/a2a-streaming.md
+++ b/docs/guides/a2a-streaming.md
@@ -68,19 +68,28 @@ async def a2a_handler(req: dict):
 
 Each SSE line must be `data: <json>\n\n`. Three event types:
 
+> **Critical — every event needs a `kind` discriminator.** `@a2a-js/sdk`'s `for await` loop routes by `kind`. Events without it are silently skipped and `A2AExecutor` sees the stream as empty. This is what Quinn #40 fixed. Wire fields are camelCase (`taskId`, `contextId`, `lastChunk`) — not snake_case.
+
+**Initial snapshot** — the first frame is a full `Task` object with `kind: "task"`:
+```json
+data: {"kind": "task", "id": "task-uuid", "contextId": "conv-uuid", "status": {"state": "submitted", "timestamp": "..."}}
+```
+
 **TaskStatusUpdateEvent** — progress indicator:
 ```json
-data: {"id": "task-uuid", "contextId": "conv-uuid", "status": {"state": "working", "message": {"parts": [{"text": "Scanning HuggingFace..."}]}}}
+data: {"kind": "status-update", "taskId": "task-uuid", "contextId": "conv-uuid", "status": {"state": "working", "message": {"role": "agent", "parts": [{"kind": "text", "text": "Scanning HuggingFace..."}]}}, "final": false}
 ```
 
 **TaskArtifactUpdateEvent** — partial result:
 ```json
-data: {"id": "task-uuid", "contextId": "conv-uuid", "artifact": {"parts": [{"kind": "text", "text": "Found 3 relevant papers..."}]}}
+data: {"kind": "artifact-update", "taskId": "task-uuid", "contextId": "conv-uuid", "artifact": {"artifactId": "task-uuid", "parts": [{"kind": "text", "text": "Found 3 relevant papers..."}]}, "append": true, "lastChunk": false}
 ```
 
-**Completion** — final result + done signal:
+**Completion** — emit TWO events: the final artifact-update, then a final status-update. `[DONE]` closes the stream:
 ```json
-data: {"id": "task-uuid", "contextId": "conv-uuid", "status": {"state": "completed"}, "artifact": {"parts": [{"kind": "text", "text": "Full research report..."}]}}
+data: {"kind": "artifact-update", "taskId": "task-uuid", "contextId": "conv-uuid", "artifact": {"artifactId": "task-uuid", "parts": [{"kind": "text", "text": "Full research report..."}]}, "append": false, "lastChunk": true}
+
+data: {"kind": "status-update", "taskId": "task-uuid", "contextId": "conv-uuid", "status": {"state": "completed", "timestamp": "..."}, "final": true}
 
 data: [DONE]
 ```
@@ -93,8 +102,8 @@ async def sse_generator(req):
     context_id = req["params"].get("contextId", task_id)
     text = extract_text(req)
 
-    # Emit "working" status
-    yield f"data: {json.dumps({'id': task_id, 'contextId': context_id, 'status': {'state': 'working', 'message': {'parts': [{'text': 'Starting...'}]}}})}\n\n"
+    # Frame 0: initial Task snapshot
+    yield f"data: {json.dumps({'kind': 'task', 'id': task_id, 'contextId': context_id, 'status': {'state': 'submitted', 'timestamp': iso_now()}})}\n\n"
 
     # Run work with progress callback
     progress_q = queue.Queue()
@@ -108,10 +117,13 @@ async def sse_generator(req):
         await asyncio.sleep(0.5)
         while not progress_q.empty():
             msg = progress_q.get_nowait()
-            yield f"data: {json.dumps({'id': task_id, 'contextId': context_id, 'status': {'state': 'working', 'message': {'parts': [{'text': msg}]}}})}\n\n"
+            yield f"data: {json.dumps({'kind': 'status-update', 'taskId': task_id, 'contextId': context_id, 'status': {'state': 'working', 'message': {'role': 'agent', 'parts': [{'kind': 'text', 'text': msg}]}}, 'final': False})}\n\n"
 
     result = task.result()
-    yield f"data: {json.dumps({'id': task_id, 'contextId': context_id, 'status': {'state': 'completed'}, 'artifact': {'parts': [{'kind': 'text', 'text': result}]}})}\n\n"
+    # Terminal: artifact-update FIRST (with the authoritative artifact),
+    # then status-update with final=True.
+    yield f"data: {json.dumps({'kind': 'artifact-update', 'taskId': task_id, 'contextId': context_id, 'artifact': {'artifactId': task_id, 'parts': [{'kind': 'text', 'text': result}]}, 'append': False, 'lastChunk': True})}\n\n"
+    yield f"data: {json.dumps({'kind': 'status-update', 'taskId': task_id, 'contextId': context_id, 'status': {'state': 'completed', 'timestamp': iso_now()}, 'final': True})}\n\n"
     yield "data: [DONE]\n\n"
 ```
 
@@ -143,10 +155,11 @@ Inbound message: "research full-duplex voice AI"
       → ExecutorRegistry → A2AExecutor (streaming: true)
         → POST /a2a  method: message/stream
           ← text/event-stream:
-              data: {"status":{"state":"working","message":"Scanning HuggingFace..."}}
-              data: {"status":{"state":"working","message":"Reading paper: PersonaPlex..."}}
-              data: {"status":{"state":"working","message":"Synthesizing findings..."}}
-              data: {"artifact":{"parts":[{"kind":"text","text":"Full report..."}]}}
+              data: {"kind":"task", "id":"...", "contextId":"...", "status":{"state":"submitted"}}
+              data: {"kind":"status-update", "taskId":"...", "status":{"state":"working","message":{...}}, "final":false}
+              data: {"kind":"status-update", "taskId":"...", "status":{"state":"working","message":{...}}, "final":false}
+              data: {"kind":"artifact-update", "taskId":"...", "artifact":{"artifactId":"...","parts":[...]}, "append":false, "lastChunk":true}
+              data: {"kind":"status-update", "taskId":"...", "status":{"state":"completed"}, "final":true}
               data: [DONE]
         Each "working" event → onStreamUpdate → Discord agent-ops channel
         Final artifact → published to replyTopic

--- a/docs/guides/build-an-a2a-agent.md
+++ b/docs/guides/build-an-a2a-agent.md
@@ -392,14 +392,14 @@ A protoAgent that ticks all of these is a first-class fleet citizen — routing,
 ### Extensions (cards + runtime)
 - [ ] [`effect-domain-v1`](../extensions/effect-domain-v1) declared on the card for every state-mutating skill (enables L1 planner ranking)
 - [ ] [`worldstate-delta-v1`](../extensions/worldstate-delta-v1) DataPart emitted on the terminal task whenever a tool with known effects succeeds (declared effects must agree with observed deltas — a drift test is cheap)
-- [ ] [`cost-v1`](../extensions/cost-v1) `{usage, durationMs, costUsd}` populated on the terminal task
+- [ ] [`cost-v1`](../extensions/cost-v1) `{usage, durationMs, costUsd?}` DataPart on every terminal task that ran an LLM. Capture token usage from your model events (LangChain: `on_chat_model_end` → `output.usage_metadata`); compute `durationMs` from `created_at`/`updated_at`; emit only when usage was actually tracked. `costUsd` is optional — derive from per-model rates or capture from the gateway response. Reference: Quinn `_terminal_artifact_parts` + `store.add_usage` (PR #56).
 - [ ] [`confidence-v1`](../extensions/confidence-v1) `{confidence, explanation}` populated when the agent can self-assess
 - [ ] Success contract: `state: completed` means the agent actually achieved the goal, not just that the skill returned without crashing
 
 ## Reference implementations
 
 - **[`Quinn/a2a_handler.py`](https://github.com/protoLabsAI/quinn/blob/main/a2a_handler.py)** — the most complete reference. All of the hardening above + decoupled SSE producer + delta-only text frames + tool-message persistence. Single 800-line file, no inheritance.
-- **[`Quinn/server.py`](https://github.com/protoLabsAI/quinn/blob/main/server.py)** — agent-side wiring. `_chat_langgraph_stream` maps LangGraph `astream_events(v2)` to the `(tool_start|tool_end|text|delta|done|error)` tuple contract the handler consumes. `_build_agent_card` shows `capabilities.extensions` with `effect-domain-v1`. `_worldstate_delta_for_tool` emits the runtime delta on `file_bug` success.
+- **[`Quinn/server.py`](https://github.com/protoLabsAI/quinn/blob/main/server.py)** — agent-side wiring. `_chat_langgraph_stream` maps LangGraph `astream_events(v2)` to the `(tool_start|tool_end|text|delta|usage|done|error)` tuple contract the handler consumes. `_build_agent_card` shows `capabilities.extensions` with `effect-domain-v1` and `cost-v1`. `_worldstate_delta_for_tool` emits the runtime delta on `file_bug` success. `on_chat_model_end` capture feeds the `usage` channel for cost-v1.
 - **[`Quinn/tools/manage_cron.py`](https://github.com/protoLabsAI/quinn/blob/main/tools/manage_cron.py)** — LangGraph tool that CRUDs ceremonies via the per-agent `X-API-Key`.
 - **[`Quinn/tests/test_a2a_handler.py`](https://github.com/protoLabsAI/quinn/blob/main/tests/test_a2a_handler.py)** — ~55 tests covering the store, background runner, SSRF, cancel races, webhook retention, subscribe reconnect, delta-only text, producer survives consumer cancellation. Clone this alongside the handler.
 - **[`protoPen/a2a_handler.py`](https://github.com/protoLabsAI/protoPen/blob/main/a2a_handler.py)** — original port target. Predates Quinn's hardening; lacks decoupled SSE producer, SSRF guard, webhook retention, atomic cancel. Kept as a reference for the minimum viable spec surface, but new agents should mirror Quinn's version.

--- a/docs/guides/build-an-a2a-agent.md
+++ b/docs/guides/build-an-a2a-agent.md
@@ -239,23 +239,28 @@ If the producer emits in-process events like `tool_start` / `tool_end` that your
 
 See [A2A Streaming (SSE)](./a2a-streaming) for the full SSE event protocol. Short version: advertise `capabilities.streaming: true`, accept `method: "message/stream"` on `/a2a` and `POST /message:stream`, emit `text/event-stream` frames as work progresses. `A2AExecutor` on Workstacean's side switches transport automatically based on the card; your `message/send` consumers stay unchanged.
 
-Terminal frames (`COMPLETED`) should carry the authoritative full artifact — text + any [worldstate-delta](../extensions/worldstate-delta-v1) DataParts — as `append: false, last_chunk: true`. Mid-run stays incremental via `append: true` text deltas only.
+On `COMPLETED`, emit **two** events per the A2A spec: first a `kind: "artifact-update"` carrying the authoritative full artifact — text + any [worldstate-delta](../extensions/worldstate-delta-v1) DataParts — as `append: false, lastChunk: true`; then a `kind: "status-update"` with `final: true` to close the stream. Mid-run stays incremental via `kind: "artifact-update"` + `append: true` text deltas only.
+
+> **Critical — SSE events must carry a `kind` discriminator.** `@a2a-js/sdk`'s `for await (const event of client.sendMessageStream(...))` routes events by `kind`. Events missing it are silently dropped, which means Workstacean's TaskTracker never attaches, push notifications never register, and HITL chains silently fail. This was Quinn #40. Every frame — initial `task`, every `status-update`, every `artifact-update` — needs `kind`.
 
 ## Push notifications
 
 Workstacean registers webhooks of the form `${WORKSTACEAN_BASE_URL}/api/a2a/callback/{taskId}` with a per-task HMAC token. When you POST a task snapshot to the URL, Workstacean verifies the token and fires the same bus event a poll would have.
 
-The webhook payload should be a `TaskStatusUpdateEvent`:
+The webhook payload is a `TaskStatusUpdateEvent` — same shape as on the wire, including the `kind` discriminator:
 
 ```json
 {
-  "task_id": "3f8a1c2d-...",
-  "context_id": "engagement-001",
+  "kind": "status-update",
+  "taskId": "3f8a1c2d-...",
+  "contextId": "engagement-001",
   "status": {"state": "completed", "timestamp": "2026-04-15T20:00:00Z"},
+  "final": true,
   "artifact": {
+    "artifactId": "3f8a1c2d-...",
     "parts": [{"kind": "text", "text": "## Results\n..."}],
     "append": false,
-    "last_chunk": true
+    "lastChunk": true
   }
 }
 ```
@@ -375,8 +380,12 @@ A protoAgent that ticks all of these is a first-class fleet citizen — routing,
 - [ ] Background producer runs independently of any SSE connection
 
 ### SSE semantics
-- [ ] Text deltas only on `append: true` — never the full `accumulated_text`
-- [ ] Terminal frame is the authoritative full artifact, `append: false, last_chunk: true`
+- [ ] Every event carries a `kind` discriminator (`task` / `status-update` / `artifact-update` / `message`) — without it `@a2a-js/sdk` silently drops the event (Quinn #40)
+- [ ] Wire fields are camelCase: `taskId`, `contextId`, `lastChunk`, `artifactId` (not `task_id` / `context_id` / `last_chunk`) — Python variable names can stay snake_case, just not dict keys that cross the wire
+- [ ] Status updates carry a `final` boolean (true on terminal states)
+- [ ] Text deltas emit as `kind: "artifact-update"` + `append: true` — never the full `accumulated_text`
+- [ ] `COMPLETED` emits TWO events per spec: `artifact-update` (full artifact, `append: false`, `lastChunk: true`) then `status-update` (`final: true`)
+- [ ] Artifact objects carry an `artifactId` for cross-event correlation
 - [ ] Tool status messages persist on the record for `:subscribe` to surface
 - [ ] Consumer disconnect does not cancel the producer
 

--- a/lib/types/confidence-v1.ts
+++ b/lib/types/confidence-v1.ts
@@ -1,0 +1,35 @@
+/**
+ * x-protolabs/confidence-v1 — artifact type for self-reported confidence.
+ *
+ * Agents emit a `kind: "data"` artifact part with this MIME type on their
+ * terminal Task to report how confident they are in the result. The
+ * confidence-v1 interceptor reads these fields off `result.data` (flattened
+ * by A2AExecutor), records a sample in `defaultConfidenceStore`, and emits
+ * calibration warnings when high-confidence tasks fail.
+ *
+ * MIME type: application/vnd.protolabs.confidence-v1+json
+ *
+ * Artifact part shape (A2A DataPart):
+ *   {
+ *     kind: "data",
+ *     data: ConfidenceArtifactData,
+ *     metadata: { mimeType: CONFIDENCE_V1_MIME_TYPE }
+ *   }
+ */
+
+/** Registered MIME type for confidence-v1 artifact parts. */
+export const CONFIDENCE_V1_MIME_TYPE =
+  "application/vnd.protolabs.confidence-v1+json";
+
+/**
+ * The `data` payload of an artifact part with
+ * `mimeType: CONFIDENCE_V1_MIME_TYPE`.
+ */
+export interface ConfidenceArtifactData {
+  /** Self-reported confidence in [0, 1]. Consumers defensively clamp out-of-range. */
+  confidence: number;
+  /** Free-text reasoning — surfaced in calibration views. */
+  explanation?: string;
+  /** Explicit success flag — overrides taskState when present. */
+  success?: boolean;
+}

--- a/lib/types/cost-v1.ts
+++ b/lib/types/cost-v1.ts
@@ -1,0 +1,44 @@
+/**
+ * x-protolabs/cost-v1 — artifact type for observed skill cost and duration.
+ *
+ * Agents emit a `kind: "data"` artifact part with this MIME type on their
+ * terminal Task to report what the skill actually cost (token usage, wall
+ * time, optional $USD). The cost-v1 interceptor reads these fields off
+ * `result.data` (flattened by A2AExecutor), records a sample in
+ * `defaultCostStore`, and publishes `autonomous.cost.*` for dashboards +
+ * planner ranking.
+ *
+ * MIME type: application/vnd.protolabs.cost-v1+json
+ *
+ * Artifact part shape (A2A DataPart):
+ *   {
+ *     kind: "data",
+ *     data: CostArtifactData,
+ *     metadata: { mimeType: COST_V1_MIME_TYPE }
+ *   }
+ */
+
+/** Registered MIME type for cost-v1 artifact parts. */
+export const COST_V1_MIME_TYPE = "application/vnd.protolabs.cost-v1+json";
+
+/** Token usage snapshot — Anthropic-shaped but framework-agnostic. */
+export interface CostArtifactUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+}
+
+/**
+ * The `data` payload of an artifact part with
+ * `mimeType: COST_V1_MIME_TYPE`.
+ */
+export interface CostArtifactData {
+  usage: CostArtifactUsage;
+  /** Wall-clock duration in milliseconds. */
+  durationMs?: number;
+  /** Dollar cost. If omitted, the consumer can compute from tokens + MODEL_RATES. */
+  costUsd?: number;
+  /** Explicit success flag — overrides taskState when present. */
+  success?: boolean;
+}

--- a/src/executor/__tests__/a2a-executor-cost-confidence.test.ts
+++ b/src/executor/__tests__/a2a-executor-cost-confidence.test.ts
@@ -1,0 +1,108 @@
+import { describe, test, expect } from "bun:test";
+import { A2AExecutor } from "../executors/a2a-executor.ts";
+import { COST_V1_MIME_TYPE } from "../../../lib/types/cost-v1.ts";
+import { CONFIDENCE_V1_MIME_TYPE } from "../../../lib/types/confidence-v1.ts";
+
+// Access the private extractors via `as any` — we're asserting pure-function
+// behavior on part arrays, not the full execute() plumbing.
+type PartsScan = {
+  _costFromParts(parts: unknown[]): unknown;
+  _confidenceFromParts(parts: unknown[]): unknown;
+  _flattenExtensionData(cost: unknown, confidence: unknown, taskState: string): Record<string, unknown>;
+};
+
+function makeExec(): PartsScan {
+  const exec = new A2AExecutor({
+    name: "quinn",
+    url: "http://quinn:7870/a2a",
+    streaming: false,
+    pushNotifications: false,
+  });
+  return exec as unknown as PartsScan;
+}
+
+describe("A2AExecutor cost-v1 / confidence-v1 extraction", () => {
+  test("_costFromParts returns the cost payload on match", () => {
+    const exec = makeExec();
+    const parts = [
+      { kind: "text", text: "ignored" },
+      {
+        kind: "data",
+        data: {
+          usage: { input_tokens: 1500, output_tokens: 420, cache_read_input_tokens: 120 },
+          durationMs: 4200,
+          costUsd: 0.0123,
+        },
+        metadata: { mimeType: COST_V1_MIME_TYPE },
+      },
+    ];
+    const cost = exec._costFromParts(parts) as { usage: { input_tokens: number }; durationMs: number; costUsd: number };
+    expect(cost).toBeDefined();
+    expect(cost.usage.input_tokens).toBe(1500);
+    expect(cost.durationMs).toBe(4200);
+    expect(cost.costUsd).toBe(0.0123);
+  });
+
+  test("_costFromParts returns undefined when no matching part", () => {
+    const exec = makeExec();
+    expect(exec._costFromParts([{ kind: "text", text: "hi" }])).toBeUndefined();
+    expect(exec._costFromParts([
+      { kind: "data", data: { foo: "bar" }, metadata: { mimeType: "application/other+json" } },
+    ])).toBeUndefined();
+  });
+
+  test("_confidenceFromParts returns payload with explanation", () => {
+    const exec = makeExec();
+    const parts = [
+      {
+        kind: "data",
+        data: { confidence: 0.88, explanation: "spec unambiguous; all tests pass" },
+        metadata: { mimeType: CONFIDENCE_V1_MIME_TYPE },
+      },
+    ];
+    const c = exec._confidenceFromParts(parts) as { confidence: number; explanation: string };
+    expect(c.confidence).toBe(0.88);
+    expect(c.explanation).toBe("spec unambiguous; all tests pass");
+  });
+
+  test("_flattenExtensionData merges cost + confidence onto result.data shape", () => {
+    const exec = makeExec();
+    const flattened = exec._flattenExtensionData(
+      { usage: { input_tokens: 100, output_tokens: 50 }, durationMs: 1000, costUsd: 0.001 },
+      { confidence: 0.75, explanation: "reasonable confidence" },
+      "completed",
+    );
+    expect(flattened.usage).toEqual({ input_tokens: 100, output_tokens: 50 });
+    expect(flattened.durationMs).toBe(1000);
+    expect(flattened.costUsd).toBe(0.001);
+    expect(flattened.success).toBe(true);
+    expect(flattened.confidence).toBe(0.75);
+    expect(flattened.confidenceExplanation).toBe("reasonable confidence");
+  });
+
+  test("_flattenExtensionData derives success=false from non-completed taskState when cost omits it", () => {
+    const exec = makeExec();
+    const flattened = exec._flattenExtensionData(
+      { usage: { input_tokens: 10, output_tokens: 5 } },
+      undefined,
+      "failed",
+    );
+    expect(flattened.success).toBe(false);
+    expect(flattened.confidence).toBeUndefined();
+  });
+
+  test("_flattenExtensionData respects explicit success flag even when taskState disagrees", () => {
+    const exec = makeExec();
+    const flattened = exec._flattenExtensionData(
+      { usage: { input_tokens: 10, output_tokens: 5 }, success: false },
+      undefined,
+      "completed",
+    );
+    expect(flattened.success).toBe(false);
+  });
+
+  test("_flattenExtensionData returns {} when neither payload present", () => {
+    const exec = makeExec();
+    expect(exec._flattenExtensionData(undefined, undefined, "completed")).toEqual({});
+  });
+});

--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -24,6 +24,14 @@ import {
   type WorldStateDeltaArtifactData,
 } from "../../../lib/types/worldstate-delta.ts";
 import {
+  COST_V1_MIME_TYPE,
+  type CostArtifactData,
+} from "../../../lib/types/cost-v1.ts";
+import {
+  CONFIDENCE_V1_MIME_TYPE,
+  type ConfidenceArtifactData,
+} from "../../../lib/types/confidence-v1.ts";
+import {
   defaultExtensionRegistry,
   type ExtensionContext,
   type ExtensionInterceptor,
@@ -427,6 +435,9 @@ export class A2AExecutor implements IExecutor {
     const taskState = task.status.state;
 
     const worldStateDelta = this._extractWorldStateDelta(task);
+    const allParts = (task.artifacts ?? []).flatMap(a => a.parts);
+    const cost = this._costFromParts(allParts);
+    const confidence = this._confidenceFromParts(allParts);
 
     return {
       text,
@@ -437,6 +448,7 @@ export class A2AExecutor implements IExecutor {
         contextId: task.contextId,
         taskState,
         ...(worldStateDelta ? { [WORLDSTATE_DELTA_MIME_TYPE]: worldStateDelta } : {}),
+        ...this._flattenExtensionData(cost, confidence, taskState),
       },
     };
   }
@@ -547,11 +559,23 @@ export class A2AExecutor implements IExecutor {
       .join("\n");
     const resultText = terminalMessage || artifactText;
 
+    // Scan accumulated artifact parts for cost-v1 + confidence-v1 payloads
+    // and flatten them onto result.data the same way the blocking path does.
+    const allStreamParts = Array.from(artifactBuffers.values()).flat();
+    const cost = this._costFromParts(allStreamParts);
+    const confidence = this._confidenceFromParts(allStreamParts);
+
     return {
       text: resultText || `Skill "${req.skill}" completed by ${this.config.name}`,
       isError: taskState === "failed" || taskState === "rejected",
       correlationId: req.correlationId,
-      data: { taskId, contextId, taskState, ...streamDeltaData },
+      data: {
+        taskId,
+        contextId,
+        taskState,
+        ...streamDeltaData,
+        ...this._flattenExtensionData(cost, confidence, taskState),
+      },
     };
   }
 
@@ -591,6 +615,64 @@ export class A2AExecutor implements IExecutor {
       }
     }
     return undefined;
+  }
+
+  /** Scan artifact parts for a cost-v1 DataPart and return the first match. */
+  private _costFromParts(
+    parts: Array<{ kind: string; data?: Record<string, unknown>; metadata?: Record<string, unknown> }>,
+  ): CostArtifactData | undefined {
+    for (const part of parts) {
+      if (
+        part.kind === "data" &&
+        part.metadata?.["mimeType"] === COST_V1_MIME_TYPE &&
+        part.data
+      ) {
+        return part.data as unknown as CostArtifactData;
+      }
+    }
+    return undefined;
+  }
+
+  /** Scan artifact parts for a confidence-v1 DataPart and return the first match. */
+  private _confidenceFromParts(
+    parts: Array<{ kind: string; data?: Record<string, unknown>; metadata?: Record<string, unknown> }>,
+  ): ConfidenceArtifactData | undefined {
+    for (const part of parts) {
+      if (
+        part.kind === "data" &&
+        part.metadata?.["mimeType"] === CONFIDENCE_V1_MIME_TYPE &&
+        part.data
+      ) {
+        return part.data as unknown as ConfidenceArtifactData;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Flatten cost-v1 + confidence-v1 DataPart payloads onto the fields the
+   * extension interceptors already read off `result.data`. Call sites merge
+   * the returned object into their `data` spread.
+   */
+  private _flattenExtensionData(
+    cost: CostArtifactData | undefined,
+    confidence: ConfidenceArtifactData | undefined,
+    taskState: string,
+  ): Record<string, unknown> {
+    return {
+      ...(cost && {
+        usage: cost.usage,
+        ...(typeof cost.durationMs === "number" ? { durationMs: cost.durationMs } : {}),
+        ...(typeof cost.costUsd === "number" ? { costUsd: cost.costUsd } : {}),
+        success: cost.success ?? (taskState === "completed"),
+      }),
+      ...(confidence && {
+        confidence: confidence.confidence,
+        ...(typeof confidence.explanation === "string"
+          ? { confidenceExplanation: confidence.explanation }
+          : {}),
+      }),
+    };
   }
 
   /**

--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -310,8 +310,11 @@ export class A2AExecutor implements IExecutor {
         pushNotificationConfig: { url: callbackUrl, token },
       });
       return true;
-    } catch {
+    } catch (err) {
       // Agent doesn't support push notifications — tracker falls back to polling
+      console.log(
+        `[a2a-executor] ${this.config.name}: push-notification register failed for ${taskId.slice(0, 8)}… — ${err instanceof Error ? err.message : String(err)}`,
+      );
       return false;
     }
   }

--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -227,9 +227,24 @@ export class A2AExecutor implements IExecutor {
         },
       };
 
-      const result = this.config.streaming
+      let result = this.config.streaming
         ? await this._executeStream(client, params, req)
         : await this._executeBlocking(client, params, req);
+
+      // Graceful degradation: if the streaming path returned nothing usable
+      // (no taskId, no terminal text), the agent's SSE events likely don't
+      // match the @a2a-js/sdk discriminator shape (missing `kind` field or
+      // similar). Fall through to message/send so the dispatcher + TaskTracker
+      // still get a proper Task handle to work with. Logs the slip so we can
+      // spot agents that need a spec-compliance fix.
+      if (this.config.streaming && !result.isError
+        && !result.data?.taskId
+        && (!result.text || result.text.startsWith(`Skill "${req.skill}" completed by`))) {
+        console.warn(
+          `[a2a-executor] ${this.config.name}: streaming returned empty result — falling back to message/send (agent SSE events may be missing "kind" field)`,
+        );
+        result = await this._executeBlocking(client, params, req);
+      }
 
       // Run extension after-hooks — they read result.data (usage, confidence,
       // worldstate-delta) and emit observability events or record samples.

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -374,9 +374,10 @@ export class SkillDispatcherPlugin implements Plugin {
           const callbackUrl = `${callbackBaseUrl.replace(/\/$/, "")}/api/a2a/callback/${encodeURIComponent(taskId)}`;
           void a2aExecutor.registerPushNotification(taskId, callbackUrl, callbackToken, correlationId, parentId)
             .then(ok => {
-              if (ok) console.log(`[skill-dispatcher] Push-notification registered for ${taskId.slice(0, 8)}…`);
+              if (ok) console.log(`[skill-dispatcher] Push-notification registered for ${taskId.slice(0, 8)}… at ${callbackUrl}`);
+              // Failure path is logged by A2AExecutor.registerPushNotification with agent + reason.
             })
-            .catch(err => console.debug("[skill-dispatcher] push-notification register failed:", err));
+            .catch(err => console.log("[skill-dispatcher] push-notification register failed:", err));
         } else if (callbackBaseUrl) {
           console.log(
             `[skill-dispatcher] ${a2aExecutor.name}: card.capabilities.pushNotifications=false — using polling for ${taskId.slice(0, 8)}…`,


### PR DESCRIPTION
## Summary
cost-v1 has had its consumer side since #372 but no worked producer reference. [Quinn #56](https://github.com/protoLabsAI/quinn/pull/56) lands the emission side. This PR cites Quinn in the extension doc + the gold-standard agent guide so the next agent author has a complete recipe (extraction + emission code) on the same hop.

## Changes
- **\`docs/extensions/cost-v1.md\`** — adds a Reference Implementations table covering both extraction (a2a-executor.ts, #372) and emission (Quinn #56)
- **\`docs/guides/build-an-a2a-agent.md\`** — gold-standard checklist item for cost-v1 now spells out the capture pattern (\`on_chat_model_end\` → \`usage_metadata\`, durationMs from timestamps, emit only when tracked, costUsd optional), and the Reference Implementations section notes Quinn's \`server.py\` adds \`usage\` to the event tuple contract.

## Closes

<!-- Docs follow-up to #372 + quinn#56 — no issue to auto-close. -->

## Test plan
- [x] Renders cleanly (markdown, no broken links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `confidence-v1` artifact type for embedding confidence scores and optional success overrides.
  * Added `cost-v1` artifact type for tracking token usage and optional cost data.

* **Documentation**
  * New guide on propagating Langfuse trace context across distributed agent fleets.
  * New reference implementation documentation for cost tracking.
  * Updated A2A streaming specification with typed event discriminators and improved completion handling.
  * Enhanced gold-standard checklist with required SSE protocol fields and camelCase requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->