### PR TITLE
fix(operator-routing): identity via users.yaml + fail loud on no channel

### DIFF
--- a/lib/plugins/__tests__/operator-routing.test.ts
+++ b/lib/plugins/__tests__/operator-routing.test.ts
@@ -2,22 +2,24 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { InMemoryEventBus } from "../../bus.ts";
 import { OperatorRoutingPlugin } from "../operator-routing.ts";
 import type { OperatorMessageRequest } from "../operator-routing.ts";
+import type { IdentityRegistry } from "../../identity/identity-registry.ts";
+
+function stubRegistry(adminDiscordId: string | null): IdentityRegistry {
+  return {
+    adminIds: (platform: string) => (platform === "discord" && adminDiscordId ? [adminDiscordId] : []),
+  } as unknown as IdentityRegistry;
+}
 
 describe("OperatorRoutingPlugin", () => {
   let bus: InMemoryEventBus;
   let plugin: OperatorRoutingPlugin;
-  const originalEnv = process.env.OPERATOR_DISCORD_USER_ID;
 
   beforeEach(() => {
     bus = new InMemoryEventBus();
-    plugin = new OperatorRoutingPlugin();
-    plugin.install(bus);
   });
 
   afterEach(() => {
-    plugin.uninstall();
-    if (originalEnv !== undefined) process.env.OPERATOR_DISCORD_USER_ID = originalEnv;
-    else delete process.env.OPERATOR_DISCORD_USER_ID;
+    plugin?.uninstall();
   });
 
   function publishReq(req: OperatorMessageRequest): void {
@@ -30,8 +32,9 @@ describe("OperatorRoutingPlugin", () => {
     });
   }
 
-  test("routes to Discord DM topic when OPERATOR_DISCORD_USER_ID is set", async () => {
-    process.env.OPERATOR_DISCORD_USER_ID = "123456789";
+  test("routes to Discord DM for the admin user's Discord ID from users.yaml", async () => {
+    plugin = new OperatorRoutingPlugin(stubRegistry("123456789"));
+    plugin.install(bus);
 
     const received: Array<{ topic: string; payload: unknown }> = [];
     bus.subscribe("message.outbound.discord.dm.user.#", "test", msg => {
@@ -57,7 +60,8 @@ describe("OperatorRoutingPlugin", () => {
   });
 
   test("prepends urgency badge on high + urgent", async () => {
-    process.env.OPERATOR_DISCORD_USER_ID = "123";
+    plugin = new OperatorRoutingPlugin(stubRegistry("123"));
+    plugin.install(bus);
 
     const received: Array<{ content: string }> = [];
     bus.subscribe("message.outbound.discord.dm.user.#", "test", msg => {
@@ -76,7 +80,8 @@ describe("OperatorRoutingPlugin", () => {
   });
 
   test("prepends [topic] when topic is set", async () => {
-    process.env.OPERATOR_DISCORD_USER_ID = "123";
+    plugin = new OperatorRoutingPlugin(stubRegistry("123"));
+    plugin.install(bus);
 
     const received: Array<{ content: string }> = [];
     bus.subscribe("message.outbound.discord.dm.user.#", "test", msg => {
@@ -97,12 +102,19 @@ describe("OperatorRoutingPlugin", () => {
     expect(received[0].content).toContain("delete the A records");
   });
 
-  test("drops with warning when no channels are configured", async () => {
-    delete process.env.OPERATOR_DISCORD_USER_ID;
+  test("fails loudly when no admin user has a Discord ID — publishes failure event, no silent drop", async () => {
+    plugin = new OperatorRoutingPlugin(stubRegistry(null));
+    plugin.install(bus);
 
-    const received: Array<{ topic: string }> = [];
-    bus.subscribe("message.outbound.#", "test", msg => {
-      received.push({ topic: msg.topic });
+    const deliveries: Array<{ topic: string }> = [];
+    bus.subscribe("message.outbound.#", "test-deliveries", msg => {
+      deliveries.push({ topic: msg.topic });
+    });
+
+    const failures: Array<{ correlationId: string; error: string }> = [];
+    bus.subscribe("operator.message.failed.#", "test-failures", msg => {
+      const p = msg.payload as { correlationId: string; error: string };
+      failures.push({ correlationId: p.correlationId, error: p.error });
     });
 
     publishReq({
@@ -113,7 +125,14 @@ describe("OperatorRoutingPlugin", () => {
       from: "ava",
     });
 
-    await new Promise(r => setTimeout(r, 10));
-    expect(received).toHaveLength(0);
+    await new Promise(r => setTimeout(r, 15));
+
+    // No message delivered on any outbound channel
+    expect(deliveries).toHaveLength(0);
+    // But a failure event IS published, loud and scoped to the correlation ID
+    expect(failures).toHaveLength(1);
+    expect(failures[0].correlationId).toBe("c1");
+    expect(failures[0].error).toContain("No operator channels available");
+    expect(failures[0].error).toContain("workspace/users.yaml");
   });
 });

--- a/lib/plugins/operator-routing.ts
+++ b/lib/plugins/operator-routing.ts
@@ -3,9 +3,11 @@
  * (Discord, SMS, Signal, email, etc.) so any agent can call `msg_operator`
  * without knowing which channel the operator is currently reachable on.
  *
- * Today's routing: single channel (Discord DM) if OPERATOR_DISCORD_USER_ID is
- * set. If unset, logs the message and drops it (agents shouldn't silently
- * fail to reach a user — they should see the drop in logs).
+ * Today's routing: single channel (Discord DM). Operator identity is sourced
+ * from workspace/users.yaml via IdentityRegistry — the first admin user with
+ * a Discord ID mapped is the recipient. If no admin has a Discord ID, each
+ * route throws: agents see a tool-call error in their ReAct loop (NOT a
+ * silent drop). Fail loud.
  *
  * Future routing: a `operator_presence` world-state domain will track live
  * signals (active-on-discord, on-phone, AFK, GPS pinned to home/office, etc).
@@ -23,9 +25,22 @@
  *     - (Future) Push: `message.outbound.push.{deviceToken}`
  *   - Transport plugins subscribe to their own topic and own the delivery.
  *   - Adding a new channel = one new subscriber, no changes here.
+ *
+ * Failure semantics: if no channel can be chosen, this plugin throws. The
+ * HTTP layer at /api/operator/message catches and returns 503 so the tool
+ * call visibly fails. See feedback_fail_fast_and_loud memory.
  */
 
 import type { EventBus, BusMessage, Plugin } from "../types.ts";
+import type { IdentityRegistry } from "../identity/identity-registry.ts";
+
+/** Thrown when the plugin has no transport available for the operator. */
+export class OperatorUnreachableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OperatorUnreachableError";
+  }
+}
 
 export interface OperatorMessageRequest {
   type: "operator_message_request";
@@ -49,11 +64,41 @@ export class OperatorRoutingPlugin implements Plugin {
     "Routes operator-bound messages across transports (Discord, SMS, etc.) based on presence + urgency";
   readonly capabilities = ["operator-routing"];
 
+  /**
+   * IdentityRegistry is the single source of truth for operator identity.
+   * The first admin user with a Discord identity in workspace/users.yaml is
+   * the DM recipient. No env var fallback — if no admin has a Discord ID
+   * mapped, route() throws OperatorUnreachableError.
+   */
+  constructor(private readonly identityRegistry: IdentityRegistry) {}
+
   install(bus: EventBus): void {
     bus.subscribe("operator.message.request", this.name, (msg: BusMessage) => {
       const req = msg.payload as OperatorMessageRequest;
       if (req?.type !== "operator_message_request") return;
-      this._route(bus, req);
+      try {
+        this._route(bus, req);
+      } catch (err) {
+        // Bus subscribers can't throw back to the publisher, so publish a
+        // failure event on a correlationId-scoped topic. Synchronous HTTP
+        // callers (the tool handler) subscribe to this and surface the
+        // error to the agent's ReAct loop.
+        const errMsg = err instanceof Error ? err.message : String(err);
+        console.error(
+          `[operator-routing] FAILED to route message from ${req.from}: ${errMsg}`,
+        );
+        bus.publish(`operator.message.failed.${req.correlationId}`, {
+          id: crypto.randomUUID(),
+          correlationId: req.correlationId,
+          topic: `operator.message.failed.${req.correlationId}`,
+          timestamp: Date.now(),
+          payload: {
+            type: "operator_message_failed",
+            correlationId: req.correlationId,
+            error: errMsg,
+          },
+        });
+      }
     });
   }
 
@@ -61,11 +106,16 @@ export class OperatorRoutingPlugin implements Plugin {
 
   /**
    * Decide which channel(s) deliver the message. Single-channel today
-   * (Discord DM when OPERATOR_DISCORD_USER_ID is set). Designed to branch
-   * here when the presence domain and channel config land.
+   * (Discord DM via the admin user in users.yaml). Designed to branch here
+   * when the presence domain and channel config land.
+   *
+   * Throws OperatorUnreachableError when no channel is available — never
+   * drops silently. The install() wrapper catches + publishes a
+   * `operator.message.failed.{correlationId}` event so HTTP callers surface
+   * the failure to the agent's ReAct loop.
    */
   private _route(bus: EventBus, req: OperatorMessageRequest): void {
-    const discordUserId = process.env.OPERATOR_DISCORD_USER_ID;
+    const discordUserId = this.identityRegistry.adminIds("discord")[0];
     const delivered: string[] = [];
 
     if (discordUserId) {
@@ -86,10 +136,9 @@ export class OperatorRoutingPlugin implements Plugin {
     }
 
     if (delivered.length === 0) {
-      console.warn(
-        `[operator-routing] No channels configured — dropped message from ${req.from} (urgency=${req.urgency}): "${req.message.slice(0, 100)}"`,
+      throw new OperatorUnreachableError(
+        "No operator channels available — configure workspace/users.yaml with an admin user and a Discord identity (identities.discord)",
       );
-      return;
     }
 
     console.log(

--- a/src/api/operator.ts
+++ b/src/api/operator.ts
@@ -50,6 +50,22 @@ export function createRoutes(ctx: ApiContext): Route[] {
       from,
     };
 
+    // Subscribe to the failure event BEFORE publishing — if routing throws
+    // (no channel available) we get a failed event and return 503 so the
+    // agent's tool call visibly fails, not silently succeeds. See
+    // feedback_fail_fast_and_loud memory.
+    const failedTopic = `operator.message.failed.${correlationId}`;
+    const failurePromise = new Promise<string | null>((resolve) => {
+      const timer = setTimeout(() => resolve(null), 250);
+      (timer as { unref?: () => void }).unref?.();
+      const subId = ctx.bus.subscribe(failedTopic, "operator-api", (msg) => {
+        clearTimeout(timer);
+        ctx.bus.unsubscribe(subId);
+        const p = msg.payload as { error?: string };
+        resolve(p?.error ?? "unknown failure");
+      });
+    });
+
     ctx.bus.publish("operator.message.request", {
       id: crypto.randomUUID(),
       correlationId,
@@ -57,6 +73,14 @@ export function createRoutes(ctx: ApiContext): Route[] {
       timestamp: Date.now(),
       payload,
     });
+
+    const failure = await failurePromise;
+    if (failure) {
+      return Response.json(
+        { success: false, error: failure },
+        { status: 503 },
+      );
+    }
 
     return Response.json({ success: true, data: { correlationId } });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -411,7 +411,9 @@ registeredPlugins.push(configChangePlugin);
 // (Discord DM today; SMS/Signal/push future) and dispatches. Pre-installed so
 // any other plugin that wants to reach the operator has a stable contract.
 const { OperatorRoutingPlugin } = await import("../lib/plugins/operator-routing.js");
-const operatorRoutingPlugin = new OperatorRoutingPlugin();
+const { IdentityRegistry } = await import("../lib/identity/identity-registry.js");
+const operatorIdentityRegistry = new IdentityRegistry(workspaceDir);
+const operatorRoutingPlugin = new OperatorRoutingPlugin(operatorIdentityRegistry);
 operatorRoutingPlugin.install(bus);
 registeredPlugins.push(operatorRoutingPlugin);
 


### PR DESCRIPTION
## Summary

Combined correctness fix for \`msg_operator\`:

1. **Single source of truth for operator identity.** Removes \`OPERATOR_DISCORD_USER_ID\` env var. \`OperatorRoutingPlugin\` now takes an \`IdentityRegistry\` in its constructor and reads \`adminIds("discord")[0]\` from \`workspace/users.yaml\`.
2. **Fails loudly when no channel is available.** Previous behavior: \`console.warn\` + silent drop. New behavior: throws \`OperatorUnreachableError\`, publishes \`operator.message.failed.{correlationId}\`, HTTP handler returns 503 so the agent sees a tool-call error in its ReAct loop.

## Why

Silent failures mean bugs hide in log noise. If the routing plugin drops a message, the agent must see the drop at the call site — not in yesterday's Discord channel scrollback. Saved as \`feedback_fail_fast_and_loud\` memory: no swallowing, no buried warnings.

## Changes

- \`lib/plugins/operator-routing.ts\` — constructor takes \`IdentityRegistry\`; throws \`OperatorUnreachableError\` when no channel is available; install() wrapper catches + publishes \`operator.message.failed.*\`
- \`src/api/operator.ts\` — subscribes to the failure topic before dispatch, waits 250ms, returns 503 if the failure fires
- \`src/index.ts\` — constructs \`IdentityRegistry\` alongside \`OperatorRoutingPlugin\`

## Test plan

- [x] \`bun test\` — 969 pass (+1 new "fails loudly" case)
- [ ] CI green
- [ ] Post-deploy: \`msg_operator\` via Ava → DMs the admin user from \`users.yaml\` (no env setup)
- [ ] Post-deploy: removing the Discord identity from \`users.yaml\` and calling \`msg_operator\` returns 503 to the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for operator message delivery failures
  * System now properly detects when operator routing cannot be completed and returns detailed error responses with configuration guidance
  * Enhanced troubleshooting with error messages referencing relevant configuration files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->