### PR TITLE
chore(ava): bump maxTurns 10 → 25

### DIFF
--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -135,7 +135,7 @@ tools:
   - send_update
   - msg_operator
 
-maxTurns: 10
+maxTurns: 25
 
 discordBotTokenEnvKey: DISCORD_BOT_TOKEN_AVA
 


### PR DESCRIPTION
Gives Ava more ReAct loop headroom for complex multi-agent delegation chains now that OpenAI-compat clients can drive her end-to-end. 10 was fine for chat; 25 absorbs richer fleet coordination.

Ship alongside v0.7.18 (OpenAI-compat + msg_operator).

- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Ava agent now supports extended conversations, enabling longer and more comprehensive interactions in a single session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->