### PR TITLE
fix(skill-dispatcher): wire alert.* executors + startup validator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -285,6 +285,20 @@ const pluginRegistry: PluginRegistryEntry[] = [
     },
   },
   {
+    // Registers Discord-alert FunctionExecutors for tier_0 `alert.*` skills
+    // that have no agent-backed handler. Without this, ActionDispatcherPlugin
+    // publishes to agent.skill.request and SkillDispatcherPlugin drops with
+    // "No executor found …" — the structural bug behind issue #426.
+    // Must install AFTER ExecutorRegistry exists (always true) and BEFORE
+    // skill-dispatcher so registrations resolve on first dispatch.
+    name: "alert-skill-executor",
+    condition: () => true,
+    factory: async () => {
+      const { AlertSkillExecutorPlugin } = await import("./plugins/alert-skill-executor-plugin.js");
+      return new AlertSkillExecutorPlugin(executorRegistry);
+    },
+  },
+  {
     // Intercepts ExecutorRegistry.resolve() to A/B test competing skill variants.
     // Must be installed AFTER registrars (agent-runtime, skill-broker) and
     // BEFORE skill-dispatcher so the hook is active when dispatches begin.
@@ -460,6 +474,23 @@ for (const entry of pluginRegistry) {
 
     // Local self-polling domains are registered AFTER Bun.serve() starts (see below)
     // to avoid "Unable to connect" on the initial immediate tick.
+  }
+}
+
+// --- Fail-loud wiring validation ---
+// Cross-check every loaded action against the live ExecutorRegistry. Any
+// action that resolves to a null executor would cause SkillDispatcherPlugin
+// to silently drop dispatches forever — see issue #426. Surface each gap
+// as a HIGH-severity Discord alert (goal `platform.skills_unwired`) and
+// log loudly. Set WORKSTACEAN_STRICT_WIRING=1 to crash startup instead.
+{
+  const { validateActionExecutors } = await import("./planner/validate-action-executors.js");
+  const unwired = validateActionExecutors(actionRegistry, executorRegistry, {
+    bus,
+    throwOnUnwired: process.env.WORKSTACEAN_STRICT_WIRING === "1",
+  });
+  if (unwired.length === 0) {
+    console.log(`[startup-validator] All ${actionRegistry.size} action(s) have a registered executor.`);
   }
 }
 

