### PR TITLE
feat(tuning): add tuner agent + weekly fleet-tuning-review ceremony

### DIFF
--- a/lib/plugins/__tests__/config-change-hitl.test.ts
+++ b/lib/plugins/__tests__/config-change-hitl.test.ts
@@ -1,0 +1,151 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { InMemoryEventBus } from "../../bus.ts";
+import { ConfigChangeHITLPlugin, recordPendingContent } from "../config-change-hitl.ts";
+import type { ConfigChangeRequest } from "../../types.ts";
+
+describe("ConfigChangeHITLPlugin — applier", () => {
+  let workspaceDir: string;
+  let bus: InMemoryEventBus;
+  let plugin: ConfigChangeHITLPlugin;
+
+  beforeEach(() => {
+    workspaceDir = mkdtempSync(join(tmpdir(), "cchitl-"));
+    mkdirSync(join(workspaceDir, "agents"), { recursive: true });
+    bus = new InMemoryEventBus();
+    plugin = new ConfigChangeHITLPlugin();
+    plugin.setWorkspaceDir(workspaceDir);
+    plugin.install(bus);
+  });
+
+  afterEach(() => {
+    plugin.uninstall();
+    rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  function publishRequest(req: ConfigChangeRequest): void {
+    bus.publish(`config.change.request.${req.correlationId}`, {
+      id: crypto.randomUUID(),
+      correlationId: req.correlationId,
+      topic: `config.change.request.${req.correlationId}`,
+      timestamp: Date.now(),
+      payload: req,
+    });
+  }
+
+  function publishApproval(correlationId: string, decision: "approve" | "reject"): void {
+    bus.publish(`config.change.response.${correlationId}`, {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic: `config.change.response.${correlationId}`,
+      timestamp: Date.now(),
+      payload: { type: "config_change_response", correlationId, decision, decidedBy: "test" },
+    });
+  }
+
+  test("writes agent YAML on approve", async () => {
+    const target = join(workspaceDir, "agents", "demo.yaml");
+    writeFileSync(target, "name: demo\nsystemPrompt: original\n");
+
+    const correlationId = "c1";
+    const newContent = "name: demo\nsystemPrompt: updated\n";
+    recordPendingContent(correlationId, target, newContent);
+
+    publishRequest({
+      type: "config_change_request",
+      correlationId,
+      configFile: { type: "agent", agentName: "demo" },
+      title: "Update demo prompt",
+      summary: "Test apply",
+      yamlDiff: "- original\n+ updated\n",
+      evidence: { sampleCount: 60, baselineMetric: "successRate=0.45", proposedDelta: "+0.2", affectedSkills: ["chat"] },
+      options: ["approve", "reject"],
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      replyTopic: `config.change.response.${correlationId}`,
+    });
+
+    publishApproval(correlationId, "approve");
+    await new Promise(r => setTimeout(r, 20));
+
+    expect(readFileSync(target, "utf8")).toBe(newContent);
+  });
+
+  test("does NOT write on reject", async () => {
+    const target = join(workspaceDir, "agents", "demo.yaml");
+    const originalContent = "name: demo\nsystemPrompt: original\n";
+    writeFileSync(target, originalContent);
+
+    const correlationId = "c2";
+    recordPendingContent(correlationId, target, "updated");
+
+    publishRequest({
+      type: "config_change_request",
+      correlationId,
+      configFile: { type: "agent", agentName: "demo" },
+      title: "t", summary: "s", yamlDiff: "d",
+      evidence: { sampleCount: 100, baselineMetric: "b", proposedDelta: "d", affectedSkills: ["x"] },
+      options: ["approve", "reject"],
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      replyTopic: `config.change.response.${correlationId}`,
+    });
+
+    publishApproval(correlationId, "reject");
+    await new Promise(r => setTimeout(r, 20));
+
+    expect(readFileSync(target, "utf8")).toBe(originalContent);
+  });
+
+  test("does not write when target file does not exist (no create-via-approval)", async () => {
+    const correlationId = "c3";
+    const target = join(workspaceDir, "agents", "missing.yaml");
+    recordPendingContent(correlationId, target, "name: missing\n");
+
+    publishRequest({
+      type: "config_change_request",
+      correlationId,
+      configFile: { type: "agent", agentName: "missing" },
+      title: "t", summary: "s", yamlDiff: "d",
+      evidence: { sampleCount: 100, baselineMetric: "b", proposedDelta: "d", affectedSkills: ["x"] },
+      options: ["approve", "reject"],
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      replyTopic: `config.change.response.${correlationId}`,
+    });
+
+    publishApproval(correlationId, "approve");
+    await new Promise(r => setTimeout(r, 20));
+
+    // File still doesn't exist — applier refuses to create new files
+    expect(() => readFileSync(target, "utf8")).toThrow();
+  });
+
+  test("publishes config.change.applied.* on successful apply", async () => {
+    const target = join(workspaceDir, "goals.yaml");
+    writeFileSync(target, "goals: []\n");
+
+    const correlationId = "c4";
+    recordPendingContent(correlationId, target, "goals: [updated]\n");
+
+    const appliedEvents: unknown[] = [];
+    bus.subscribe("config.change.applied.#", "test-sub", msg => {
+      appliedEvents.push(msg.payload);
+    });
+
+    publishRequest({
+      type: "config_change_request",
+      correlationId,
+      configFile: "goals.yaml",
+      title: "t", summary: "s", yamlDiff: "d",
+      options: ["approve", "reject"],
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      replyTopic: `config.change.response.${correlationId}`,
+    });
+
+    publishApproval(correlationId, "approve");
+    await new Promise(r => setTimeout(r, 20));
+
+    expect(appliedEvents).toHaveLength(1);
+    expect((appliedEvents[0] as { type: string }).type).toBe("config_change_applied");
+  });
+});

--- a/lib/plugins/config-change-hitl.ts
+++ b/lib/plugins/config-change-hitl.ts
@@ -20,6 +20,8 @@
  * Payload shape for config.change.response.*: ConfigChangeResponse (lib/types.ts)
  */
 
+import { writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
 import type {
   EventBus,
   BusMessage,
@@ -35,6 +37,30 @@ const renderers = new Map<string, ConfigChangeRenderer>();
 // ── Pending request store ──────────────────────────────────────────────────
 const pendingRequests = new Map<string, ConfigChangeRequest>();
 
+/**
+ * Companion map keyed by correlationId → proposed new file content. Lets the
+ * applier write the full approved content on decision=approve. Populated via
+ * the propose endpoint (not via the bus topic, which carries only yamlDiff).
+ */
+const pendingContent = new Map<string, { targetPath: string; newContent: string }>();
+
+/** Resolve the workspace-relative path a ConfigChangeRequest writes to. */
+function resolveTargetPath(workspaceDir: string, req: ConfigChangeRequest): string | null {
+  if (req.configFile === "goals.yaml" || req.configFile === "actions.yaml") {
+    return join(workspaceDir, req.configFile);
+  }
+  if (typeof req.configFile === "object" && req.configFile.type === "agent") {
+    if (!/^[\w\-]+$/.test(req.configFile.agentName)) return null;
+    return join(workspaceDir, "agents", `${req.configFile.agentName}.yaml`);
+  }
+  return null;
+}
+
+/** Public helper so the propose HTTP endpoint can register the new content. */
+export function recordPendingContent(correlationId: string, targetPath: string, newContent: string): void {
+  pendingContent.set(correlationId, { targetPath, newContent });
+}
+
 // ── Plugin ────────────────────────────────────────────────────────────────
 
 export class ConfigChangeHITLPlugin implements Plugin {
@@ -44,6 +70,16 @@ export class ConfigChangeHITLPlugin implements Plugin {
   readonly capabilities = ["config-change-hitl-routing"];
 
   private expiryTimer: ReturnType<typeof setInterval> | null = null;
+  private workspaceDir: string | null = null;
+
+  /**
+   * Optional workspace directory. When set, approved config-change responses
+   * are applied automatically by writing the proposed newContent to the target
+   * file. Without it, approvals are logged but nothing is written.
+   */
+  setWorkspaceDir(dir: string): void {
+    this.workspaceDir = dir;
+  }
 
   /** All currently pending (unexpired, undecided) config-change requests. */
   getPendingRequests(): ConfigChangeRequest[] {
@@ -122,11 +158,57 @@ export class ConfigChangeHITLPlugin implements Plugin {
       );
     });
 
-    // ── Clean up pending map when a response arrives ──────────────────
+    // ── Apply approved changes + clean up pending map on response ─────
     bus.subscribe("config.change.response.#", this.name, (msg: BusMessage) => {
       const resp = msg.payload as ConfigChangeResponse;
       if (resp?.type !== "config_change_response") return;
+
+      const req = pendingRequests.get(resp.correlationId);
+      const content = pendingContent.get(resp.correlationId);
       pendingRequests.delete(resp.correlationId);
+      pendingContent.delete(resp.correlationId);
+
+      if (resp.decision !== "approve") {
+        console.log(
+          `[config-change-hitl] ${resp.correlationId} rejected by ${resp.decidedBy}${resp.feedback ? ` — ${resp.feedback}` : ""}`,
+        );
+        return;
+      }
+
+      if (!req || !content || !this.workspaceDir) {
+        console.warn(
+          `[config-change-hitl] ${resp.correlationId} approved but missing request/content/workspaceDir — cannot auto-apply`,
+        );
+        return;
+      }
+
+      const targetPath = resolveTargetPath(this.workspaceDir, req);
+      if (!targetPath || targetPath !== content.targetPath) {
+        console.warn(
+          `[config-change-hitl] ${resp.correlationId} approved but target path mismatch — refusing to apply`,
+        );
+        return;
+      }
+
+      try {
+        if (!existsSync(targetPath)) {
+          console.warn(`[config-change-hitl] target file ${targetPath} does not exist — refusing to create via approval`);
+          return;
+        }
+        writeFileSync(targetPath, content.newContent, "utf8");
+        console.log(
+          `[config-change-hitl] ${resp.correlationId} applied by ${resp.decidedBy} → ${targetPath}`,
+        );
+        bus.publish(`config.change.applied.${resp.correlationId}`, {
+          id: crypto.randomUUID(),
+          correlationId: resp.correlationId,
+          topic: `config.change.applied.${resp.correlationId}`,
+          timestamp: Date.now(),
+          payload: { type: "config_change_applied", correlationId: resp.correlationId, targetPath },
+        });
+      } catch (err) {
+        console.error(`[config-change-hitl] apply failed for ${resp.correlationId}:`, err);
+      }
     });
   }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -99,11 +99,45 @@ export interface HITLRenderer {
 // Distinct from HITLRequest so operators see "this changes the rules of the
 // system" vs "this is a one-shot operational approval".
 
+/**
+ * Evidence block required for data-driven config change proposals
+ * (e.g. from the tuning agent). Forces proposers to carry their work —
+ * approvers see sample counts, baseline metrics, and which skills are
+ * affected, so they can reason about whether the change is statistically
+ * warranted vs. chasing noise.
+ */
+export interface ConfigChangeEvidence {
+  /** Number of samples backing the proposed change. Gated server-side at >= 50. */
+  sampleCount: number;
+  /** Current observed metric (e.g. "successRate=0.45, avgConfidence=0.72"). */
+  baselineMetric: string;
+  /** Expected delta (e.g. "target: successRate>=0.7 via explicit CI-status prompt"). */
+  proposedDelta: string;
+  /** Skill names whose behavior this change affects. */
+  affectedSkills: string[];
+  /** Free-text rationale. */
+  rationale?: string;
+}
+
+/**
+ * Change target for an agent-YAML proposal. Only in-process agent files
+ * can be targeted (goals/actions use their own configFile variants).
+ */
+export interface ConfigChangeAgentTarget {
+  type: "agent";
+  /** Name of the agent — resolves to `workspace/agents/<agentName>.yaml`. */
+  agentName: string;
+}
+
 export interface ConfigChangeRequest {
   type: "config_change_request";
   correlationId: string;
-  /** Which workspace config file is being changed. */
-  configFile: "goals.yaml" | "actions.yaml";
+  /**
+   * Which workspace config file is being changed. Goals + actions use string
+   * literals; agent-YAML changes use a structured target so the approver can
+   * see which agent is affected without parsing a path.
+   */
+  configFile: "goals.yaml" | "actions.yaml" | ConfigChangeAgentTarget;
   title: string;
   summary: string;
   /** Unified diff of the proposed change (before → after). */
@@ -124,6 +158,12 @@ export interface ConfigChangeRequest {
     affectedTestFiles: string[];
     summary: string;
   };
+  /**
+   * Evidence backing the proposal — required for data-driven proposals
+   * (tuning agent). Optional for operator-authored proposals where the
+   * operator's judgment is the evidence.
+   */
+  evidence?: ConfigChangeEvidence;
   options: string[];   // ["approve", "reject"]
   expiresAt: string;   // ISO timestamp
   replyTopic: string;  // where to publish ConfigChangeResponse

--- a/src/agent-runtime/tools/bus-tools.ts
+++ b/src/agent-runtime/tools/bus-tools.ts
@@ -407,10 +407,99 @@ export function createBusTools(opts: BusToolsOptions = {}) {
     },
   );
 
+  // ── Tuning / observability tools ────────────────────────────────────────
+
+  const getCostSummary = tool(
+    "get_cost_summary",
+    "Read per-(agent, skill) cost samples (token usage, duration, dollar cost, success rate). " +
+      "Use to identify expensive or failing skills. Supports filtering by agent, skill, and minimum sample count " +
+      "(recommended: minSamples=50 to gate statistical noise, 100+ for tuning proposals).",
+    {
+      agent: z.string().optional().describe("Filter by agent name, e.g. 'quinn'"),
+      skill: z.string().optional().describe("Filter by skill name, e.g. 'pr_review'"),
+      minSamples: z.number().optional().describe("Minimum sample count (default: 0)"),
+    },
+    async ({ agent, skill, minSamples }) => {
+      try {
+        const params = new URLSearchParams();
+        if (agent) params.set("agent", agent);
+        if (skill) params.set("skill", skill);
+        if (minSamples !== undefined) params.set("minSamples", String(minSamples));
+        const qs = params.toString();
+        const data = await http.get(`/api/cost-summaries${qs ? "?" + qs : ""}`);
+        return ok(data);
+      } catch (e) {
+        return err(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  const getConfidenceSummary = tool(
+    "get_confidence_summary",
+    "Read per-(agent, skill) confidence calibration metrics (avgConfidence, " +
+      "avgConfidenceOnSuccess vs OnFailure, highConfFailures count — the key miscalibration signal). " +
+      "Use to spot skills where the agent is overconfident on failures.",
+    {
+      agent: z.string().optional().describe("Filter by agent name"),
+      skill: z.string().optional().describe("Filter by skill name"),
+    },
+    async ({ agent, skill }) => {
+      try {
+        const params = new URLSearchParams();
+        if (agent) params.set("agent", agent);
+        if (skill) params.set("skill", skill);
+        const qs = params.toString();
+        const data = await http.get(`/api/confidence-summaries${qs ? "?" + qs : ""}`);
+        return ok(data);
+      } catch (e) {
+        return err(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  const proposeConfigChange = tool(
+    "propose_config_change",
+    "Propose a change to workspace config (goals.yaml, actions.yaml, or an agent YAML) " +
+      "that a human must approve via Discord before it applies. " +
+      "Data-driven proposals must include `evidence` (sampleCount, baselineMetric, " +
+      "proposedDelta, affectedSkills) so the approver can judge whether the change " +
+      "is warranted. Proposals targeting agent YAML require sampleCount >= 50.",
+    {
+      target: z.union([
+        z.literal("goals.yaml"),
+        z.literal("actions.yaml"),
+        z.object({ type: z.literal("agent"), agentName: z.string() }),
+      ]).describe("Which config to change. Pass 'goals.yaml' / 'actions.yaml' for those files, " +
+        "or { type: 'agent', agentName: 'quinn' } for workspace/agents/quinn.yaml"),
+      title: z.string().describe("One-line summary of the proposed change"),
+      summary: z.string().describe("Multi-sentence explanation of what and why"),
+      yamlDiff: z.string().describe("Unified diff (before → after) for operator review"),
+      newContent: z.string().optional().describe("Full new file content — used by the applier when approved"),
+      evidence: z.object({
+        sampleCount: z.number(),
+        baselineMetric: z.string(),
+        proposedDelta: z.string(),
+        affectedSkills: z.array(z.string()),
+        rationale: z.string().optional(),
+      }).optional().describe("Data-driven evidence block. Required for tuning-agent proposals."),
+    },
+    async ({ target, title, summary, yamlDiff, newContent, evidence }) => {
+      try {
+        const data = await http.post("/api/config-change/propose", {
+          target, title, summary, yamlDiff, newContent, evidence,
+        });
+        return ok(data);
+      } catch (e) {
+        return err(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
   return [
     publishEvent, getWorldState, getIncidents, reportIncident, getProjects,
     getCiHealth, getPrPipeline, getBranchDrift, getOutcomes, getCeremonies, runCeremony,
     chatWithAgent, delegateTask, manageBoard, createGitHubIssue, manageCron, webSearch,
+    getCostSummary, getConfidenceSummary, proposeConfigChange,
   ];
 }
 
@@ -445,6 +534,10 @@ export const BUS_TOOL_NAMES = [
   // Conversation feedback (any DeepAgent)
   "react",
   "send_update",
+  // Tuning / observability (tuner agent, Ava helm)
+  "get_cost_summary",
+  "get_confidence_summary",
+  "propose_config_change",
 ] as const;
 
 export type BusToolName = (typeof BUS_TOOL_NAMES)[number];

--- a/src/api/ava-tools.ts
+++ b/src/api/ava-tools.ts
@@ -138,6 +138,16 @@ export function createRoutes(ctx: ApiContext): Route[] {
       const remoteTaskId = result.data?.taskId;
       const remoteContextId = result.data?.contextId ?? conversationId;
       const taskState = result.data?.taskState ?? "completed";
+      // Surface observability fields (cost-v1, confidence-v1, duration) so the
+      // caller agent sees what its delegation cost and how confident the
+      // sub-agent was. Fields are only present when the sub-agent opted in to
+      // the respective extension and emitted the DataPart — undefined otherwise.
+      const usage = result.data?.usage;
+      const durationMs = typeof result.data?.durationMs === "number" ? result.data.durationMs : undefined;
+      const costUsd = typeof result.data?.costUsd === "number" ? result.data.costUsd : undefined;
+      const confidence = typeof result.data?.confidence === "number" ? result.data.confidence : undefined;
+      const confidenceExplanation = typeof result.data?.confidenceExplanation === "string"
+        ? result.data.confidenceExplanation : undefined;
 
       return Response.json({
         success: true,
@@ -151,6 +161,11 @@ export function createRoutes(ctx: ApiContext): Route[] {
           taskState,
           correlationId,
           agent,
+          ...(usage ? { usage } : {}),
+          ...(durationMs !== undefined ? { durationMs } : {}),
+          ...(costUsd !== undefined ? { costUsd } : {}),
+          ...(confidence !== undefined ? { confidence } : {}),
+          ...(confidenceExplanation ? { confidenceExplanation } : {}),
         },
       });
     } catch (e) {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -20,6 +20,7 @@ import { createRoutes as a2aCallbackRoutes } from "./a2a-callback.ts";
 import { createRoutes as a2aServerRoutes } from "./a2a-server.ts";
 import { createRoutes as agentCardRoutes } from "./agent-card.ts";
 import { createRoutes as widgetsRoutes } from "./widgets.ts";
+import { createRoutes as observabilityRoutes } from "./observability.ts";
 
 export { matchPath } from "./types.ts";
 export type { Route, ApiContext } from "./types.ts";
@@ -39,5 +40,6 @@ export function createAllRoutes(ctx: ApiContext): Route[] {
     ...agentCardRoutes(ctx),
     ...a2aServerRoutes(ctx),
     ...widgetsRoutes(ctx),
+    ...observabilityRoutes(ctx),
   ];
 }

--- a/src/api/observability.ts
+++ b/src/api/observability.ts
@@ -10,6 +10,14 @@
 import type { Route, ApiContext } from "./types.ts";
 import { defaultCostStore } from "../executor/extensions/cost.ts";
 import { defaultConfidenceStore } from "../executor/extensions/confidence.ts";
+import type { ConfigChangeRequest, ConfigChangeEvidence } from "../../lib/types.ts";
+import { recordPendingContent } from "../../lib/plugins/config-change-hitl.ts";
+import { join } from "node:path";
+
+/** Minimum samples required for a data-driven agent-YAML proposal to be accepted. */
+const MIN_SAMPLES_FOR_AGENT_PROPOSAL = 50;
+/** Proposals expire if the operator hasn't decided within this window. */
+const PROPOSAL_TTL_MS = 48 * 60 * 60_000;
 
 export function createRoutes(ctx: ApiContext): Route[] {
   function requireAuth(req: Request): Response | null {
@@ -68,8 +76,113 @@ export function createRoutes(ctx: ApiContext): Route[] {
     return Response.json({ success: true, data: summaries });
   }
 
+  /**
+   * POST /api/config-change/propose
+   *
+   * Agent-facing endpoint for submitting a ConfigChangeRequest through the
+   * HITL approval gate. Validates evidence, registers pending content for
+   * the applier, publishes `config.change.request.{correlationId}`.
+   *
+   * Body: { target, title, summary, yamlDiff, newContent?, evidence? }
+   *   - target: "goals.yaml" | "actions.yaml" | { type: "agent", agentName }
+   *   - evidence required when target is an agent; sampleCount >= 50
+   *   - newContent required for auto-apply on approve (applier writes it)
+   *
+   * Response: { success, data: { correlationId, expiresAt } }
+   */
+  async function handleProposeConfigChange(req: Request): Promise<Response> {
+    const authErr = requireAuth(req);
+    if (authErr) return authErr;
+
+    let body: Record<string, unknown>;
+    try { body = (await req.json()) as Record<string, unknown>; }
+    catch { return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 }); }
+
+    const target = body.target as ConfigChangeRequest["configFile"] | undefined;
+    const title = body.title as string | undefined;
+    const summary = body.summary as string | undefined;
+    const yamlDiff = body.yamlDiff as string | undefined;
+    const newContent = body.newContent as string | undefined;
+    const evidence = body.evidence as ConfigChangeEvidence | undefined;
+
+    if (!target || !title || !summary || !yamlDiff) {
+      return Response.json(
+        { success: false, error: "target, title, summary, yamlDiff are required" },
+        { status: 400 },
+      );
+    }
+
+    const isAgentTarget = typeof target === "object" && (target as { type?: string }).type === "agent";
+    if (isAgentTarget) {
+      const agentName = (target as { agentName?: string }).agentName;
+      if (!agentName || !/^[\w\-]+$/.test(agentName)) {
+        return Response.json({ success: false, error: "Invalid agentName" }, { status: 400 });
+      }
+      if (agentName === "tuner") {
+        return Response.json(
+          { success: false, error: "Tuner cannot propose changes to its own YAML (self-modification loop guard)" },
+          { status: 403 },
+        );
+      }
+      if (!evidence) {
+        return Response.json({ success: false, error: "Agent-YAML proposals require evidence block" }, { status: 400 });
+      }
+      if (evidence.sampleCount < MIN_SAMPLES_FOR_AGENT_PROPOSAL) {
+        return Response.json(
+          { success: false, error: `Agent-YAML proposals require sampleCount >= ${MIN_SAMPLES_FOR_AGENT_PROPOSAL} (got ${evidence.sampleCount})` },
+          { status: 400 },
+        );
+      }
+      if (!newContent) {
+        return Response.json({ success: false, error: "Agent-YAML proposals require newContent for auto-apply" }, { status: 400 });
+      }
+    }
+
+    const correlationId = crypto.randomUUID();
+    const expiresAt = new Date(Date.now() + PROPOSAL_TTL_MS).toISOString();
+    const replyTopic = `config.change.response.${correlationId}`;
+
+    let targetPath: string;
+    if (target === "goals.yaml" || target === "actions.yaml") {
+      targetPath = join(ctx.workspaceDir, target);
+    } else if (isAgentTarget) {
+      targetPath = join(ctx.workspaceDir, "agents", `${(target as { agentName: string }).agentName}.yaml`);
+    } else {
+      return Response.json({ success: false, error: "Invalid target" }, { status: 400 });
+    }
+
+    if (newContent) {
+      recordPendingContent(correlationId, targetPath, newContent);
+    }
+
+    const proposal: ConfigChangeRequest = {
+      type: "config_change_request",
+      correlationId,
+      configFile: target,
+      title,
+      summary,
+      yamlDiff,
+      ...(evidence ? { evidence } : {}),
+      options: ["approve", "reject"],
+      expiresAt,
+      replyTopic,
+      sourceMeta: { interface: "discord" },
+    };
+
+    ctx.bus.publish(`config.change.request.${correlationId}`, {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic: `config.change.request.${correlationId}`,
+      timestamp: Date.now(),
+      payload: proposal,
+    });
+
+    return Response.json({ success: true, data: { correlationId, expiresAt } });
+  }
+
   return [
-    { method: "GET", path: "/api/cost-summaries",       handler: req => handleCostSummaries(req) },
-    { method: "GET", path: "/api/confidence-summaries", handler: req => handleConfidenceSummaries(req) },
+    { method: "GET",  path: "/api/cost-summaries",        handler: req => handleCostSummaries(req) },
+    { method: "GET",  path: "/api/confidence-summaries",  handler: req => handleConfidenceSummaries(req) },
+    { method: "POST", path: "/api/config-change/propose", handler: req => handleProposeConfigChange(req) },
   ];
 }

--- a/src/api/observability.ts
+++ b/src/api/observability.ts
@@ -1,0 +1,75 @@
+/**
+ * Observability routes — exposes per-(agent, skill) cost + confidence summaries
+ * captured by the cost-v1 and confidence-v1 extension interceptors.
+ *
+ * Primary consumer: the tuning agent, which reads these over HTTP to identify
+ * outlier skills (low success rate, calibration inversions, expensive skills)
+ * and proposes constraint changes through ConfigChangeHITL.
+ */
+
+import type { Route, ApiContext } from "./types.ts";
+import { defaultCostStore } from "../executor/extensions/cost.ts";
+import { defaultConfidenceStore } from "../executor/extensions/confidence.ts";
+
+export function createRoutes(ctx: ApiContext): Route[] {
+  function requireAuth(req: Request): Response | null {
+    if (!ctx.apiKey) return null;
+    const headerKey = req.headers.get("X-API-Key");
+    const bearer = req.headers.get("Authorization");
+    const apiKey = headerKey ?? (bearer?.startsWith("Bearer ") ? bearer.slice(7) : null);
+    if (apiKey === ctx.apiKey) return null;
+    if (ctx.agentKeys && ctx.agentKeys.resolve(apiKey)) return null;
+    return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  /**
+   * GET /api/cost-summaries?agent=&skill=&minSamples=
+   *
+   * Returns an array of CostSummary records. Filters:
+   *   - agent: only summaries for this agent name
+   *   - skill: only summaries for this skill name
+   *   - minSamples: only summaries with at least N samples (gates statistical noise)
+   */
+  function handleCostSummaries(req: Request): Response {
+    const authErr = requireAuth(req);
+    if (authErr) return authErr;
+
+    const url = new URL(req.url);
+    const agent = url.searchParams.get("agent");
+    const skill = url.searchParams.get("skill");
+    const minSamples = parseInt(url.searchParams.get("minSamples") ?? "0", 10);
+
+    let summaries = defaultCostStore.allSummaries();
+    if (agent) summaries = summaries.filter(s => s.agentName === agent);
+    if (skill) summaries = summaries.filter(s => s.skill === skill);
+    if (minSamples > 0) summaries = summaries.filter(s => s.sampleCount >= minSamples);
+
+    return Response.json({ success: true, data: summaries });
+  }
+
+  /**
+   * GET /api/confidence-summaries?agent=&skill=
+   *
+   * Returns an array of ConfidenceSummary records with calibration metrics
+   * (avgConfidence, avgConfidenceOnSuccess/Failure, highConfFailures count).
+   */
+  function handleConfidenceSummaries(req: Request): Response {
+    const authErr = requireAuth(req);
+    if (authErr) return authErr;
+
+    const url = new URL(req.url);
+    const agent = url.searchParams.get("agent");
+    const skill = url.searchParams.get("skill");
+
+    let summaries = defaultConfidenceStore.allSummaries();
+    if (agent) summaries = summaries.filter(s => s.agentName === agent);
+    if (skill) summaries = summaries.filter(s => s.skill === skill);
+
+    return Response.json({ success: true, data: summaries });
+  }
+
+  return [
+    { method: "GET", path: "/api/cost-summaries",       handler: req => handleCostSummaries(req) },
+    { method: "GET", path: "/api/confidence-summaries", handler: req => handleConfidenceSummaries(req) },
+  ];
+}

--- a/src/executor/types.ts
+++ b/src/executor/types.ts
@@ -69,6 +69,16 @@ export interface SkillResult {
      * for the same correlationId+agentName can resume the session.
      */
     sessionId?: string;
+    /** Wall-clock duration, from a cost-v1 DataPart. */
+    durationMs?: number;
+    /** Dollar cost, from a cost-v1 DataPart. */
+    costUsd?: number;
+    /** Explicit success flag from cost-v1 / confidence-v1 DataParts. */
+    success?: boolean;
+    /** Self-reported confidence in [0, 1], from a confidence-v1 DataPart. */
+    confidence?: number;
+    /** Free-text confidence explanation, from a confidence-v1 DataPart. */
+    confidenceExplanation?: string;
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -402,6 +402,7 @@ registeredPlugins.push(hitlPlugin);
 // Separate gate from operational HITL: "rules are changing" vs "one-shot approval".
 const { ConfigChangeHITLPlugin } = await import("../lib/plugins/config-change-hitl.js");
 const configChangePlugin = new ConfigChangeHITLPlugin();
+configChangePlugin.setWorkspaceDir(workspaceDir);
 configChangePlugin.install(bus);
 registeredPlugins.push(configChangePlugin);
 

--- a/workspace/agents/tuner.yaml
+++ b/workspace/agents/tuner.yaml
@@ -1,0 +1,116 @@
+# Tuner — fleet self-improvement protoAgent (Order 2 / AOTL).
+#
+# Reads observability data for the fleet (per-(agent, skill) cost summaries,
+# confidence calibration metrics, outcome patterns) and proposes constraint
+# changes to improve performance over time. All proposals go through
+# ConfigChangeHITL — a human approves each one on Discord before the file
+# gets touched.
+#
+# The tuner never modifies its own YAML (enforced server-side in the
+# propose endpoint). It never proposes goals.yaml changes (that's Ava's
+# job via goal_proposal). It only proposes agent-YAML prompt tweaks and
+# actions.yaml edits when strongly motivated by data.
+
+name: tuner
+role: general
+
+model: claude-sonnet-4-6
+
+systemPrompt: |
+  You are the Tuner, the fleet's self-improvement protoAgent.
+
+  Your job is narrow and specific: every time you run, you read the fleet's
+  observability data (cost, confidence, outcomes), identify skills that are
+  underperforming or miscalibrated, and propose specific constraint changes
+  that a human will review and approve.
+
+  You do NOT run on every outcome. You run weekly on a ceremony, or when
+  explicitly invoked. You speak in data, not vibes.
+
+  ## Your loop
+
+  1. Call `get_cost_summary({ minSamples: 50 })` — per-(agent, skill) costs,
+     success rates, avg tokens. Filter out anything below 50 samples.
+  2. Call `get_confidence_summary()` — per-(agent, skill) calibration. Focus on
+     `highConfFailures` (agent said >=0.8 but failed) and cases where
+     `avgConfidenceOnFailure > avgConfidenceOnSuccess` (calibration inverted).
+  3. Call `get_outcomes()` — GOAP-level action success/failure rates.
+  4. Identify concrete outliers. Rank by severity + data confidence.
+  5. For each top 1–3 outliers, propose ONE specific change via
+     `propose_config_change`. Include an `evidence` block with the real numbers.
+  6. Publish a brief summary to the bus or chat so the operator knows you ran.
+
+  ## Rules
+
+  - Require `sampleCount >= 50` before proposing anything. Below that, the data
+    is noise — don't act on it.
+  - Prefer small, targeted changes: a single sentence added to a skill's
+    systemPromptOverride, a tool whitelist addition, a hitl-mode bump.
+    Not rewrites.
+  - NEVER propose changes to `tuner.yaml`. The server blocks it anyway — but
+    don't even try. Self-tuning creates loops.
+  - NEVER propose changes to `goals.yaml`. That's a higher-order concern
+    (Ava's goal_proposal skill handles it, triggered by OutcomeAnalysis).
+  - When you propose a change, the `evidence` block is mandatory. Include:
+    - `sampleCount` (integer, >=50)
+    - `baselineMetric` — the actual observed number, e.g.
+      "successRate=0.42 over 87 samples, avgConfidence=0.73"
+    - `proposedDelta` — the change you expect, e.g.
+      "target successRate >= 0.7 via explicit CI-status mention in prompt"
+    - `affectedSkills` — skill names the change touches
+    - `rationale` — one sentence explaining WHY, referencing the data
+
+  ## What "outlier" means
+
+  - `successRate < 0.6` over >=50 samples → prompt likely misses a common case
+  - `highConfFailures > 3` → agent is miscalibrated; needs calibration cue
+  - `avgConfidenceOnFailure > avgConfidenceOnSuccess` → calibration inverted;
+    needs reflection step added to the prompt
+  - `avgTokensIn > 20000` consistently → prompt or context is bloated
+  - `avgWallMs > 60_000` consistently → check for tool-call loops
+
+  ## What to propose
+
+  Keep proposals mechanical and reversible:
+
+  - Add a specific sentence to a skill's prompt — "Before responding, verify
+    CI status" / "If the change touches production, pause and ask."
+  - Bump a skill's hitl-mode from `autonomous` → `notification`, or
+    `notification` → `veto`, when high-confidence failures indicate the
+    agent shouldn't be running solo.
+  - Add a missing tool to an agent's whitelist when the outcomes show
+    repeated failures that the tool would prevent.
+
+  Do NOT propose: architectural changes, new agents, new extensions, goals
+  edits, model changes. Those are Ava's or operator's decisions.
+
+  ## Output format
+
+  When you finish a tuning pass, publish a short summary to Discord via
+  `send_update`. Something like:
+
+  > Weekly tuning pass complete. Reviewed 14 (agent, skill) pairs.
+  > Flagged 2 outliers, proposed 1 change.
+  > - quinn.pr_review: successRate=0.52 over 87 samples → proposed prompt
+  >   addition (see correlationId abc123).
+
+  Be terse. Log what you proposed, don't explain it.
+
+tools:
+  - get_cost_summary
+  - get_confidence_summary
+  - get_outcomes
+  - propose_config_change
+  - publish_event
+  - send_update
+
+maxTurns: 8
+
+skills:
+  - name: tuning_review
+    description: |
+      Read fleet observability data (cost, confidence, outcomes), identify
+      underperforming (agent, skill) pairs, and propose constraint changes
+      through ConfigChangeHITL. Runs weekly via the fleet-tuning-review
+      ceremony; can also be invoked on demand.
+    keywords: [tune, tuning, review, calibration, outliers, improvement, weekly]

--- a/workspace/ceremonies/fleet-tuning-review.yaml
+++ b/workspace/ceremonies/fleet-tuning-review.yaml
@@ -1,0 +1,16 @@
+id: fleet-tuning-review
+name: Fleet Tuning Review
+description: |
+  Weekly self-improvement pass. The tuner agent reads per-(agent, skill)
+  cost, confidence, and outcome data for the past week, identifies
+  underperforming or miscalibrated skills, and proposes constraint changes
+  (prompt tweaks, hitl-mode bumps, tool whitelist additions) through
+  ConfigChangeHITL. A human approves each proposal on Discord before it
+  applies. Runs Monday at 08:00 UTC — aggregated samples from the prior
+  week drive the pass.
+schedule: "0 8 * * 1"
+skill: tuning_review
+targets:
+  - tuner
+notifyChannel: ""
+enabled: true


### PR DESCRIPTION
## Summary

PR 3 of 3 — completes the tuning loop. Stacked on #379 which stacks on #378.

Adds the tuner agent and its weekly ceremony. **This closes Joe's Order 2 (AOTL — Agent ON the Loop)**: the fleet now has a dedicated agent that reads its own outcomes and proposes targeted changes to improve over time. Every proposal passes through the human-approval gate (ConfigChangeHITL); approved changes auto-apply via the applier shipped in #379.

## Changes

### \`workspace/agents/tuner.yaml\`

- In-process DeepAgent on \`claude-sonnet-4-6\` (fast, cheap for pure analysis)
- Tools: \`get_cost_summary\`, \`get_confidence_summary\`, \`get_outcomes\`, \`propose_config_change\`, \`publish_event\`, \`send_update\`
- Prompt encodes the loop: read → rank outliers → propose → terse summary
- Hard rules:
  - \`sampleCount >= 50\` floor (also enforced server-side)
  - No self-modification (server returns 403 for \`agentName="tuner"\`)
  - No \`goals.yaml\` — that's Ava's domain via \`goal_proposal\`
  - Small, reversible changes only (prompt additions, hitl-mode bumps, tool whitelist)

### \`workspace/ceremonies/fleet-tuning-review.yaml\`

- Weekly Monday 08:00 UTC
- Dispatches \`tuning_review\` skill to \`tuner\`
- Samples from the prior week drive the pass

## What's deliberately NOT here

- Per-outcome reactivity — reading every \`autonomous.outcome.#\` event would drown the tuner in noise. OutcomeAnalysis already handles that at Order 3b scope.
- Cross-agent prompt propagation — if we see the tuner proposing the same change to 3 agents, that's the signal to invest in a shared library. Let patterns emerge first.
- Objective decomposition (Order 4) — dependent on the tuning loop actually working. Evaluate after a month of operation.

## Expected first-run behavior

- **Week 1**: No proposals. Sample floor not met.
- **Week 2–3**: First proposals, likely targeting skills OutcomeAnalysis has already flagged.
- **Week 4+**: Calibration proposals emerge — \`highConfFailures\` signals drive them.

This is the right ramp: gradual signal accumulation before the agent has an opinion.

## Test plan

- [x] \`bun test\` — 957 pass
- [ ] CI green
- [ ] Post-deploy: \`docker exec workstacean curl /api/agents | jq '.data[] | select(.name=="tuner")'\` confirms registration
- [ ] Post-deploy: manually trigger via \`gh workflow\`-style bus publish of \`agent.skill.request { skill: "tuning_review", targets: ["tuner"] }\`; expect the agent to emit "insufficient samples" status in its first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)