### PR TITLE
feat(tuning): bus tools + apply-on-approve subscriber

### DIFF
--- a/lib/plugins/__tests__/config-change-hitl.test.ts
+++ b/lib/plugins/__tests__/config-change-hitl.test.ts
@@ -1,0 +1,151 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { InMemoryEventBus } from "../../bus.ts";
+import { ConfigChangeHITLPlugin, recordPendingContent } from "../config-change-hitl.ts";
+import type { ConfigChangeRequest } from "../../types.ts";
+
+describe("ConfigChangeHITLPlugin — applier", () => {
+  let workspaceDir: string;
+  let bus: InMemoryEventBus;
+  let plugin: ConfigChangeHITLPlugin;
+
+  beforeEach(() => {
+    workspaceDir = mkdtempSync(join(tmpdir(), "cchitl-"));
+    mkdirSync(join(workspaceDir, "agents"), { recursive: true });
+    bus = new InMemoryEventBus();
+    plugin = new ConfigChangeHITLPlugin();
+    plugin.setWorkspaceDir(workspaceDir);
+    plugin.install(bus);
+  });
+
+  afterEach(() => {
+    plugin.uninstall();
+    rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  function publishRequest(req: ConfigChangeRequest): void {
+    bus.publish(`config.change.request.${req.correlationId}`, {
+      id: crypto.randomUUID(),
+      correlationId: req.correlationId,
+      topic: `config.change.request.${req.correlationId}`,
+      timestamp: Date.now(),
+      payload: req,
+    });
+  }
+
+  function publishApproval(correlationId: string, decision: "approve" | "reject"): void {
+    bus.publish(`config.change.response.${correlationId}`, {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic: `config.change.response.${correlationId}`,
+      timestamp: Date.now(),
+      payload: { type: "config_change_response", correlationId, decision, decidedBy: "test" },
+    });
+  }
+
+  test("writes agent YAML on approve", async () => {
+    const target = join(workspaceDir, "agents", "demo.yaml");
+    writeFileSync(target, "name: demo\nsystemPrompt: original\n");
+
+    const correlationId = "c1";
+    const newContent = "name: demo\nsystemPrompt: updated\n";
+    recordPendingContent(correlationId, target, newContent);
+
+    publishRequest({
+      type: "config_change_request",
+      correlationId,
+      configFile: { type: "agent", agentName: "demo" },
+      title: "Update demo prompt",
+      summary: "Test apply",
+      yamlDiff: "- original\n+ updated\n",
+      evidence: { sampleCount: 60, baselineMetric: "successRate=0.45", proposedDelta: "+0.2", affectedSkills: ["chat"] },
+      options: ["approve", "reject"],
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      replyTopic: `config.change.response.${correlationId}`,
+    });
+
+    publishApproval(correlationId, "approve");
+    await new Promise(r => setTimeout(r, 20));
+
+    expect(readFileSync(target, "utf8")).toBe(newContent);
+  });
+
+  test("does NOT write on reject", async () => {
+    const target = join(workspaceDir, "agents", "demo.yaml");
+    const originalContent = "name: demo\nsystemPrompt: original\n";
+    writeFileSync(target, originalContent);
+
+    const correlationId = "c2";
+    recordPendingContent(correlationId, target, "updated");
+
+    publishRequest({
+      type: "config_change_request",
+      correlationId,
+      configFile: { type: "agent", agentName: "demo" },
+      title: "t", summary: "s", yamlDiff: "d",
+      evidence: { sampleCount: 100, baselineMetric: "b", proposedDelta: "d", affectedSkills: ["x"] },
+      options: ["approve", "reject"],
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      replyTopic: `config.change.response.${correlationId}`,
+    });
+
+    publishApproval(correlationId, "reject");
+    await new Promise(r => setTimeout(r, 20));
+
+    expect(readFileSync(target, "utf8")).toBe(originalContent);
+  });
+
+  test("does not write when target file does not exist (no create-via-approval)", async () => {
+    const correlationId = "c3";
+    const target = join(workspaceDir, "agents", "missing.yaml");
+    recordPendingContent(correlationId, target, "name: missing\n");
+
+    publishRequest({
+      type: "config_change_request",
+      correlationId,
+      configFile: { type: "agent", agentName: "missing" },
+      title: "t", summary: "s", yamlDiff: "d",
+      evidence: { sampleCount: 100, baselineMetric: "b", proposedDelta: "d", affectedSkills: ["x"] },
+      options: ["approve", "reject"],
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      replyTopic: `config.change.response.${correlationId}`,
+    });
+
+    publishApproval(correlationId, "approve");
+    await new Promise(r => setTimeout(r, 20));
+
+    // File still doesn't exist — applier refuses to create new files
+    expect(() => readFileSync(target, "utf8")).toThrow();
+  });
+
+  test("publishes config.change.applied.* on successful apply", async () => {
+    const target = join(workspaceDir, "goals.yaml");
+    writeFileSync(target, "goals: []\n");
+
+    const correlationId = "c4";
+    recordPendingContent(correlationId, target, "goals: [updated]\n");
+
+    const appliedEvents: unknown[] = [];
+    bus.subscribe("config.change.applied.#", "test-sub", msg => {
+      appliedEvents.push(msg.payload);
+    });
+
+    publishRequest({
+      type: "config_change_request",
+      correlationId,
+      configFile: "goals.yaml",
+      title: "t", summary: "s", yamlDiff: "d",
+      options: ["approve", "reject"],
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      replyTopic: `config.change.response.${correlationId}`,
+    });
+
+    publishApproval(correlationId, "approve");
+    await new Promise(r => setTimeout(r, 20));
+
+    expect(appliedEvents).toHaveLength(1);
+    expect((appliedEvents[0] as { type: string }).type).toBe("config_change_applied");
+  });
+});

--- a/lib/plugins/config-change-hitl.ts
+++ b/lib/plugins/config-change-hitl.ts
@@ -20,6 +20,8 @@
  * Payload shape for config.change.response.*: ConfigChangeResponse (lib/types.ts)
  */
 
+import { writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
 import type {
   EventBus,
   BusMessage,
@@ -35,6 +37,30 @@ const renderers = new Map<string, ConfigChangeRenderer>();
 // ── Pending request store ──────────────────────────────────────────────────
 const pendingRequests = new Map<string, ConfigChangeRequest>();
 
+/**
+ * Companion map keyed by correlationId → proposed new file content. Lets the
+ * applier write the full approved content on decision=approve. Populated via
+ * the propose endpoint (not via the bus topic, which carries only yamlDiff).
+ */
+const pendingContent = new Map<string, { targetPath: string; newContent: string }>();
+
+/** Resolve the workspace-relative path a ConfigChangeRequest writes to. */
+function resolveTargetPath(workspaceDir: string, req: ConfigChangeRequest): string | null {
+  if (req.configFile === "goals.yaml" || req.configFile === "actions.yaml") {
+    return join(workspaceDir, req.configFile);
+  }
+  if (typeof req.configFile === "object" && req.configFile.type === "agent") {
+    if (!/^[\w\-]+$/.test(req.configFile.agentName)) return null;
+    return join(workspaceDir, "agents", `${req.configFile.agentName}.yaml`);
+  }
+  return null;
+}
+
+/** Public helper so the propose HTTP endpoint can register the new content. */
+export function recordPendingContent(correlationId: string, targetPath: string, newContent: string): void {
+  pendingContent.set(correlationId, { targetPath, newContent });
+}
+
 // ── Plugin ────────────────────────────────────────────────────────────────
 
 export class ConfigChangeHITLPlugin implements Plugin {
@@ -44,6 +70,16 @@ export class ConfigChangeHITLPlugin implements Plugin {
   readonly capabilities = ["config-change-hitl-routing"];
 
   private expiryTimer: ReturnType<typeof setInterval> | null = null;
+  private workspaceDir: string | null = null;
+
+  /**
+   * Optional workspace directory. When set, approved config-change responses
+   * are applied automatically by writing the proposed newContent to the target
+   * file. Without it, approvals are logged but nothing is written.
+   */
+  setWorkspaceDir(dir: string): void {
+    this.workspaceDir = dir;
+  }
 
   /** All currently pending (unexpired, undecided) config-change requests. */
   getPendingRequests(): ConfigChangeRequest[] {
@@ -122,11 +158,57 @@ export class ConfigChangeHITLPlugin implements Plugin {
       );
     });
 
-    // ── Clean up pending map when a response arrives ──────────────────
+    // ── Apply approved changes + clean up pending map on response ─────
     bus.subscribe("config.change.response.#", this.name, (msg: BusMessage) => {
       const resp = msg.payload as ConfigChangeResponse;
       if (resp?.type !== "config_change_response") return;
+
+      const req = pendingRequests.get(resp.correlationId);
+      const content = pendingContent.get(resp.correlationId);
       pendingRequests.delete(resp.correlationId);
+      pendingContent.delete(resp.correlationId);
+
+      if (resp.decision !== "approve") {
+        console.log(
+          `[config-change-hitl] ${resp.correlationId} rejected by ${resp.decidedBy}${resp.feedback ? ` — ${resp.feedback}` : ""}`,
+        );
+        return;
+      }
+
+      if (!req || !content || !this.workspaceDir) {
+        console.warn(
+          `[config-change-hitl] ${resp.correlationId} approved but missing request/content/workspaceDir — cannot auto-apply`,
+        );
+        return;
+      }
+
+      const targetPath = resolveTargetPath(this.workspaceDir, req);
+      if (!targetPath || targetPath !== content.targetPath) {
+        console.warn(
+          `[config-change-hitl] ${resp.correlationId} approved but target path mismatch — refusing to apply`,
+        );
+        return;
+      }
+
+      try {
+        if (!existsSync(targetPath)) {
+          console.warn(`[config-change-hitl] target file ${targetPath} does not exist — refusing to create via approval`);
+          return;
+        }
+        writeFileSync(targetPath, content.newContent, "utf8");
+        console.log(
+          `[config-change-hitl] ${resp.correlationId} applied by ${resp.decidedBy} → ${targetPath}`,
+        );
+        bus.publish(`config.change.applied.${resp.correlationId}`, {
+          id: crypto.randomUUID(),
+          correlationId: resp.correlationId,
+          topic: `config.change.applied.${resp.correlationId}`,
+          timestamp: Date.now(),
+          payload: { type: "config_change_applied", correlationId: resp.correlationId, targetPath },
+        });
+      } catch (err) {
+        console.error(`[config-change-hitl] apply failed for ${resp.correlationId}:`, err);
+      }
     });
   }
 

--- a/src/agent-runtime/tools/bus-tools.ts
+++ b/src/agent-runtime/tools/bus-tools.ts
@@ -407,10 +407,99 @@ export function createBusTools(opts: BusToolsOptions = {}) {
     },
   );
 
+  // ── Tuning / observability tools ────────────────────────────────────────
+
+  const getCostSummary = tool(
+    "get_cost_summary",
+    "Read per-(agent, skill) cost samples (token usage, duration, dollar cost, success rate). " +
+      "Use to identify expensive or failing skills. Supports filtering by agent, skill, and minimum sample count " +
+      "(recommended: minSamples=50 to gate statistical noise, 100+ for tuning proposals).",
+    {
+      agent: z.string().optional().describe("Filter by agent name, e.g. 'quinn'"),
+      skill: z.string().optional().describe("Filter by skill name, e.g. 'pr_review'"),
+      minSamples: z.number().optional().describe("Minimum sample count (default: 0)"),
+    },
+    async ({ agent, skill, minSamples }) => {
+      try {
+        const params = new URLSearchParams();
+        if (agent) params.set("agent", agent);
+        if (skill) params.set("skill", skill);
+        if (minSamples !== undefined) params.set("minSamples", String(minSamples));
+        const qs = params.toString();
+        const data = await http.get(`/api/cost-summaries${qs ? "?" + qs : ""}`);
+        return ok(data);
+      } catch (e) {
+        return err(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  const getConfidenceSummary = tool(
+    "get_confidence_summary",
+    "Read per-(agent, skill) confidence calibration metrics (avgConfidence, " +
+      "avgConfidenceOnSuccess vs OnFailure, highConfFailures count — the key miscalibration signal). " +
+      "Use to spot skills where the agent is overconfident on failures.",
+    {
+      agent: z.string().optional().describe("Filter by agent name"),
+      skill: z.string().optional().describe("Filter by skill name"),
+    },
+    async ({ agent, skill }) => {
+      try {
+        const params = new URLSearchParams();
+        if (agent) params.set("agent", agent);
+        if (skill) params.set("skill", skill);
+        const qs = params.toString();
+        const data = await http.get(`/api/confidence-summaries${qs ? "?" + qs : ""}`);
+        return ok(data);
+      } catch (e) {
+        return err(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  const proposeConfigChange = tool(
+    "propose_config_change",
+    "Propose a change to workspace config (goals.yaml, actions.yaml, or an agent YAML) " +
+      "that a human must approve via Discord before it applies. " +
+      "Data-driven proposals must include `evidence` (sampleCount, baselineMetric, " +
+      "proposedDelta, affectedSkills) so the approver can judge whether the change " +
+      "is warranted. Proposals targeting agent YAML require sampleCount >= 50.",
+    {
+      target: z.union([
+        z.literal("goals.yaml"),
+        z.literal("actions.yaml"),
+        z.object({ type: z.literal("agent"), agentName: z.string() }),
+      ]).describe("Which config to change. Pass 'goals.yaml' / 'actions.yaml' for those files, " +
+        "or { type: 'agent', agentName: 'quinn' } for workspace/agents/quinn.yaml"),
+      title: z.string().describe("One-line summary of the proposed change"),
+      summary: z.string().describe("Multi-sentence explanation of what and why"),
+      yamlDiff: z.string().describe("Unified diff (before → after) for operator review"),
+      newContent: z.string().optional().describe("Full new file content — used by the applier when approved"),
+      evidence: z.object({
+        sampleCount: z.number(),
+        baselineMetric: z.string(),
+        proposedDelta: z.string(),
+        affectedSkills: z.array(z.string()),
+        rationale: z.string().optional(),
+      }).optional().describe("Data-driven evidence block. Required for tuning-agent proposals."),
+    },
+    async ({ target, title, summary, yamlDiff, newContent, evidence }) => {
+      try {
+        const data = await http.post("/api/config-change/propose", {
+          target, title, summary, yamlDiff, newContent, evidence,
+        });
+        return ok(data);
+      } catch (e) {
+        return err(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
   return [
     publishEvent, getWorldState, getIncidents, reportIncident, getProjects,
     getCiHealth, getPrPipeline, getBranchDrift, getOutcomes, getCeremonies, runCeremony,
     chatWithAgent, delegateTask, manageBoard, createGitHubIssue, manageCron, webSearch,
+    getCostSummary, getConfidenceSummary, proposeConfigChange,
   ];
 }
 
@@ -445,6 +534,10 @@ export const BUS_TOOL_NAMES = [
   // Conversation feedback (any DeepAgent)
   "react",
   "send_update",
+  // Tuning / observability (tuner agent, Ava helm)
+  "get_cost_summary",
+  "get_confidence_summary",
+  "propose_config_change",
 ] as const;
 
 export type BusToolName = (typeof BUS_TOOL_NAMES)[number];

--- a/src/api/observability.ts
+++ b/src/api/observability.ts
@@ -10,6 +10,14 @@
 import type { Route, ApiContext } from "./types.ts";
 import { defaultCostStore } from "../executor/extensions/cost.ts";
 import { defaultConfidenceStore } from "../executor/extensions/confidence.ts";
+import type { ConfigChangeRequest, ConfigChangeEvidence } from "../../lib/types.ts";
+import { recordPendingContent } from "../../lib/plugins/config-change-hitl.ts";
+import { join } from "node:path";
+
+/** Minimum samples required for a data-driven agent-YAML proposal to be accepted. */
+const MIN_SAMPLES_FOR_AGENT_PROPOSAL = 50;
+/** Proposals expire if the operator hasn't decided within this window. */
+const PROPOSAL_TTL_MS = 48 * 60 * 60_000;
 
 export function createRoutes(ctx: ApiContext): Route[] {
   function requireAuth(req: Request): Response | null {
@@ -68,8 +76,113 @@ export function createRoutes(ctx: ApiContext): Route[] {
     return Response.json({ success: true, data: summaries });
   }
 
+  /**
+   * POST /api/config-change/propose
+   *
+   * Agent-facing endpoint for submitting a ConfigChangeRequest through the
+   * HITL approval gate. Validates evidence, registers pending content for
+   * the applier, publishes `config.change.request.{correlationId}`.
+   *
+   * Body: { target, title, summary, yamlDiff, newContent?, evidence? }
+   *   - target: "goals.yaml" | "actions.yaml" | { type: "agent", agentName }
+   *   - evidence required when target is an agent; sampleCount >= 50
+   *   - newContent required for auto-apply on approve (applier writes it)
+   *
+   * Response: { success, data: { correlationId, expiresAt } }
+   */
+  async function handleProposeConfigChange(req: Request): Promise<Response> {
+    const authErr = requireAuth(req);
+    if (authErr) return authErr;
+
+    let body: Record<string, unknown>;
+    try { body = (await req.json()) as Record<string, unknown>; }
+    catch { return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 }); }
+
+    const target = body.target as ConfigChangeRequest["configFile"] | undefined;
+    const title = body.title as string | undefined;
+    const summary = body.summary as string | undefined;
+    const yamlDiff = body.yamlDiff as string | undefined;
+    const newContent = body.newContent as string | undefined;
+    const evidence = body.evidence as ConfigChangeEvidence | undefined;
+
+    if (!target || !title || !summary || !yamlDiff) {
+      return Response.json(
+        { success: false, error: "target, title, summary, yamlDiff are required" },
+        { status: 400 },
+      );
+    }
+
+    const isAgentTarget = typeof target === "object" && (target as { type?: string }).type === "agent";
+    if (isAgentTarget) {
+      const agentName = (target as { agentName?: string }).agentName;
+      if (!agentName || !/^[\w\-]+$/.test(agentName)) {
+        return Response.json({ success: false, error: "Invalid agentName" }, { status: 400 });
+      }
+      if (agentName === "tuner") {
+        return Response.json(
+          { success: false, error: "Tuner cannot propose changes to its own YAML (self-modification loop guard)" },
+          { status: 403 },
+        );
+      }
+      if (!evidence) {
+        return Response.json({ success: false, error: "Agent-YAML proposals require evidence block" }, { status: 400 });
+      }
+      if (evidence.sampleCount < MIN_SAMPLES_FOR_AGENT_PROPOSAL) {
+        return Response.json(
+          { success: false, error: `Agent-YAML proposals require sampleCount >= ${MIN_SAMPLES_FOR_AGENT_PROPOSAL} (got ${evidence.sampleCount})` },
+          { status: 400 },
+        );
+      }
+      if (!newContent) {
+        return Response.json({ success: false, error: "Agent-YAML proposals require newContent for auto-apply" }, { status: 400 });
+      }
+    }
+
+    const correlationId = crypto.randomUUID();
+    const expiresAt = new Date(Date.now() + PROPOSAL_TTL_MS).toISOString();
+    const replyTopic = `config.change.response.${correlationId}`;
+
+    let targetPath: string;
+    if (target === "goals.yaml" || target === "actions.yaml") {
+      targetPath = join(ctx.workspaceDir, target);
+    } else if (isAgentTarget) {
+      targetPath = join(ctx.workspaceDir, "agents", `${(target as { agentName: string }).agentName}.yaml`);
+    } else {
+      return Response.json({ success: false, error: "Invalid target" }, { status: 400 });
+    }
+
+    if (newContent) {
+      recordPendingContent(correlationId, targetPath, newContent);
+    }
+
+    const proposal: ConfigChangeRequest = {
+      type: "config_change_request",
+      correlationId,
+      configFile: target,
+      title,
+      summary,
+      yamlDiff,
+      ...(evidence ? { evidence } : {}),
+      options: ["approve", "reject"],
+      expiresAt,
+      replyTopic,
+      sourceMeta: { interface: "discord" },
+    };
+
+    ctx.bus.publish(`config.change.request.${correlationId}`, {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic: `config.change.request.${correlationId}`,
+      timestamp: Date.now(),
+      payload: proposal,
+    });
+
+    return Response.json({ success: true, data: { correlationId, expiresAt } });
+  }
+
   return [
-    { method: "GET", path: "/api/cost-summaries",       handler: req => handleCostSummaries(req) },
-    { method: "GET", path: "/api/confidence-summaries", handler: req => handleConfidenceSummaries(req) },
+    { method: "GET",  path: "/api/cost-summaries",        handler: req => handleCostSummaries(req) },
+    { method: "GET",  path: "/api/confidence-summaries",  handler: req => handleConfidenceSummaries(req) },
+    { method: "POST", path: "/api/config-change/propose", handler: req => handleProposeConfigChange(req) },
   ];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -402,6 +402,7 @@ registeredPlugins.push(hitlPlugin);
 // Separate gate from operational HITL: "rules are changing" vs "one-shot approval".
 const { ConfigChangeHITLPlugin } = await import("../lib/plugins/config-change-hitl.js");
 const configChangePlugin = new ConfigChangeHITLPlugin();
+configChangePlugin.setWorkspaceDir(workspaceDir);
 configChangePlugin.install(bus);
 registeredPlugins.push(configChangePlugin);
 


### PR DESCRIPTION
## Summary

PR 2 of 3 — bus tools + config-change applier. Replaces closed #379 (rebased onto dev after #378 merged).

Adds \`get_cost_summary\`, \`get_confidence_summary\`, \`propose_config_change\` tools, the \`POST /api/config-change/propose\` endpoint with safety gates (sampleCount>=50, no self-modification, 48h TTL), and extends ConfigChangeHITLPlugin with an applier that writes approved changes to disk.

Full notes on closed #379; code unchanged.

## Test plan

- [x] \`bun test\` — 957 pass / 0 fail
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration change proposal system with human-in-the-loop approval workflow
  * Added cost summary and confidence summary query tools
  * New API endpoint for proposing configuration changes with validation and 48-hour expiration
  * Support for approving or rejecting proposed changes via event bus

<!-- end of auto-generated comment: release notes by coderabbit.ai -->