--- a/src/planner/__tests__/validate-action-executors.test.ts
+++ b/src/planner/__tests__/validate-action-executors.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, mock } from "bun:test";
+import {
+  findUnwiredActions,
+  validateActionExecutors,
+  UnwiredActionsError,
+} from "../validate-action-executors.ts";
+import { ActionRegistry } from "../action-registry.ts";
+import { ExecutorRegistry } from "../../executor/executor-registry.ts";
+import { FunctionExecutor } from "../../executor/executors/function-executor.ts";
+import type { Action } from "../types/action.ts";
+import type { BusMessage } from "../../../lib/types.ts";
+
+function makeAction(overrides: Partial<Action> & { id: string; goalId: string }): Action {
+  return {
+    name: overrides.name ?? overrides.id,
+    description: overrides.description ?? "",
+    tier: overrides.tier ?? "tier_0",
+    cost: overrides.cost ?? 0,
+    priority: overrides.priority ?? 0,
+    preconditions: overrides.preconditions ?? [],
+    effects: overrides.effects ?? [],
+    meta: overrides.meta ?? {},
+    ...overrides,
+  };
+}
+
+const noopExecutor = new FunctionExecutor(async (req) => ({
+  text: "ok",
+  isError: false,
+  correlationId: req.correlationId,
+}));
+
+describe("findUnwiredActions", () => {
+  it("returns empty when every action has a registered executor", () => {
+    const actions = new ActionRegistry();
+    const executors = new ExecutorRegistry();
+    actions.register(makeAction({ id: "alert.foo", goalId: "g.foo" }));
+    executors.register("alert.foo", noopExecutor);
+
+    expect(findUnwiredActions(actions, executors)).toEqual([]);
+  });
+
+  it("flags an action whose id has no executor and no skillHint", () => {
+    const actions = new ActionRegistry();
+    const executors = new ExecutorRegistry();
+    actions.register(makeAction({ id: "alert.unwired", goalId: "g.x" }));
+
+    const unwired = findUnwiredActions(actions, executors);
+    expect(unwired.length).toBe(1);
+    expect(unwired[0]).toEqual({
+      actionId: "alert.unwired",
+      skill: "alert.unwired",
+      targets: [],
+    });
+  });
+
+  it("uses skillHint over action.id when present", () => {
+    const actions = new ActionRegistry();
+    const executors = new ExecutorRegistry();
+    actions.register(makeAction({
+      id: "action.do_thing",
+      goalId: "g.x",
+      meta: { skillHint: "real_skill" },
+    }));
+    executors.register("real_skill", noopExecutor);
+
+    expect(findUnwiredActions(actions, executors)).toEqual([]);
+  });
+
+  it("resolves via meta.agentId when set", () => {
+    const actions = new ActionRegistry();
+    const executors = new ExecutorRegistry();
+    actions.register(makeAction({
+      id: "action.delegate",
+      goalId: "g.x",
+      meta: { skillHint: "any_skill", agentId: "ava" },
+    }));
+    // Register only by agentName, not skill — emulates AgentRuntimePlugin
+    executors.register("some_other_skill", noopExecutor, { agentName: "ava" });
+
+    expect(findUnwiredActions(actions, executors)).toEqual([]);
+  });
+
+  it("flags action with agentId target when agent has no executor", () => {
+    const actions = new ActionRegistry();
+    const executors = new ExecutorRegistry();
+    actions.register(makeAction({
+      id: "action.delegate",
+      goalId: "g.x",
+      meta: { skillHint: "any_skill", agentId: "missing_agent" },
+    }));
+
+    const unwired = findUnwiredActions(actions, executors);
+    expect(unwired.length).toBe(1);
+    expect(unwired[0].targets).toEqual(["missing_agent"]);
+    expect(unwired[0].skill).toBe("any_skill");
+  });
+
+  it("collects multiple gaps in one pass", () => {
+    const actions = new ActionRegistry();
+    const executors = new ExecutorRegistry();
+    actions.register(makeAction({ id: "alert.a", goalId: "g.1" }));
+    actions.register(makeAction({ id: "alert.b", goalId: "g.2" }));
+    actions.register(makeAction({ id: "alert.c", goalId: "g.3" }));
+    executors.register("alert.b", noopExecutor); // only b is wired
+
+    const ids = findUnwiredActions(actions, executors).map(u => u.actionId).sort();
+    expect(ids).toEqual(["alert.a", "alert.c"]);
+  });
+});
+
+describe("validateActionExecutors", () => {
+  it("returns empty array when fully wired", () => {
+    const actions = new ActionRegistry();
+    const executors = new ExecutorRegistry();
+    actions.register(makeAction({ id: "alert.foo", goalId: "g.foo" }));
+    executors.register("alert.foo", noopExecutor);
+
+    expect(validateActionExecutors(actions, executors)).toEqual([]);
+  });
+
+  it("throws UnwiredActionsError when throwOnUnwired is true", () => {
+    const actions = new ActionRegistry();
+    const executors = new ExecutorRegistry();
+    actions.register(makeAction({ id: "alert.bad", goalId: "g.x" }));
+
+    expect(() => validateActionExecutors(actions, executors, { throwOnUnwired: true }))
+      .toThrow(UnwiredActionsError);
+  });
+
+  it("does NOT throw by default — returns the unwired list", () => {
+    const actions = new ActionRegistry();
+    const executors = new ExecutorRegistry();
+    actions.register(makeAction({ id: "alert.bad", goalId: "g.x" }));
+
+    const unwired = validateActionExecutors(actions, executors);
+    expect(unwired.length).toBe(1);
+    expect(unwired[0].actionId).toBe("alert.bad");
+  });
+
+  it("publishes one HIGH-severity Discord alert per unwired action when bus is provided", () => {
+    const actions = new ActionRegistry();
+    const executors = new ExecutorRegistry();
+    actions.register(makeAction({ id: "alert.x", goalId: "g.1" }));
+    actions.register(makeAction({ id: "alert.y", goalId: "g.2" }));
+    executors.register("alert.x", noopExecutor); // only x is wired
+
+    const published: BusMessage[] = [];
+    const bus = {
+      subscribe: mock(() => "sub-id"),
+      unsubscribe: mock(() => {}),
+      publish: mock((_topic: string, msg: BusMessage) => { published.push(msg); }),
+      topics: () => [],
+    };
+
+    validateActionExecutors(actions, executors, { bus: bus as never });
+
+    const alerts = published.filter(m => m.topic === "message.outbound.discord.alert");
+    expect(alerts.length).toBe(1);
+    const p = alerts[0]!.payload as Record<string, unknown>;
+    expect(p.actionId).toBe("alert.y");
+    expect(p.goalId).toBe("platform.skills_unwired");
+    const meta = p.meta as Record<string, unknown>;
+    expect(meta.severity).toBe("high");
+    expect(meta.agentId).toBe("startup-validator");
+  });
+
+  it("error message lists every unwired action", () => {
+    const actions = new ActionRegistry();
+    const executors = new ExecutorRegistry();
+    actions.register(makeAction({ id: "alert.a", goalId: "g.1" }));
+    actions.register(makeAction({
+      id: "action.b",
+      goalId: "g.2",
+      meta: { skillHint: "real_b", agentId: "missing_agent" },
+    }));
+
+    let caught: UnwiredActionsError | null = null;
+    try {
+      validateActionExecutors(actions, executors, { throwOnUnwired: true });
+    } catch (err) {
+      caught = err as UnwiredActionsError;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.unwired.length).toBe(2);
+    expect(caught!.message).toContain("alert.a");
+    expect(caught!.message).toContain("action.b");
+    expect(caught!.message).toContain("real_b");
+    expect(caught!.message).toContain("missing_agent");
+  });
+});

