### PR TITLE
promote: v0.7.18 — msg_operator + OpenAI-compat + maxTurns:25

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean-dashboard",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "private": true,
   "type": "module",
   "scripts": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean-dashboard",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/lib/plugins/__tests__/operator-routing.test.ts
+++ b/lib/plugins/__tests__/operator-routing.test.ts
@@ -1,0 +1,119 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { InMemoryEventBus } from "../../bus.ts";
+import { OperatorRoutingPlugin } from "../operator-routing.ts";
+import type { OperatorMessageRequest } from "../operator-routing.ts";
+
+describe("OperatorRoutingPlugin", () => {
+  let bus: InMemoryEventBus;
+  let plugin: OperatorRoutingPlugin;
+  const originalEnv = process.env.OPERATOR_DISCORD_USER_ID;
+
+  beforeEach(() => {
+    bus = new InMemoryEventBus();
+    plugin = new OperatorRoutingPlugin();
+    plugin.install(bus);
+  });
+
+  afterEach(() => {
+    plugin.uninstall();
+    if (originalEnv !== undefined) process.env.OPERATOR_DISCORD_USER_ID = originalEnv;
+    else delete process.env.OPERATOR_DISCORD_USER_ID;
+  });
+
+  function publishReq(req: OperatorMessageRequest): void {
+    bus.publish("operator.message.request", {
+      id: crypto.randomUUID(),
+      correlationId: req.correlationId,
+      topic: "operator.message.request",
+      timestamp: Date.now(),
+      payload: req,
+    });
+  }
+
+  test("routes to Discord DM topic when OPERATOR_DISCORD_USER_ID is set", async () => {
+    process.env.OPERATOR_DISCORD_USER_ID = "123456789";
+
+    const received: Array<{ topic: string; payload: unknown }> = [];
+    bus.subscribe("message.outbound.discord.dm.user.#", "test", msg => {
+      received.push({ topic: msg.topic, payload: msg.payload });
+    });
+
+    publishReq({
+      type: "operator_message_request",
+      correlationId: "c1",
+      message: "test message",
+      urgency: "normal",
+      from: "ava",
+    });
+
+    await new Promise(r => setTimeout(r, 10));
+    expect(received).toHaveLength(1);
+    expect(received[0].topic).toBe("message.outbound.discord.dm.user.123456789");
+    const payload = received[0].payload as { content: string; agentId: string; urgency: string };
+    expect(payload.content).toContain("test message");
+    expect(payload.content).toContain("ava");
+    expect(payload.agentId).toBe("ava");
+    expect(payload.urgency).toBe("normal");
+  });
+
+  test("prepends urgency badge on high + urgent", async () => {
+    process.env.OPERATOR_DISCORD_USER_ID = "123";
+
+    const received: Array<{ content: string }> = [];
+    bus.subscribe("message.outbound.discord.dm.user.#", "test", msg => {
+      received.push(msg.payload as { content: string });
+    });
+
+    publishReq({ type: "operator_message_request", correlationId: "c1", message: "x", urgency: "high", from: "ava" });
+    publishReq({ type: "operator_message_request", correlationId: "c2", message: "x", urgency: "urgent", from: "ava" });
+    publishReq({ type: "operator_message_request", correlationId: "c3", message: "x", urgency: "low", from: "ava" });
+
+    await new Promise(r => setTimeout(r, 20));
+    expect(received[0].content).toContain("⚠️");
+    expect(received[1].content).toContain("🚨");
+    expect(received[2].content).not.toContain("⚠️");
+    expect(received[2].content).not.toContain("🚨");
+  });
+
+  test("prepends [topic] when topic is set", async () => {
+    process.env.OPERATOR_DISCORD_USER_ID = "123";
+
+    const received: Array<{ content: string }> = [];
+    bus.subscribe("message.outbound.discord.dm.user.#", "test", msg => {
+      received.push(msg.payload as { content: string });
+    });
+
+    publishReq({
+      type: "operator_message_request",
+      correlationId: "c1",
+      message: "delete the A records",
+      urgency: "normal",
+      topic: "todo",
+      from: "ava",
+    });
+
+    await new Promise(r => setTimeout(r, 10));
+    expect(received[0].content).toContain("**[todo]**");
+    expect(received[0].content).toContain("delete the A records");
+  });
+
+  test("drops with warning when no channels are configured", async () => {
+    delete process.env.OPERATOR_DISCORD_USER_ID;
+
+    const received: Array<{ topic: string }> = [];
+    bus.subscribe("message.outbound.#", "test", msg => {
+      received.push({ topic: msg.topic });
+    });
+
+    publishReq({
+      type: "operator_message_request",
+      correlationId: "c1",
+      message: "test",
+      urgency: "normal",
+      from: "ava",
+    });
+
+    await new Promise(r => setTimeout(r, 10));
+    expect(received).toHaveLength(0);
+  });
+});

