### PR TITLE
chore: remove protoaudio + protovoice from rollcall

### DIFF
--- a/scripts/agent-rollcall.sh
+++ b/scripts/agent-rollcall.sh
@@ -28,9 +28,7 @@ AGENTS=(
   "quinn:7873:a2a:Quinn (QA Engineer)"
   "protocontent:18791:a2a:protoContent / Jon (Content Pipeline)"
   "researcher:7874:a2a:Researcher (rabbit-hole.io)"
-  "protovoice:7880:http:protoVoice (Voice Agent)"
-  "protoaudio:8210:health:protoAudio (Audio Pipeline)"
-  "workstacean:8081:http:Workstacean (Orchestrator — hosts Ava + protoBot DeepAgents)"
+  "workstacean:8081:http:Workstacean (Orchestrator — hosts Ava + protoBot + Tuner DeepAgents)"
 )
 
 # Remote agents — not Docker containers, accessed over Tailscale


### PR DESCRIPTION
Decommissioned services removed from agent-rollcall.sh. homelab-iac compose cleanup is separate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed two external services (protovoice and protoaudio) from agent monitoring.
  * Updated agent configuration labels to reflect the current DeepAgents setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->