--- a/src/planner/validate-action-executors.ts
+++ b/src/planner/validate-action-executors.ts
@@ -1,0 +1,153 @@
+/**
+ * validate-action-executors — fail-loud cross-check between actions.yaml
+ * and the live ExecutorRegistry.
+ *
+ * For every loaded action, compute the skill name that ActionDispatcherPlugin
+ * will publish on `agent.skill.request` (skillHint > action.id) and the
+ * routing target (meta.agentId, when set). Confirm the registry can resolve
+ * a non-null IExecutor for that pair. If anything is unresolvable, log a
+ * console.error (always) and publish a HIGH-severity Discord alert so the
+ * gap surfaces in the operator dashboard instead of being buried in logs.
+ *
+ * Called once at startup AFTER all registrar plugins (agent-runtime,
+ * skill-broker, alert-skill-executor) have installed. Pre-existing
+ * unwired actions don't crash the process — but each one is a feature
+ * request signal that the GOAP loop is dispatching into the void on
+ * every planning cycle (issue #426).
+ *
+ * In strict mode (`{ throwOnUnwired: true }`) the function throws an
+ * UnwiredActionsError instead. Used by tests and operators who want
+ * the build/CI to break on regressions.
+ */
+
+import type { ActionRegistry } from "./action-registry.ts";
+import type { ExecutorRegistry } from "../executor/executor-registry.ts";
+import type { EventBus, BusMessage } from "../../lib/types.ts";
+
+export interface UnwiredAction {
+  /** Action id from actions.yaml. */
+  actionId: string;
+  /** The skill name that would be published on agent.skill.request. */
+  skill: string;
+  /** Routing target derived from meta.agentId (empty when none). */
+  targets: string[];
+}
+
+export class UnwiredActionsError extends Error {
+  readonly unwired: UnwiredAction[];
+  constructor(unwired: UnwiredAction[]) {
+    const lines = unwired.map(
+      u => `  - action '${u.actionId}' → skill '${u.skill}'${u.targets.length > 0 ? ` (targets: ${u.targets.join(", ")})` : ""}`,
+    );
+    super(
+      `${unwired.length} action(s) in workspace/actions.yaml reference skill(s) ` +
+      `with no registered executor. Each missing executor would cause ` +
+      `SkillDispatcherPlugin to silently drop the dispatch on every GOAP ` +
+      `planning cycle.\n${lines.join("\n")}\n` +
+      `Fix: register an executor (agent-runtime, skill-broker, alert-skill-executor, ` +
+      `or a FunctionExecutor) for each skill, or remove the action from ` +
+      `workspace/actions.yaml.`,
+    );
+    this.name = "UnwiredActionsError";
+    this.unwired = unwired;
+  }
+}
+
+/**
+ * Scan ActionRegistry against ExecutorRegistry and return every action whose
+ * (skill, targets) pair resolves to a null executor.
+ *
+ * Mirrors the resolution rules of ActionDispatcherPlugin._dispatch():
+ *   skill   = action.meta.skillHint ?? action.id
+ *   targets = action.meta.agentId ? [action.meta.agentId] : []
+ *
+ * and SkillDispatcherPlugin._dispatch():
+ *   executor = registry.resolve(skill, targets)
+ */
+export function findUnwiredActions(
+  actions: ActionRegistry,
+  executors: ExecutorRegistry,
+): UnwiredAction[] {
+  const unwired: UnwiredAction[] = [];
+  for (const action of actions.getAll()) {
+    const meta = (action.meta ?? {}) as Record<string, unknown>;
+    const skill = (typeof meta.skillHint === "string" && meta.skillHint) || action.id;
+    const targets = typeof meta.agentId === "string" && meta.agentId ? [meta.agentId] : [];
+    const executor = executors.resolve(skill, targets);
+    if (!executor) {
+      unwired.push({ actionId: action.id, skill, targets });
+    }
+  }
+  return unwired;
+}
+
+export interface ValidateOptions {
+  /** Throw UnwiredActionsError if any actions are unwired. Default: false. */
+  throwOnUnwired?: boolean;
+  /**
+   * EventBus for publishing a HIGH-severity Discord alert per unwired action.
+   * When omitted, only the console.error path runs. Pass the live bus from
+   * src/index.ts so operators see the gap in the alerts channel.
+   */
+  bus?: EventBus;
+}
+
+/**
+ * Validate every loaded action has a resolvable executor. Logs to console
+ * and (optionally) publishes a HIGH-severity Discord alert per gap. Throws
+ * an UnwiredActionsError when `opts.throwOnUnwired` is set.
+ *
+ * Returns the list of unwired actions so callers can branch on the result
+ * without needing to subscribe to the alert topic.
+ */
+export function validateActionExecutors(
+  actions: ActionRegistry,
+  executors: ExecutorRegistry,
+  opts: ValidateOptions = {},
+): UnwiredAction[] {
+  const unwired = findUnwiredActions(actions, executors);
+  if (unwired.length === 0) return unwired;
+
+  // Always log loudly — the dispatcher's per-cycle "No executor found" warning
+  // is a symptom; this is the diagnosis, printed once at startup with full
+  // context and a fix recommendation.
+  console.error(
+    `[startup-validator] ${unwired.length} action(s) reference unwired skills:`,
+  );
+  for (const u of unwired) {
+    const tgt = u.targets.length > 0 ? ` targets=[${u.targets.join(", ")}]` : "";
+    console.error(`[startup-validator]   - ${u.actionId} → skill='${u.skill}'${tgt}`);
+  }
+  console.error(
+    `[startup-validator] Each gap silently drops on every GOAP planning cycle. ` +
+    `Wire an executor or remove the action from workspace/actions.yaml.`,
+  );
+
+  if (opts.bus) {
+    for (const u of unwired) {
+      const text = `Action \`${u.actionId}\` references skill \`${u.skill}\` with no registered executor — every GOAP dispatch will silently drop. (issue #426)`;
+      const alertMsg: BusMessage = {
+        id: crypto.randomUUID(),
+        correlationId: crypto.randomUUID(),
+        topic: "message.outbound.discord.alert",
+        timestamp: Date.now(),
+        payload: {
+          text,
+          actionId: u.actionId,
+          goalId: "platform.skills_unwired",
+          meta: {
+            severity: "high",
+            agentId: "startup-validator",
+            extra: { skill: u.skill, targets: u.targets },
+          },
+        },
+      };
+      opts.bus.publish("message.outbound.discord.alert", alertMsg);
+    }
+  }
+
+  if (opts.throwOnUnwired) {
+    throw new UnwiredActionsError(unwired);
+  }
+  return unwired;
+}