--- a/lib/plugins/discord/outbound.ts
+++ b/lib/plugins/discord/outbound.ts
@@ -250,6 +250,38 @@ export function registerOutboundHandlers(ctx: DiscordContext): void {
     }
   });
 
+  // ── DM-by-user-id: resolve a user ID to their DM channel on demand ───────
+  // Subscribers publish to `message.outbound.discord.dm.user.{userId}` when
+  // they want to DM a user without knowing the channel ID. The agent bot
+  // (stamped via payload.agentId) opens the DM via users.fetch().createDM()
+  // so the message comes from the correct bot identity.
+  ctx.bus.subscribe("message.outbound.discord.dm.user.#", "discord-dm-user", async (msg: BusMessage) => {
+    const payload = msg.payload as Record<string, unknown>;
+    const content = String(payload.content ?? "").slice(0, 2000);
+    if (!content) return;
+
+    // Extract user ID from topic: message.outbound.discord.dm.user.{userId}
+    const parts = msg.topic.split(".");
+    const userId = parts[parts.length - 1];
+    if (!userId || !/^\d+$/.test(userId)) {
+      console.warn(`[discord] Invalid user ID on DM topic ${msg.topic}`);
+      return;
+    }
+
+    const agentId = payload.agentId as string | undefined;
+    const agentClient = agentId ? ctx.agentClients.get(agentId) : undefined;
+    const client = agentClient ?? ctx.client;
+
+    try {
+      const user = await client.users.fetch(userId);
+      const dm = await user.createDM();
+      await dm.send({ content });
+      console.log(`[discord] DM delivered to user ${userId} via ${agentId ?? "default"} bot`);
+    } catch (err) {
+      console.error(`[discord] DM to user ${userId} failed:`, err);
+    }
+  });
+
   // ── HITL renderer registration ────────────────────────────────────────────
   if (ctx.hitlPlugin) {
     ctx.hitlPlugin.registerRenderer("discord", {

--- a/lib/plugins/operator-routing.ts
+++ b/lib/plugins/operator-routing.ts
@@ -1,0 +1,99 @@
+/**
+ * OperatorRoutingPlugin — abstracts operator-bound messages from the transport
+ * (Discord, SMS, Signal, email, etc.) so any agent can call `msg_operator`
+ * without knowing which channel the operator is currently reachable on.
+ *
+ * Today's routing: single channel (Discord DM) if OPERATOR_DISCORD_USER_ID is
+ * set. If unset, logs the message and drops it (agents shouldn't silently
+ * fail to reach a user — they should see the drop in logs).
+ *
+ * Future routing: a `operator_presence` world-state domain will track live
+ * signals (active-on-discord, on-phone, AFK, GPS pinned to home/office, etc).
+ * This plugin will consult that domain + a per-channel config to pick the
+ * right surface — DM when they're on Discord, SMS when AFK > 30min, pager
+ * duty when urgency=urgent and nothing else responds within a TTL, etc.
+ *
+ * Abstraction contract:
+ *   - Agents publish `operator.message.request` with an OperatorMessageRequest
+ *     payload (content + urgency + topic + from).
+ *   - This plugin picks channel(s) and publishes channel-specific topics:
+ *     - Discord DM: `message.outbound.discord.dm.user.{userId}`
+ *     - (Future) SMS: `message.outbound.sms.{phoneE164}`
+ *     - (Future) Signal: `message.outbound.signal.{number}`
+ *     - (Future) Push: `message.outbound.push.{deviceToken}`
+ *   - Transport plugins subscribe to their own topic and own the delivery.
+ *   - Adding a new channel = one new subscriber, no changes here.
+ */
+
+import type { EventBus, BusMessage, Plugin } from "../types.ts";
+
+export interface OperatorMessageRequest {
+  type: "operator_message_request";
+  correlationId: string;
+  /** The message body to deliver to the operator. */
+  message: string;
+  /**
+   * Urgency. Today all urgencies use the same channel; future routing will
+   * gate channels by urgency floor (e.g. SMS only for high+).
+   */
+  urgency: "low" | "normal" | "high" | "urgent";
+  /** What the message is about — for subject lines / grouping. */
+  topic?: string;
+  /** Agent name that originated the request (for attribution + rate limiting). */
+  from: string;
+}
+
+export class OperatorRoutingPlugin implements Plugin {
+  readonly name = "operator-routing";
+  readonly description =
+    "Routes operator-bound messages across transports (Discord, SMS, etc.) based on presence + urgency";
+  readonly capabilities = ["operator-routing"];
+
+  install(bus: EventBus): void {
+    bus.subscribe("operator.message.request", this.name, (msg: BusMessage) => {
+      const req = msg.payload as OperatorMessageRequest;
+      if (req?.type !== "operator_message_request") return;
+      this._route(bus, req);
+    });
+  }
+
+  uninstall(): void {}
+
+  /**
+   * Decide which channel(s) deliver the message. Single-channel today
+   * (Discord DM when OPERATOR_DISCORD_USER_ID is set). Designed to branch
+   * here when the presence domain and channel config land.
+   */
+  private _route(bus: EventBus, req: OperatorMessageRequest): void {
+    const discordUserId = process.env.OPERATOR_DISCORD_USER_ID;
+    const delivered: string[] = [];
+
+    if (discordUserId) {
+      const prefix = req.topic ? `**[${req.topic}]** ` : "";
+      const urgencyBadge = req.urgency === "urgent" ? "🚨 " : req.urgency === "high" ? "⚠️ " : "";
+      const attribution = req.from ? `\n_— ${req.from}_` : "";
+      const content = `${urgencyBadge}${prefix}${req.message}${attribution}`;
+
+      const topic = `message.outbound.discord.dm.user.${discordUserId}`;
+      bus.publish(topic, {
+        id: crypto.randomUUID(),
+        correlationId: req.correlationId,
+        topic,
+        timestamp: Date.now(),
+        payload: { content, agentId: req.from, urgency: req.urgency },
+      });
+      delivered.push("discord-dm");
+    }
+
+    if (delivered.length === 0) {
+      console.warn(
+        `[operator-routing] No channels configured — dropped message from ${req.from} (urgency=${req.urgency}): "${req.message.slice(0, 100)}"`,
+      );
+      return;
+    }
+
+    console.log(
+      `[operator-routing] Delivered message from ${req.from} via ${delivered.join(", ")} (urgency=${req.urgency}, topic=${req.topic ?? "none"})`,
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "type": "module",
   "scripts": {
     "start": "bun run src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "type": "module",
   "scripts": {
     "start": "bun run src/index.ts",

--- a/src/agent-runtime/tools/bus-tools.ts
+++ b/src/agent-runtime/tools/bus-tools.ts
@@ -495,11 +495,38 @@ export function createBusTools(opts: BusToolsOptions = {}) {
     },
   );
 
+  const msgOperator = tool(
+    "msg_operator",
+    "Send a message to the human operator. The routing plugin picks the transport " +
+      "(Discord DM today; SMS/Signal/push in the future) based on operator presence + " +
+      "urgency. Use this when you need to reach the operator directly, not when posting " +
+      "to a shared channel. Include urgency to help routing pick the right surface; " +
+      "only escalate to 'urgent' when the system actually needs immediate human attention.",
+    {
+      message: z.string().describe("The message body to deliver"),
+      urgency: z.enum(["low", "normal", "high", "urgent"]).default("normal").describe(
+        "How urgently the operator should see this. 'low' = FYI, 'normal' = default, " +
+        "'high' = needs attention this session, 'urgent' = act now",
+      ),
+      topic: z.string().optional().describe(
+        "Short subject tag, e.g. 'todo', 'alert', 'hitl-prompt'. Shown as [topic] prefix.",
+      ),
+    },
+    async ({ message, urgency, topic }) => {
+      try {
+        const data = await http.post("/api/operator/message", { message, urgency, topic });
+        return ok(data);
+      } catch (e) {
+        return err(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
   return [
     publishEvent, getWorldState, getIncidents, reportIncident, getProjects,
     getCiHealth, getPrPipeline, getBranchDrift, getOutcomes, getCeremonies, runCeremony,
     chatWithAgent, delegateTask, manageBoard, createGitHubIssue, manageCron, webSearch,
-    getCostSummary, getConfidenceSummary, proposeConfigChange,
+    getCostSummary, getConfidenceSummary, proposeConfigChange, msgOperator,
   ];
 }
 
@@ -538,6 +565,8 @@ export const BUS_TOOL_NAMES = [
   "get_cost_summary",
   "get_confidence_summary",
   "propose_config_change",
+  // Operator comms (Ava helm, HITL)
+  "msg_operator",
 ] as const;
 
 export type BusToolName = (typeof BUS_TOOL_NAMES)[number];

--- a/src/api/__tests__/openai-compat.test.ts
+++ b/src/api/__tests__/openai-compat.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect } from "bun:test";
+import { modelToRouting, flattenMessages } from "../openai-compat.ts";
+
+describe("openai-compat — modelToRouting", () => {
+  test("bare skill ID → skill, no targets", () => {
+    expect(modelToRouting("chat")).toEqual({ skill: "chat", targets: [] });
+    expect(modelToRouting("pr_review")).toEqual({ skill: "pr_review", targets: [] });
+  });
+
+  test("agent/skill form → skill + target agent", () => {
+    expect(modelToRouting("quinn/pr_review")).toEqual({ skill: "pr_review", targets: ["quinn"] });
+    expect(modelToRouting("protopen/passive_recon")).toEqual({ skill: "passive_recon", targets: ["protopen"] });
+  });
+
+  test("'ava' alias → chat skill on ava", () => {
+    expect(modelToRouting("ava")).toEqual({ skill: "chat", targets: ["ava"] });
+  });
+
+  test("empty model → default chat", () => {
+    expect(modelToRouting("")).toEqual({ skill: "chat", targets: [] });
+  });
+
+  test("leading slash does not split", () => {
+    expect(modelToRouting("/weird")).toEqual({ skill: "/weird", targets: [] });
+  });
+});
+
+describe("openai-compat — flattenMessages", () => {
+  test("joins all roles with prefixes", () => {
+    const prompt = flattenMessages([
+      { role: "system", content: "you are a helper" },
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello" },
+      { role: "user", content: "what's up?" },
+    ]);
+    expect(prompt).toContain("[system] you are a helper");
+    expect(prompt).toContain("[user] hi");
+    expect(prompt).toContain("[assistant] hello");
+    expect(prompt).toContain("[user] what's up?");
+  });
+
+  test("skips messages with null or empty content", () => {
+    const prompt = flattenMessages([
+      { role: "user", content: "real" },
+      { role: "tool", content: "" },
+      { role: "assistant", content: null },
+    ]);
+    expect(prompt).toBe("[user] real");
+  });
+
+  test("tool role is skipped (not a content role for our flow)", () => {
+    const prompt = flattenMessages([
+      { role: "user", content: "u" },
+      { role: "tool", content: "some tool output" },
+    ]);
+    expect(prompt).not.toContain("tool output");
+  });
+});

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -22,6 +22,7 @@ import { createRoutes as agentCardRoutes } from "./agent-card.ts";
 import { createRoutes as widgetsRoutes } from "./widgets.ts";
 import { createRoutes as observabilityRoutes } from "./observability.ts";
 import { createRoutes as operatorRoutes } from "./operator.ts";
+import { createRoutes as openaiCompatRoutes } from "./openai-compat.ts";
 
 export { matchPath } from "./types.ts";
 export type { Route, ApiContext } from "./types.ts";
@@ -43,5 +44,6 @@ export function createAllRoutes(ctx: ApiContext): Route[] {
     ...widgetsRoutes(ctx),
     ...observabilityRoutes(ctx),
     ...operatorRoutes(ctx),
+    ...openaiCompatRoutes(ctx),
   ];
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -21,6 +21,7 @@ import { createRoutes as a2aServerRoutes } from "./a2a-server.ts";
 import { createRoutes as agentCardRoutes } from "./agent-card.ts";
 import { createRoutes as widgetsRoutes } from "./widgets.ts";
 import { createRoutes as observabilityRoutes } from "./observability.ts";
+import { createRoutes as operatorRoutes } from "./operator.ts";
 
 export { matchPath } from "./types.ts";
 export type { Route, ApiContext } from "./types.ts";
@@ -41,5 +42,6 @@ export function createAllRoutes(ctx: ApiContext): Route[] {
     ...a2aServerRoutes(ctx),
     ...widgetsRoutes(ctx),
     ...observabilityRoutes(ctx),
+    ...operatorRoutes(ctx),
   ];
 }

--- a/src/api/openai-compat.ts
+++ b/src/api/openai-compat.ts
@@ -1,0 +1,295 @@
+/**
+ * OpenAI-compatible API — exposes the fleet via the de-facto chat-completions
+ * protocol so any OpenAI-speaking client (Cursor, Zed, aider, `llm` CLI,
+ * ChatGPT desktop proxies, LiteLLM routers, etc.) can dispatch to any skill.
+ *
+ * Endpoints:
+ *   GET  /v1/models               — list skills from the agent card as models
+ *   POST /v1/chat/completions     — dispatch (streaming + non-streaming)
+ *
+ * Model-to-skill mapping (the `model` field in the request body):
+ *   - "chat"              → skill=chat, targets=[]  (workstacean default-routes)
+ *   - "ava"               → skill=chat, targets=["ava"]   (agent-only alias)
+ *   - "quinn/pr_review"   → skill=pr_review, targets=["quinn"]  (explicit)
+ *   - "<skill>"           → skill=<skill>, targets=[]  (broker routes by skill)
+ *
+ * Dispatch path reuses the same bus → SkillDispatcherPlugin → executor flow
+ * as the A2A server and /api/a2a/chat. Responses translate back to the
+ * ChatCompletion / ChatCompletionChunk shape OpenAI clients expect.
+ *
+ * Streaming: SSE frames `data: {chunk}\n\n` with a final `data: [DONE]`.
+ * Text arrives as a single delta today (executor emits the final text once);
+ * future integration with streaming artifact chunks (Phase 5 of the A2A
+ * refactor) can split text deltas per chunk without changing the contract.
+ */
+
+import type { Route, ApiContext } from "./types.ts";
+import type { BusMessage } from "../../lib/types.ts";
+import { buildAgentCard } from "./agent-card.ts";
+
+interface ChatMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string | null;
+}
+
+interface ChatCompletionRequest {
+  model: string;
+  messages: ChatMessage[];
+  stream?: boolean;
+  temperature?: number;
+  max_tokens?: number;
+  user?: string;
+}
+
+interface SkillRouting {
+  skill: string;
+  targets: string[];
+}
+
+/**
+ * Parse the `model` field into a skill + optional target-agent list.
+ * Accepts:
+ *   - "skill"           → { skill, targets: [] }
+ *   - "agent/skill"     → { skill, targets: [agent] }
+ *   - "ava" (special)   → { skill: "chat", targets: ["ava"] }
+ */
+function modelToRouting(model: string): SkillRouting {
+  if (!model) return { skill: "chat", targets: [] };
+  if (model === "ava") return { skill: "chat", targets: ["ava"] };
+  const slash = model.indexOf("/");
+  if (slash > 0) {
+    return {
+      skill: model.slice(slash + 1),
+      targets: [model.slice(0, slash)],
+    };
+  }
+  return { skill: model, targets: [] };
+}
+
+/**
+ * Compose a prompt from the messages array. Collapses system + prior turns
+ * into a single text blob with role prefixes; the last user message is the
+ * "current" content. This mirrors what a non-multi-turn executor expects.
+ */
+function flattenMessages(messages: ChatMessage[]): string {
+  const parts: string[] = [];
+  for (const m of messages) {
+    const content = typeof m.content === "string" ? m.content : "";
+    if (!content) continue;
+    if (m.role === "system") parts.push(`[system] ${content}`);
+    else if (m.role === "user") parts.push(`[user] ${content}`);
+    else if (m.role === "assistant") parts.push(`[assistant] ${content}`);
+  }
+  return parts.join("\n\n");
+}
+
+export function createRoutes(ctx: ApiContext): Route[] {
+  function requireAuth(req: Request): Response | null {
+    if (!ctx.apiKey) return null;
+    const headerKey = req.headers.get("X-API-Key");
+    const bearer = req.headers.get("Authorization");
+    const apiKey = headerKey ?? (bearer?.startsWith("Bearer ") ? bearer.slice(7) : null);
+    if (apiKey === ctx.apiKey) return null;
+    if (ctx.agentKeys && ctx.agentKeys.resolve(apiKey)) return null;
+    return Response.json({ error: { message: "Unauthorized", type: "auth_error" } }, { status: 401 });
+  }
+
+  /**
+   * GET /v1/models — advertise every fleet skill as a model.
+   *
+   * Emits both the bare skill ID ("pr_review") and the agent/skill form
+   * ("quinn/pr_review") so callers can pick either by default-routing or
+   * by explicit targeting.
+   */
+  function handleListModels(req: Request): Response {
+    const authErr = requireAuth(req);
+    if (authErr) return authErr;
+
+    const card = buildAgentCard(ctx);
+    const created = Math.floor(Date.now() / 1000);
+    const seen = new Set<string>();
+    const models: Array<Record<string, unknown>> = [];
+
+    for (const skill of card.skills ?? []) {
+      const id = String(skill.id ?? "");
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      models.push({ id, object: "model", created, owned_by: "protolabs-fleet" });
+
+      // Also expose agent/skill aliases from the tags
+      const agentTag = (skill.tags ?? []).find(t => t !== "routed");
+      if (agentTag) {
+        const aliased = `${agentTag}/${id}`;
+        if (!seen.has(aliased)) {
+          seen.add(aliased);
+          models.push({ id: aliased, object: "model", created, owned_by: "protolabs-fleet" });
+        }
+      }
+    }
+
+    // Top-level "ava" alias (chat skill targeted at ava)
+    if (!seen.has("ava")) {
+      models.push({ id: "ava", object: "model", created, owned_by: "protolabs-fleet" });
+    }
+
+    return Response.json({ object: "list", data: models });
+  }
+
+  /**
+   * Dispatch a chat-completion request onto the bus and await the response
+   * on the reply topic. Resolves to the final text or throws on error.
+   */
+  async function dispatchChat(routing: SkillRouting, prompt: string): Promise<{ text: string; error?: string }> {
+    const correlationId = crypto.randomUUID();
+    const replyTopic = `agent.skill.response.${correlationId}`;
+
+    return new Promise((resolve) => {
+      let settled = false;
+      const timeoutMs = 10 * 60_000;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        ctx.bus.unsubscribe(subId);
+        resolve({ text: "", error: `timeout waiting for ${routing.skill} reply` });
+      }, timeoutMs);
+      (timer as { unref?: () => void }).unref?.();
+
+      const subId = ctx.bus.subscribe(replyTopic, "openai-compat", (msg: BusMessage) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        ctx.bus.unsubscribe(subId);
+
+        const payload = (msg.payload ?? {}) as { content?: string; error?: string };
+        if (payload.error) {
+          resolve({ text: "", error: payload.error });
+        } else {
+          resolve({ text: payload.content ?? "" });
+        }
+      });
+
+      ctx.bus.publish("agent.skill.request", {
+        id: crypto.randomUUID(),
+        correlationId,
+        topic: "agent.skill.request",
+        timestamp: Date.now(),
+        payload: {
+          skill: routing.skill,
+          content: prompt,
+          targets: routing.targets,
+          meta: { via: "openai-compat" },
+        },
+        reply: { topic: replyTopic },
+        source: { interface: "openai-compat" },
+      });
+    });
+  }
+
+  /**
+   * POST /v1/chat/completions — the meat.
+   *
+   * Non-streaming: returns a ChatCompletion object with a single choice.
+   * Streaming: returns text/event-stream with one delta chunk + a stop chunk
+   *           + terminator `data: [DONE]`.
+   */
+  async function handleChatCompletions(req: Request): Promise<Response> {
+    const authErr = requireAuth(req);
+    if (authErr) return authErr;
+
+    let body: ChatCompletionRequest;
+    try {
+      body = (await req.json()) as ChatCompletionRequest;
+    } catch {
+      return Response.json({ error: { message: "Invalid JSON", type: "invalid_request_error" } }, { status: 400 });
+    }
+
+    if (!body.model || typeof body.model !== "string") {
+      return Response.json({ error: { message: "model is required", type: "invalid_request_error" } }, { status: 400 });
+    }
+    if (!Array.isArray(body.messages) || body.messages.length === 0) {
+      return Response.json({ error: { message: "messages is required and must be non-empty", type: "invalid_request_error" } }, { status: 400 });
+    }
+
+    const routing = modelToRouting(body.model);
+    const prompt = flattenMessages(body.messages);
+    const id = `chatcmpl-${crypto.randomUUID().slice(0, 16)}`;
+    const created = Math.floor(Date.now() / 1000);
+    const wantStream = body.stream === true;
+
+    if (!wantStream) {
+      const { text, error } = await dispatchChat(routing, prompt);
+      if (error) {
+        return Response.json({
+          error: { message: error, type: "server_error" },
+        }, { status: 502 });
+      }
+      return Response.json({
+        id,
+        object: "chat.completion",
+        created,
+        model: body.model,
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: text },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+      });
+    }
+
+    // Streaming — SSE with ChatCompletionChunk frames
+    const stream = new ReadableStream({
+      async start(controller) {
+        const encoder = new TextEncoder();
+        const send = (obj: Record<string, unknown>) =>
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(obj)}\n\n`));
+
+        // Role chunk — OpenAI clients often look for role in the first delta
+        send({
+          id, object: "chat.completion.chunk", created, model: body.model,
+          choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
+        });
+
+        const { text, error } = await dispatchChat(routing, prompt);
+        if (error) {
+          send({
+            id, object: "chat.completion.chunk", created, model: body.model,
+            choices: [{ index: 0, delta: { content: `[error] ${error}` }, finish_reason: "stop" }],
+          });
+        } else {
+          // Single content delta — future work: split into chunks when the
+          // executor emits streaming artifact text events.
+          send({
+            id, object: "chat.completion.chunk", created, model: body.model,
+            choices: [{ index: 0, delta: { content: text }, finish_reason: null }],
+          });
+          send({
+            id, object: "chat.completion.chunk", created, model: body.model,
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+          });
+        }
+
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+        connection: "keep-alive",
+      },
+    });
+  }
+
+  return [
+    { method: "GET",  path: "/v1/models",           handler: req => handleListModels(req) },
+    { method: "POST", path: "/v1/chat/completions", handler: req => handleChatCompletions(req) },
+  ];
+}
+
+/** Exposed for tests — deterministic mapping, pure function. */
+export { modelToRouting, flattenMessages };

--- a/src/api/operator.ts
+++ b/src/api/operator.ts
@@ -1,0 +1,67 @@
+/**
+ * Operator comms routes — entry points for agents to message the operator.
+ *
+ * Thin HTTP shim: validates payload, publishes `operator.message.request`.
+ * OperatorRoutingPlugin subscribes, picks transport(s), dispatches.
+ */
+
+import type { Route, ApiContext } from "./types.ts";
+import type { OperatorMessageRequest } from "../../lib/plugins/operator-routing.ts";
+
+const VALID_URGENCIES = ["low", "normal", "high", "urgent"] as const;
+
+export function createRoutes(ctx: ApiContext): Route[] {
+  async function handleMessage(req: Request): Promise<Response> {
+    // Auth: admin OR any registered per-agent key (all fleet agents may message the operator).
+    if (ctx.apiKey) {
+      const headerKey = req.headers.get("X-API-Key");
+      const bearer = req.headers.get("Authorization");
+      const apiKey = headerKey ?? (bearer?.startsWith("Bearer ") ? bearer.slice(7) : null);
+      const isAdmin = apiKey === ctx.apiKey;
+      const isAgent = ctx.agentKeys?.resolve(apiKey) != null;
+      if (!isAdmin && !isAgent) {
+        return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+      }
+    }
+
+    let body: Record<string, unknown>;
+    try { body = (await req.json()) as Record<string, unknown>; }
+    catch { return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 }); }
+
+    const message = body.message as string | undefined;
+    const urgencyIn = (body.urgency as string | undefined) ?? "normal";
+    const topic = body.topic as string | undefined;
+    const from = (body.from as string | undefined) ?? "unknown";
+
+    if (!message || typeof message !== "string" || message.trim().length === 0) {
+      return Response.json({ success: false, error: "message is required" }, { status: 400 });
+    }
+    if (!(VALID_URGENCIES as readonly string[]).includes(urgencyIn)) {
+      return Response.json({ success: false, error: `urgency must be one of: ${VALID_URGENCIES.join(", ")}` }, { status: 400 });
+    }
+
+    const correlationId = crypto.randomUUID();
+    const payload: OperatorMessageRequest = {
+      type: "operator_message_request",
+      correlationId,
+      message: message.trim(),
+      urgency: urgencyIn as OperatorMessageRequest["urgency"],
+      ...(topic ? { topic } : {}),
+      from,
+    };
+
+    ctx.bus.publish("operator.message.request", {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic: "operator.message.request",
+      timestamp: Date.now(),
+      payload,
+    });
+
+    return Response.json({ success: true, data: { correlationId } });
+  }
+
+  return [
+    { method: "POST", path: "/api/operator/message", handler: req => handleMessage(req) },
+  ];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -406,6 +406,15 @@ configChangePlugin.setWorkspaceDir(workspaceDir);
 configChangePlugin.install(bus);
 registeredPlugins.push(configChangePlugin);
 
+// ── OperatorRoutingPlugin — abstracts operator messaging across transports ──
+// Agents publish `operator.message.request`; this plugin picks channel(s)
+// (Discord DM today; SMS/Signal/push future) and dispatches. Pre-installed so
+// any other plugin that wants to reach the operator has a stable contract.
+const { OperatorRoutingPlugin } = await import("../lib/plugins/operator-routing.js");
+const operatorRoutingPlugin = new OperatorRoutingPlugin();
+operatorRoutingPlugin.install(bus);
+registeredPlugins.push(operatorRoutingPlugin);
+
 for (const entry of pluginRegistry) {
   if (entry.condition()) {
     const plugin = await entry.factory();

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -135,7 +135,7 @@ tools:
   - send_update
   - msg_operator
 
-maxTurns: 10
+maxTurns: 25
 
 discordBotTokenEnvKey: DISCORD_BOT_TOKEN_AVA
 

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -133,6 +133,7 @@ tools:
   - manage_cron
   - react
   - send_update
+  - msg_operator
 
 maxTurns: 10
 


### PR DESCRIPTION
## Summary

- #390 — msg_operator tool + pluggable transport routing (Discord DM today)
- #392 — OpenAI-compatible /v1/chat/completions + /v1/models
- #394 — Ava maxTurns 10 → 25
- Bump to v0.7.18 (rolls #391 bump forward)

Unlocks: OpenAI clients (Cursor/Zed/aider) dispatch to the fleet; Ava can message the operator directly; richer multi-agent delegation chains in a single call.

## Test plan

- [ ] CI green
- [ ] Post-deploy: GET /v1/models lists all skills; POST /v1/chat/completions {"model":"ava"} responds
- [ ] Post-deploy: set OPERATOR_DISCORD_USER_ID; trigger msg_operator via Ava; DM lands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents can now send messages to operators with urgency levels and optional topics
  * Added OpenAI-compatible API endpoints for accessing models and submitting chat completion requests
  * New Discord messaging integration for operator notifications
  * Enhanced Ava agent with increased conversation capacity (up to 25 turns per session)

* **Chores**
  * Version updated to 0.7.18

<!-- end of auto-generated comment: release notes by coderabbit.ai -->