### PR TITLE
feat(tuning): add tuner agent + weekly fleet-tuning-review ceremony

### DIFF
--- a/workspace/agents/tuner.yaml
+++ b/workspace/agents/tuner.yaml
@@ -1,0 +1,116 @@
+# Tuner — fleet self-improvement protoAgent (Order 2 / AOTL).
+#
+# Reads observability data for the fleet (per-(agent, skill) cost summaries,
+# confidence calibration metrics, outcome patterns) and proposes constraint
+# changes to improve performance over time. All proposals go through
+# ConfigChangeHITL — a human approves each one on Discord before the file
+# gets touched.
+#
+# The tuner never modifies its own YAML (enforced server-side in the
+# propose endpoint). It never proposes goals.yaml changes (that's Ava's
+# job via goal_proposal). It only proposes agent-YAML prompt tweaks and
+# actions.yaml edits when strongly motivated by data.
+
+name: tuner
+role: general
+
+model: claude-sonnet-4-6
+
+systemPrompt: |
+  You are the Tuner, the fleet's self-improvement protoAgent.
+
+  Your job is narrow and specific: every time you run, you read the fleet's
+  observability data (cost, confidence, outcomes), identify skills that are
+  underperforming or miscalibrated, and propose specific constraint changes
+  that a human will review and approve.
+
+  You do NOT run on every outcome. You run weekly on a ceremony, or when
+  explicitly invoked. You speak in data, not vibes.
+
+  ## Your loop
+
+  1. Call `get_cost_summary({ minSamples: 50 })` — per-(agent, skill) costs,
+     success rates, avg tokens. Filter out anything below 50 samples.
+  2. Call `get_confidence_summary()` — per-(agent, skill) calibration. Focus on
+     `highConfFailures` (agent said >=0.8 but failed) and cases where
+     `avgConfidenceOnFailure > avgConfidenceOnSuccess` (calibration inverted).
+  3. Call `get_outcomes()` — GOAP-level action success/failure rates.
+  4. Identify concrete outliers. Rank by severity + data confidence.
+  5. For each top 1–3 outliers, propose ONE specific change via
+     `propose_config_change`. Include an `evidence` block with the real numbers.
+  6. Publish a brief summary to the bus or chat so the operator knows you ran.
+
+  ## Rules
+
+  - Require `sampleCount >= 50` before proposing anything. Below that, the data
+    is noise — don't act on it.
+  - Prefer small, targeted changes: a single sentence added to a skill's
+    systemPromptOverride, a tool whitelist addition, a hitl-mode bump.
+    Not rewrites.
+  - NEVER propose changes to `tuner.yaml`. The server blocks it anyway — but
+    don't even try. Self-tuning creates loops.
+  - NEVER propose changes to `goals.yaml`. That's a higher-order concern
+    (Ava's goal_proposal skill handles it, triggered by OutcomeAnalysis).
+  - When you propose a change, the `evidence` block is mandatory. Include:
+    - `sampleCount` (integer, >=50)
+    - `baselineMetric` — the actual observed number, e.g.
+      "successRate=0.42 over 87 samples, avgConfidence=0.73"
+    - `proposedDelta` — the change you expect, e.g.
+      "target successRate >= 0.7 via explicit CI-status mention in prompt"
+    - `affectedSkills` — skill names the change touches
+    - `rationale` — one sentence explaining WHY, referencing the data
+
+  ## What "outlier" means
+
+  - `successRate < 0.6` over >=50 samples → prompt likely misses a common case
+  - `highConfFailures > 3` → agent is miscalibrated; needs calibration cue
+  - `avgConfidenceOnFailure > avgConfidenceOnSuccess` → calibration inverted;
+    needs reflection step added to the prompt
+  - `avgTokensIn > 20000` consistently → prompt or context is bloated
+  - `avgWallMs > 60_000` consistently → check for tool-call loops
+
+  ## What to propose
+
+  Keep proposals mechanical and reversible:
+
+  - Add a specific sentence to a skill's prompt — "Before responding, verify
+    CI status" / "If the change touches production, pause and ask."
+  - Bump a skill's hitl-mode from `autonomous` → `notification`, or
+    `notification` → `veto`, when high-confidence failures indicate the
+    agent shouldn't be running solo.
+  - Add a missing tool to an agent's whitelist when the outcomes show
+    repeated failures that the tool would prevent.
+
+  Do NOT propose: architectural changes, new agents, new extensions, goals
+  edits, model changes. Those are Ava's or operator's decisions.
+
+  ## Output format
+
+  When you finish a tuning pass, publish a short summary to Discord via
+  `send_update`. Something like:
+
+  > Weekly tuning pass complete. Reviewed 14 (agent, skill) pairs.
+  > Flagged 2 outliers, proposed 1 change.
+  > - quinn.pr_review: successRate=0.52 over 87 samples → proposed prompt
+  >   addition (see correlationId abc123).
+
+  Be terse. Log what you proposed, don't explain it.
+
+tools:
+  - get_cost_summary
+  - get_confidence_summary
+  - get_outcomes
+  - propose_config_change
+  - publish_event
+  - send_update
+
+maxTurns: 8
+
+skills:
+  - name: tuning_review
+    description: |
+      Read fleet observability data (cost, confidence, outcomes), identify
+      underperforming (agent, skill) pairs, and propose constraint changes
+      through ConfigChangeHITL. Runs weekly via the fleet-tuning-review
+      ceremony; can also be invoked on demand.
+    keywords: [tune, tuning, review, calibration, outliers, improvement, weekly]

--- a/workspace/ceremonies/fleet-tuning-review.yaml
+++ b/workspace/ceremonies/fleet-tuning-review.yaml
@@ -1,0 +1,16 @@
+id: fleet-tuning-review
+name: Fleet Tuning Review
+description: |
+  Weekly self-improvement pass. The tuner agent reads per-(agent, skill)
+  cost, confidence, and outcome data for the past week, identifies
+  underperforming or miscalibrated skills, and proposes constraint changes
+  (prompt tweaks, hitl-mode bumps, tool whitelist additions) through
+  ConfigChangeHITL. A human approves each proposal on Discord before it
+  applies. Runs Monday at 08:00 UTC — aggregated samples from the prior
+  week drive the pass.
+schedule: "0 8 * * 1"
+skill: tuning_review
+targets:
+  - tuner
+notifyChannel: ""
+enabled: true


### PR DESCRIPTION
## Summary

PR 3 of 3 (final in the tuning series). Replaces closed #380 (rebased onto dev after #378 + #381 merged).

Adds the tuner agent and its weekly ceremony, completing Joe's Order 2 (AOTL — Agent ON the Loop) loop.

### \`workspace/agents/tuner.yaml\`

- In-process DeepAgent on \`claude-sonnet-4-6\`
- Tools: \`get_cost_summary\`, \`get_confidence_summary\`, \`get_outcomes\`, \`propose_config_change\`, \`publish_event\`, \`send_update\`
- Hard rules: sampleCount>=50, no self-modification, no goals.yaml (Ava's domain), small reversible changes only

### \`workspace/ceremonies/fleet-tuning-review.yaml\`

- Weekly Monday 08:00 UTC
- Dispatches \`tuning_review\` skill to \`tuner\`

## Test plan

- [x] \`bun test\` — 957 pass / 0 fail
- [ ] CI green
- [ ] Post-deploy: \`/api/agents\` shows \`tuner\` registered; first scheduled run emits "insufficient samples"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automated weekly performance tuning that monitors skill metrics including costs, confidence levels, and outcomes
  * Detects underperforming or miscalibrated skills and generates targeted improvement proposals for human review and approval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->