### PR TITLE
feat: manage_board list + a2a.trace extension (closes #247, #359)

### DIFF
--- a/src/agent-runtime/tools/bus-tools.ts
+++ b/src/agent-runtime/tools/bus-tools.ts
@@ -300,21 +300,27 @@ export function createBusTools(opts: BusToolsOptions = {}) {
 
   const manageBoard = tool(
     "manage_board",
-    "Create or update features on the protoMaker board. Use action 'create' to file " +
-      "new work items, 'update' to change status/priority/description of existing features.",
+    "Create, update, or list features on the protoMaker board. Use 'list' to query " +
+      "features by status, 'create' to file new work items, 'update' to change existing features.",
     {
-      action: z.enum(["create", "update"]).describe("Operation to perform"),
+      action: z.enum(["create", "update", "list"]).describe("Operation to perform"),
       projectPath: z.string().describe("Absolute path to the project directory"),
       title: z.string().optional().describe("Feature title (required for create)"),
       description: z.string().optional().describe("Feature description"),
       featureId: z.string().optional().describe("Feature ID (required for update)"),
-      status: z.enum(["backlog", "in-progress", "review", "done"]).optional(),
+      status: z.enum(["backlog", "in-progress", "review", "done"]).optional().describe("Filter by status (for list) or set status (for create/update)"),
       priority: z.number().optional().describe("0=none, 1=urgent, 2=high, 3=normal, 4=low"),
       complexity: z.enum(["small", "medium", "large", "architectural"]).optional(),
       projectSlug: z.string().optional(),
     },
     async ({ action, projectPath, title, description, featureId, status, priority, complexity, projectSlug }) => {
       try {
+        if (action === "list") {
+          const query = new URLSearchParams({ projectPath });
+          if (status) query.set("status", status);
+          const data = await http.get(`/api/board/features/list?${query}`);
+          return ok(data);
+        }
         const endpoint = action === "create" ? "/api/board/features/create" : "/api/board/features/update";
         const data = await http.post(endpoint, {
           projectPath, title, description, featureId, status, priority, complexity, projectSlug,

--- a/src/api/board.ts
+++ b/src/api/board.ts
@@ -108,7 +108,46 @@ export function createRoutes(ctx: ApiContext): Route[] {
     }
   }
 
+  async function handleListFeatures(req: Request): Promise<Response> {
+    if (ctx.apiKey && req.headers.get("X-API-Key") !== ctx.apiKey) {
+      return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const url = new URL(req.url);
+    const projectPath = url.searchParams.get("projectPath");
+
+    if (!projectPath) {
+      return Response.json(
+        { success: false, error: "projectPath query parameter is required" },
+        { status: 400 },
+      );
+    }
+
+    const status = url.searchParams.get("status");
+
+    try {
+      const query = new URLSearchParams({ projectPath });
+      if (status) query.set("status", status);
+
+      const resp = await studioHttp.fetch(`${STUDIO_URL}/features/list?${query}`, {
+        method: "GET",
+        headers: { Accept: "application/json" },
+      });
+
+      if (!resp.ok) {
+        const errText = await resp.text().catch(() => "(no body)");
+        return Response.json({ success: false, error: `Studio: ${resp.status} ${errText}` }, { status: resp.status });
+      }
+
+      const data = await resp.json();
+      return Response.json({ success: true, data });
+    } catch (e) {
+      return Response.json({ success: false, error: String(e) }, { status: 502 });
+    }
+  }
+
   return [
+    { method: "GET",  path: "/api/board/features/list",   handler: (req) => handleListFeatures(req) },
     { method: "POST", path: "/api/board/features/create", handler: (req) => handleCreateFeature(req) },
     { method: "POST", path: "/api/board/features/update", handler: (req) => handleUpdateFeature(req) },
   ];

--- a/src/executor/extensions/langfuse-trace.ts
+++ b/src/executor/extensions/langfuse-trace.ts
@@ -1,0 +1,37 @@
+/**
+ * Langfuse trace propagation extension — stamps a2a.trace metadata on
+ * outbound A2A dispatches so downstream agents (Quinn, etc.) can link
+ * their Langfuse traces back to the originating workstacean invocation.
+ *
+ * The correlationId serves as the trace ID (it's the unique identifier
+ * for the entire skill dispatch chain). The extension stamps it into
+ * `params.metadata["a2a.trace"]` which Quinn reads on the receiving end
+ * to set `caller_trace_id` in her Langfuse trace metadata.
+ *
+ * Extension URI: https://proto-labs.ai/a2a/ext/trace-v1
+ */
+
+import type { ExtensionInterceptor, ExtensionContext } from "../extension-registry.ts";
+import { defaultExtensionRegistry } from "../extension-registry.ts";
+
+const TRACE_URI = "https://proto-labs.ai/a2a/ext/trace-v1";
+
+export function registerLangfuseTraceExtension(): void {
+  const interceptor: ExtensionInterceptor = {
+    before(ctx: ExtensionContext): void {
+      ctx.metadata["a2a.trace"] = {
+        traceId: ctx.correlationId,
+        callerAgent: ctx.agentName,
+        skill: ctx.skill,
+        project: "protolabs",
+      };
+    },
+  };
+
+  defaultExtensionRegistry.register({
+    uri: TRACE_URI,
+    interceptor,
+    description:
+      "Trace v1: stamps Langfuse trace context on outbound A2A calls for cross-agent trace linking",
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,11 +52,13 @@ import { registerConfidenceExtension } from "./executor/extensions/confidence.ts
 import { registerEffectDomainExtension } from "./executor/extensions/effect-domain.ts";
 import { registerBlastExtension } from "./executor/extensions/blast.ts";
 import { registerHitlModeExtension } from "./executor/extensions/hitl-mode.ts";
+import { registerLangfuseTraceExtension } from "./executor/extensions/langfuse-trace.ts";
 registerCostExtension(bus);
 registerConfidenceExtension(bus);
 registerEffectDomainExtension(bus);
 registerBlastExtension();
 registerHitlModeExtension();
+registerLangfuseTraceExtension();
 
 // --- ChannelRegistry — loaded from workspace/channels.yaml, shared by RouterPlugin + DiscordPlugin ---
 import { ChannelRegistry } from "../lib/channels/channel-registry.js";


### PR DESCRIPTION
## Summary
- **manage_board list action (#247)**: Added `list` action with optional `status` filter. Ava can now query features by status directly instead of only seeing counts from world state.
- **a2a.trace extension (#359)**: New Langfuse trace propagation extension stamps `a2a.trace` metadata (traceId, callerAgent, skill) on all outbound A2A dispatches for cross-agent trace linking.

## Test plan
- [x] 969 tests pass, 0 fail
- [ ] Verify manage_board list works with Studio endpoint after deploy
- [ ] Verify a2a.trace appears in Quinn's Langfuse trace metadata

Closes #247, closes #359.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Board feature listing: Enhanced board management capabilities with list operations enabling users to query features using optional status filtering, improving project visibility, streamlining navigation, and enhancing overall board organization.
  * System observability: New Langfuse trace propagation extension provides comprehensive operation monitoring, detailed system tracing, and improved performance visibility across the entire platform and all operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->