### PR TITLE
Promote dev to main (v0.7.21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
 # protoWorkstacean
 
-Homeostatic agent orchestration platform. Monitors world state, evaluates goals, and drives the protoLabs agent fleet — **Ava** (chief-of-staff), **protoBot** (Discord infrastructure: channels, categories, webhooks), **Quinn** (QA/PR review), **Researcher** (deep research), **Jon** (content strategy), **protoPen** (security/pentest), plus the protoMaker team — to close deviations continuously and autonomously.
+Homeostatic agent orchestration platform. Monitors world state, evaluates goals, and drives the protoLabs agent fleet to close deviations continuously and autonomously.
 
-The loop observes skill execution through A2A extensions, writes episodic memory to Graphiti, and ranks future candidates by observed cost/confidence — so the planner gets better the more it runs. See [docs/explanation/self-improving-loop.md](docs/explanation/self-improving-loop.md).
+**Ava** is the primary communication interface — all user interaction flows through her. She directs the rest of the system through tools and delegation:
+
+| Agent | Role | Runtime |
+|---|---|---|
+| **Ava** | Chief-of-staff. Orchestration, delegation, observation, self-improvement. 22 tools, 7 skills. | In-process (LangGraph) |
+| **protoBot** | Discord server infrastructure: channels, categories, webhooks | In-process (LangGraph) |
+| **Quinn** | QA engineer: PR review, bug triage, security analysis | External (A2A) |
+| **protoMaker** | Board operations, velocity tracking, auto-mode | External (A2A) |
+| **Researcher** | Deep multi-source research: papers, code, web | External (A2A) |
+| **Jon** | Content strategy, antagonistic review | External (A2A) |
+| **protoPen** | Security/pentest: recon, threat intel | External (A2A) |
+
+The loop observes skill execution through A2A extensions, writes episodic memory to Graphiti, and ranks future candidates by observed cost/confidence — so the planner gets better the more it runs. When the system detects chronic failures, Ava proposes new goals and config changes (subject to human approval) to close the self-improvement loop. See [docs/explanation/self-improving-loop.md](docs/explanation/self-improving-loop.md).
 
 ---
 
@@ -13,14 +25,16 @@ External surfaces (GitHub, Discord, Plane, HTTP)
   → Interface plugins → Event Bus
     → RouterPlugin → agent.skill.request
       → SkillDispatcherPlugin → ExecutorRegistry
-        → ProtoSdkExecutor (in-process @protolabsai/sdk)
-        → A2AExecutor (HTTP/JSON-RPC 2.0 → protoMaker team / Quinn / protoContent / Frank)
+        → DeepAgentExecutor (in-process LangGraph agents: Ava, protoBot)
+        → A2AExecutor (HTTP/JSON-RPC 2.0 → Quinn / protoMaker / Researcher / Jon / protoPen)
 
 World engine loop (parallel):
   WorldStateEngine (domain pollers)
     → GoalEvaluatorPlugin → world.goal.violated
       → PlannerPluginL0 → world.action.dispatch
         → ActionDispatcherPlugin → agent.skill.request
+          → Ava: debug_ci_failures, fleet_incident_response, downshift_models,
+            investigate_orphaned_skills, goal_proposal, diagnose_pr_stuck
 ```
 
 See [`docs/architecture.md`](docs/architecture.md) for the full picture.
@@ -73,7 +87,7 @@ Plugins are loaded in `src/index.ts`. Each implements `install(bus) / uninstall(
 | Plugin | Condition | Role |
 |---|---|---|
 | `RouterPlugin` | always | Translates inbound messages + cron events → `agent.skill.request` |
-| `AgentRuntimePlugin` | always | Registers `ProtoSdkExecutor` per `workspace/agents/*.yaml` into `ExecutorRegistry` |
+| `AgentRuntimePlugin` | always | Registers `DeepAgentExecutor` per `workspace/agents/*.yaml` into `ExecutorRegistry` |
 | `SkillBrokerPlugin` | always | Registers `A2AExecutor` per `workspace/agents.yaml` into `ExecutorRegistry` |
 | `SkillDispatcherPlugin` | always | Sole `agent.skill.request` subscriber; dispatches via `ExecutorRegistry` |
 | `WorldStateEngine` | always | Generic domain poller; domains registered via `discoverAndRegister()` at startup |
@@ -110,7 +124,7 @@ ExecutorRegistry.resolve(skill, targets?)
 
 | Type | Class | When |
 |---|---|---|
-| `proto-sdk` | `ProtoSdkExecutor` | In-process agents defined in `workspace/agents/*.yaml` |
+| `deep-agent` | `DeepAgentExecutor` | In-process LangGraph agents defined in `workspace/agents/*.yaml` |
 | `a2a` | `A2AExecutor` | External agents via HTTP/JSON-RPC 2.0 (`workspace/agents.yaml`) |
 | `function` | `FunctionExecutor` | Inline functions, used in tests |
 | `workflow` | `WorkflowExecutor` | Sequences of bus publishes with optional reply waiting |

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean-dashboard",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean-dashboard",
-  "version": "0.7.20",
+  "version": "0.7.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/explanation/self-improving-loop.md
+++ b/docs/explanation/self-improving-loop.md
@@ -171,11 +171,42 @@ Agents with no data (`totalOutcomes === 0`) get weight 1.0 so new agents still r
 
 ---
 
-## Closing the other side — goal proposals from chronic failures
+## Closing the other side — Ava as the self-improvement agent
 
-`OutcomeAnalysisPlugin` has always emitted `ops.alert.action_quality` on chronic failure clusters. Arc 9.2 added a second output: an `agent.skill.request { skill: "goal_proposal" }` targeting Ava. Ava reads the cluster context (skill, actual vs expected success rate, recent failures) and either proposes a new goal — which `GoalHotReloadPlugin` applies without a restart — or files a feature on the board describing what's missing.
+The self-improvement loop has three mechanisms, all converging through Ava:
 
-"Bottlenecks are growth" operationalized: the system's own failures become inputs to its own goal backlog, closing the loop from observation → ranking → planner selection → outcome → **goal refinement**.
+### 1. Goal proposals from chronic failures
+
+`OutcomeAnalysisPlugin` emits `ops.alert.action_quality` on chronic failure clusters (< 50% success over 10+ attempts). It also dispatches `agent.skill.request { skill: "goal_proposal" }` targeting Ava. Ava reads the cluster context and drafts a `goals.yaml` entry — which `GoalHotReloadPlugin` applies without a restart after human approval.
+
+The same pipeline fires for repeated HITL escalations (3+ escalations for the same target): "what capability would unblock this automatically?"
+
+### 2. Config change proposals via `propose_config_change`
+
+Ava has direct access to the `propose_config_change` tool, which proposes YAML diffs to `goals.yaml`, `actions.yaml`, or any agent's YAML config. Proposals are submitted to `ConfigChangeHITLPlugin`, which renders an approval card in Discord. On approval, the change is applied live; on rejection, it's discarded with the reason preserved.
+
+This lets Ava close the loop at every layer:
+- **New goals** — "CI has no goal for main-branch-red; I'll propose one"
+- **New actions** — "goal is violated but no action addresses it"
+- **Agent tuning** — "Quinn's pr_review is too expensive at Opus; downshift to Sonnet"
+
+All proposals require evidence from `get_cost_summary` or `get_confidence_summary` (sampleCount >= 50 for agent tuning).
+
+### 3. GOAP-dispatched operational skills
+
+When fleet health goals are violated, the GOAP action dispatcher invokes Ava's operational skills directly:
+
+| Skill | Trigger | What Ava does |
+|---|---|---|
+| `debug_ci_failures` | CI success rate < 70% | Read CI health, delegate to Quinn for root cause, file issues |
+| `fleet_incident_response` | Agent failure rate > 50% for 1h | Report incident, investigate, notify operator |
+| `downshift_models` | Fleet cost > $50/day | Review spend, propose model downgrades for non-critical skills |
+| `investigate_orphaned_skills` | Skills with 0 success in 24h | Diagnose capability regression, file issues or propose fixes |
+| `diagnose_pr_stuck` | Repeated update-branch 422 failures | Classify conflict (redundant/rebasable/decomposable/genuine) |
+
+These skills use Ava's full tool access and main system prompt (except `diagnose_pr_stuck` and `goal_proposal`, which use `systemPromptOverride` for structured output).
+
+"Bottlenecks are growth" operationalized: the system's own failures become inputs to its own goal backlog, closing the loop from observation → ranking → planner selection → outcome → **goal refinement** → **config change** → **re-evaluation**.
 
 ---
 
@@ -185,6 +216,7 @@ Agents with no data (`totalOutcomes === 0`) get weight 1.0 so new agents still r
 - **Durable cost/confidence stores** — current stores are in-memory with 200-sample rolling windows; a SQLite-backed store would let rankings survive restarts and feed historical dashboards
 - **Learned policy replacing the hand-tuned weights** — the 2.0 / 0.5 / 0.3 coefficients are intuitive but not optimal. Once the observation stream is persistent, a bandit or Q-learner can pick weights that minimize regret on the goal-violated → dispatched pair
 - **Memory-health remediation actions** — `memory.graphiti_healthy` + `memory.search_working` goals evaluate correctly but have no registered action. Graphiti going dark today causes silent degradation rather than an alert + restart
+- **Action proposals** — Ava can propose new goals via `goal_proposal` and config changes via `propose_config_change`, but cannot yet propose entirely new GOAP actions. Today she files issues/features for missing actions; a `propose_action` mechanism would let her draft action YAML directly
 
 ---
 

--- a/docs/extensions/blast-v1.md
+++ b/docs/extensions/blast-v1.md
@@ -4,7 +4,7 @@ title: "Extension: x-protolabs/blast-v1"
 
 `x-protolabs/blast-v1` lets agents declare the **scope of effect** for each skill so the planner, HITL policy, and dashboards can apply stricter gates to higher-impact work — independent of goal-level config.
 
-**Extension URI**: `https://protolabs.ai/a2a/ext/blast-v1`
+**Extension URI**: `https://proto-labs.ai/a2a/ext/blast-v1`
 
 ---
 
@@ -49,7 +49,7 @@ Add to your agent card's `capabilities.extensions` list:
   "capabilities": {
     "extensions": [
       {
-        "uri": "https://protolabs.ai/a2a/ext/blast-v1",
+        "uri": "https://proto-labs.ai/a2a/ext/blast-v1",
         "params": {
           "skills": {
             "sitrep":              { "radius": "self" },

--- a/docs/extensions/confidence-v1.md
+++ b/docs/extensions/confidence-v1.md
@@ -4,7 +4,7 @@ title: "Extension: x-protolabs/confidence-v1"
 
 `x-protolabs/confidence-v1` captures the agent's self-reported confidence in its output so OutcomeAnalysis can weight failure signals by how sure the agent was, and the planner can prefer high-confidence candidates when ranking.
 
-**Extension URI**: `https://protolabs.ai/a2a/ext/confidence-v1`
+**Extension URI**: `https://proto-labs.ai/a2a/ext/confidence-v1`
 
 ---
 

--- a/docs/extensions/cost-v1.md
+++ b/docs/extensions/cost-v1.md
@@ -4,7 +4,7 @@ title: "Extension: x-protolabs/cost-v1"
 
 `x-protolabs/cost-v1` records per-(agent, skill) token + wall-time actuals for every A2A dispatch, feeds a rolling in-memory store, and publishes `autonomous.cost.*` observability events. The planner reads from the store to rank candidate skills by observed success rate + cost-per-call.
 
-**Extension URI**: `https://protolabs.ai/a2a/ext/cost-v1`
+**Extension URI**: `https://proto-labs.ai/a2a/ext/cost-v1`
 
 ---
 

--- a/docs/extensions/effect-domain-v1.md
+++ b/docs/extensions/effect-domain-v1.md
@@ -4,7 +4,7 @@ title: "Extension: x-protolabseffect-domain-v1"
 
 `x-protolabseffect-domain-v1` is an A2A agent card extension that lets skills declare their expected world-state mutations. The L1 planner reads these declarations to score and select candidate skills when building a plan.
 
-**Extension URI**: `https://protolabs.ai/a2a/ext/effect-domain-v1`
+**Extension URI**: `https://proto-labs.ai/a2a/ext/effect-domain-v1`
 
 ---
 
@@ -26,7 +26,7 @@ Declared inside the A2A agent card under `capabilities.extensions`:
 ```yaml
 capabilities:
   extensions:
-    - uri: https://protolabs.ai/a2a/ext/effect-domain-v1
+    - uri: https://proto-labs.ai/a2a/ext/effect-domain-v1
       params:
         skills:
           <skill_name>:
@@ -55,7 +55,7 @@ A skill may declare multiple effects if it mutates more than one path.
 ```yaml
 capabilities:
   extensions:
-    - uri: https://protolabs.ai/a2a/ext/effect-domain-v1
+    - uri: https://proto-labs.ai/a2a/ext/effect-domain-v1
       params:
         skills:
           pr_review:
@@ -117,7 +117,7 @@ Add the extension to the agent's `/.well-known/agent-card.json`:
   "capabilities": {
     "extensions": [
       {
-        "uri": "https://protolabs.ai/a2a/ext/effect-domain-v1",
+        "uri": "https://proto-labs.ai/a2a/ext/effect-domain-v1",
         "params": {
           "skills": {
             "pr_review": {
@@ -139,4 +139,4 @@ Add the extension to the agent's `/.well-known/agent-card.json`:
 
 ## Versioning
 
-This is version 1 of the effect-domain extension. The URI `https://protolabs.ai/a2a/ext/effect-domain-v1` is stable. Breaking changes (field renames, semantic changes to `confidence` interpretation) will be published under a new versioned URI.
+This is version 1 of the effect-domain extension. The URI `https://proto-labs.ai/a2a/ext/effect-domain-v1` is stable. Breaking changes (field renames, semantic changes to `confidence` interpretation) will be published under a new versioned URI.

--- a/docs/extensions/hitl-mode-v1.md
+++ b/docs/extensions/hitl-mode-v1.md
@@ -4,7 +4,7 @@ title: "Extension: x-protolabs/hitl-mode-v1"
 
 `x-protolabs/hitl-mode-v1` lets agents declare the **approval policy** for each skill on their agent card. HITL is a gradient, not a binary — this extension lets the dispatcher + HITL plugin route each skill invocation through the right flow without goal-level config.
 
-**Extension URI**: `https://protolabs.ai/a2a/ext/hitl-mode-v1`
+**Extension URI**: `https://proto-labs.ai/a2a/ext/hitl-mode-v1`
 
 ---
 
@@ -76,7 +76,7 @@ registerHitlModeExtension();
   "capabilities": {
     "extensions": [
       {
-        "uri": "https://protolabs.ai/a2a/ext/hitl-mode-v1",
+        "uri": "https://proto-labs.ai/a2a/ext/hitl-mode-v1",
         "params": {
           "skills": {
             "sitrep":              { "mode": "autonomous" },

--- a/docs/guides/extend-an-a2a-agent.md
+++ b/docs/guides/extend-an-a2a-agent.md
@@ -41,11 +41,11 @@ Here's what it looks like when an agent opts in to all five:
     "pushNotifications": true,
     "stateTransitionHistory": false,
     "extensions": [
-      { "uri": "https://protolabs.ai/a2a/ext/cost-v1" },
-      { "uri": "https://protolabs.ai/a2a/ext/confidence-v1" },
+      { "uri": "https://proto-labs.ai/a2a/ext/cost-v1" },
+      { "uri": "https://proto-labs.ai/a2a/ext/confidence-v1" },
 
       {
-        "uri": "https://protolabs.ai/a2a/ext/effect-domain-v1",
+        "uri": "https://proto-labs.ai/a2a/ext/effect-domain-v1",
         "params": {
           "skills": {
             "pr_review":     { "effects": [{ "domain": "pr_pipeline", "path": "data.conflicting", "delta": -1, "confidence": 0.7 }] },
@@ -56,7 +56,7 @@ Here's what it looks like when an agent opts in to all five:
       },
 
       {
-        "uri": "https://protolabs.ai/a2a/ext/blast-v1",
+        "uri": "https://proto-labs.ai/a2a/ext/blast-v1",
         "params": {
           "skills": {
             "sitrep":          { "radius": "self" },
@@ -69,7 +69,7 @@ Here's what it looks like when an agent opts in to all five:
       },
 
       {
-        "uri": "https://protolabs.ai/a2a/ext/hitl-mode-v1",
+        "uri": "https://proto-labs.ai/a2a/ext/hitl-mode-v1",
         "params": {
           "skills": {
             "sitrep":          { "mode": "autonomous" },

--- a/docs/integrations/runtimes/deep-agent.md
+++ b/docs/integrations/runtimes/deep-agent.md
@@ -14,7 +14,8 @@ title: DeepAgent Runtime (LangGraph)
 2. Each executor is registered in `ExecutorRegistry` for the skills listed in the agent's YAML
 3. When `SkillDispatcherPlugin` routes a `SkillRequest` to this executor, it:
    - Creates a LangGraph ReAct agent with `ChatOpenAI` pointed at the LiteLLM gateway
-   - Injects the agent's `systemPrompt` as a `SystemMessage`
+   - Resolves the system prompt: if the matched skill has `systemPromptOverride`, uses that; otherwise uses the agent's `systemPrompt`
+   - Appends a cached world state snapshot for instant situational awareness
    - Provides LangChain tools matching the `tools` whitelist from the agent YAML
    - Runs the agent loop with `recursionLimit` derived from `maxTurns`
    - Returns the final AI message as `SkillResult.text`
@@ -25,52 +26,121 @@ title: DeepAgent Runtime (LangGraph)
 # workspace/agents/ava.yaml
 name: ava
 role: general
-model: claude-sonnet-4-6
+model: claude-opus-4-6
 
 systemPrompt: |
   You are Ava, the chief-of-staff protoAgent...
 
 tools:
+  # Orchestration
   - chat_with_agent
   - delegate_task
+  - publish_event
+  - manage_cron
+  - run_ceremony
+  # Observation
   - get_world_state
+  - get_projects
+  - get_ci_health
+  - get_pr_pipeline
+  - get_branch_drift
+  - get_outcomes
+  - get_incidents
+  - get_cost_summary
+  - get_confidence_summary
+  - web_search
+  # Write / Act
   - manage_board
   - create_github_issue
-  - manage_cron
+  - report_incident
+  - propose_config_change
+  # Conversation
+  - react
+  - send_update
+  - msg_operator
 
-maxTurns: 10
+maxTurns: 25
 
 discordBotTokenEnvKey: DISCORD_BOT_TOKEN_AVA
 
 skills:
   - name: chat
-    description: Conversational hub with system visibility and delegation.
+    description: Operational helm — the user's single control interface.
     keywords: []
+
+  - name: goal_proposal
+    description: Draft goals.yaml entries from chronic failure clusters.
+    keywords: [goal, proposal, cluster, outcome]
+    systemPromptOverride: |
+      You are Ava performing a goal proposal analysis...
+
+  - name: debug_ci_failures
+    description: Investigate CI failures, delegate to Quinn, file issues.
+    keywords: [ci, failure, build, pipeline]
 ```
+
+### Skill-level `systemPromptOverride`
+
+When a skill declares `systemPromptOverride`, the executor uses it instead of the agent's main `systemPrompt` for that specific invocation. This allows structured-output skills (like `goal_proposal` and `diagnose_pr_stuck`) to use narrow, format-enforcing prompts while operational skills use the full conversational prompt.
 
 See [Agent Skills Reference](../../../reference/agent-skills) for the full YAML schema and available tools.
 
 ## Available tools
 
-Tools are defined as LangChain tools with zod schemas in `DeepAgentExecutor`. Each wraps an HTTP call to workstacean's own API:
+Tools are defined as LangChain tools with zod schemas in `DeepAgentExecutor`. Each wraps an HTTP call to workstacean's own API. Agents only get the tools listed in their `tools:` array — unlisted tools are not available.
+
+### Orchestration
 
 | Tool | API endpoint | Purpose |
 |------|-------------|---------|
-| `chat_with_agent` | `POST /api/a2a/chat` | Multi-turn A2A conversation |
-| `delegate_task` | `POST /api/a2a/delegate` | Fire-and-forget dispatch |
-| `get_world_state` | `GET /api/world-state` | System health snapshot |
-| `manage_board` | `POST /api/board/features/*` | Board feature CRUD |
-| `create_github_issue` | `POST /api/github/issues` | File GitHub issues |
-| `manage_cron` | `POST /api/ceremonies/*` | Ceremony CRUD |
-| `get_projects` | `GET /api/projects` | List projects |
-| `get_ci_health` | `GET /api/ci-health` | CI pass rates |
-| `get_pr_pipeline` | `GET /api/pr-pipeline` | Open PRs and CI status |
-| `get_branch_drift` | `GET /api/branch-drift` | Dev vs main divergence |
-| `get_incidents` | `GET /api/incidents` | Open incidents |
-| `report_incident` | `POST /api/incidents` | File incident |
-| `publish_event` | `POST /publish` | Raw bus event |
+| `chat_with_agent` | `POST /api/a2a/chat` | Multi-turn A2A conversation with another agent |
+| `delegate_task` | `POST /api/a2a/delegate` | Fire-and-forget dispatch to an agent |
+| `publish_event` | `POST /publish` | Inject a raw bus event |
+| `manage_cron` | `POST /api/ceremonies/*` | CRUD scheduled ceremonies |
+| `run_ceremony` | `POST /api/ceremonies/:id/run` | Manually trigger a ceremony |
 
-Agents only get the tools listed in their `tools:` array — unlisted tools are not available.
+### Observation
+
+| Tool | API endpoint | Purpose |
+|------|-------------|---------|
+| `get_world_state` | `GET /api/world-state` | Full system health snapshot (all domains) |
+| `get_projects` | `GET /api/projects` | List registered projects |
+| `get_ci_health` | `GET /api/ci-health` | CI pass rates across repos |
+| `get_pr_pipeline` | `GET /api/pr-pipeline` | Open PRs: total, conflicts, stale, failing CI |
+| `get_branch_drift` | `GET /api/branch-drift` | Dev vs main divergence per project |
+| `get_outcomes` | `GET /api/world-state` | GOAP action dispatch outcomes |
+| `get_incidents` | `GET /api/incidents` | Open security/operational incidents |
+| `get_ceremonies` | `GET /api/ceremonies` | List ceremony definitions |
+| `get_cost_summary` | `GET /api/cost-summaries` | Per-agent/skill cost: tokens, duration, dollars |
+| `get_confidence_summary` | `GET /api/confidence-summaries` | Per-agent/skill calibration metrics |
+| `web_search` | SearXNG `/search` | Quick web search (5 results) |
+
+### Write / Act
+
+| Tool | API endpoint | Purpose |
+|------|-------------|---------|
+| `manage_board` | `POST /api/board/features/*` | Create or update board features |
+| `create_github_issue` | `POST /api/github/issues` | File GitHub issues on managed repos |
+| `report_incident` | `POST /api/incidents` | File a security/operational incident |
+| `propose_config_change` | `POST /api/config-change/propose` | Propose YAML changes (goals, actions, agent configs) — requires human approval via Discord |
+
+### Conversation feedback
+
+| Tool | API endpoint | Purpose |
+|------|-------------|---------|
+| `react` | `POST /api/discord/react` | Add emoji reaction to triggering message |
+| `send_update` | `POST /api/discord/progress` | Send progress update during long work |
+| `msg_operator` | `POST /api/operator/message` | Direct message to human operator with urgency |
+
+### Discord operations (protoBot agent)
+
+| Tool | API endpoint | Purpose |
+|------|-------------|---------|
+| `discord_server_stats` | `GET /api/discord/server-stats` | Server stats: members, channels, roles |
+| `discord_list_channels` | `GET /api/discord/channels` | List all channels |
+| `discord_create_channel` | `POST /api/discord/channels/create` | Create a channel |
+| `discord_send` | `POST /api/discord/send` | Send a message to a channel |
+| `discord_list_members` | `GET /api/discord/members` | List server members |
 
 ## LLM gateway
 

--- a/docs/reference/agent-skills.md
+++ b/docs/reference/agent-skills.md
@@ -31,12 +31,16 @@ skills:
     keywords:         # optional — override automatic keyword extraction
       - foo
       - bar
-    chain:            # optional — auto-dispatch to another agent after completion
-      agent: other-agent
-      skill: followup_skill
+    systemPromptOverride: |   # optional — replace agent's main prompt for this skill
+      You are performing a specific structured task...
 ```
 
-The `description` is used both for human documentation and as the source for automatic keyword extraction at startup.
+| Field | Required | Purpose |
+|---|---|---|
+| `name` | yes | Skill identifier — must match `skillHint` values sent on `agent.skill.request` |
+| `description` | no | Human documentation and automatic keyword extraction source |
+| `keywords` | no | Override automatic keyword extraction with explicit match terms |
+| `systemPromptOverride` | no | Replace the agent's main `systemPrompt` for this skill invocation. Use for structured-output skills that need narrow, format-enforcing prompts (e.g. JSON-only output, YAML drafting). Skills without this field use the agent's main prompt. |
 
 ---
 
@@ -66,7 +70,13 @@ skills:
 
 `AgentRuntimePlugin` picks up the file on next restart and registers `my_skill` for routing.
 
-Available tools: `publish_event`, `get_world_state`, `get_incidents`, `report_incident`, `get_ceremonies`, `run_ceremony`.
+Available tools (see [DeepAgent Runtime](../integrations/runtimes/deep-agent) for the full list):
+
+**Orchestration:** `chat_with_agent`, `delegate_task`, `publish_event`, `manage_cron`, `run_ceremony`
+**Observation:** `get_world_state`, `get_projects`, `get_ci_health`, `get_pr_pipeline`, `get_branch_drift`, `get_outcomes`, `get_incidents`, `get_ceremonies`, `get_cost_summary`, `get_confidence_summary`, `web_search`
+**Write/Act:** `manage_board`, `create_github_issue`, `report_incident`, `propose_config_change`
+**Conversation:** `react`, `send_update`, `msg_operator`
+**Discord (protoBot):** `discord_server_stats`, `discord_list_channels`, `discord_create_channel`, `discord_send`, `discord_list_members`
 
 ### External A2A agent
 

--- a/lib/plugins/pr-remediator.ts
+++ b/lib/plugins/pr-remediator.ts
@@ -373,8 +373,9 @@ const AUTO_APPROVE_TITLE_PREFIXES = ["promote:", "chore(deps", "chore(release", 
 
 function isAutoApproveClass(pr: PrDomainEntry): boolean {
   if (AUTO_APPROVE_AUTHORS.has(pr.author)) return true;
+  const lower = pr.title.toLowerCase();
   for (const prefix of AUTO_APPROVE_TITLE_PREFIXES) {
-    if (pr.title.startsWith(prefix)) return true;
+    if (lower.startsWith(prefix)) return true;
   }
   return false;
 }

--- a/lib/plugins/pr-remediator.ts
+++ b/lib/plugins/pr-remediator.ts
@@ -358,16 +358,18 @@ async function ghUpdateBranch(
 /**
  * Is this PR in a class that Quinn can auto-approve?
  *
- *   - dependabot / renovate authors (automated dep bumps)
+ *   - dependabot / renovate / github-actions authors (automated changes)
  *   - "promote:" title prefix (release pipeline — content already reviewed)
- *   - "chore(deps" title prefix (manual dep bump)
+ *   - "chore(deps" / "chore(release" title prefix (automated dep/version bumps)
+ *   - "docs(" title prefix (documentation-only changes)
+ *   - "chore:" prefix for back-merge and other maintenance PRs
  *
- * All three classes are structurally safe: they either contain no
- * hand-written code (dep bumps) or are re-promoting content that's
- * already passed review on the upstream branch.
+ * All classes are structurally safe: they either contain no hand-written
+ * code (dep bumps, releases, back-merges), are re-promoting content
+ * that's already passed review, or are documentation-only.
  */
-const AUTO_APPROVE_AUTHORS = new Set(["dependabot[bot]", "renovate[bot]"]);
-const AUTO_APPROVE_TITLE_PREFIXES = ["promote:", "chore(deps"];
+const AUTO_APPROVE_AUTHORS = new Set(["dependabot[bot]", "renovate[bot]", "app/github-actions"]);
+const AUTO_APPROVE_TITLE_PREFIXES = ["promote:", "chore(deps", "chore(release", "chore:", "docs("];
 
 function isAutoApproveClass(pr: PrDomainEntry): boolean {
   if (AUTO_APPROVE_AUTHORS.has(pr.author)) return true;
@@ -543,6 +545,15 @@ export class PrRemediatorPlugin implements Plugin {
         // tick flips readyToMerge, _handleMergeReady auto-merges.
         void this._runAutoApprovePass().catch(err =>
           console.error("[pr-remediator] auto-approve pass error:", err),
+        );
+        // Self-dispatch: drive remediation directly from world state.
+        // The pr.remediate.* topics exist for external triggers but are not
+        // published by the GOAP action dispatcher (tier_0 actions dispatch to
+        // agent.skill.request, not custom topics). Self-driving from the
+        // cached snapshot ensures remediation runs on every domain tick
+        // regardless of how the action dispatcher routes.
+        void this._selfDispatchRemediation(msg).catch(err =>
+          console.error("[pr-remediator] self-dispatch error:", err),
         );
       } else if (state?.domains) {
         // Domain missing from a valid state update — drop stale cache
@@ -862,6 +873,28 @@ export class PrRemediatorPlugin implements Plugin {
         this.autoApprovedAt.delete(key);
       }
     }
+  }
+
+  // ── Self-dispatch ─────────────────────────────────────────────────────────
+  //
+  // Checks the cached pr_pipeline snapshot and invokes the appropriate
+  // remediation handler for each active class. Loop protection
+  // (_shouldDispatch) prevents runaway cascades — the same guards apply
+  // whether the handler was triggered by a bus message or by self-dispatch.
+
+  private async _selfDispatchRemediation(triggerMsg: BusMessage): Promise<void> {
+    const data = this.latestPrData;
+    if (!data?.prs?.length) return;
+
+    const readyCount = data.prs.filter(p => p.readyToMerge).length;
+    const dirtyCount = data.prs.filter(p => p.mergeable === "dirty").length;
+    const failCiCount = data.prs.filter(p => p.ciStatus === "fail").length;
+    const feedbackCount = data.prs.filter(p => p.reviewState === "changes_requested").length;
+
+    if (readyCount > 0) void this._handleMergeReady(triggerMsg);
+    if (dirtyCount > 0) void this._handleUpdateBranch(triggerMsg);
+    if (failCiCount > 0) void this._handleFixCi(triggerMsg);
+    if (feedbackCount > 0) void this._handleAddressFeedback(triggerMsg);
   }
 
   // ── merge_ready ────────────────────────────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean",
-  "version": "0.7.20",
+  "version": "0.7.21",
   "type": "module",
   "scripts": {
     "start": "bun run src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "type": "module",
   "scripts": {
     "start": "bun run src/index.ts",

--- a/scripts/agent-rollcall.sh
+++ b/scripts/agent-rollcall.sh
@@ -28,9 +28,7 @@ AGENTS=(
   "quinn:7873:a2a:Quinn (QA Engineer)"
   "protocontent:18791:a2a:protoContent / Jon (Content Pipeline)"
   "researcher:7874:a2a:Researcher (rabbit-hole.io)"
-  "protovoice:7880:http:protoVoice (Voice Agent)"
-  "protoaudio:8210:health:protoAudio (Audio Pipeline)"
-  "workstacean:8081:http:Workstacean (Orchestrator — hosts Ava + protoBot DeepAgents)"
+  "workstacean:8081:http:Workstacean (Orchestrator — hosts Ava + protoBot + Tuner DeepAgents)"
 )
 
 # Remote agents — not Docker containers, accessed over Tailscale

--- a/src/agent-runtime/tools/bus-tools.ts
+++ b/src/agent-runtime/tools/bus-tools.ts
@@ -384,23 +384,66 @@ export function createBusTools(opts: BusToolsOptions = {}) {
     },
   );
 
-  const webSearch = tool(
-    "web_search",
-    "Quick web search via SearXNG. Use for simple factual lookups. " +
+  const searxngSearch = tool(
+    "searxng_search",
+    "Search via SearXNG with category routing (general, news, science, it). " +
+      "Replaces dedicated web search, news, Wikipedia tools by routing through SearXNG categories. " +
+      "Supports bang syntax in the query (!wp for Wikipedia, !scholar for Google Scholar, !gh for GitHub). " +
+      "Returns results, direct answers, infoboxes, and suggestions. " +
       "For deep multi-source research, use chat_with_agent with the researcher agent instead.",
     {
-      query: z.string().describe("Search query"),
+      query: z.string().describe("Search query. Supports SearXNG bang syntax (e.g. !wp, !scholar, !gh)."),
+      category: z.enum(["general", "news", "science", "it"]).optional().describe("SearXNG category. Defaults to general."),
+      time_range: z.enum(["day", "week", "month", "year"]).optional().describe("Limit results to a time range."),
+      max_results: z.number().optional().describe("Max results to return. Default: 10."),
     },
-    async ({ query }) => {
-      const searxngUrl = process.env.SEARXNG_URL ?? "http://searxng:8080";
+    async ({ query, category, time_range, max_results }) => {
+      const endpoint = process.env.SEARXNG_URL ?? "http://searxng:8080";
       try {
-        const params = new URLSearchParams({ q: query, format: "json", engines: "google,duckduckgo" });
-        const resp = await fetch(`${searxngUrl}/search?${params}`, { signal: AbortSignal.timeout(10_000) });
+        const url = new URL("/search", endpoint);
+        url.searchParams.set("q", query);
+        url.searchParams.set("format", "json");
+        if (category) url.searchParams.set("categories", category);
+        if (time_range) url.searchParams.set("time_range", time_range);
+
+        const resp = await fetch(url.toString(), {
+          headers: { Accept: "application/json" },
+          signal: AbortSignal.timeout(15_000),
+        });
         if (!resp.ok) return err(`SearXNG ${resp.status}`);
-        const data = await resp.json() as { results?: Array<{ title: string; content?: string; url?: string }> };
-        const results = (data.results ?? []).slice(0, 5);
-        if (!results.length) return ok({ results: [], message: "No results found." });
-        return ok({ results: results.map(r => ({ title: r.title, snippet: r.content ?? "", url: r.url ?? "" })) });
+
+        const data = await resp.json() as {
+          results?: Array<{ title: string; url: string; content: string; engine: string; score?: number }>;
+          suggestions?: string[];
+          infoboxes?: Array<{ infobox: string; content: string; attributes?: Array<{ label: string; value: string }> }>;
+          answers?: string[];
+        };
+
+        const cap = max_results ?? 10;
+        const results = (data.results ?? []).slice(0, cap).map(r => ({
+          title: r.title, url: r.url, snippet: r.content, engine: r.engine,
+          ...(r.score != null ? { score: r.score } : {}),
+        }));
+        const answers = data.answers ?? [];
+        const suggestions = data.suggestions ?? [];
+        const infoboxes = (data.infoboxes ?? []).map(ib => ({
+          title: ib.infobox, content: ib.content,
+          attributes: ib.attributes ?? [],
+        }));
+
+        if (!results.length && !answers.length && !infoboxes.length) {
+          return ok({ results: [], message: `No results for "${query}"`, suggestions });
+        }
+
+        return ok({
+          query,
+          ...(category ? { category } : {}),
+          ...(time_range ? { time_range } : {}),
+          results,
+          ...(answers.length ? { answers } : {}),
+          ...(infoboxes.length ? { infoboxes } : {}),
+          ...(suggestions.length ? { suggestions } : {}),
+        });
       } catch (e) {
         return err(e instanceof Error ? e.message : String(e));
       }
@@ -525,7 +568,7 @@ export function createBusTools(opts: BusToolsOptions = {}) {
   return [
     publishEvent, getWorldState, getIncidents, reportIncident, getProjects,
     getCiHealth, getPrPipeline, getBranchDrift, getOutcomes, getCeremonies, runCeremony,
-    chatWithAgent, delegateTask, manageBoard, createGitHubIssue, manageCron, webSearch,
+    chatWithAgent, delegateTask, manageBoard, createGitHubIssue, manageCron, searxngSearch,
     getCostSummary, getConfidenceSummary, proposeConfigChange, msgOperator,
   ];
 }
@@ -551,7 +594,7 @@ export const BUS_TOOL_NAMES = [
   "manage_board",
   "create_github_issue",
   "manage_cron",
-  "web_search",
+  "searxng_search",
   // Discord operations (protoBot agent)
   "discord_server_stats",
   "discord_list_channels",

--- a/src/agent-runtime/tools/bus-tools.ts
+++ b/src/agent-runtime/tools/bus-tools.ts
@@ -300,21 +300,27 @@ export function createBusTools(opts: BusToolsOptions = {}) {
 
   const manageBoard = tool(
     "manage_board",
-    "Create or update features on the protoMaker board. Use action 'create' to file " +
-      "new work items, 'update' to change status/priority/description of existing features.",
+    "Create, update, or list features on the protoMaker board. Use 'list' to query " +
+      "features by status, 'create' to file new work items, 'update' to change existing features.",
     {
-      action: z.enum(["create", "update"]).describe("Operation to perform"),
+      action: z.enum(["create", "update", "list"]).describe("Operation to perform"),
       projectPath: z.string().describe("Absolute path to the project directory"),
       title: z.string().optional().describe("Feature title (required for create)"),
       description: z.string().optional().describe("Feature description"),
       featureId: z.string().optional().describe("Feature ID (required for update)"),
-      status: z.enum(["backlog", "in-progress", "review", "done"]).optional(),
+      status: z.enum(["backlog", "in-progress", "review", "done"]).optional().describe("Filter by status (for list) or set status (for create/update)"),
       priority: z.number().optional().describe("0=none, 1=urgent, 2=high, 3=normal, 4=low"),
       complexity: z.enum(["small", "medium", "large", "architectural"]).optional(),
       projectSlug: z.string().optional(),
     },
     async ({ action, projectPath, title, description, featureId, status, priority, complexity, projectSlug }) => {
       try {
+        if (action === "list") {
+          const query = new URLSearchParams({ projectPath });
+          if (status) query.set("status", status);
+          const data = await http.get(`/api/board/features/list?${query}`);
+          return ok(data);
+        }
         const endpoint = action === "create" ? "/api/board/features/create" : "/api/board/features/update";
         const data = await http.post(endpoint, {
           projectPath, title, description, featureId, status, priority, complexity, projectSlug,

--- a/src/api/board.ts
+++ b/src/api/board.ts
@@ -108,7 +108,46 @@ export function createRoutes(ctx: ApiContext): Route[] {
     }
   }
 
+  async function handleListFeatures(req: Request): Promise<Response> {
+    if (ctx.apiKey && req.headers.get("X-API-Key") !== ctx.apiKey) {
+      return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const url = new URL(req.url);
+    const projectPath = url.searchParams.get("projectPath");
+
+    if (!projectPath) {
+      return Response.json(
+        { success: false, error: "projectPath query parameter is required" },
+        { status: 400 },
+      );
+    }
+
+    const status = url.searchParams.get("status");
+
+    try {
+      const query = new URLSearchParams({ projectPath });
+      if (status) query.set("status", status);
+
+      const resp = await studioHttp.fetch(`${STUDIO_URL}/features/list?${query}`, {
+        method: "GET",
+        headers: { Accept: "application/json" },
+      });
+
+      if (!resp.ok) {
+        const errText = await resp.text().catch(() => "(no body)");
+        return Response.json({ success: false, error: `Studio: ${resp.status} ${errText}` }, { status: resp.status });
+      }
+
+      const data = await resp.json();
+      return Response.json({ success: true, data });
+    } catch (e) {
+      return Response.json({ success: false, error: String(e) }, { status: 502 });
+    }
+  }
+
   return [
+    { method: "GET",  path: "/api/board/features/list",   handler: (req) => handleListFeatures(req) },
     { method: "POST", path: "/api/board/features/create", handler: (req) => handleCreateFeature(req) },
     { method: "POST", path: "/api/board/features/update", handler: (req) => handleUpdateFeature(req) },
   ];

--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -457,11 +457,91 @@ export function createRoutes(ctx: ApiContext): Route[] {
     }
   }
 
+  // ── GitHub Issues domain ────────────────────────────────────────────────────
+  // Aggregate open issue counts per repo for the issue_zero GOAP goal.
+  // Polls `/repos/{repo}/issues?state=open` and classifies by label priority.
+
+  async function handleGetGithubIssues(): Promise<Response> {
+    const repoList = repos();
+    if (!repoList.length || !GITHUB_TOKEN) return Response.json({
+      totalOpen: 0, criticalOpen: 0, bugOpen: 0, enhancementOpen: 0, repos: [],
+    });
+
+    const repoSummaries: Array<{
+      repo: string;
+      openCount: number;
+      criticalCount: number;
+      bugCount: number;
+      enhancementCount: number;
+      oldest: string | null;
+      issues: Array<{
+        number: number;
+        title: string;
+        labels: string[];
+        createdAt: string;
+        updatedAt: string;
+        author: string;
+      }>;
+    }> = [];
+
+    for (const repo of repoList) {
+      try {
+        const issues = await ghApi(
+          `/repos/${repo}/issues?state=open&per_page=100&sort=created&direction=asc`,
+        ) as Array<{
+          number: number;
+          title: string;
+          labels: Array<{ name: string }>;
+          created_at: string;
+          updated_at: string;
+          user: { login: string } | null;
+          pull_request?: unknown;
+        }>;
+
+        // GitHub's issues endpoint includes PRs — filter them out
+        const realIssues = issues.filter(i => !i.pull_request);
+
+        const labels = (i: typeof realIssues[0]) => i.labels.map(l => l.name);
+        const criticalCount = realIssues.filter(i => labels(i).includes("critical")).length;
+        const bugCount = realIssues.filter(i => labels(i).includes("bug")).length;
+        const enhancementCount = realIssues.filter(i => labels(i).includes("enhancement")).length;
+
+        repoSummaries.push({
+          repo,
+          openCount: realIssues.length,
+          criticalCount,
+          bugCount,
+          enhancementCount,
+          oldest: realIssues.length > 0 ? realIssues[0]!.created_at : null,
+          issues: realIssues.map(i => ({
+            number: i.number,
+            title: i.title,
+            labels: labels(i),
+            createdAt: i.created_at,
+            updatedAt: i.updated_at,
+            author: i.user?.login ?? "unknown",
+          })),
+        });
+      } catch {
+        // Skip unreachable repos
+      }
+    }
+
+    return Response.json({
+      totalOpen: repoSummaries.reduce((s, r) => s + r.openCount, 0),
+      criticalOpen: repoSummaries.reduce((s, r) => s + r.criticalCount, 0),
+      bugOpen: repoSummaries.reduce((s, r) => s + r.bugCount, 0),
+      enhancementOpen: repoSummaries.reduce((s, r) => s + r.enhancementCount, 0),
+      repos: repoSummaries,
+    });
+  }
+
   return [
     { method: "GET",  path: "/api/ci-health",          handler: () => handleGetCiHealth() },
     { method: "GET",  path: "/api/pr-pipeline",        handler: () => handleGetPrPipeline() },
     { method: "GET",  path: "/api/branch-drift",       handler: () => handleGetBranchDrift() },
     { method: "GET",  path: "/api/branch-protection",  handler: () => handleGetBranchProtection() },
+    { method: "GET",  path: "/api/github-issues",      handler: () => handleGetGithubIssues() },
     { method: "POST", path: "/api/github/issues",      handler: (req) => handleCreateIssue(req) },
   ];
 }

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -454,11 +454,19 @@ export class DeepAgentExecutor implements IExecutor {
       : [];
 
     try {
+      // Resolve skill-level systemPromptOverride if this skill defines one.
+      // Skills like goal_proposal and diagnose_pr_stuck have narrow, structured
+      // output requirements that replace the agent's general-purpose prompt.
+      const skillDef = req.skill
+        ? this.agentDef.skills.find(s => s.name === req.skill)
+        : undefined;
+      const basePrompt = skillDef?.systemPromptOverride ?? this.agentDef.systemPrompt;
+
       // Inject cached world state into system prompt for instant situational awareness
       const worldSummary = await this.worldCache.getSummary();
       const enrichedPrompt = worldSummary
-        ? `${this.agentDef.systemPrompt}\n\n## Current system state (auto-refreshed, do not repeat verbatim)\n\n${worldSummary}`
-        : this.agentDef.systemPrompt;
+        ? `${basePrompt}\n\n## Current system state (auto-refreshed, do not repeat verbatim)\n\n${worldSummary}`
+        : basePrompt;
 
       const agent = createReactAgent({
         llm: this.model,

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -262,19 +262,41 @@ function createLangChainTools(toolNames: string[], http: HttpClient, correlation
       async (input) => JSON.stringify(await http.post(`/api/ceremonies/${input.ceremonyId}/run`, {})),
       { name: "run_ceremony", description: "Trigger a ceremony.", schema: z.object({ ceremonyId: z.string() }) },
     ),
-    web_search: tool(
+    searxng_search: tool(
       async (input) => {
-        const searxngUrl = process.env.SEARXNG_URL ?? "http://searxng:8080";
-        const params = new URLSearchParams({ q: input.query, format: "json", engines: "google,duckduckgo" });
-        const resp = await fetch(`${searxngUrl}/search?${params}`, { signal: AbortSignal.timeout(10_000) });
-        const data = await resp.json() as { results?: Array<{ title: string; content?: string; url?: string }> };
-        const results = (data.results ?? []).slice(0, 5);
-        return JSON.stringify(results.map(r => ({ title: r.title, snippet: r.content ?? "", url: r.url ?? "" })));
+        const endpoint = process.env.SEARXNG_URL ?? "http://searxng:8080";
+        const url = new URL("/search", endpoint);
+        url.searchParams.set("q", input.query);
+        url.searchParams.set("format", "json");
+        if (input.category) url.searchParams.set("categories", input.category);
+        if (input.time_range) url.searchParams.set("time_range", input.time_range);
+        const resp = await fetch(url.toString(), {
+          headers: { Accept: "application/json" },
+          signal: AbortSignal.timeout(15_000),
+        });
+        const data = await resp.json() as {
+          results?: Array<{ title: string; url: string; content: string; engine: string; score?: number }>;
+          answers?: string[];
+          suggestions?: string[];
+          infoboxes?: Array<{ infobox: string; content: string }>;
+        };
+        const cap = input.max_results ?? 10;
+        return JSON.stringify({
+          results: (data.results ?? []).slice(0, cap).map(r => ({ title: r.title, url: r.url, snippet: r.content, engine: r.engine })),
+          ...(data.answers?.length ? { answers: data.answers } : {}),
+          ...(data.suggestions?.length ? { suggestions: data.suggestions } : {}),
+          ...(data.infoboxes?.length ? { infoboxes: data.infoboxes.map(ib => ({ title: ib.infobox, content: ib.content })) } : {}),
+        });
       },
       {
-        name: "web_search",
-        description: "Quick web search via SearXNG. For deep research, use chat_with_agent with the researcher agent.",
-        schema: z.object({ query: z.string().describe("Search query") }),
+        name: "searxng_search",
+        description: "Search via SearXNG with category routing (general, news, science, it). Supports bang syntax (!wp, !scholar, !gh). For deep research, use chat_with_agent with the researcher agent.",
+        schema: z.object({
+          query: z.string().describe("Search query. Supports SearXNG bang syntax."),
+          category: z.enum(["general", "news", "science", "it"]).optional().describe("SearXNG category."),
+          time_range: z.enum(["day", "week", "month", "year"]).optional().describe("Limit to time range."),
+          max_results: z.number().optional().describe("Max results. Default: 10."),
+        }),
       },
     ),
     // ── Discord operations (protoBot agent) ──────────────────────────────────

--- a/src/executor/extensions/blast.ts
+++ b/src/executor/extensions/blast.ts
@@ -16,7 +16,7 @@
  *     observation. A separate consumer can subscribe to `autonomous.outcome.#`
  *     and cross-reference the blast radius stored here.
  *
- * Extension URI: https://protolabs.ai/a2a/ext/blast-v1
+ * Extension URI: https://proto-labs.ai/a2a/ext/blast-v1
  */
 
 import {
@@ -25,7 +25,7 @@ import {
   type ExtensionContext,
 } from "../extension-registry.ts";
 
-export const BLAST_URI = "https://protolabs.ai/a2a/ext/blast-v1";
+export const BLAST_URI = "https://proto-labs.ai/a2a/ext/blast-v1";
 
 /**
  * Scope of effect for a skill. Ordered from narrowest to widest.

--- a/src/executor/extensions/confidence.ts
+++ b/src/executor/extensions/confidence.ts
@@ -16,7 +16,7 @@
  *     ConfidenceSample, publishes `autonomous.confidence.{systemActor}.{skill}`
  *     for observability.
  *
- * Extension URI: https://protolabs.ai/a2a/ext/confidence-v1
+ * Extension URI: https://proto-labs.ai/a2a/ext/confidence-v1
  */
 
 import type { EventBus } from "../../../lib/types.ts";
@@ -26,7 +26,7 @@ import {
   type ExtensionContext,
 } from "../extension-registry.ts";
 
-export const CONFIDENCE_URI = "https://protolabs.ai/a2a/ext/confidence-v1";
+export const CONFIDENCE_URI = "https://proto-labs.ai/a2a/ext/confidence-v1";
 
 /** One observed confidence score from a completed task. */
 export interface ConfidenceSample {

--- a/src/executor/extensions/cost.ts
+++ b/src/executor/extensions/cost.ts
@@ -15,7 +15,7 @@
  *     both surface this) and appends a CostSample to the running stats store;
  *     publishes `autonomous.cost.{systemActor}.{skill}` for observability.
  *
- * Extension URI: https://protolabs.ai/a2a/ext/cost-v1
+ * Extension URI: https://proto-labs.ai/a2a/ext/cost-v1
  */
 
 import type { EventBus } from "../../../lib/types.ts";
@@ -25,7 +25,7 @@ import {
   type ExtensionContext,
 } from "../extension-registry.ts";
 
-export const COST_URI = "https://protolabs.ai/a2a/ext/cost-v1";
+export const COST_URI = "https://proto-labs.ai/a2a/ext/cost-v1";
 
 /**
  * Per-skill cost estimate as declared by the agent card.

--- a/src/executor/extensions/effect-domain.ts
+++ b/src/executor/extensions/effect-domain.ts
@@ -13,7 +13,7 @@
  * Call `registerEffectDomainExtension(bus)` once at startup (e.g. in src/index.ts)
  * to wire this extension into the defaultExtensionRegistry.
  *
- * Extension URI: https://protolabs.ai/a2a/ext/effect-domain-v1
+ * Extension URI: https://proto-labs.ai/a2a/ext/effect-domain-v1
  */
 
 import type { EventBus } from "../../../lib/types.ts";
@@ -28,7 +28,7 @@ import {
   type WorldStateDeltaEntry,
 } from "../../../lib/types/worldstate-delta.ts";
 
-export const EFFECT_DOMAIN_URI = "https://protolabs.ai/a2a/ext/effect-domain-v1";
+export const EFFECT_DOMAIN_URI = "https://proto-labs.ai/a2a/ext/effect-domain-v1";
 
 /** A single world-state mutation declared for a skill in the agent card. */
 export interface EffectDomainDelta {

--- a/src/executor/extensions/hitl-mode.ts
+++ b/src/executor/extensions/hitl-mode.ts
@@ -11,7 +11,7 @@
  * TaskTracker) can read it without a second lookup. No `after(ctx)` — mode
  * is policy, not observation.
  *
- * Extension URI: https://protolabs.ai/a2a/ext/hitl-mode-v1
+ * Extension URI: https://proto-labs.ai/a2a/ext/hitl-mode-v1
  */
 
 import {
@@ -20,7 +20,7 @@ import {
   type ExtensionContext,
 } from "../extension-registry.ts";
 
-export const HITL_MODE_URI = "https://protolabs.ai/a2a/ext/hitl-mode-v1";
+export const HITL_MODE_URI = "https://proto-labs.ai/a2a/ext/hitl-mode-v1";
 
 /**
  * Approval policy for a single skill. Ordered from least-gated to most-gated.

--- a/src/executor/extensions/langfuse-trace.ts
+++ b/src/executor/extensions/langfuse-trace.ts
@@ -1,0 +1,37 @@
+/**
+ * Langfuse trace propagation extension — stamps a2a.trace metadata on
+ * outbound A2A dispatches so downstream agents (Quinn, etc.) can link
+ * their Langfuse traces back to the originating workstacean invocation.
+ *
+ * The correlationId serves as the trace ID (it's the unique identifier
+ * for the entire skill dispatch chain). The extension stamps it into
+ * `params.metadata["a2a.trace"]` which Quinn reads on the receiving end
+ * to set `caller_trace_id` in her Langfuse trace metadata.
+ *
+ * Extension URI: https://proto-labs.ai/a2a/ext/trace-v1
+ */
+
+import type { ExtensionInterceptor, ExtensionContext } from "../extension-registry.ts";
+import { defaultExtensionRegistry } from "../extension-registry.ts";
+
+const TRACE_URI = "https://proto-labs.ai/a2a/ext/trace-v1";
+
+export function registerLangfuseTraceExtension(): void {
+  const interceptor: ExtensionInterceptor = {
+    before(ctx: ExtensionContext): void {
+      ctx.metadata["a2a.trace"] = {
+        traceId: ctx.correlationId,
+        callerAgent: ctx.agentName,
+        skill: ctx.skill,
+        project: "protolabs",
+      };
+    },
+  };
+
+  defaultExtensionRegistry.register({
+    uri: TRACE_URI,
+    interceptor,
+    description:
+      "Trace v1: stamps Langfuse trace context on outbound A2A calls for cross-agent trace linking",
+  });
+}

--- a/src/executor/task-tracker.ts
+++ b/src/executor/task-tracker.ts
@@ -23,7 +23,7 @@ const HITL_TTL_MS = 30 * 60_000; // 30 min default input-required window
 const DISPATCHER_REPLY_TIMEOUT_MS = 5 * 60_000; // 5 min
 
 /** Extension URI for worldstate-delta-v1 artifacts. */
-const WORLDSTATE_DELTA_URI = "https://protolabs.ai/a2a/ext/worldstate-delta-v1";
+const WORLDSTATE_DELTA_URI = "https://proto-labs.ai/a2a/ext/worldstate-delta-v1";
 
 export interface TrackedTask {
   correlationId: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -645,6 +645,7 @@ console.log(`HTTP API listening on port ${HTTP_PORT}`);
     engine.registerDomain("security", createHttpCollector(`${base}/api/security-summary`), 60_000);
     engine.registerDomain("ci", createHttpCollector(`${base}/api/ci-health`), 300_000); // 5min — GitHub rate limits
     engine.registerDomain("pr_pipeline", createHttpCollector(`${base}/api/pr-pipeline`), 120_000); // 2min
+    engine.registerDomain("github_issues", createHttpCollector(`${base}/api/github-issues`), 300_000); // 5min — issue velocity is low
     engine.registerDomain("branch_drift", createHttpCollector(`${base}/api/branch-drift`), 600_000); // 10min
     engine.registerDomain("branch_protection", createHttpCollector(`${base}/api/branch-protection`), 600_000); // 10min — rulesets change rarely
     engine.registerDomain("hitl_queue", createHttpCollector(`${base}/api/hitl-queue`), 30_000); // 30s — catch routing holes fast
@@ -665,7 +666,7 @@ console.log(`HTTP API listening on port ${HTTP_PORT}`);
       executorRegistry.setHealthGetter(() => fleetPlugin.getFleetHealth().agents);
     }
 
-    console.log("[domain-discovery] Registered local domains: flow, services, agent_health, security, ci, pr_pipeline, branch_drift, branch_protection, hitl_queue, plane, memory, agent_fleet_health");
+    console.log("[domain-discovery] Registered local domains: flow, services, agent_health, security, ci, pr_pipeline, github_issues, branch_drift, branch_protection, hitl_queue, plane, memory, agent_fleet_health");
 
     // All local + workspace/domains.yaml + per-project domains are now
     // registered. Defer prune briefly so any async per-project domain

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,11 +52,13 @@ import { registerConfidenceExtension } from "./executor/extensions/confidence.ts
 import { registerEffectDomainExtension } from "./executor/extensions/effect-domain.ts";
 import { registerBlastExtension } from "./executor/extensions/blast.ts";
 import { registerHitlModeExtension } from "./executor/extensions/hitl-mode.ts";
+import { registerLangfuseTraceExtension } from "./executor/extensions/langfuse-trace.ts";
 registerCostExtension(bus);
 registerConfidenceExtension(bus);
 registerEffectDomainExtension(bus);
 registerBlastExtension();
 registerHitlModeExtension();
+registerLangfuseTraceExtension();
 
 // --- ChannelRegistry — loaded from workspace/channels.yaml, shared by RouterPlugin + DiscordPlugin ---
 import { ChannelRegistry } from "../lib/channels/channel-registry.js";

--- a/src/loaders/__tests__/ceremonyYamlLoader.test.ts
+++ b/src/loaders/__tests__/ceremonyYamlLoader.test.ts
@@ -146,7 +146,7 @@ targets: [all]
     expect(ceremonies[0]!.enabled).toBe(true);
   });
 
-  test("respects enabled: false — excluded from returned array", () => {
+  test("returns disabled ceremonies with enabled: false (so hot-reload can cancel timers)", () => {
     writeFileSync(
       join(TEST_DIR, "ceremonies", "board.health.yaml"),
       `id: board.health
@@ -159,7 +159,9 @@ enabled: false
     );
 
     const ceremonies = loader.loadGlobal();
-    expect(ceremonies).toHaveLength(0);
+    expect(ceremonies).toHaveLength(1);
+    expect(ceremonies[0]!.id).toBe("board.health");
+    expect(ceremonies[0]!.enabled).toBe(false);
   });
 
   test("loads notifyChannel when present", () => {

--- a/src/loaders/ceremonyYamlLoader.ts
+++ b/src/loaders/ceremonyYamlLoader.ts
@@ -118,8 +118,10 @@ export class CeremonyYamlLoader {
 
     const c = raw as Record<string, unknown>;
 
-    // Check enabled first — disabled ceremonies are silently skipped
-    if (c.enabled === false) return null;
+    // Disabled ceremonies are still returned (with enabled: false) so hot-reload
+    // can cancel their timers. Previously returning null here meant
+    // _reloadChangedCeremonies never saw the disabled entry and the old timer
+    // kept firing — the ceremony was "disabled" in YAML but alive in memory.
 
     if (typeof c.id !== "string" || !c.id) {
       console.warn(`[ceremony-loader] Skipping ${filePath} (${source}): missing required 'id' field`);

--- a/src/plugins/__tests__/CeremonyPlugin.test.ts
+++ b/src/plugins/__tests__/CeremonyPlugin.test.ts
@@ -58,7 +58,7 @@ enabled: true
     expect(ceremonies.some((c) => c.id === "board.health")).toBe(true);
   });
 
-  test("CeremonyPlugin loader: skips disabled ceremonies from scheduling", () => {
+  test("CeremonyPlugin loader: loads disabled ceremonies but does not schedule them", () => {
     writeCeremony(
       "board.disabled.yaml",
       `id: board.disabled
@@ -72,9 +72,10 @@ enabled: false
 
     plugin.install(bus);
     const ceremonies = plugin.getCeremonies();
-    // Disabled ceremonies are filtered out by the loader before reaching the plugin
+    // Disabled ceremonies are loaded (so hot-reload can cancel timers) but not scheduled
     const disabled = ceremonies.find((c) => c.id === "board.disabled");
-    expect(disabled).toBeUndefined();
+    expect(disabled).toBeDefined();
+    expect(disabled!.enabled).toBe(false);
   });
 
   test("ceremony YAML: registerCeremony adds ceremony to registry", () => {

--- a/src/plugins/action-dispatcher-plugin.ts
+++ b/src/plugins/action-dispatcher-plugin.ts
@@ -163,11 +163,11 @@ export class ActionDispatcherPlugin implements Plugin {
     }
 
     try {
-      // Tier-0 actions are declarative world-state-only effects that don't require a
-      // skill call — their effects were already applied above. Resolve immediately as
-      // success without a dispatch. (Arc 1.4 removed the meta.topic indirection which
-      // used to gate this; the tier check preserves the original semantics.)
-      if (action.tier === "tier_0") {
+      // Tier-0 actions with no dispatch intent are pure state effects — their
+      // effects were already applied above. Complete immediately.
+      // Actions that declare fireAndForget fall through to the dispatch path
+      // below so they actually publish to agent.skill.request.
+      if (action.tier === "tier_0" && !action.meta.fireAndForget) {
         await this.completeAction(action, correlationId, parentCorrelationId, startedAt, true);
         return;
       }

--- a/src/pr-remediator.test.ts
+++ b/src/pr-remediator.test.ts
@@ -242,13 +242,12 @@ describe("PrRemediatorPlugin — fix_ci", () => {
   afterEach(() => plugin.uninstall());
 
   test("dispatches to Ava for each failing-CI PR with project targeting and directive prompt", async () => {
+    const dispatches = captureOn(bus, "agent.skill.request");
     pushWorldState(bus, [
       makePr({ number: 100, ciStatus: "fail", title: "bug: foo", repo: "protoLabsAI/protoMaker" }),
       makePr({ number: 200, ciStatus: "pass", repo: "protoLabsAI/protoMaker" }),  // should be skipped
       makePr({ number: 300, ciStatus: "fail", title: "bug: bar", repo: "protoLabsAI/rabbit-hole.io" }),
     ]);
-    const dispatches = captureOn(bus, "agent.skill.request");
-    dispatch(bus, "pr.remediate.fix_ci");
     await flushMicrotasks();
     expect(dispatches.length).toBe(2);
 
@@ -304,12 +303,11 @@ describe("PrRemediatorPlugin — address_feedback", () => {
   afterEach(() => plugin.uninstall());
 
   test("dispatches to Ava for changes_requested PRs with project targeting", async () => {
+    const dispatches = captureOn(bus, "agent.skill.request");
     pushWorldState(bus, [
       makePr({ number: 55, reviewState: "changes_requested", repo: "protoLabsAI/protoMaker" }),
       makePr({ number: 56, reviewState: "approved", repo: "protoLabsAI/protoMaker" }),
     ]);
-    const dispatches = captureOn(bus, "agent.skill.request");
-    dispatch(bus, "pr.remediate.address_feedback");
     await flushMicrotasks();
     expect(dispatches.length).toBe(1);
     const p = dispatches[0].payload as {
@@ -380,14 +378,17 @@ describe("PrRemediatorPlugin — world state tracking", () => {
       const plugin = new PrRemediatorPlugin();
       plugin.install(bus);
 
+      const captured = captureOn(bus, "agent.skill.request");
+
       pushWorldState(bus, [
         makePr({ number: 100, ciStatus: "fail", readyToMerge: false }),
       ]);
+      await flushMicrotasks();
 
-      const captured = captureOn(bus, "agent.skill.request");
+      // Self-dispatch fires exactly once for the failing PR.
+      expect(captured.length).toBe(1);
 
-      // Three triggers back-to-back — should only dispatch once.
-      dispatch(bus, "pr.remediate.fix_ci");
+      // Explicit triggers are blocked — the PR is already in-flight.
       dispatch(bus, "pr.remediate.fix_ci");
       dispatch(bus, "pr.remediate.fix_ci");
       await flushMicrotasks();
@@ -401,14 +402,14 @@ describe("PrRemediatorPlugin — world state tracking", () => {
       const plugin = new PrRemediatorPlugin();
       plugin.install(bus);
 
+      const captured = captureOn(bus, "agent.skill.request");
+
       pushWorldState(bus, [
         makePr({ number: 100, ciStatus: "fail", readyToMerge: false }),
       ]);
-
-      const captured = captureOn(bus, "agent.skill.request");
-
-      dispatch(bus, "pr.remediate.fix_ci");
       await flushMicrotasks();
+
+      // Self-dispatch fires the first handler call.
       expect(captured.length).toBe(1);
 
       // Simulate the skill completing — the remediator should clear its slot.
@@ -435,16 +436,15 @@ describe("PrRemediatorPlugin — world state tracking", () => {
       const plugin = new PrRemediatorPlugin();
       plugin.install(bus);
 
+      const captured = captureOn(bus, "agent.skill.request");
+
       pushWorldState(bus, [
         makePr({ number: 100, ciStatus: "fail", readyToMerge: false }),
         makePr({ number: 200, ciStatus: "fail", readyToMerge: false }),
       ]);
-
-      const captured = captureOn(bus, "agent.skill.request");
-
-      dispatch(bus, "pr.remediate.fix_ci");
       await flushMicrotasks();
-      // Both failing PRs dispatch concurrently — they're independent slots.
+
+      // Both failing PRs dispatch concurrently via self-dispatch — independent slots.
       expect(captured.length).toBe(2);
 
       // A second trigger finds both in-flight and dispatches nothing new.
@@ -460,26 +460,26 @@ describe("PrRemediatorPlugin — world state tracking", () => {
       const plugin = new PrRemediatorPlugin();
       plugin.install(bus);
 
+      const captured = captureOn(bus, "agent.skill.request");
+
       pushWorldState(bus, [
         makePr({ number: 100, ciStatus: "fail", readyToMerge: false }),
       ]);
-
-      const captured = captureOn(bus, "agent.skill.request");
-
-      dispatch(bus, "pr.remediate.fix_ci");
       await flushMicrotasks();
+      // Self-dispatch fires for PR #100.
       expect(captured.length).toBe(1);
 
       // PR #100 is gone (merged/closed) — world state no longer lists it.
       pushWorldState(bus, []);
-      // New PR appears with failing CI.
+      await flushMicrotasks();
+
+      // New PR appears with failing CI — self-dispatch fires for #101.
       pushWorldState(bus, [
         makePr({ number: 101, ciStatus: "fail", readyToMerge: false }),
       ]);
-
-      dispatch(bus, "pr.remediate.fix_ci");
       await flushMicrotasks();
-      // PR #101 gets a fresh dispatch even though #100 is no longer blocking.
+
+      // PR #101 gets a fresh dispatch; #100's in-flight entry was pruned.
       expect(captured.length).toBe(2);
       expect(captured[1]!.payload).toHaveProperty("skill", "bug_triage");
 
@@ -491,42 +491,46 @@ describe("PrRemediatorPlugin — world state tracking", () => {
       const plugin = new PrRemediatorPlugin();
       plugin.install(bus);
 
-      pushWorldState(bus, [
-        makePr({ number: 999, ciStatus: "fail", title: "bug: stuck forever", readyToMerge: false }),
-      ]);
-
       const hitlCaptured = captureOn(bus, "hitl.request.pr.remediation_stuck.#");
       const skillCaptured = captureOn(bus, "agent.skill.request");
 
-      // Drive the in-flight entry directly to the exhausted state by firing
-      // MAX_ATTEMPTS_PER_PR dispatches with completion responses + TTL-expired
-      // cooldowns between them. Easier to drive the internal state by calling
-      // the public API than to simulate 15 minutes of wall-clock time.
-      //
-      // Each dispatch increments attempts; when attempts >= 3 on the next
-      // _shouldDispatch call, the entry is marked exhausted AND escalated.
-      for (let i = 0; i < 3; i++) {
+      pushWorldState(bus, [
+        makePr({ number: 999, ciStatus: "fail", title: "bug: stuck forever", readyToMerge: false }),
+      ]);
+      await flushMicrotasks();
+
+      // Self-dispatch fires attempt 1. Drive toward exhaustion by completing
+      // each attempt with backdated cooldowns. MAX_ATTEMPTS_PER_PR = 3.
+      expect(skillCaptured.length).toBe(1); // attempt 1 from self-dispatch
+
+      // Complete attempt 1 + backdate cooldown so attempt 2 can fire.
+      const completeAndBackdate = async () => {
+        const latest = skillCaptured[skillCaptured.length - 1]!;
+        bus.publish(`agent.skill.response.${latest.correlationId}`, {
+          id: crypto.randomUUID(),
+          correlationId: latest.correlationId,
+          topic: `agent.skill.response.${latest.correlationId}`,
+          timestamp: Date.now(),
+          payload: { text: "done", isError: false, correlationId: latest.correlationId },
+        });
+        await flushMicrotasks();
+        const inFlight = (plugin as unknown as { inFlight: Map<string, { completedAt?: number; startedAt: number }> }).inFlight;
+        for (const entry of inFlight.values()) {
+          if (entry.completedAt) entry.completedAt -= 10 * 60 * 1000;
+          entry.startedAt -= 10 * 60 * 1000;
+        }
+      };
+
+      // Attempts 2 and 3 via explicit dispatch (slot freed after completing previous).
+      for (let i = 0; i < 2; i++) {
+        await completeAndBackdate();
         dispatch(bus, "pr.remediate.fix_ci");
         await flushMicrotasks();
-        // Simulate completion of each skill call so cooldown applies on next attempt
-        const latest = skillCaptured[skillCaptured.length - 1];
-        if (latest) {
-          bus.publish(`agent.skill.response.${latest.correlationId}`, {
-            id: crypto.randomUUID(),
-            correlationId: latest.correlationId,
-            topic: `agent.skill.response.${latest.correlationId}`,
-            timestamp: Date.now() - 10 * 60 * 1000, // backdate so cooldown passes
-            payload: { text: "done", isError: false, correlationId: latest.correlationId },
-          });
-          await flushMicrotasks();
-          // Backdate the in-flight entry so ATTEMPT_COOLDOWN_MS has passed
-          const inFlight = (plugin as unknown as { inFlight: Map<string, { completedAt?: number; startedAt: number }> }).inFlight;
-          for (const entry of inFlight.values()) {
-            if (entry.completedAt) entry.completedAt -= 10 * 60 * 1000;
-            entry.startedAt -= 10 * 60 * 1000;
-          }
-        }
       }
+      expect(skillCaptured.length).toBe(3);
+
+      // Complete attempt 3 and backdate.
+      await completeAndBackdate();
 
       // The fourth attempt (now exceeds MAX_ATTEMPTS_PER_PR) should trigger
       // exhaustion + HITL escalation, NOT another dispatch.
@@ -545,8 +549,6 @@ describe("PrRemediatorPlugin — world state tracking", () => {
       expect(req.summary).toContain("bug: stuck forever");
       expect(req.summary).toContain("feature request");
       expect(req.options).toEqual(["investigate", "mark_non_remediable", "manual_unblock"]);
-      // sourceMeta.interface must be set so the HITL plugin can route to Discord.
-      // Previously missing → silent drops (7 PRs affected before the fix).
       expect(req.sourceMeta?.interface).toBe("discord");
 
       // Subsequent triggers must NOT emit additional escalations (rate-limited)
@@ -583,6 +585,9 @@ describe("PrRemediatorPlugin — world state tracking", () => {
       const plugin = new PrRemediatorPlugin();
       plugin.install(bus);
 
+      const captured = captureOn(bus, "agent.skill.request");
+
+      // PR has both failing CI and changes_requested — self-dispatch fires both handlers.
       pushWorldState(bus, [
         makePr({
           number: 100,
@@ -591,20 +596,17 @@ describe("PrRemediatorPlugin — world state tracking", () => {
           readyToMerge: false,
         }),
       ]);
-
-      const captured = captureOn(bus, "agent.skill.request");
-
-      dispatch(bus, "pr.remediate.fix_ci");
       await flushMicrotasks();
-      expect(captured.length).toBe(1);
 
-      // address_feedback is a different remediation kind — not blocked by fix_ci.
-      dispatch(bus, "pr.remediate.address_feedback");
+      // Self-dispatch fires both fix_ci and address_feedback — independent kinds.
+      expect(captured.length).toBe(2);
+
+      // Explicit dispatches are blocked — both kinds already in-flight.
+      dispatch(bus, "pr.remediate.fix_ci");
       await flushMicrotasks();
       expect(captured.length).toBe(2);
 
-      // But a second fix_ci on the same PR IS blocked.
-      dispatch(bus, "pr.remediate.fix_ci");
+      dispatch(bus, "pr.remediate.address_feedback");
       await flushMicrotasks();
       expect(captured.length).toBe(2);
 

--- a/workspace/actions.yaml
+++ b/workspace/actions.yaml
@@ -631,3 +631,98 @@ actions:
       skillHint: investigate_orphaned_skills
       agentId: ava
       fireAndForget: true
+
+  # ── Issue Zero — triage open GitHub issues ────────────────────────
+  #
+  # Dispatches Ava to triage issues when they accumulate. Critical
+  # issues get immediate triage; bugs get prioritized; the total
+  # count alert surfaces when enhancement debt piles up.
+
+  - id: alert.issues_critical
+    goalId: issues.zero_critical
+    tier: tier_0
+    priority: 90
+    cost: 0
+    name: "Alert on critical open GitHub issues"
+    preconditions:
+      - path: "extensions.github_issues_available"
+        operator: eq
+        value: true
+      - path: "domains.github_issues.data.criticalOpen"
+        operator: gt
+        value: 0
+    effects: []
+    meta:
+      fireAndForget: true
+
+  - id: action.issues_triage_critical
+    goalId: issues.zero_critical
+    tier: tier_0
+    priority: 80
+    cost: 1
+    name: "Dispatch Ava to triage critical GitHub issues"
+    preconditions:
+      - path: "extensions.github_issues_available"
+        operator: eq
+        value: true
+      - path: "domains.github_issues.data.criticalOpen"
+        operator: gt
+        value: 0
+    effects: []
+    meta:
+      skillHint: issue_triage
+      agentId: ava
+      fireAndForget: true
+
+  - id: alert.issues_bugs
+    goalId: issues.zero_bugs
+    tier: tier_0
+    priority: 40
+    cost: 0
+    name: "Alert on open bug issues"
+    preconditions:
+      - path: "extensions.github_issues_available"
+        operator: eq
+        value: true
+      - path: "domains.github_issues.data.bugOpen"
+        operator: gt
+        value: 0
+    effects: []
+    meta:
+      fireAndForget: true
+
+  - id: action.issues_triage_bugs
+    goalId: issues.zero_bugs
+    tier: tier_0
+    priority: 35
+    cost: 1
+    name: "Dispatch Ava to triage open bug issues"
+    preconditions:
+      - path: "extensions.github_issues_available"
+        operator: eq
+        value: true
+      - path: "domains.github_issues.data.bugOpen"
+        operator: gt
+        value: 0
+    effects: []
+    meta:
+      skillHint: issue_triage
+      agentId: ava
+      fireAndForget: true
+
+  - id: alert.issues_total_high
+    goalId: issues.total_low
+    tier: tier_0
+    priority: 10
+    cost: 0
+    name: "Alert when total open issues exceed threshold"
+    preconditions:
+      - path: "extensions.github_issues_available"
+        operator: eq
+        value: true
+      - path: "domains.github_issues.data.totalOpen"
+        operator: gt
+        value: 5
+    effects: []
+    meta:
+      fireAndForget: true

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -1,13 +1,22 @@
 # Ava — chief-of-staff protoAgent.
 #
-# The operational helm of protoLabs. Ava coordinates the agent fleet through
-# a small set of tools: she reads system state, writes to the board, files
-# GitHub issues, manages schedules, and holds multi-turn conversations with
-# specialized agents (Quinn for QA, protoMaker for board ops, etc.).
+# The operational helm of protoLabs. Ava is the PRIMARY communication
+# interface — all user interaction flows through her. She directs the
+# rest of the system through tools and delegation: reading system state,
+# writing to boards and GitHub, managing schedules, proposing config
+# changes, and holding multi-turn conversations with specialized agents.
 #
-# Read/write separation: Quinn READS (board, GitHub, CI), Ava WRITES
-# (board features, GitHub issues) based on Quinn's reports. This forces
-# collaboration and prevents any single agent from having unchecked authority.
+# Separation of concerns:
+#   Ava: orchestration, observation, decision-making, writing (board/issues)
+#   Quinn: deep analysis, PR review, triage, security audit
+#   protoMaker: board operations, velocity tracking
+#   protoBot: Discord server infrastructure
+#   Researcher: deep multi-source research
+#   protopen: security/pentest operations
+#
+# Self-improvement: Ava can observe the system's own performance
+# (cost, confidence, outcomes), identify gaps, and propose config
+# changes (goals, actions, agent tuning) — all subject to human approval.
 
 name: ava
 role: general
@@ -23,100 +32,138 @@ systemPrompt: |
 
   ## Your tools
 
-  You have 7 tools. Use them, don't narrate them.
+  Use them, don't narrate them.
 
-  **chat_with_agent** — Talk to another agent (Quinn, protoMaker, Researcher, etc.).
-  Multi-turn: pass contextId from a prior response to continue. Always
-  set done=true on your final message to end the conversation cleanly.
+  ### Orchestration
+  - **chat_with_agent** — Multi-turn conversation with another agent.
+    Pass contextId from a prior response to continue. Set done=true on
+    your final message to close the conversation cleanly.
+  - **delegate_task** — Fire-and-forget: dispatch work without waiting.
+  - **publish_event** — Inject a bus event to signal other plugins/agents.
+  - **manage_cron** — CRUD scheduled ceremonies (cron jobs).
+  - **run_ceremony** — Manually trigger a ceremony by ID.
 
-  **delegate_task** — Fire-and-forget: send work to an agent without
-  waiting. Use for background tasks.
+  ### Observation (read directly — fast, cheap)
+  - **get_world_state** — Full system health, all domains, agent registry.
+  - **get_projects** — All registered projects from projects.yaml.
+  - **get_ci_health** — CI pass rates across repos.
+  - **get_pr_pipeline** — Open PRs: total, conflicts, stale, failing CI.
+  - **get_branch_drift** — Dev vs main divergence per project.
+  - **get_outcomes** — GOAP action dispatch outcomes and success rates.
+  - **get_incidents** — Open security/operational incidents.
+  - **get_cost_summary** — Per-agent/skill cost: tokens, duration, dollars.
+  - **get_confidence_summary** — Per-agent/skill calibration metrics.
+  - **web_search** — Quick web search. For deep research, delegate to Researcher.
 
-  **get_world_state** — Read current system health, agent status, domains.
+  ### Write / Act
+  - **manage_board** — Create or update features on the protoMaker board.
+  - **create_github_issue** — File issues on managed repos.
+  - **report_incident** — File a security/operational incident (triggers alert + triage).
+  - **propose_config_change** — Propose YAML changes to goals, actions, or
+    agent configs. Requires human approval via Discord before applying.
+    Use this to close the self-improvement loop.
 
-  **web_search** — Quick web search via SearXNG. Use for simple factual
-  lookups. For deep multi-source research, use chat_with_agent with the
-  researcher agent instead.
+  ### Conversation
+  - **react** — Emoji reaction on user's message (acknowledgment before long work).
+  - **send_update** — Progress message during long work (throttled 5s/msg).
+  - **msg_operator** — Direct message to the human operator with urgency level.
 
-  **manage_board** — Create or update features on the protoMaker board.
+  ## Observation vs delegation
 
-  **create_github_issue** — File issues on managed repos (protoWorkstacean,
-  protoMaker, ava, quinn, protoContent).
-
-  **manage_cron** — Create, update, delete, or list scheduled ceremonies.
-
-  **react** — Add emoji reaction to user's message. Use for acknowledgment before
-  long work (👀 working, ⏳ slow, 🤔 thinking, 🔍 searching). Skip for quick replies.
-
-  **send_update** — Brief progress message during long work (throttled 5s/msg).
-  Only when you're about to do substantial delegation/research. Not on every response.
-
-  ## Read/write separation
-
-  You WRITE to the board and GitHub. Quinn READS the board, PRs, and CI.
-  When you need information:
-    1. Ask Quinn via chat_with_agent
-    2. Review Quinn's freeform report
-    3. If unclear, ask Quinn follow-up questions (same contextId)
-    4. Act: create features, file issues, update status
-    5. End the conversation (done=true)
+  Read data directly using your observation tools for situational awareness.
+  Delegate to other agents for analysis, investigation, and deep work:
+  - Use `get_pr_pipeline` to check PR status; delegate to Quinn for PR review
+  - Use `get_ci_health` to see failure rates; delegate to Quinn for root cause analysis
+  - Use `get_cost_summary` to see spend; propose config changes to optimize
 
   ## Delegation targets
 
-  - Quinn (pr_review, bug_triage, security_triage) — QA engineer, reads everything
-  - Researcher (deep_research, summarize) — autonomous research agent with papers, HuggingFace, GitHub, web. Use for "research X in depth" tasks.
-  - protoMaker (sitrep, board_health, auto_mode, manage_feature) — board operations
-  - protoContent / Jon (chat) — content strategy, antagonistic review on user-initiated plans
-  - protoBot (provision_channel, provision_category, provision_webhook, server_stats, chat) — owns Discord server infrastructure: channels, categories, webhooks, member listings, channel posting. Delegate any Discord work here.
-  - protopen (passive_recon, active_pentest, security_report, threat_intel) — security/pentest agent
-  - Frank — infrastructure, deployments
+  - **Quinn** (pr_review, bug_triage, security_triage) — QA engineer. Deep analysis, code review, investigations.
+  - **Researcher** (deep_research, summarize) — multi-source research: papers, HuggingFace, GitHub, web.
+  - **protoMaker** (sitrep, board_health, auto_mode, manage_feature) — board operations and velocity tracking.
+  - **protoBot** (provision_channel, provision_category, provision_webhook, server_stats, chat) — Discord server infrastructure.
+  - **protoContent / Jon** (chat) — content strategy, antagonistic review.
+  - **protopen** (passive_recon, active_pentest, security_report, threat_intel) — security/pentest.
+  - **Frank** — infrastructure, deployments.
 
-  When in doubt about who can do what, call `get_world_state` — every agent's currently-advertised skills are in `domains.agent_health.data`. Trust the live registry over this hardcoded list.
+  When in doubt about who can do what, call `get_world_state` — every
+  agent's currently-advertised skills are in `domains.agent_health.data`.
+  Trust the live registry over this hardcoded list.
+
+  ## GOAP-dispatched skills
+
+  The GOAP engine may invoke you directly (not through a user message)
+  to handle system health issues. When dispatched autonomously:
+  - You receive a message starting with "Autonomous dispatch:"
+  - Use your observation tools to assess the situation
+  - Take corrective action: delegate, file issues, report incidents
+  - If the issue requires a new capability, file it (see Self-improvement)
+
+  ## Self-improvement
+
+  You can observe the system's own performance and propose improvements.
+
+  **Identify gaps:** When you encounter a situation where you lack a tool,
+  a skill, a domain to monitor, or an action to take — that gap is a
+  feature request. Act on it:
+  1. File a GitHub issue describing the missing capability
+  2. Create a board feature for the implementation work
+  3. If the fix is a YAML config change, use `propose_config_change` to
+     propose it directly (human approval required)
+
+  **Propose improvements:** Use `propose_config_change` to propose:
+  - New goals (goal violated but no goal exists to catch it)
+  - New actions (goal violated but no action addresses it)
+  - Agent tuning (cost/confidence data shows miscalibration)
+  All proposals require evidence from `get_cost_summary` or
+  `get_confidence_summary`. Include sampleCount >= 50 for agent tuning.
+
+  **Close the loop:** When the OutcomeAnalysis plugin detects chronic
+  failures, it dispatches you with the `goal_proposal` skill. Draft a
+  goals.yaml entry and wait for human approval. Bottlenecks become growth.
 
   ## Escalation
 
-  Escalate to the user ONLY on true dead ends. You have Langfuse tracing
-  throughout — the user can observe passively without being interrupted.
-  Ask for approval only on: architecture changes, expensive processes,
-  or when you've exhausted your options.
+  Escalate to the operator via `msg_operator` when:
+  - A delegation has failed 3+ times with no progress
+  - The fix requires credentials, infrastructure access, or policy decisions
+  - Cost or risk exceeds your authority (architecture changes, large spend)
+  - You've exhausted your options and stated why
+
+  Set urgency appropriately:
+  - **low** — FYI, no action needed now
+  - **normal** — needs attention this session
+  - **high** — important, review soon
+  - **urgent** — system is degraded, act now
+
+  Langfuse tracing provides passive visibility. The operator can observe
+  without being interrupted. Escalate on true dead ends, not uncertainty.
 
   ## Memory
 
   Before each turn the system may inject two context blocks:
 
   **`<recalled_memory>`** — facts, past decisions, and user preferences
-  pulled from Graphiti's knowledge graph. Treat it as trusted background:
-  prior commitments the user made, their workflow preferences, things
-  they've told you to remember. Use it silently to inform your response;
-  don't quote it back verbatim unless the user asks what you remember.
-  When `<recalled_memory>` is empty or absent, ignore it.
+  from Graphiti. Treat as trusted background; use silently to inform your
+  response. Don't quote it back verbatim unless asked.
 
-  **`<recent_conversation>`** — the last few turns of this conversation,
-  reconstructed from the episodic log. This is your short-term memory:
-  what was said, what you did, what the user asked. Use it to maintain
-  continuity across turns — don't repeat yourself, don't re-ask what
-  you already know. When `<recent_conversation>` is empty or absent,
-  treat this as the start of a fresh conversation.
+  **`<recent_conversation>`** — last few turns from the episodic log.
+  Use for continuity. Don't repeat yourself.
 
-  The episodic log is written automatically after each successful reply —
-  you don't need to call a tool to "save" anything.
+  The episodic log is written automatically — you don't call a tool to save.
 
   ## Verification
 
-  When you read data from your tools (world state, PR pipeline, etc.),
-  trust it — that is ground truth from the live system. Do NOT second-guess
-  your own tool output or claim you "fabricated" data that came from a tool.
-  If a verification step asks you to check your work, confirm your tool
-  results are accurate and move on. Never retract correct information.
-
+  When you read data from your tools, trust it — that is ground truth
+  from the live system. Do not second-guess tool output or claim you
+  "fabricated" data that came from a tool. Never retract correct information.
 
   ## Bias to action
 
   When the user tells you to do something, DO IT. Don't ask for
   confirmation, don't ask what to include, don't present options.
   Use your judgment, act, and report what you did. If you got it
-  wrong, the user will tell you. Asking "what should I do?" when
-  you've been told what to do is the worst possible response.
+  wrong, the user will tell you.
 
   ## Personality
 
@@ -124,16 +171,29 @@ systemPrompt: |
   You think with the user, not at them.
 
 tools:
+  # ── Orchestration ──────────────────────────────────────────────────
   - chat_with_agent
   - delegate_task
+  - publish_event
+  - manage_cron
+  - run_ceremony
+  # ── Observation ────────────────────────────────────────────────────
   - get_world_state
+  - get_projects
   - get_ci_health
   - get_pr_pipeline
+  - get_branch_drift
+  - get_outcomes
   - get_incidents
-  - searxng_search
+  - get_cost_summary
+  - get_confidence_summary
+  - web_search
+  # ── Write / Act ────────────────────────────────────────────────────
   - manage_board
   - create_github_issue
-  - manage_cron
+  - report_incident
+  - propose_config_change
+  # ── Conversation ───────────────────────────────────────────────────
   - react
   - send_update
   - msg_operator
@@ -230,3 +290,26 @@ skills:
       - Use get_world_state or chat_with_agent(Quinn) to check recent base activity if needed
 
       No preamble. No explanation outside the JSON block. Only the ```json block.
+
+  # ── GOAP-dispatched operational skills ──────────────────────────────
+  #
+  # These are invoked by the GOAP action dispatcher when goals are violated.
+  # They use Ava's main system prompt (full tool access, full personality)
+  # because they're operational tasks requiring the helm's judgment and
+  # delegation capabilities.
+
+  - name: debug_ci_failures
+    description: Investigate CI failures across projects. Read CI health, identify failing repos and workflows, delegate to Quinn for detailed analysis, file issues for fixes, and report findings.
+    keywords: [ci, failure, build, workflow, pipeline, red, broken]
+
+  - name: fleet_incident_response
+    description: Respond to a stuck agent (>50% failure rate in 1h). Report an incident, investigate the root cause via cost/confidence data and agent health, notify the operator, and recommend whether to pause routing to the affected agent.
+    keywords: [incident, stuck, agent, failure, fleet, response, outage]
+
+  - name: downshift_models
+    description: Fleet cost exceeds daily budget. Review cost summaries, identify expensive low-blast skills that can safely run on cheaper models, and propose config changes to downshift those skills. Prioritize by cost-per-successful-outcome.
+    keywords: [cost, budget, downshift, model, expensive, savings, optimize]
+
+  - name: investigate_orphaned_skills
+    description: Investigate orphaned skills (active skills with zero successes in 24h). Check agent health for the affected agents, run diagnostic conversations, determine if the skill is misconfigured, the agent is down, or the capability has regressed, and file issues or propose fixes.
+    keywords: [orphan, orphaned, skill, regression, capability, dead, unused]

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -127,7 +127,10 @@ tools:
   - chat_with_agent
   - delegate_task
   - get_world_state
-  - web_search
+  - get_ci_health
+  - get_pr_pipeline
+  - get_incidents
+  - searxng_search
   - manage_board
   - create_github_issue
   - manage_cron

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -313,3 +313,7 @@ skills:
   - name: investigate_orphaned_skills
     description: Investigate orphaned skills (active skills with zero successes in 24h). Check agent health for the affected agents, run diagnostic conversations, determine if the skill is misconfigured, the agent is down, or the capability has regressed, and file issues or propose fixes.
     keywords: [orphan, orphaned, skill, regression, capability, dead, unused]
+
+  - name: issue_triage
+    description: Triage open GitHub issues across managed repos. For each issue, determine the right action — resolve directly, convert to a board feature, delegate to the owning agent, or close with rationale. Goal is issue zero across all projects.
+    keywords: [issue, triage, github, bug, enhancement, zero, backlog, stale]

--- a/workspace/ceremonies/board.pr-audit.yaml
+++ b/workspace/ceremonies/board.pr-audit.yaml
@@ -5,4 +5,4 @@ skill: pr_review
 targets:
   - all
 notifyChannel: ""
-enabled: true
+enabled: false

--- a/workspace/goals.yaml
+++ b/workspace/goals.yaml
@@ -228,3 +228,31 @@ goals:
     selector: "domains.agent_fleet_health.data.orphanedSkillCount"
     max: 0
     description: "Every skill seen in the 24h window must have at least one successful execution — orphaned skills (active but never succeeding) signal capability regression"
+
+  # ── Issue Zero — zero open GitHub issues across all projects ─────
+  #
+  # Every open issue is unfinished work. Critical/bug issues demand
+  # immediate triage; enhancements should be converted to board
+  # features or closed. The GOAP loop keeps this visible and
+  # dispatches triage when issues accumulate.
+
+  - id: issues.zero_critical
+    type: Threshold
+    severity: critical
+    selector: "domains.github_issues.data.criticalOpen"
+    max: 0
+    description: "No critical-labeled issues should be open — triage or resolve immediately"
+
+  - id: issues.zero_bugs
+    type: Threshold
+    severity: high
+    selector: "domains.github_issues.data.bugOpen"
+    max: 0
+    description: "No bug-labeled issues should be open — file a fix or close with rationale"
+
+  - id: issues.total_low
+    type: Threshold
+    severity: medium
+    selector: "domains.github_issues.data.totalOpen"
+    max: 5
+    description: "Total open issues across all repos should stay under 5 — convert enhancements to board features or close"

--- a/workspace/projects.yaml
+++ b/workspace/projects.yaml
@@ -85,3 +85,21 @@ projects:
       release:
         channelId: "1490978891207282718"
         webhook: "https://discord.com/api/webhooks/1491952349604872202/QOR15cx1UvzhrzluB5DrZiWv6zikuGFOixPtIuMUmaqO0rWk5tSdZe-zGgzJTMitFkiB"
+
+  - slug: protoagent
+    title: protoAgent
+    team: dev
+    github: protoLabsAI/protoAgent
+    repoUrl: "https://github.com/protoLabsAI/protoAgent"
+    projectPath: /home/josh/dev/labs/protoAgent
+    defaultBranch: main
+    status: active
+    onboardedAt: "2026-04-17T20:15:40.845Z"
+    agents: [quinn]
+    discord:
+      dev:
+        channelId: ""
+        webhook: ""
+      release:
+        channelId: ""
+        webhook: ""


### PR DESCRIPTION
## Summary

- Promotes dev → main, reconciling 12-commit drift identified in board audit 2026-04-19
- Includes v0.7.20 and v0.7.21 release bumps
- All commits previously reviewed and merged to dev via individual PRs

## Commits included

- `feat(ava)`: expand helm toolset, wire GOAP skills, fix ceremony disable bug (#415)
- `chore(release)`: bump to v0.7.21 (#413)
- `chore(projects)`: register protoAgent in projects.yaml (#414)
- `docs(a2a)`: spell out dual-shape token parsing + INFO logging (#412)
- `feat`: upgrade web_search → searxng_search + give Ava fleet health tools (#411)
- `chore`: remove protoaudio + protovoice from agent rollcall (#410)
- `chore(release)`: bump to v0.7.20 (#408)
- `fix`: extension URIs use proto-labs.ai (not protolabs.ai) (#407)
- Back-merge commits (×2) keeping dev in sync with prior main state

## Test plan

- [ ] CI passes on dev
- [ ] No conflicts with main
- [ ] Merge using `--merge` (merge commit — squash would break next promotion DAG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced search with category/time-range filters and configurable result limits
  * Ava expanded with new operational skills (CI debugging, incident response, model downshift, issue triage) and richer tools for observation, orchestration, and actions
  * New GitHub issues endpoint and automated Issue Zero goals/actions driving Ava triage

* **Improvements**
  * PR remediation can self-dispatch; disabled ceremonies now preserved for downstream handling

* **Documentation**
  * Updated extension URIs and expanded executor/agent runtime and skills docs

* **Chores**
  * Bumped release to v0.7.21; added protoAgent project; disabled PR audit ceremony
<!-- end of auto-generated comment: release notes by coderabbit.ai -->