### PR TITLE
fix(operator-routing): source operator identity from users.yaml only

### DIFF
--- a/lib/plugins/__tests__/operator-routing.test.ts
+++ b/lib/plugins/__tests__/operator-routing.test.ts
@@ -2,22 +2,24 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { InMemoryEventBus } from "../../bus.ts";
 import { OperatorRoutingPlugin } from "../operator-routing.ts";
 import type { OperatorMessageRequest } from "../operator-routing.ts";
+import type { IdentityRegistry } from "../../identity/identity-registry.ts";
+
+function stubRegistry(adminDiscordId: string | null): IdentityRegistry {
+  return {
+    adminIds: (platform: string) => (platform === "discord" && adminDiscordId ? [adminDiscordId] : []),
+  } as unknown as IdentityRegistry;
+}
 
 describe("OperatorRoutingPlugin", () => {
   let bus: InMemoryEventBus;
   let plugin: OperatorRoutingPlugin;
-  const originalEnv = process.env.OPERATOR_DISCORD_USER_ID;
 
   beforeEach(() => {
     bus = new InMemoryEventBus();
-    plugin = new OperatorRoutingPlugin();
-    plugin.install(bus);
   });
 
   afterEach(() => {
-    plugin.uninstall();
-    if (originalEnv !== undefined) process.env.OPERATOR_DISCORD_USER_ID = originalEnv;
-    else delete process.env.OPERATOR_DISCORD_USER_ID;
+    plugin?.uninstall();
   });
 
   function publishReq(req: OperatorMessageRequest): void {
@@ -30,8 +32,9 @@ describe("OperatorRoutingPlugin", () => {
     });
   }
 
-  test("routes to Discord DM topic when OPERATOR_DISCORD_USER_ID is set", async () => {
-    process.env.OPERATOR_DISCORD_USER_ID = "123456789";
+  test("routes to Discord DM for the admin user's Discord ID from users.yaml", async () => {
+    plugin = new OperatorRoutingPlugin(stubRegistry("123456789"));
+    plugin.install(bus);
 
     const received: Array<{ topic: string; payload: unknown }> = [];
     bus.subscribe("message.outbound.discord.dm.user.#", "test", msg => {
@@ -57,7 +60,8 @@ describe("OperatorRoutingPlugin", () => {
   });
 
   test("prepends urgency badge on high + urgent", async () => {
-    process.env.OPERATOR_DISCORD_USER_ID = "123";
+    plugin = new OperatorRoutingPlugin(stubRegistry("123"));
+    plugin.install(bus);
 
     const received: Array<{ content: string }> = [];
     bus.subscribe("message.outbound.discord.dm.user.#", "test", msg => {
@@ -76,7 +80,8 @@ describe("OperatorRoutingPlugin", () => {
   });
 
   test("prepends [topic] when topic is set", async () => {
-    process.env.OPERATOR_DISCORD_USER_ID = "123";
+    plugin = new OperatorRoutingPlugin(stubRegistry("123"));
+    plugin.install(bus);
 
     const received: Array<{ content: string }> = [];
     bus.subscribe("message.outbound.discord.dm.user.#", "test", msg => {
@@ -97,8 +102,9 @@ describe("OperatorRoutingPlugin", () => {
     expect(received[0].content).toContain("delete the A records");
   });
 
-  test("drops with warning when no channels are configured", async () => {
-    delete process.env.OPERATOR_DISCORD_USER_ID;
+  test("drops with warning when no admin user has a Discord ID mapped", async () => {
+    plugin = new OperatorRoutingPlugin(stubRegistry(null));
+    plugin.install(bus);
 
     const received: Array<{ topic: string }> = [];
     bus.subscribe("message.outbound.#", "test", msg => {

--- a/lib/plugins/operator-routing.ts
+++ b/lib/plugins/operator-routing.ts
@@ -3,9 +3,10 @@
  * (Discord, SMS, Signal, email, etc.) so any agent can call `msg_operator`
  * without knowing which channel the operator is currently reachable on.
  *
- * Today's routing: single channel (Discord DM) if OPERATOR_DISCORD_USER_ID is
- * set. If unset, logs the message and drops it (agents shouldn't silently
- * fail to reach a user — they should see the drop in logs).
+ * Today's routing: single channel (Discord DM) if the first admin user in
+ * workspace/users.yaml has a Discord ID mapped. If not, each request is
+ * dropped with a visible warning — agents shouldn't silently fail to reach
+ * the operator.
  *
  * Future routing: a `operator_presence` world-state domain will track live
  * signals (active-on-discord, on-phone, AFK, GPS pinned to home/office, etc).
@@ -26,6 +27,7 @@
  */
 
 import type { EventBus, BusMessage, Plugin } from "../types.ts";
+import type { IdentityRegistry } from "../identity/identity-registry.ts";
 
 export interface OperatorMessageRequest {
   type: "operator_message_request";
@@ -49,6 +51,15 @@ export class OperatorRoutingPlugin implements Plugin {
     "Routes operator-bound messages across transports (Discord, SMS, etc.) based on presence + urgency";
   readonly capabilities = ["operator-routing"];
 
+  /**
+   * IdentityRegistry is the single source of truth for operator identity.
+   * The first admin user with a Discord identity in workspace/users.yaml is
+   * the DM recipient. No env var fallback — if no admin has a Discord ID
+   * mapped, operator messaging is disabled and each request is dropped with
+   * a visible warning.
+   */
+  constructor(private readonly identityRegistry: IdentityRegistry) {}
+
   install(bus: EventBus): void {
     bus.subscribe("operator.message.request", this.name, (msg: BusMessage) => {
       const req = msg.payload as OperatorMessageRequest;
@@ -65,7 +76,9 @@ export class OperatorRoutingPlugin implements Plugin {
    * here when the presence domain and channel config land.
    */
   private _route(bus: EventBus, req: OperatorMessageRequest): void {
-    const discordUserId = process.env.OPERATOR_DISCORD_USER_ID;
+    // Operator identity is sourced from workspace/users.yaml — the first
+    // admin user with a Discord ID mapped. If none, we drop the message.
+    const discordUserId = this.identityRegistry.adminIds("discord")[0];
     const delivered: string[] = [];
 
     if (discordUserId) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -411,7 +411,9 @@ registeredPlugins.push(configChangePlugin);
 // (Discord DM today; SMS/Signal/push future) and dispatches. Pre-installed so
 // any other plugin that wants to reach the operator has a stable contract.
 const { OperatorRoutingPlugin } = await import("../lib/plugins/operator-routing.js");
-const operatorRoutingPlugin = new OperatorRoutingPlugin();
+const { IdentityRegistry } = await import("../lib/identity/identity-registry.js");
+const operatorIdentityRegistry = new IdentityRegistry(workspaceDir);
+const operatorRoutingPlugin = new OperatorRoutingPlugin(operatorIdentityRegistry);
 operatorRoutingPlugin.install(bus);
 registeredPlugins.push(operatorRoutingPlugin);
 


### PR DESCRIPTION
## Summary

\`workspace/users.yaml\` already maps platform identities per canonical user (Discord, GitHub, Plane, Signal). The env var \`OPERATOR_DISCORD_USER_ID\` was a redundant second source of truth.

## Changes

- \`OperatorRoutingPlugin\` constructor now takes a required \`IdentityRegistry\`
- Discord user ID resolved via \`registry.adminIds("discord")[0]\`
- Env var fallback removed — single source of truth
- When no admin user has a Discord ID mapped, each request is logged + dropped with a visible warning
- \`src/index.ts\` wires a new IdentityRegistry instance (separate from the one SkillDispatcherPlugin uses; cheap — both tail the same \`workspace/users.yaml\`)

## Test plan

- [x] \`bun test\` — 969 pass / 0 fail
- [ ] CI green
- [ ] Post-deploy: trigger \`msg_operator\` via Ava; DM lands in operator's Discord

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Operator routing now sources the operator Discord ID from workspace identity configuration instead of environment variables.
  * Added warning when operator Discord ID is not configured; operator messages are dropped in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->