### PR TITLE
promote: docs link fix (strip .md from cross-references)

### DIFF
--- a/docs/explanation/self-improving-loop.md
+++ b/docs/explanation/self-improving-loop.md
@@ -105,11 +105,11 @@ When two candidates score identically (common in the cold regime with matching c
 
 | Extension | Reads from | Writes to | Consumer |
 |---|---|---|---|
-| [`cost-v1`](../extensions/cost-v1.md) | `result.data.usage`, `durationMs`, `costUsd`, `success` | `defaultCostStore` + `autonomous.cost.*` topic | Planner ranking, dashboard, `OutcomeAnalysis` action-quality alerts |
-| [`confidence-v1`](../extensions/confidence-v1.md) | `result.data.confidence`, `confidenceExplanation`, `success` | `defaultConfidenceStore` + `autonomous.confidence.*` topic | Planner ranking, calibration dashboard |
-| [`effect-domain-v1`](../extensions/effect-domain-v1.md) | `worldstate-delta-v1` artifact DataPart | `world.state.delta` bus event | `WorldStateEngine` applies deltas, planner sees fresh state faster |
-| [`blast-v1`](../extensions/blast-v1.md) | `capabilities.extensions[].params.skills` on the agent card | `defaultBlastRegistry` + stamps `x-blast-radius` on outbound metadata | HITL policy + planner tiebreaker + dashboard severity coloring |
-| [`hitl-mode-v1`](../extensions/hitl-mode-v1.md) | `capabilities.extensions[].params.skills` on the agent card | `defaultHitlModeRegistry` + stamps `x-hitl-mode` on outbound metadata | `HITLPlugin` flow selection (autonomous / notification / veto / gated / compound); sub-agent `input-required` routes back to dispatching agent, human fallback |
+| [`cost-v1`](../extensions/cost-v1) | `result.data.usage`, `durationMs`, `costUsd`, `success` | `defaultCostStore` + `autonomous.cost.*` topic | Planner ranking, dashboard, `OutcomeAnalysis` action-quality alerts |
+| [`confidence-v1`](../extensions/confidence-v1) | `result.data.confidence`, `confidenceExplanation`, `success` | `defaultConfidenceStore` + `autonomous.confidence.*` topic | Planner ranking, calibration dashboard |
+| [`effect-domain-v1`](../extensions/effect-domain-v1) | `worldstate-delta-v1` artifact DataPart | `world.state.delta` bus event | `WorldStateEngine` applies deltas, planner sees fresh state faster |
+| [`blast-v1`](../extensions/blast-v1) | `capabilities.extensions[].params.skills` on the agent card | `defaultBlastRegistry` + stamps `x-blast-radius` on outbound metadata | HITL policy + planner tiebreaker + dashboard severity coloring |
+| [`hitl-mode-v1`](../extensions/hitl-mode-v1) | `capabilities.extensions[].params.skills` on the agent card | `defaultHitlModeRegistry` + stamps `x-hitl-mode` on outbound metadata | `HITLPlugin` flow selection (autonomous / notification / veto / gated / compound); sub-agent `input-required` routes back to dispatching agent, human fallback |
 
 All five interceptors are registered once at startup (`src/index.ts`) and fire on every A2A dispatch regardless of whether the agent's card opts in — they self-gate by checking for their expected response fields or card declarations. Agents that don't opt in produce no samples and no metadata stamps; agents that do get their samples counted. No config change needed on either side when a new agent joins the fleet.
 

--- a/docs/extensions/blast-v1.md
+++ b/docs/extensions/blast-v1.md
@@ -74,7 +74,7 @@ When `SkillBrokerPlugin` refreshes your card (every 10 min), declarations are pa
 
 Blast is useful whenever "this action is big" needs to affect routing or gating:
 
-- **HITL policy** — the [hitl-mode-v1](hitl-mode-v1.md) extension can say `mode: gated` only for skills with `radius >= repo`, leaving smaller-blast work fully autonomous. The two extensions compose.
+- **HITL policy** — the [hitl-mode-v1](hitl-mode-v1) extension can say `mode: gated` only for skills with `radius >= repo`, leaving smaller-blast work fully autonomous. The two extensions compose.
 - **Planner tiebreaker** — `PlannerL0` can prefer lower-blast options when two skills produce the same effect (Arc 6.4 ranking).
 - **Dashboard** — the fleet view colors skills by blast radius so operators see at a glance which work needs attention vs. which runs quietly.
 - **Ops alerts** — `ops.alert.action_quality` on a `public`-radius skill is a much bigger signal than one on a `self` skill. Alert severity can scale.
@@ -101,6 +101,6 @@ Registry is populated by `SkillBrokerPlugin` on every card refresh. Missing decl
 
 ## Related
 
-- [hitl-mode-v1](hitl-mode-v1.md) — per-skill approval policy; composes with blast to gate high-impact skills
-- [cost-v1](cost-v1.md) — per-skill cost observations; planner tiebreaker alongside blast
-- [Build an A2A Agent](../guides/build-an-a2a-agent.md) — agent-author recipe (task store, webhooks, health)
+- [hitl-mode-v1](hitl-mode-v1) — per-skill approval policy; composes with blast to gate high-impact skills
+- [cost-v1](cost-v1) — per-skill cost observations; planner tiebreaker alongside blast
+- [Build an A2A Agent](../guides/build-an-a2a-agent) — agent-author recipe (task store, webhooks, health)

--- a/docs/extensions/confidence-v1.md
+++ b/docs/extensions/confidence-v1.md
@@ -104,7 +104,7 @@ score (warm) = 2.0 * cost.successRate
 
 `avgConfidenceOnSuccess` specifically (not overall average) is used — it answers "when this agent succeeds at this skill, how sure is it?" which is the right question for ranking future candidates.
 
-See [`self-improving-loop.md`](../explanation/self-improving-loop.md) for the full flow.
+See [`self-improving-loop.md`](../explanation/self-improving-loop) for the full flow.
 
 ---
 
@@ -120,5 +120,5 @@ Payload is the raw `ConfidenceSample`. Subscribers: dashboard calibration view, 
 
 ## Related
 
-- [`cost-v1`](cost-v1.md) — companion metric; planner reads both together
-- [`effect-domain-v1`](effect-domain-v1.md) — card-side declaration of effects; observed confidence overrides the declared prior once warm
+- [`cost-v1`](cost-v1) — companion metric; planner reads both together
+- [`effect-domain-v1`](effect-domain-v1) — card-side declaration of effects; observed confidence overrides the declared prior once warm

--- a/docs/extensions/cost-v1.md
+++ b/docs/extensions/cost-v1.md
@@ -88,7 +88,7 @@ const summary = defaultCostStore.summary("quinn", "pr_review");
 - ≥ 5 samples → warm: sort by `2.0 * successRate + 0.5 * avgConfidenceOnSuccess − 0.3 * clamp(avgWallMs / 60_000, 0, 2)`
 - \< 5 samples → cold: fall back to card-declared confidence
 
-See [`self-improving-loop.md`](../explanation/self-improving-loop.md) for the full observation → ranking flow.
+See [`self-improving-loop.md`](../explanation/self-improving-loop) for the full observation → ranking flow.
 
 ---
 
@@ -119,6 +119,6 @@ Quinn currently emits `usage` + `durationMs` only — `costUsd` capture from the
 
 ## Related
 
-- [`confidence-v1`](confidence-v1.md) — companion extension for agent-reported confidence, read alongside cost in the same planner ranking
-- [`effect-domain-v1`](effect-domain-v1.md) — card-side effect declarations; Arc 6.4 ranking layers observed cost/confidence on top
-- [`worldstate-delta-v1`](worldstate-delta-v1.md) — artifact format for observed mutations
+- [`confidence-v1`](confidence-v1) — companion extension for agent-reported confidence, read alongside cost in the same planner ranking
+- [`effect-domain-v1`](effect-domain-v1) — card-side effect declarations; Arc 6.4 ranking layers observed cost/confidence on top
+- [`worldstate-delta-v1`](worldstate-delta-v1) — artifact format for observed mutations

--- a/docs/extensions/hitl-mode-v1.md
+++ b/docs/extensions/hitl-mode-v1.md
@@ -108,7 +108,7 @@ Keys:
 
 - **`HITLPlugin`** — reads `x-hitl-mode` from the metadata on `input-required` and selects the rendering path: Discord button, resume-prompt, or auto-approve-on-TTL. Without the extension, falls back to legacy HITL config.
 - **`TaskTracker`** — honors `vetoTtlMs` for veto-mode skills; auto-resumes the task on timeout if no cancel arrived.
-- **Planner** — can compose with [blast-v1](blast-v1.md) to require `gated` only for skills with `radius >= repo`.
+- **Planner** — can compose with [blast-v1](blast-v1) to require `gated` only for skills with `radius >= repo`.
 - **Dashboard** — fleet view shows which skills are gated vs. autonomous, how often each mode fires.
 
 ---
@@ -142,6 +142,6 @@ if (decl && HITL_MODE_ORDER[decl.mode] >= HITL_MODE_ORDER.gated) {
 
 ## Related
 
-- [blast-v1](blast-v1.md) — per-skill scope declaration; compose with hitl-mode to gate high-impact skills
-- [Build an A2A Agent](../guides/build-an-a2a-agent.md) — agent-author recipe for the A2A spec surface
-- [self-improving-loop](../explanation/self-improving-loop.md) — how observations feed back into planner + goal proposals
+- [blast-v1](blast-v1) — per-skill scope declaration; compose with hitl-mode to gate high-impact skills
+- [Build an A2A Agent](../guides/build-an-a2a-agent) — agent-author recipe for the A2A spec surface
+- [self-improving-loop](../explanation/self-improving-loop) — how observations feed back into planner + goal proposals

--- a/docs/guides/a2a-streaming.md
+++ b/docs/guides/a2a-streaming.md
@@ -180,7 +180,7 @@ The caller receives the same `SkillResult` it would have received from a blockin
 
 If a streaming agent returns `input-required`, the task does not complete. `TaskTracker` detects the state, raises an `HITLRequest` on the bus, and the HITL renderer surfaces the pause point to a human on the originating interface. When the human responds, `TaskTracker` resumes the task via `message/send` with the same `taskId`. The agent picks up where it left off.
 
-This is the same flow whether the request came from a human message or an autonomous GOAP action. See [HITL guide](./hitl.md) for the full flow.
+This is the same flow whether the request came from a human message or an autonomous GOAP action. See [HITL guide](./hitl) for the full flow.
 
 ## Fallback behavior
 

--- a/docs/guides/extend-an-a2a-agent.md
+++ b/docs/guides/extend-an-a2a-agent.md
@@ -2,15 +2,15 @@
 title: Extend an A2A Agent — the x-protolabs extensions pack
 ---
 
-Once you've built the A2A spec surface ([Build an A2A Agent](./build-an-a2a-agent.md)) your agent works as a plain A2A responder — workstacean discovers skills, dispatches, tracks tasks, reports to fleet health. But five additional capabilities let the dispatcher, planner, and HITL policy make smarter decisions about each skill:
+Once you've built the A2A spec surface ([Build an A2A Agent](./build-an-a2a-agent)) your agent works as a plain A2A responder — workstacean discovers skills, dispatches, tracks tasks, reports to fleet health. But five additional capabilities let the dispatcher, planner, and HITL policy make smarter decisions about each skill:
 
 | Extension | Purpose | Direction |
 |---|---|---|
-| [cost-v1](../extensions/cost-v1.md) | Token + wall-time observations → planner tiebreaker | workstacean → stores → planner |
-| [confidence-v1](../extensions/confidence-v1.md) | Agent self-reported confidence → calibration + ranking | your agent → stores → planner |
-| [effect-domain-v1](../extensions/effect-domain-v1.md) | Declared world-state deltas → faster planner convergence | your agent's card + response artifacts |
-| [blast-v1](../extensions/blast-v1.md) | Scope-of-effect declaration → HITL/policy routing | your agent's card |
-| [hitl-mode-v1](../extensions/hitl-mode-v1.md) | Per-skill approval policy → HITL flow selection | your agent's card |
+| [cost-v1](../extensions/cost-v1) | Token + wall-time observations → planner tiebreaker | workstacean → stores → planner |
+| [confidence-v1](../extensions/confidence-v1) | Agent self-reported confidence → calibration + ranking | your agent → stores → planner |
+| [effect-domain-v1](../extensions/effect-domain-v1) | Declared world-state deltas → faster planner convergence | your agent's card + response artifacts |
+| [blast-v1](../extensions/blast-v1) | Scope-of-effect declaration → HITL/policy routing | your agent's card |
+| [hitl-mode-v1](../extensions/hitl-mode-v1) | Per-skill approval policy → HITL flow selection | your agent's card |
 
 You don't have to implement any of them. You keep working as a plain A2A agent. But each extension unlocks behavior on the workstacean side that only fires when you opt in.
 
@@ -186,6 +186,6 @@ Each step is independently useful. The pack composes — e.g. blast-v1 + hitl-mo
 
 ## Related
 
-- [Build an A2A Agent](./build-an-a2a-agent.md) — the spec-side recipe (task store, webhooks, health)
-- [Self-improving loop](../explanation/self-improving-loop.md) — how extension observations feed the planner + goal proposals
-- Extension reference pages — [cost-v1](../extensions/cost-v1.md), [confidence-v1](../extensions/confidence-v1.md), [effect-domain-v1](../extensions/effect-domain-v1.md), [blast-v1](../extensions/blast-v1.md), [hitl-mode-v1](../extensions/hitl-mode-v1.md)
+- [Build an A2A Agent](./build-an-a2a-agent) — the spec-side recipe (task store, webhooks, health)
+- [Self-improving loop](../explanation/self-improving-loop) — how extension observations feed the planner + goal proposals
+- Extension reference pages — [cost-v1](../extensions/cost-v1), [confidence-v1](../extensions/confidence-v1), [effect-domain-v1](../extensions/effect-domain-v1), [blast-v1](../extensions/blast-v1), [hitl-mode-v1](../extensions/hitl-mode-v1)

--- a/docs/how-to/configure-discord.md
+++ b/docs/how-to/configure-discord.md
@@ -171,6 +171,6 @@ Changes take effect within a few seconds in Discord (guild-scoped commands updat
 
 ## Related docs
 
-- [reference/bus-topics.md](../reference/bus-topics.md) — Discord bus topics
-- [reference/config-files.md](../reference/config-files.md) — full `discord.yaml` schema reference
-- [explanation/plugin-lifecycle.md](../explanation/plugin-lifecycle.md) — how the DiscordPlugin registers and subscribes
+- [reference/bus-topics.md](../reference/bus-topics) — Discord bus topics
+- [reference/config-files.md](../reference/config-files) — full `discord.yaml` schema reference
+- [explanation/plugin-lifecycle.md](../explanation/plugin-lifecycle) — how the DiscordPlugin registers and subscribes

--- a/docs/how-to/onboard-a-project.md
+++ b/docs/how-to/onboard-a-project.md
@@ -13,7 +13,7 @@ Onboarding a project provisions it across every system protoLabs uses: GitHub (`
 
 ### Option A — Automatic (org webhook)
 
-If you have the GitHub org webhook registered (see [how-to/use-quinn-pr-review.md](use-quinn-pr-review.md) for webhook setup), any new repository created under the org automatically triggers onboarding. No manual action needed.
+If you have the GitHub org webhook registered (see [how-to/use-quinn-pr-review.md](use-quinn-pr-review) for webhook setup), any new repository created under the org automatically triggers onboarding. No manual action needed.
 
 ### Option B — Discord slash command
 
@@ -106,6 +106,6 @@ curl -s -X POST http://workstacean:3000/publish \
 
 ## Related docs
 
-- [reference/agent-skills.md](../reference/agent-skills.md) — full skill registry including `onboard_project` parameters
-- [reference/config-files.md](../reference/config-files.md) — `projects.yaml` schema
-- [explanation/agent-identity.md](../explanation/agent-identity.md) — why Quinn handles Discord provisioning (not Ava)
+- [reference/agent-skills.md](../reference/agent-skills) — full skill registry including `onboard_project` parameters
+- [reference/config-files.md](../reference/config-files) — `projects.yaml` schema
+- [explanation/agent-identity.md](../explanation/agent-identity) — why Quinn handles Discord provisioning (not Ava)

--- a/docs/how-to/set-up-google-workspace.md
+++ b/docs/how-to/set-up-google-workspace.md
@@ -143,6 +143,6 @@ On startup, the plugin logs which services it activated:
 
 ## Related docs
 
-- [reference/bus-topics.md](../reference/bus-topics.md) — Google bus topics
-- [reference/config-files.md](../reference/config-files.md) — full `google.yaml` schema
-- [explanation/plugin-lifecycle.md](../explanation/plugin-lifecycle.md) — plugin install/uninstall lifecycle
+- [reference/bus-topics.md](../reference/bus-topics) — Google bus topics
+- [reference/config-files.md](../reference/config-files) — full `google.yaml` schema
+- [explanation/plugin-lifecycle.md](../explanation/plugin-lifecycle) — plugin install/uninstall lifecycle

--- a/docs/how-to/use-quinn-pr-review.md
+++ b/docs/how-to/use-quinn-pr-review.md
@@ -155,7 +155,7 @@ Trigger by @mention: `@protoquinn <description>` (admin users only).
 
 ## Related docs
 
-- [reference/plugins.md](../reference/plugins.md) — GitHubPlugin API contract
-- [reference/bus-topics.md](../reference/bus-topics.md) — GitHub bus topics
-- [reference/agent-skills.md](../reference/agent-skills.md) — `pr_review` and `bug_triage` skill specs
-- [explanation/architecture.md](../explanation/architecture.md) — Quinn's vector context pipeline in detail
+- [reference/plugins.md](../reference/plugins) — GitHubPlugin API contract
+- [reference/bus-topics.md](../reference/bus-topics) — GitHub bus topics
+- [reference/agent-skills.md](../reference/agent-skills) — `pr_review` and `bug_triage` skill specs
+- [explanation/architecture.md](../explanation/architecture) — Quinn's vector context pipeline in detail

--- a/docs/reference/bus-topics.md
+++ b/docs/reference/bus-topics.md
@@ -165,7 +165,7 @@ Emitted by extensions running inside `A2AExecutor` and by `ActionDispatcherPlugi
 }
 ```
 
-See [`self-improving-loop.md`](../explanation/self-improving-loop.md) for the end-to-end observation → planner-ranking path and [`cost-v1`](../extensions/cost-v1.md) / [`confidence-v1`](../extensions/confidence-v1.md) for the extension-specific payload shapes.
+See [`self-improving-loop.md`](../explanation/self-improving-loop) for the end-to-end observation → planner-ranking path and [`cost-v1`](../extensions/cost-v1) / [`confidence-v1`](../extensions/confidence-v1) for the extension-specific payload shapes.
 
 ---
 

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -122,7 +122,7 @@ Agents can declare their own Discord bot tokens via `discordBotTokenEnvKey` in e
 |----------|---------|--------|-------------|
 | `GRAPHITI_URL` | `http://graphiti:8000` | SkillDispatcherPlugin, world-state `memory` domain | Base URL of the Graphiti sidecar. If unreachable, memory enrichment is skipped silently (the message is still processed). |
 
-Graphiti itself (running as a sidecar) reads additional env vars — see [User Memory (Graphiti)](../integrations/memory.md) for the full list, including the required `text-embedding-3-small` and `gpt-4.1-nano` gateway aliases.
+Graphiti itself (running as a sidecar) reads additional env vars — see [User Memory (Graphiti)](../integrations/memory) for the full list, including the required `text-embedding-3-small` and `gpt-4.1-nano` gateway aliases.
 
 ## Signal (optional integration)
 


### PR DESCRIPTION
Docs-only. 46 cross-reference links had .md suffix → 404 on Starlight. No version bump.