### PR TITLE
chore: point researcher + graphiti at new homelab-iac hostnames

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -22,10 +22,12 @@ WORKSPACE_DIR=./workspace
 DATA_DIR=./data
 
 # Graphiti — temporal user memory sidecar
-# Points at rabbit-hole's research-neo4j in production.
-# For standalone (no rabbit-hole): use docker-compose.graphiti-standalone.yml
+# In production (homelab-iac/stacks/ai), graphiti connects to the shared
+# neo4j in homelab-iac/stacks/infra over infra_default. Locally, default
+# to `bolt://neo4j:7687` for a sibling container in the same compose, or
+# point at your dev neo4j via Tailscale.
 GRAPHITI_URL=http://graphiti:8000
-NEO4J_URI=bolt://research-neo4j:7687
+NEO4J_URI=bolt://neo4j:7687
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=changeme
 

--- a/docker-compose.graphiti-standalone.yml
+++ b/docker-compose.graphiti-standalone.yml
@@ -1,26 +1,26 @@
 # docker-compose.graphiti-standalone.yml
 #
-# Self-contained Graphiti + Neo4j stack for running workstacean WITHOUT
-# the rabbit-hole.io research stack.
+# Self-contained Graphiti + Neo4j stack for running workstacean locally
+# without the shared homelab-iac neo4j.
 #
 # Usage:
 #   docker compose -f docker-compose.yml -f docker-compose.graphiti-standalone.yml up
 #
 # This overlay:
-#   1. Starts a dedicated Neo4j instance for Graphiti (separate from rabbit-hole)
-#   2. Wires Graphiti to use it instead of rabbit-hole's research-neo4j
-#   3. Exposes Neo4j UI on port 7575 (avoids conflict if research-neo4j is running)
+#   1. Starts a dedicated Neo4j instance for Graphiti
+#   2. Wires Graphiti to use it instead of the shared homelab-iac neo4j
+#   3. Exposes Neo4j UI on port 7575 (avoids conflict with the shared 7474/7687)
 #
-# If you DO have rabbit-hole running, use docker-compose.yml alone and set:
-#   NEO4J_URI=bolt://research-neo4j:7687
-#   NEO4J_USER=neo4j
-#   NEO4J_PASSWORD=<your research-neo4j password>
-# in your .env — Graphiti and rabbit-hole use different node labels, no conflicts.
+# Graphiti and rabbit-hole use different node labels, so they can share a
+# single neo4j in production (homelab-iac/stacks/infra). This overlay is
+# only for offline/laptop work where reaching the shared instance isn't
+# practical.
 
 services:
   # ── Dedicated Neo4j for Graphiti ─────────────────────────────────────────────
   # Graphiti uses labels: EpisodicNode, EntityNode, Community, EpisodicEdge
-  # These don't conflict with rabbit-hole's Entity:* labels if sharing an instance.
+  # These don't conflict with rabbit-hole's Entity:* labels — production
+  # shares a single neo4j in homelab-iac/stacks/infra.
   graphiti-neo4j:
     image: neo4j:5.26.2
     restart: unless-stopped
@@ -32,7 +32,7 @@ services:
       start_period: 20s
     ports:
       - "7575:7474"   # Browser UI — http://localhost:7575
-      - "7688:7687"   # Bolt (avoids conflict with research-neo4j on 7687)
+      - "7688:7687"   # Bolt (avoids conflict with shared neo4j on 7687)
     volumes:
       - graphiti-neo4j-data:/data
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,10 @@ services:
 
   # ── Graphiti — temporal user memory ──────────────────────────────────────────
   # Stores conversation episodes and extracts temporal facts per user.
-  # Points at research-neo4j (rabbit-hole.io stack) in production.
-  # For standalone dev (no rabbit-hole), see docker-compose.graphiti-standalone.yml.
+  # In production, graphiti runs from homelab-iac/stacks/ai against the
+  # shared neo4j in homelab-iac/stacks/infra. This compose entry is for
+  # local development; docker-compose.graphiti-standalone.yml provides a
+  # fully self-contained alternative (own neo4j) for laptops offline.
   graphiti:
     image: zepai/graphiti:latest
     restart: unless-stopped