--- a/src/plugins/__tests__/alert-skill-executor-plugin.test.ts
+++ b/src/plugins/__tests__/alert-skill-executor-plugin.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { AlertSkillExecutorPlugin, ALERT_SKILLS } from "../alert-skill-executor-plugin.ts";
+import { ExecutorRegistry } from "../../executor/executor-registry.ts";
+import type { BusMessage } from "../../../lib/types.ts";
+
+/**
+ * Minimal in-memory bus mirroring the shape used by other dispatcher tests
+ * — captures every published message for assertion. Subscribers fire
+ * synchronously so we don't need timing tricks.
+ */
+function makeBus() {
+  const subs = new Map<string, Array<(msg: BusMessage) => void>>();
+  const published: BusMessage[] = [];
+  return {
+    published,
+    subscribe(topic: string, _name: string, handler: (msg: BusMessage) => void) {
+      if (!subs.has(topic)) subs.set(topic, []);
+      subs.get(topic)!.push(handler);
+      return `sub-${topic}-${Math.random()}`;
+    },
+    unsubscribe(_id: string) {},
+    publish(topic: string, msg: BusMessage) {
+      published.push(msg);
+      const handlers = subs.get(topic) ?? [];
+      for (const h of handlers) h(msg);
+    },
+    topics() { return []; },
+  };
+}
+
+describe("AlertSkillExecutorPlugin", () => {
+  let registry: ExecutorRegistry;
+  let plugin: AlertSkillExecutorPlugin;
+  let bus: ReturnType<typeof makeBus>;
+
+  beforeEach(() => {
+    registry = new ExecutorRegistry();
+    plugin = new AlertSkillExecutorPlugin(registry);
+    bus = makeBus();
+    plugin.install(bus as never);
+  });
+
+  it("registers executors for every alert skill named in the issue", () => {
+    const requiredFromIssue426 = [
+      "alert.branch_unprotected",
+      "alert.ci_main_red",
+      "alert.issues_bugs",
+      "alert.security_incident",
+      "alert.branch_drift",
+      "alert.branch_bypass_actors",
+    ];
+    for (const skill of requiredFromIssue426) {
+      expect(registry.resolve(skill)).not.toBeNull();
+    }
+  });
+
+  it("registry size matches ALERT_SKILLS length", () => {
+    expect(registry.size).toBe(ALERT_SKILLS.length);
+  });
+
+  it("publishes message.outbound.discord.alert with severity from the table", async () => {
+    const executor = registry.resolve("alert.branch_unprotected")!;
+    const result = await executor.execute({
+      skill: "alert.branch_unprotected",
+      correlationId: "corr-1",
+      replyTopic: "reply.test",
+      payload: { skill: "alert.branch_unprotected", goalId: "branch.main_protected" },
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.correlationId).toBe("corr-1");
+
+    const alert = bus.published.find(m => m.topic === "message.outbound.discord.alert");
+    expect(alert).toBeDefined();
+
+    const p = alert!.payload as Record<string, unknown>;
+    expect(p.actionId).toBe("alert.branch_unprotected");
+    expect(p.goalId).toBe("branch.main_protected");
+
+    const meta = p.meta as Record<string, unknown>;
+    expect(meta.severity).toBe("high");
+    expect(meta.agentId).toBe("goap");
+  });
+
+  it("falls back to action.id and 'unknown' goalId when meta is empty", async () => {
+    const executor = registry.resolve("alert.issues_bugs")!;
+    await executor.execute({
+      skill: "alert.issues_bugs",
+      correlationId: "corr-2",
+      replyTopic: "reply.test",
+      payload: { skill: "alert.issues_bugs" }, // no meta, no goalId
+    });
+
+    const alert = bus.published.find(m => m.topic === "message.outbound.discord.alert");
+    const p = alert!.payload as Record<string, unknown>;
+    expect(p.actionId).toBe("alert.issues_bugs");
+    expect(p.goalId).toBe("unknown");
+  });
+
+  it("forwards meta.actionId and meta.goalId from a GOAP-shaped dispatch", async () => {
+    const executor = registry.resolve("alert.ci_main_red")!;
+    await executor.execute({
+      skill: "alert.ci_main_red",
+      correlationId: "corr-3",
+      replyTopic: "reply.test",
+      payload: {
+        skill: "alert.ci_main_red",
+        meta: {
+          systemActor: "goap",
+          actionId: "alert.ci_main_red",
+          goalId: "ci.main_last_push_green",
+        },
+      },
+    });
+
+    const alert = bus.published.find(m => m.topic === "message.outbound.discord.alert");
+    const p = alert!.payload as Record<string, unknown>;
+    expect(p.actionId).toBe("alert.ci_main_red");
+    expect(p.goalId).toBe("ci.main_last_push_green");
+  });
+
+  it("propagates correlationId on the published alert", async () => {
+    const executor = registry.resolve("alert.security_incident")!;
+    await executor.execute({
+      skill: "alert.security_incident",
+      correlationId: "corr-trace-xyz",
+      replyTopic: "reply.test",
+      payload: { skill: "alert.security_incident" },
+    });
+
+    const alert = bus.published.find(m => m.topic === "message.outbound.discord.alert");
+    expect(alert!.correlationId).toBe("corr-trace-xyz");
+  });
+
+  it("returns SkillResult.text containing severity tag and headline", async () => {
+    const executor = registry.resolve("alert.branch_drift")!;
+    const result = await executor.execute({
+      skill: "alert.branch_drift",
+      correlationId: "c4",
+      replyTopic: "r",
+      payload: { skill: "alert.branch_drift" },
+    });
+    expect(result.text).toContain("[MEDIUM]");
+    expect(result.text).toContain("Branch drift");
+  });
+
+  it("uninstall clears the bus reference", () => {
+    plugin.uninstall();
+    // Re-installing on a fresh bus should still work — proves no leftover state
+    const bus2 = makeBus();
+    const reg2 = new ExecutorRegistry();
+    const plugin2 = new AlertSkillExecutorPlugin(reg2);
+    expect(() => plugin2.install(bus2 as never)).not.toThrow();
+  });
+});

--- a/src/plugins/alert-skill-executor-plugin.ts
+++ b/src/plugins/alert-skill-executor-plugin.ts
@@ -1,0 +1,148 @@
+/**
+ * AlertSkillExecutorPlugin — registers FunctionExecutors for the GOAP-wired
+ * `alert.*` skills that previously had no handler.
+ *
+ * Six tier_0 fire-and-forget actions in `workspace/actions.yaml` dispatch
+ * skills with the same id as the action (no `meta.skillHint`, no
+ * `meta.agentId`). Without a registered executor, SkillDispatcherPlugin
+ * logged "No executor found … dropping" on every planning cycle and the
+ * GOAP loop never produced any visible side-effect.
+ *
+ * Each executor here translates the dispatch into a structured Discord
+ * alert published on `message.outbound.discord.alert` — the same topic
+ * `WorldEngineAlertPlugin` already routes to the operator-facing webhook.
+ *
+ * This is a registrar plugin: it does not subscribe to any topic at runtime.
+ * Install order matters — must run AFTER ExecutorRegistry construction and
+ * BEFORE SkillDispatcherPlugin so registrations are resolvable on first
+ * dispatch.
+ */
+
+import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
+import type { ExecutorRegistry } from "../executor/executor-registry.ts";
+import type { SkillRequest, SkillResult } from "../executor/types.ts";
+import { FunctionExecutor } from "../executor/executors/function-executor.ts";
+
+/**
+ * Every `alert.*` skill in workspace/actions.yaml that has no other handler.
+ * Each is a tier_0 fire-and-forget action whose dispatched skill name equals
+ * the action id (no skillHint, no agentId routing).
+ *
+ * The six explicitly tracked by issue #426 are at the top — the rest share
+ * the same structural pattern (precondition violated → broadcast a Discord
+ * alert) and were silently dropping for the same reason. Wiring them all
+ * here closes the systemic gap rather than just the symptoms.
+ *
+ * Severity is the operator-facing escalation tier surfaced by
+ * WorldEngineAlertPlugin's embed colour and Discord routing.
+ */
+export const ALERT_SKILLS: ReadonlyArray<{
+  skill: string;
+  severity: "low" | "medium" | "high";
+  headline: string;
+}> = [
+  // ── Issue #426 — explicitly listed ──────────────────────────────────────
+  { skill: "alert.branch_unprotected",        severity: "high",   headline: "Repo missing main-branch ruleset" },
+  { skill: "alert.ci_main_red",               severity: "high",   headline: "Latest push to main is red" },
+  { skill: "alert.issues_bugs",               severity: "medium", headline: "Open bug issues need triage" },
+  { skill: "alert.security_incident",         severity: "high",   headline: "Open security incident" },
+  { skill: "alert.branch_drift",              severity: "medium", headline: "Branch drift exceeds threshold" },
+  { skill: "alert.branch_bypass_actors",      severity: "high",   headline: "Bypass actors present on main ruleset" },
+  // ── Same structural gap — all bare `alert.*` actions ─────────────────────
+  { skill: "alert.efficiency_low",            severity: "medium", headline: "Flow efficiency below threshold" },
+  { skill: "alert.discord_disconnected",      severity: "high",   headline: "Discord bot disconnected" },
+  { skill: "alert.no_agents",                 severity: "high",   headline: "No agents registered" },
+  { skill: "alert.ci_failures",               severity: "medium", headline: "CI failure rate elevated" },
+  { skill: "alert.pr_stale",                  severity: "low",    headline: "Stale PRs accumulating" },
+  { skill: "alert.protomaker_board_blocked",  severity: "medium", headline: "protoMaker board has excessive blocked features" },
+  { skill: "alert.protomaker_backlog_piling", severity: "low",    headline: "protoMaker backlog growing" },
+  { skill: "alert.plane_urgent_stale",        severity: "high",   headline: "Excessive urgent Plane issues" },
+  { skill: "alert.plane_stale_backlog",       severity: "medium", headline: "Plane issues >14 days old" },
+  { skill: "alert.plane_unassigned_piling",   severity: "medium", headline: "Unassigned Plane issues piling up" },
+  { skill: "alert.memory_down",               severity: "high",   headline: "Graphiti memory healthcheck failed" },
+  { skill: "alert.memory_search_broken",      severity: "high",   headline: "Graphiti search probe failed" },
+  { skill: "alert.fleet_agent_stuck",         severity: "high",   headline: "Agent failure rate >50% over 1h" },
+  { skill: "alert.hitl_routing_broken",       severity: "high",   headline: "HITL requests not reaching renderer" },
+  { skill: "alert.fleet_cost_over_budget",    severity: "medium", headline: "Fleet LLM spend exceeds daily budget" },
+  { skill: "alert.fleet_skill_orphaned",      severity: "medium", headline: "Active skill with no recent successes" },
+  { skill: "alert.issues_critical",           severity: "high",   headline: "Critical GitHub issues open" },
+  { skill: "alert.issues_total_high",         severity: "low",    headline: "Total open issues exceed threshold" },
+];
+
+export class AlertSkillExecutorPlugin implements Plugin {
+  readonly name = "alert-skill-executor";
+  readonly description = "Registers Discord-alert FunctionExecutors for the GOAP `alert.*` skills";
+  readonly capabilities = ["alert-dispatch", "executor-registrar"];
+
+  private bus?: EventBus;
+
+  constructor(private readonly registry: ExecutorRegistry) {}
+
+  install(bus: EventBus): void {
+    this.bus = bus;
+    for (const entry of ALERT_SKILLS) {
+      const executor = new FunctionExecutor(async (req) => this._execute(req, entry));
+      this.registry.register(entry.skill, executor, { priority: 5 });
+    }
+    console.log(
+      `[alert-skill-executor] Registered ${ALERT_SKILLS.length} alert executor(s): ${ALERT_SKILLS.map(a => a.skill).join(", ")}`,
+    );
+  }
+
+  uninstall(): void {
+    this.bus = undefined;
+  }
+
+  /**
+   * Translate a GOAP skill dispatch into a Discord-alert bus event.
+   *
+   * The published payload matches the shape `WorldEngineAlertPlugin`
+   * already consumes — actionId, goalId, meta.{severity, agentId, extra}.
+   * Returning a non-error SkillResult lets ActionDispatcherPlugin record
+   * a successful outcome instead of timing out.
+   */
+  private async _execute(
+    req: SkillRequest,
+    entry: { skill: string; severity: "low" | "medium" | "high"; headline: string },
+  ): Promise<SkillResult> {
+    if (!this.bus) {
+      return {
+        text: "alert-skill-executor not installed",
+        isError: true,
+        correlationId: req.correlationId,
+      };
+    }
+
+    const meta = (req.payload?.meta ?? {}) as Record<string, unknown>;
+    const actionId = typeof meta.actionId === "string" ? meta.actionId : entry.skill;
+    const goalId = typeof meta.goalId === "string" ? meta.goalId
+      : typeof req.payload?.goalId === "string" ? req.payload.goalId
+      : "unknown";
+
+    const text = `[${entry.severity.toUpperCase()}] ${entry.headline} — goal ${goalId} violated`;
+
+    const alertMsg: BusMessage = {
+      id: crypto.randomUUID(),
+      correlationId: req.correlationId,
+      topic: "message.outbound.discord.alert",
+      timestamp: Date.now(),
+      payload: {
+        text,
+        actionId,
+        goalId,
+        meta: {
+          severity: entry.severity,
+          agentId: "goap",
+          extra: { skill: entry.skill, content: req.content },
+        },
+      },
+    };
+    this.bus.publish("message.outbound.discord.alert", alertMsg);
+
+    return {
+      text,
+      isError: false,
+      correlationId: req.correlationId,
+    };
+  }
+}


### PR DESCRIPTION
Closes #426.

## Summary

- New `AlertSkillExecutorPlugin` registers `FunctionExecutor`s for all 24 bare `alert.*` skills declared in `workspace/actions.yaml` (the 6 explicitly listed in #426 plus the rest sharing the same structural pattern). Each translates a GOAP dispatch into a `message.outbound.discord.alert` event already consumed by `WorldEngineAlertPlugin`.
- New `validate-action-executors.ts` cross-checks every loaded action against the live `ExecutorRegistry` at startup. Each gap is logged loudly and (optionally) republished as a HIGH-severity Discord alert under goal `platform.skills_unwired`. Set `WORKSTACEAN_STRICT_WIRING=1` to crash startup instead of just alerting — the issue body offered both options.
- `action.issues_triage_bugs` is verified to already resolve via `meta.agentId: ava` to Ava's `issue_triage` `DeepAgentExecutor`, so no duplicate executor was added (greenfield).

After this PR the live workspace goes from **27 unwired actions → 9** (the remainder are `ceremony.*`, `action.pr_*`, `action.protomaker_*`, and `action.dispatch_backmerge` — out of scope for this fix; they need their own handler wiring or topic alignment and are now visible via the validator's startup alerts).

## Test plan

- [x] `bun test` — 988 tests pass (19 new across `alert-skill-executor-plugin.test.ts` and `validate-action-executors.test.ts`).
- [x] Each of the 6 alert skills named in #426 resolves to a non-null executor.
- [x] Executors publish `message.outbound.discord.alert` with the expected `actionId`, `goalId`, and `meta.severity` shape.
- [x] Validator returns the unwired list when not strict, throws `UnwiredActionsError` when `throwOnUnwired: true`, and emits one Discord alert per gap when given a bus.
- [x] Smoke-tested against the real `workspace/actions.yaml` — confirmed 24 alert skills wired, validator correctly identifies the remaining 9 follow-up gaps (filed implicitly via the startup alert on first boot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added startup validation to detect misconfigured action handlers with optional strict mode for enhanced reliability
  * Introduced Discord alert notifications for unwired actions, enabling faster troubleshooting and system diagnostics

* **Tests**
  * Added comprehensive test coverage for action validation and alert notification systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->