### PR TITLE
fix: extension URIs use proto-labs.ai (not protolabs.ai)

### DIFF
--- a/docs/extensions/blast-v1.md
+++ b/docs/extensions/blast-v1.md
@@ -4,7 +4,7 @@ title: "Extension: x-protolabs/blast-v1"
 
 `x-protolabs/blast-v1` lets agents declare the **scope of effect** for each skill so the planner, HITL policy, and dashboards can apply stricter gates to higher-impact work — independent of goal-level config.
 
-**Extension URI**: `https://protolabs.ai/a2a/ext/blast-v1`
+**Extension URI**: `https://proto-labs.ai/a2a/ext/blast-v1`
 
 ---
 
@@ -49,7 +49,7 @@ Add to your agent card's `capabilities.extensions` list:
   "capabilities": {
     "extensions": [
       {
-        "uri": "https://protolabs.ai/a2a/ext/blast-v1",
+        "uri": "https://proto-labs.ai/a2a/ext/blast-v1",
         "params": {
           "skills": {
             "sitrep":              { "radius": "self" },

--- a/docs/extensions/confidence-v1.md
+++ b/docs/extensions/confidence-v1.md
@@ -4,7 +4,7 @@ title: "Extension: x-protolabs/confidence-v1"
 
 `x-protolabs/confidence-v1` captures the agent's self-reported confidence in its output so OutcomeAnalysis can weight failure signals by how sure the agent was, and the planner can prefer high-confidence candidates when ranking.
 
-**Extension URI**: `https://protolabs.ai/a2a/ext/confidence-v1`
+**Extension URI**: `https://proto-labs.ai/a2a/ext/confidence-v1`
 
 ---
 

--- a/docs/extensions/cost-v1.md
+++ b/docs/extensions/cost-v1.md
@@ -4,7 +4,7 @@ title: "Extension: x-protolabs/cost-v1"
 
 `x-protolabs/cost-v1` records per-(agent, skill) token + wall-time actuals for every A2A dispatch, feeds a rolling in-memory store, and publishes `autonomous.cost.*` observability events. The planner reads from the store to rank candidate skills by observed success rate + cost-per-call.
 
-**Extension URI**: `https://protolabs.ai/a2a/ext/cost-v1`
+**Extension URI**: `https://proto-labs.ai/a2a/ext/cost-v1`
 
 ---
 

--- a/docs/extensions/effect-domain-v1.md
+++ b/docs/extensions/effect-domain-v1.md
@@ -4,7 +4,7 @@ title: "Extension: x-protolabseffect-domain-v1"
 
 `x-protolabseffect-domain-v1` is an A2A agent card extension that lets skills declare their expected world-state mutations. The L1 planner reads these declarations to score and select candidate skills when building a plan.
 
-**Extension URI**: `https://protolabs.ai/a2a/ext/effect-domain-v1`
+**Extension URI**: `https://proto-labs.ai/a2a/ext/effect-domain-v1`
 
 ---
 
@@ -26,7 +26,7 @@ Declared inside the A2A agent card under `capabilities.extensions`:
 ```yaml
 capabilities:
   extensions:
-    - uri: https://protolabs.ai/a2a/ext/effect-domain-v1
+    - uri: https://proto-labs.ai/a2a/ext/effect-domain-v1
       params:
         skills:
           <skill_name>:
@@ -55,7 +55,7 @@ A skill may declare multiple effects if it mutates more than one path.
 ```yaml
 capabilities:
   extensions:
-    - uri: https://protolabs.ai/a2a/ext/effect-domain-v1
+    - uri: https://proto-labs.ai/a2a/ext/effect-domain-v1
       params:
         skills:
           pr_review:
@@ -117,7 +117,7 @@ Add the extension to the agent's `/.well-known/agent-card.json`:
   "capabilities": {
     "extensions": [
       {
-        "uri": "https://protolabs.ai/a2a/ext/effect-domain-v1",
+        "uri": "https://proto-labs.ai/a2a/ext/effect-domain-v1",
         "params": {
           "skills": {
             "pr_review": {
@@ -139,4 +139,4 @@ Add the extension to the agent's `/.well-known/agent-card.json`:
 
 ## Versioning
 
-This is version 1 of the effect-domain extension. The URI `https://protolabs.ai/a2a/ext/effect-domain-v1` is stable. Breaking changes (field renames, semantic changes to `confidence` interpretation) will be published under a new versioned URI.
+This is version 1 of the effect-domain extension. The URI `https://proto-labs.ai/a2a/ext/effect-domain-v1` is stable. Breaking changes (field renames, semantic changes to `confidence` interpretation) will be published under a new versioned URI.

--- a/docs/extensions/hitl-mode-v1.md
+++ b/docs/extensions/hitl-mode-v1.md
@@ -4,7 +4,7 @@ title: "Extension: x-protolabs/hitl-mode-v1"
 
 `x-protolabs/hitl-mode-v1` lets agents declare the **approval policy** for each skill on their agent card. HITL is a gradient, not a binary — this extension lets the dispatcher + HITL plugin route each skill invocation through the right flow without goal-level config.
 
-**Extension URI**: `https://protolabs.ai/a2a/ext/hitl-mode-v1`
+**Extension URI**: `https://proto-labs.ai/a2a/ext/hitl-mode-v1`
 
 ---
 
@@ -76,7 +76,7 @@ registerHitlModeExtension();
   "capabilities": {
     "extensions": [
       {
-        "uri": "https://protolabs.ai/a2a/ext/hitl-mode-v1",
+        "uri": "https://proto-labs.ai/a2a/ext/hitl-mode-v1",
         "params": {
           "skills": {
             "sitrep":              { "mode": "autonomous" },

--- a/docs/guides/extend-an-a2a-agent.md
+++ b/docs/guides/extend-an-a2a-agent.md
@@ -41,11 +41,11 @@ Here's what it looks like when an agent opts in to all five:
     "pushNotifications": true,
     "stateTransitionHistory": false,
     "extensions": [
-      { "uri": "https://protolabs.ai/a2a/ext/cost-v1" },
-      { "uri": "https://protolabs.ai/a2a/ext/confidence-v1" },
+      { "uri": "https://proto-labs.ai/a2a/ext/cost-v1" },
+      { "uri": "https://proto-labs.ai/a2a/ext/confidence-v1" },
 
       {
-        "uri": "https://protolabs.ai/a2a/ext/effect-domain-v1",
+        "uri": "https://proto-labs.ai/a2a/ext/effect-domain-v1",
         "params": {
           "skills": {
             "pr_review":     { "effects": [{ "domain": "pr_pipeline", "path": "data.conflicting", "delta": -1, "confidence": 0.7 }] },
@@ -56,7 +56,7 @@ Here's what it looks like when an agent opts in to all five:
       },
 
       {
-        "uri": "https://protolabs.ai/a2a/ext/blast-v1",
+        "uri": "https://proto-labs.ai/a2a/ext/blast-v1",
         "params": {
           "skills": {
             "sitrep":          { "radius": "self" },
@@ -69,7 +69,7 @@ Here's what it looks like when an agent opts in to all five:
       },
 
       {
-        "uri": "https://protolabs.ai/a2a/ext/hitl-mode-v1",
+        "uri": "https://proto-labs.ai/a2a/ext/hitl-mode-v1",
         "params": {
           "skills": {
             "sitrep":          { "mode": "autonomous" },

--- a/src/executor/extensions/blast.ts
+++ b/src/executor/extensions/blast.ts
@@ -16,7 +16,7 @@
  *     observation. A separate consumer can subscribe to `autonomous.outcome.#`
  *     and cross-reference the blast radius stored here.
  *
- * Extension URI: https://protolabs.ai/a2a/ext/blast-v1
+ * Extension URI: https://proto-labs.ai/a2a/ext/blast-v1
  */
 
 import {
@@ -25,7 +25,7 @@ import {
   type ExtensionContext,
 } from "../extension-registry.ts";
 
-export const BLAST_URI = "https://protolabs.ai/a2a/ext/blast-v1";
+export const BLAST_URI = "https://proto-labs.ai/a2a/ext/blast-v1";
 
 /**
  * Scope of effect for a skill. Ordered from narrowest to widest.

--- a/src/executor/extensions/confidence.ts
+++ b/src/executor/extensions/confidence.ts
@@ -16,7 +16,7 @@
  *     ConfidenceSample, publishes `autonomous.confidence.{systemActor}.{skill}`
  *     for observability.
  *
- * Extension URI: https://protolabs.ai/a2a/ext/confidence-v1
+ * Extension URI: https://proto-labs.ai/a2a/ext/confidence-v1
  */
 
 import type { EventBus } from "../../../lib/types.ts";
@@ -26,7 +26,7 @@ import {
   type ExtensionContext,
 } from "../extension-registry.ts";
 
-export const CONFIDENCE_URI = "https://protolabs.ai/a2a/ext/confidence-v1";
+export const CONFIDENCE_URI = "https://proto-labs.ai/a2a/ext/confidence-v1";
 
 /** One observed confidence score from a completed task. */
 export interface ConfidenceSample {

--- a/src/executor/extensions/cost.ts
+++ b/src/executor/extensions/cost.ts
@@ -15,7 +15,7 @@
  *     both surface this) and appends a CostSample to the running stats store;
  *     publishes `autonomous.cost.{systemActor}.{skill}` for observability.
  *
- * Extension URI: https://protolabs.ai/a2a/ext/cost-v1
+ * Extension URI: https://proto-labs.ai/a2a/ext/cost-v1
  */
 
 import type { EventBus } from "../../../lib/types.ts";
@@ -25,7 +25,7 @@ import {
   type ExtensionContext,
 } from "../extension-registry.ts";
 
-export const COST_URI = "https://protolabs.ai/a2a/ext/cost-v1";
+export const COST_URI = "https://proto-labs.ai/a2a/ext/cost-v1";
 
 /**
  * Per-skill cost estimate as declared by the agent card.

--- a/src/executor/extensions/effect-domain.ts
+++ b/src/executor/extensions/effect-domain.ts
@@ -13,7 +13,7 @@
  * Call `registerEffectDomainExtension(bus)` once at startup (e.g. in src/index.ts)
  * to wire this extension into the defaultExtensionRegistry.
  *
- * Extension URI: https://protolabs.ai/a2a/ext/effect-domain-v1
+ * Extension URI: https://proto-labs.ai/a2a/ext/effect-domain-v1
  */
 
 import type { EventBus } from "../../../lib/types.ts";
@@ -28,7 +28,7 @@ import {
   type WorldStateDeltaEntry,
 } from "../../../lib/types/worldstate-delta.ts";
 
-export const EFFECT_DOMAIN_URI = "https://protolabs.ai/a2a/ext/effect-domain-v1";
+export const EFFECT_DOMAIN_URI = "https://proto-labs.ai/a2a/ext/effect-domain-v1";
 
 /** A single world-state mutation declared for a skill in the agent card. */
 export interface EffectDomainDelta {

--- a/src/executor/extensions/hitl-mode.ts
+++ b/src/executor/extensions/hitl-mode.ts
@@ -11,7 +11,7 @@
  * TaskTracker) can read it without a second lookup. No `after(ctx)` — mode
  * is policy, not observation.
  *
- * Extension URI: https://protolabs.ai/a2a/ext/hitl-mode-v1
+ * Extension URI: https://proto-labs.ai/a2a/ext/hitl-mode-v1
  */
 
 import {
@@ -20,7 +20,7 @@ import {
   type ExtensionContext,
 } from "../extension-registry.ts";
 
-export const HITL_MODE_URI = "https://protolabs.ai/a2a/ext/hitl-mode-v1";
+export const HITL_MODE_URI = "https://proto-labs.ai/a2a/ext/hitl-mode-v1";
 
 /**
  * Approval policy for a single skill. Ordered from least-gated to most-gated.

--- a/src/executor/task-tracker.ts
+++ b/src/executor/task-tracker.ts
@@ -23,7 +23,7 @@ const HITL_TTL_MS = 30 * 60_000; // 30 min default input-required window
 const DISPATCHER_REPLY_TIMEOUT_MS = 5 * 60_000; // 5 min
 
 /** Extension URI for worldstate-delta-v1 artifacts. */
-const WORLDSTATE_DELTA_URI = "https://protolabs.ai/a2a/ext/worldstate-delta-v1";
+const WORLDSTATE_DELTA_URI = "https://proto-labs.ai/a2a/ext/worldstate-delta-v1";
 
 export interface TrackedTask {
   correlationId: string;


### PR DESCRIPTION
27 references to \`https://protolabs.ai/a2a/ext/*\` → \`https://proto-labs.ai/a2a/ext/*\`. Code + docs.

**Breaking for external agents:** Quinn/protoPen cards declare the old URI. Until they update, their extension declarations won't match the registry. Filed on Quinn.

- [x] \`bun test\` — 969 pass
- [ ] CI green