### PR TITLE
chore(projects): register protoAgent in projects.yaml

### DIFF
--- a/workspace/projects.yaml
+++ b/workspace/projects.yaml
@@ -85,3 +85,21 @@ projects:
       release:
         channelId: "1490978891207282718"
         webhook: "https://discord.com/api/webhooks/1491952349604872202/QOR15cx1UvzhrzluB5DrZiWv6zikuGFOixPtIuMUmaqO0rWk5tSdZe-zGgzJTMitFkiB"
+
+  - slug: protoagent
+    title: protoAgent
+    team: dev
+    github: protoLabsAI/protoAgent
+    repoUrl: "https://github.com/protoLabsAI/protoAgent"
+    projectPath: /home/josh/dev/labs/protoAgent
+    defaultBranch: main
+    status: active
+    onboardedAt: "2026-04-17T20:15:40.845Z"
+    agents: [quinn]
+    discord:
+      dev:
+        channelId: ""
+        webhook: ""
+      release:
+        channelId: ""
+        webhook: ""


### PR DESCRIPTION
## Summary

- Registers the new protoAgent template repo ([protoLabsAI/protoAgent](https://github.com/protoLabsAI/protoAgent)) as an active dev project
- Follows the existing entry shape: slug / title / github / repoUrl / projectPath / agents / discord
- Cloned locally at \`/home/josh/dev/labs/protoAgent\` to match fleet convention

## Context

protoAgent is the GitHub Template that replaces per-agent A2A bootstrapping — a generalized fork of Quinn with placeholder identity/tools/skills ready for fresh agent spawns.

## What's TODO

The onboard plugin's Plane / GitHub webhook / Discord / Google Drive steps were skipped because those integrations aren't configured in this deployment (no PLANE_API_KEY, WORKSTACEAN_PUBLIC_URL, or Google creds). The Discord webhook fields stay as empty-string placeholders — can be populated when Ava's \`provision_discord\` skill is run against this repo.

## Test plan

- [x] \`docker exec workstacean curl -X POST /api/onboard\` ran the pipeline green; projects.yaml was re-loaded automatically (hot-reload via feature-notifier)
- [ ] Verify Quinn's board scan picks up the new project on next run
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added protoAgent project configuration to the workspace, including project metadata and notification settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->