### PR TITLE
feat(observability): expose cost + confidence stores, surface usage in chat API

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -99,11 +99,45 @@ export interface HITLRenderer {
 // Distinct from HITLRequest so operators see "this changes the rules of the
 // system" vs "this is a one-shot operational approval".
 
+/**
+ * Evidence block required for data-driven config change proposals
+ * (e.g. from the tuning agent). Forces proposers to carry their work —
+ * approvers see sample counts, baseline metrics, and which skills are
+ * affected, so they can reason about whether the change is statistically
+ * warranted vs. chasing noise.
+ */
+export interface ConfigChangeEvidence {
+  /** Number of samples backing the proposed change. Gated server-side at >= 50. */
+  sampleCount: number;
+  /** Current observed metric (e.g. "successRate=0.45, avgConfidence=0.72"). */
+  baselineMetric: string;
+  /** Expected delta (e.g. "target: successRate>=0.7 via explicit CI-status prompt"). */
+  proposedDelta: string;
+  /** Skill names whose behavior this change affects. */
+  affectedSkills: string[];
+  /** Free-text rationale. */
+  rationale?: string;
+}
+
+/**
+ * Change target for an agent-YAML proposal. Only in-process agent files
+ * can be targeted (goals/actions use their own configFile variants).
+ */
+export interface ConfigChangeAgentTarget {
+  type: "agent";
+  /** Name of the agent — resolves to `workspace/agents/<agentName>.yaml`. */
+  agentName: string;
+}
+
 export interface ConfigChangeRequest {
   type: "config_change_request";
   correlationId: string;
-  /** Which workspace config file is being changed. */
-  configFile: "goals.yaml" | "actions.yaml";
+  /**
+   * Which workspace config file is being changed. Goals + actions use string
+   * literals; agent-YAML changes use a structured target so the approver can
+   * see which agent is affected without parsing a path.
+   */
+  configFile: "goals.yaml" | "actions.yaml" | ConfigChangeAgentTarget;
   title: string;
   summary: string;
   /** Unified diff of the proposed change (before → after). */
@@ -124,6 +158,12 @@ export interface ConfigChangeRequest {
     affectedTestFiles: string[];
     summary: string;
   };
+  /**
+   * Evidence backing the proposal — required for data-driven proposals
+   * (tuning agent). Optional for operator-authored proposals where the
+   * operator's judgment is the evidence.
+   */
+  evidence?: ConfigChangeEvidence;
   options: string[];   // ["approve", "reject"]
   expiresAt: string;   // ISO timestamp
   replyTopic: string;  // where to publish ConfigChangeResponse

--- a/src/api/ava-tools.ts
+++ b/src/api/ava-tools.ts
@@ -138,6 +138,16 @@ export function createRoutes(ctx: ApiContext): Route[] {
       const remoteTaskId = result.data?.taskId;
       const remoteContextId = result.data?.contextId ?? conversationId;
       const taskState = result.data?.taskState ?? "completed";
+      // Surface observability fields (cost-v1, confidence-v1, duration) so the
+      // caller agent sees what its delegation cost and how confident the
+      // sub-agent was. Fields are only present when the sub-agent opted in to
+      // the respective extension and emitted the DataPart — undefined otherwise.
+      const usage = result.data?.usage;
+      const durationMs = typeof result.data?.durationMs === "number" ? result.data.durationMs : undefined;
+      const costUsd = typeof result.data?.costUsd === "number" ? result.data.costUsd : undefined;
+      const confidence = typeof result.data?.confidence === "number" ? result.data.confidence : undefined;
+      const confidenceExplanation = typeof result.data?.confidenceExplanation === "string"
+        ? result.data.confidenceExplanation : undefined;
 
       return Response.json({
         success: true,
@@ -151,6 +161,11 @@ export function createRoutes(ctx: ApiContext): Route[] {
           taskState,
           correlationId,
           agent,
+          ...(usage ? { usage } : {}),
+          ...(durationMs !== undefined ? { durationMs } : {}),
+          ...(costUsd !== undefined ? { costUsd } : {}),
+          ...(confidence !== undefined ? { confidence } : {}),
+          ...(confidenceExplanation ? { confidenceExplanation } : {}),
         },
       });
     } catch (e) {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -20,6 +20,7 @@ import { createRoutes as a2aCallbackRoutes } from "./a2a-callback.ts";
 import { createRoutes as a2aServerRoutes } from "./a2a-server.ts";
 import { createRoutes as agentCardRoutes } from "./agent-card.ts";
 import { createRoutes as widgetsRoutes } from "./widgets.ts";
+import { createRoutes as observabilityRoutes } from "./observability.ts";
 
 export { matchPath } from "./types.ts";
 export type { Route, ApiContext } from "./types.ts";
@@ -39,5 +40,6 @@ export function createAllRoutes(ctx: ApiContext): Route[] {
     ...agentCardRoutes(ctx),
     ...a2aServerRoutes(ctx),
     ...widgetsRoutes(ctx),
+    ...observabilityRoutes(ctx),
   ];
 }

--- a/src/api/observability.ts
+++ b/src/api/observability.ts
@@ -1,0 +1,75 @@
+/**
+ * Observability routes — exposes per-(agent, skill) cost + confidence summaries
+ * captured by the cost-v1 and confidence-v1 extension interceptors.
+ *
+ * Primary consumer: the tuning agent, which reads these over HTTP to identify
+ * outlier skills (low success rate, calibration inversions, expensive skills)
+ * and proposes constraint changes through ConfigChangeHITL.
+ */
+
+import type { Route, ApiContext } from "./types.ts";
+import { defaultCostStore } from "../executor/extensions/cost.ts";
+import { defaultConfidenceStore } from "../executor/extensions/confidence.ts";
+
+export function createRoutes(ctx: ApiContext): Route[] {
+  function requireAuth(req: Request): Response | null {
+    if (!ctx.apiKey) return null;
+    const headerKey = req.headers.get("X-API-Key");
+    const bearer = req.headers.get("Authorization");
+    const apiKey = headerKey ?? (bearer?.startsWith("Bearer ") ? bearer.slice(7) : null);
+    if (apiKey === ctx.apiKey) return null;
+    if (ctx.agentKeys && ctx.agentKeys.resolve(apiKey)) return null;
+    return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  /**
+   * GET /api/cost-summaries?agent=&skill=&minSamples=
+   *
+   * Returns an array of CostSummary records. Filters:
+   *   - agent: only summaries for this agent name
+   *   - skill: only summaries for this skill name
+   *   - minSamples: only summaries with at least N samples (gates statistical noise)
+   */
+  function handleCostSummaries(req: Request): Response {
+    const authErr = requireAuth(req);
+    if (authErr) return authErr;
+
+    const url = new URL(req.url);
+    const agent = url.searchParams.get("agent");
+    const skill = url.searchParams.get("skill");
+    const minSamples = parseInt(url.searchParams.get("minSamples") ?? "0", 10);
+
+    let summaries = defaultCostStore.allSummaries();
+    if (agent) summaries = summaries.filter(s => s.agentName === agent);
+    if (skill) summaries = summaries.filter(s => s.skill === skill);
+    if (minSamples > 0) summaries = summaries.filter(s => s.sampleCount >= minSamples);
+
+    return Response.json({ success: true, data: summaries });
+  }
+
+  /**
+   * GET /api/confidence-summaries?agent=&skill=
+   *
+   * Returns an array of ConfidenceSummary records with calibration metrics
+   * (avgConfidence, avgConfidenceOnSuccess/Failure, highConfFailures count).
+   */
+  function handleConfidenceSummaries(req: Request): Response {
+    const authErr = requireAuth(req);
+    if (authErr) return authErr;
+
+    const url = new URL(req.url);
+    const agent = url.searchParams.get("agent");
+    const skill = url.searchParams.get("skill");
+
+    let summaries = defaultConfidenceStore.allSummaries();
+    if (agent) summaries = summaries.filter(s => s.agentName === agent);
+    if (skill) summaries = summaries.filter(s => s.skill === skill);
+
+    return Response.json({ success: true, data: summaries });
+  }
+
+  return [
+    { method: "GET", path: "/api/cost-summaries",       handler: req => handleCostSummaries(req) },
+    { method: "GET", path: "/api/confidence-summaries", handler: req => handleConfidenceSummaries(req) },
+  ];
+}

--- a/src/executor/types.ts
+++ b/src/executor/types.ts
@@ -69,6 +69,16 @@ export interface SkillResult {
      * for the same correlationId+agentName can resume the session.
      */
     sessionId?: string;
+    /** Wall-clock duration, from a cost-v1 DataPart. */
+    durationMs?: number;
+    /** Dollar cost, from a cost-v1 DataPart. */
+    costUsd?: number;
+    /** Explicit success flag from cost-v1 / confidence-v1 DataParts. */
+    success?: boolean;
+    /** Self-reported confidence in [0, 1], from a confidence-v1 DataPart. */
+    confidence?: number;
+    /** Free-text confidence explanation, from a confidence-v1 DataPart. */
+    confidenceExplanation?: string;
   };
 }
 


### PR DESCRIPTION
## Summary

PR 1 of 3 — foundation for the **fleet tuning agent** (Joe's Order 2 / AOTL).

Following the due-diligence plan: data foundation first, then tools, then the agent.

## Changes

### 1. New observability endpoints

- \`GET /api/cost-summaries?agent=&skill=&minSamples=\` — per-(agent, skill) rolling-window stats from \`defaultCostStore\`
- \`GET /api/confidence-summaries?agent=&skill=\` — calibration metrics including \`highConfFailures\`

Gated by \`X-API-Key\` (admin or per-agent). The \`?minSamples\` filter lets callers enforce a statistical floor — research recommends \`>=50\` samples before acting, \`>=100\` for high-confidence tuning proposals.

### 2. Chat API surfaces observability fields

Before this PR, \`/api/a2a/chat\` stripped \`usage\`, \`costUsd\`, \`durationMs\`, \`confidence\`, \`confidenceExplanation\` from the response. After: those fields flow through when populated by the cost-v1 / confidence-v1 DataPart extractors shipped in v0.7.14. Caller agents now see what delegations cost and how confident sub-agents were.

### 3. ConfigChangeRequest extended for agent YAML + evidence

- \`configFile\` now accepts a structured \`ConfigChangeAgentTarget { type: "agent", agentName }\` alongside the \`"goals.yaml" | "actions.yaml"\` literals
- New \`evidence?: ConfigChangeEvidence\` block with \`sampleCount\`, \`baselineMetric\`, \`proposedDelta\`, \`affectedSkills\`, \`rationale\` — forces data-driven proposals to carry their work

Operator-authored proposals can still omit \`evidence\`. The tuning agent (PR 3) will require it.

## What's NOT in this PR

- Diff-apply subscriber (lands in PR 2 alongside the \`propose_config_change\` tool)
- Tuning agent YAML (PR 3)
- Bus tools for reading summaries (PR 2)

## Verification

- [x] \`bun test\` — 953 pass / 0 fail
- [ ] CI green
- [ ] Post-deploy: \`curl /api/cost-summaries\` returns \`{ success: true, data: [] }\` (empty until Quinn emits DataParts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for data-driven configuration proposals with evidence metrics and rationale
  * Enabled agent-specific configuration targeting for more precise updates
  * New observability API endpoints for retrieving cost and confidence summaries with filtering

* **Improvements**
  * Enhanced API responses with execution metrics (duration, cost, confidence levels)
  * Extended skill execution tracking with detailed performance and reliability indicators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->