### PR TITLE
fix(push-callback): add external flag for Tailscale agents

### DIFF
--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -81,6 +81,14 @@ export interface A2AAgentConfig {
    * source-of-truth story as streaming — card advertises, broker refreshes.
    */
   pushNotifications?: boolean;
+  /**
+   * Agent runs on an external network (Tailscale, public Internet) rather
+   * than the shared docker network. Consumed by SkillDispatcherPlugin to
+   * pick the correct push-notification callback base URL — internal agents
+   * get WORKSTACEAN_INTERNAL_BASE_URL (docker service name), externals get
+   * WORKSTACEAN_BASE_URL (Tailscale / public hostname).
+   */
+  external?: boolean;
   /** Callback for intermediate streaming updates (e.g. publish to bus). */
   onStreamUpdate?: (update: { type: string; text?: string; state?: string }) => void;
   /**
@@ -163,6 +171,11 @@ export class A2AExecutor implements IExecutor {
   /** Expose the configured agent URL so the dispatcher can pick an appropriate callback base URL. */
   get url(): string {
     return this.config.url;
+  }
+
+  /** True when the agent runs on an external network — dispatcher uses WORKSTACEAN_BASE_URL for callbacks. */
+  get external(): boolean {
+    return this.config.external === true;
   }
 
   /**

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -367,9 +367,13 @@ export class SkillDispatcherPlugin implements Plugin {
         //     WORKSTACEAN_INTERNAL_BASE_URL (default http://workstacean:3000)
         //     which resolves inside the shared docker network.
         //   - External agents reached over Tailscale / public networks
-        //     (hostname has a dot, e.g. `http://host.tailnet.ts.net:...`)
-        //     use WORKSTACEAN_BASE_URL — the operator-configured public URL.
-        const callbackBaseUrl = this._pickCallbackBaseUrl(a2aExecutor.url);
+        //     (explicitly flagged `external: true` in agents.yaml, or
+        //     hostname has a dot like `host.tailnet.ts.net:...`) use
+        //     WORKSTACEAN_BASE_URL — the operator-configured public URL.
+        //     The `external` flag is needed because some Tailscale hosts
+        //     (e.g. `steamdeck`) use single-label MagicDNS names that the
+        //     hostname-shape heuristic can't distinguish from docker services.
+        const callbackBaseUrl = this._pickCallbackBaseUrl(a2aExecutor.url, a2aExecutor.external);
         if (callbackBaseUrl && a2aExecutor.pushNotifications) {
           const callbackUrl = `${callbackBaseUrl.replace(/\/$/, "")}/api/a2a/callback/${encodeURIComponent(taskId)}`;
           void a2aExecutor.registerPushNotification(taskId, callbackUrl, callbackToken, correlationId, parentId)
@@ -618,11 +622,19 @@ export class SkillDispatcherPlugin implements Plugin {
    * Internal default: http://workstacean:3000 (resolves on shared docker net).
    * External default: process.env.WORKSTACEAN_BASE_URL.
    */
-  private _pickCallbackBaseUrl(agentUrl: string | undefined): string | undefined {
+  private _pickCallbackBaseUrl(agentUrl: string | undefined, external: boolean = false): string | undefined {
+    // Explicit opt-out: agent runs off-network (Tailscale / public), so the
+    // docker-internal callback won't reach it. Use the operator-configured
+    // external URL regardless of hostname shape.
+    if (external) return process.env.WORKSTACEAN_BASE_URL;
+
     if (!agentUrl) return process.env.WORKSTACEAN_BASE_URL;
     try {
       const { hostname } = new URL(agentUrl);
-      // Docker service names are single-label (no dot, not an IP).
+      // Docker service names are single-label (no dot, not an IP). This
+      // heuristic is correct for quinn / jon / researcher but incorrect for
+      // single-label Tailscale MagicDNS hostnames — those agents must set
+      // `external: true` in workspace/agents.yaml.
       const isDockerInternal = !hostname.includes(".") && !hostname.includes(":");
       if (isDockerInternal) {
         return process.env.WORKSTACEAN_INTERNAL_BASE_URL ?? "http://workstacean:3000";

--- a/src/plugins/skill-broker-plugin.ts
+++ b/src/plugins/skill-broker-plugin.ts
@@ -57,6 +57,15 @@ interface AgentDef {
   /** Extra static request headers — e.g. extension opt-in. */
   headers?: Record<string, string>;
   streaming?: boolean;
+  /**
+   * Agent runs on an external network (Tailscale, public Internet) rather
+   * than the shared docker network. When true, push-notification callback
+   * URLs use WORKSTACEAN_BASE_URL (operator-configured external/Tailscale
+   * hostname) instead of the docker-internal workstacean:3000. Required for
+   * agents whose hostnames are single-label but not docker service names
+   * (e.g. protoPen on steamdeck via Tailscale MagicDNS).
+   */
+  external?: boolean;
   skills?: Array<AgentSkill | string>;
 }
 
@@ -122,6 +131,7 @@ export class SkillBrokerPlugin implements Plugin {
         auth: agent.auth,
         extraHeaders: agent.headers,
         streaming: agent.streaming ?? false,
+        external: agent.external ?? false,
         onStreamUpdate: opsChannel
           ? (update) => {
               bus.publish(`message.outbound.discord.push.${opsChannel}`, {

--- a/workspace/agents.yaml
+++ b/workspace/agents.yaml
@@ -80,5 +80,9 @@ agents:
       scheme: apiKey
       credentialsEnv: PROTOPEN_API_KEY
     streaming: true
+    # Runs off-docker on steamdeck via Tailscale — push-notification callback
+    # URLs must use WORKSTACEAN_BASE_URL (the operator-configured Tailscale
+    # hostname) rather than the docker-internal workstacean:3000.
+    external: true
     subscribesTo:
       - message.inbound.discord.#


### PR DESCRIPTION
## Summary

Discovered during v0.7.15 protoPen smoke test: push-notification registration fails with \`Invalid or unsafe webhook URL (Code: -32602)\`. ProtoPen's SSRF guard correctly rejects \`http://workstacean:3000/...\` because steamdeck (her host, via Tailscale) can't reach that docker-internal address.

Root cause: \`_pickCallbackBaseUrl\` hostname-shape heuristic classified \`steamdeck\` as docker-internal (single-label, no dot). It's actually a Tailscale MagicDNS name.

## Fix

- New \`external\` field on \`AgentDef\` (skill-broker-plugin) and \`A2AAgentConfig\` (a2a-executor)
- \`A2AExecutor.external\` getter exposed to dispatcher
- \`_pickCallbackBaseUrl(agentUrl, external)\` returns \`WORKSTACEAN_BASE_URL\` when \`external: true\`, regardless of hostname shape
- Flagged \`protopen\` with \`external: true\` in workspace/agents.yaml

Quinn / Jon / Researcher unchanged — they're legit docker services where the hostname heuristic is correct.

## Verification

- \`bun test\` — 957 pass / 0 fail
- Polling fallback confirmed working during the test (task completed in 40s)
- Closes \`feature-1776365794934-rq3io46gl\`

## Test plan

- [ ] CI green
- [ ] Post-deploy: next protoPen dispatch logs \`Push-notification registered for ... at http://ava:8081/api/a2a/callback/...\` (not workstacean:3000)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* New `external` configuration option for agents running outside the shared network environment.
* Automatic callback endpoint routing: when enabled, push-notification URLs use public addresses instead of internal network references.
* Configuration propagated across agent definitions to support external deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->