### PR TITLE
fix(rollcall): point /rollcall skill at in-repo script

### DIFF
--- a/.claude/commands/rollcall.md
+++ b/.claude/commands/rollcall.md
@@ -1,7 +1,11 @@
-Run the agent roll call smoke test. Reports status of all agents (local + remote), AI infrastructure, media stack, and monitoring services.
+Run the agent roll call smoke test. Reports status of all agents (in-process DeepAgents, A2A external services), AI infrastructure, media stack, and monitoring services.
 
 ## Steps
 
-1. Run `bash /home/josh/dev/homelab-iac/scripts/agent-rollcall.sh`
+1. Run `bash /home/josh/dev/protoWorkstacean/scripts/agent-rollcall.sh`
 2. Report the output to the user
 3. If any services are down, suggest remediation steps
+
+## Note
+
+The script lives in this repo (`scripts/agent-rollcall.sh`) so the agent roster stays in sync with `workspace/agents/*.yaml` and the in-process DeepAgent runtime. Do not call any other copy.


### PR DESCRIPTION
Closes #425.

## Summary

The `/rollcall` skill called `bash /home/josh/dev/homelab-iac/scripts/agent-rollcall.sh`, but that copy of the script had drifted from the in-repo copy at `scripts/agent-rollcall.sh`. The in-repo copy is the canonical one — it knows about the in-process DeepAgent runtime (Ava, protoBot, Tuner) and current A2A fleet (Researcher, etc.). The homelab-iac copy still probed for the archived \`ava-agent\` container and the deprecated \`protoaudio\`/\`protovoice\` services, producing false-negative \"container missing\" entries on every rollcall.

Pointing the skill at the in-repo script makes this single source of truth.

## Test plan

- [ ] Run \`/rollcall\` and verify no entries for \`ava-agent\`, \`protoaudio\`, \`protovoice\`
- [ ] Verify the in-process DeepAgent header (\"Agents (In-process DeepAgents)\") appears
- [ ] Verify Researcher (rabbit-hole.io) shows up under A2A external services