@@ -34,7 +36,8 @@ services:
       - OPENAI_BASE_URL=${OPENAI_BASE_URL:-https://api.openai.com/v1}
       - MODEL_NAME=${GRAPHITI_MODEL:-gpt-4o-mini}
       - EMBEDDING_MODEL_NAME=${GRAPHITI_EMBEDDING_MODEL:-text-embedding-3-small}
-      # Neo4j — rabbit-hole.io instance in production; override for standalone
+      # Neo4j — production uses the shared instance in homelab-iac/stacks/infra;
+      # override NEO4J_URI for local standalone dev (see graphiti-standalone.yml).
       - NEO4J_URI=${NEO4J_URI:-bolt://neo4j:7687}
       - NEO4J_USER=${NEO4J_USER:-neo4j}
       - NEO4J_PASSWORD=${NEO4J_PASSWORD:-password}

--- a/docs/integrations/memory.md
+++ b/docs/integrations/memory.md
@@ -203,6 +203,6 @@ This is a hard delete from Neo4j — irreversible.
 See `homelab-iac/stacks/ai/docker-compose.yml` for the reference deployment. Key points:
 
 - Graphiti runs as a sidecar (`zepai/graphiti:latest`)
-- Shares the `research-neo4j` Neo4j instance with other tools
+- Connects to the shared `neo4j` instance in `homelab-iac/stacks/infra` over `infra_default`
 - `NEO4J_PASSWORD` and `LITELLM_MASTER_KEY` are injected via Infisical
 - workstacean's `GRAPHITI_URL` points at `http://graphiti:8000`

--- a/lib/memory/graphiti-client.ts
+++ b/lib/memory/graphiti-client.ts
@@ -1,8 +1,9 @@
 /**
  * GraphitiClient — user memory via Graphiti (Zep OSS temporal knowledge graph).
  *
- * Graphiti runs as a sidecar container, stores data in the shared research-neo4j
- * instance. Each user gets a scoped group_id so facts never bleed across users.
+ * Graphiti runs as a sidecar container and stores data in the shared neo4j
+ * instance in homelab-iac/stacks/infra, alongside rabbit-hole.io's knowledge
+ * graph. Each user gets a scoped group_id so facts never bleed across users.
  *
  * Key operations:
  *   getContextBlock()  — retrieve relevant facts before routing a message

--- a/scripts/agent-rollcall.sh
+++ b/scripts/agent-rollcall.sh
@@ -27,7 +27,7 @@ AGENTS=(
   # Ava + protoBot are in-process DeepAgents inside workstacean — checked separately below.
   "quinn:7873:a2a:Quinn (QA Engineer)"
   "protocontent:18791:a2a:protoContent / Jon (Content Pipeline)"
-  "research-langgraph-agent:7874:a2a:Researcher (rabbit-hole.io deep research)"
+  "researcher:7874:a2a:Researcher (rabbit-hole.io)"
   "protovoice:7880:http:protoVoice (Voice Agent)"
   "protoaudio:8210:health:protoAudio (Audio Pipeline)"
   "workstacean:8081:http:Workstacean (Orchestrator — hosts Ava + protoBot DeepAgents)"

--- a/workspace/agents.yaml
+++ b/workspace/agents.yaml
@@ -44,9 +44,12 @@ agents:
       - message.inbound.discord.#
 
   # Researcher — rabbit-hole.io deep research agent.
-  # Same host→container port mapping as Quinn: internal listen is 7870.
+  # Container `researcher` lives in homelab-iac/stacks/rabbit-hole and
+  # attaches to ai_default so workstacean can reach it by hostname.
+  # Internal listen 7870 (matches Quinn's pattern); host 7874 exposed
+  # for Tailscale-internal clients like agent-rollcall.sh.
   - name: researcher
-    url: http://research-langgraph-agent:7870/a2a
+    url: http://researcher:7870/a2a
     auth:
       scheme: apiKey
       credentialsEnv: RESEARCHER_API_KEY


### PR DESCRIPTION
## Summary

Cutover-prep for the new homelab-iac topology:
- rabbit-hole.io's A2A agent container renamed `research-langgraph-agent` → `researcher` (new `homelab-iac/stacks/rabbit-hole`)
- Neo4j promoted to shared infra — `research-neo4j` → `neo4j` (new `homelab-iac/stacks/infra`)

Every fleet-side reference updated:

| File | Change |
|---|---|
| `workspace/agents.yaml` | `researcher.url` → `http://researcher:7870/a2a` |
| `scripts/agent-rollcall.sh` | `AGENTS` entry → `researcher:7874` |
| `.env.dist` | `NEO4J_URI` default → `bolt://neo4j:7687` |
| `docker-compose.yml` | Comment clarifies production shared-neo4j topology |
| `docker-compose.graphiti-standalone.yml` | Header drops `research-neo4j` refs, describes overlay as self-contained alternative |
| `lib/memory/graphiti-client.ts` | Comment updated for shared neo4j |
| `docs/integrations/memory.md` | Deployment notes reflect `stacks/infra` |

Blocked on: `homelab-iac/stacks/{infra,rabbit-hole}` deployment (coming after rabbit-hole.io v0.1.0 lands and images populate GHCR).

## Test plan
- [ ] Merge when homelab-iac pieces land together
- [ ] `./scripts/agent-rollcall.sh` shows `researcher: v0.1.0 — A2A card OK`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated Neo4j database connection settings to use shared instance
  * Modified researcher agent service hostname references

* **Documentation**
  * Clarified deployment architecture and connectivity details for memory service integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->