### PR TITLE
feat(ceremony): wire ceremony.security_triage + ceremony.service_health_discord

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -299,6 +299,21 @@ const pluginRegistry: PluginRegistryEntry[] = [
     },
   },
   {
+    // Registers FunctionExecutors that bridge GOAP `ceremony.*` actions to
+    // the matching `ceremony.<id>.execute` bus trigger CeremonyPlugin already
+    // listens for. Without this, ActionDispatcherPlugin publishes to
+    // agent.skill.request and SkillDispatcherPlugin drops with
+    // "No executor found …" — the structural gap behind issue #430.
+    // Must install AFTER ExecutorRegistry exists (always true) and BEFORE
+    // skill-dispatcher so registrations resolve on first dispatch.
+    name: "ceremony-skill-executor",
+    condition: () => true,
+    factory: async () => {
+      const { CeremonySkillExecutorPlugin } = await import("./plugins/ceremony-skill-executor-plugin.js");
+      return new CeremonySkillExecutorPlugin(executorRegistry);
+    },
+  },
+  {
     // Intercepts ExecutorRegistry.resolve() to A/B test competing skill variants.
     // Must be installed AFTER registrars (agent-runtime, skill-broker) and
     // BEFORE skill-dispatcher so the hook is active when dispatches begin.

--- a/src/planner/validate-action-executors.ts
+++ b/src/planner/validate-action-executors.ts
@@ -10,7 +10,7 @@
  * gap surfaces in the operator dashboard instead of being buried in logs.
  *
  * Called once at startup AFTER all registrar plugins (agent-runtime,
- * skill-broker, alert-skill-executor) have installed. Pre-existing
+ * skill-broker, alert-skill-executor, ceremony-skill-executor) have installed. Pre-existing
  * unwired actions don't crash the process — but each one is a feature
  * request signal that the GOAP loop is dispatching into the void on
  * every planning cycle (issue #426).
@@ -45,7 +45,7 @@ export class UnwiredActionsError extends Error {
       `SkillDispatcherPlugin to silently drop the dispatch on every GOAP ` +
       `planning cycle.\n${lines.join("\n")}\n` +
       `Fix: register an executor (agent-runtime, skill-broker, alert-skill-executor, ` +
-      `or a FunctionExecutor) for each skill, or remove the action from ` +
+      `ceremony-skill-executor, or a FunctionExecutor) for each skill, or remove the action from ` +
       `workspace/actions.yaml.`,
     );
     this.name = "UnwiredActionsError";

--- a/src/plugins/__tests__/ceremony-skill-executor-plugin.test.ts
+++ b/src/plugins/__tests__/ceremony-skill-executor-plugin.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { CeremonySkillExecutorPlugin, CEREMONY_SKILLS } from "../ceremony-skill-executor-plugin.ts";
+import { ExecutorRegistry } from "../../executor/executor-registry.ts";
+import type { BusMessage } from "../../../lib/types.ts";
+
+/**
+ * Minimal in-memory bus mirroring the shape used by alert-skill-executor's
+ * tests — captures every published message for assertion. Subscribers fire
+ * synchronously so we don't need timing tricks.
+ */
+function makeBus() {
+  const subs = new Map<string, Array<(msg: BusMessage) => void>>();
+  const published: BusMessage[] = [];
+  return {
+    published,
+    subscribe(topic: string, _name: string, handler: (msg: BusMessage) => void) {
+      if (!subs.has(topic)) subs.set(topic, []);
+      subs.get(topic)!.push(handler);
+      return `sub-${topic}-${Math.random()}`;
+    },
+    unsubscribe(_id: string) {},
+    publish(topic: string, msg: BusMessage) {
+      published.push(msg);
+      const handlers = subs.get(topic) ?? [];
+      for (const h of handlers) h(msg);
+    },
+    topics() { return []; },
+  };
+}
+
+describe("CeremonySkillExecutorPlugin", () => {
+  let registry: ExecutorRegistry;
+  let plugin: CeremonySkillExecutorPlugin;
+  let bus: ReturnType<typeof makeBus>;
+
+  beforeEach(() => {
+    registry = new ExecutorRegistry();
+    plugin = new CeremonySkillExecutorPlugin(registry);
+    bus = makeBus();
+    plugin.install(bus as never);
+  });
+
+  it("registers executors for every ceremony skill named in issue #430", () => {
+    const requiredFromIssue430 = [
+      "ceremony.security_triage",
+      "ceremony.service_health_discord",
+    ];
+    for (const skill of requiredFromIssue430) {
+      expect(registry.resolve(skill)).not.toBeNull();
+    }
+  });
+
+  it("registry size matches CEREMONY_SKILLS length", () => {
+    expect(registry.size).toBe(CEREMONY_SKILLS.length);
+  });
+
+  it("publishes ceremony.security-triage.execute when ceremony.security_triage dispatches", async () => {
+    const executor = registry.resolve("ceremony.security_triage")!;
+    const result = await executor.execute({
+      skill: "ceremony.security_triage",
+      correlationId: "corr-1",
+      replyTopic: "reply.test",
+      payload: {
+        skill: "ceremony.security_triage",
+        meta: { actionId: "ceremony.security_triage", goalId: "security.no_open_incidents" },
+      },
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.correlationId).toBe("corr-1");
+
+    const trigger = bus.published.find(m => m.topic === "ceremony.security-triage.execute");
+    expect(trigger).toBeDefined();
+
+    const p = trigger!.payload as Record<string, unknown>;
+    expect(p.type).toBe("external.trigger");
+    expect(p.source).toBe("goap");
+    expect(p.actionId).toBe("ceremony.security_triage");
+    expect(p.goalId).toBe("security.no_open_incidents");
+    expect(p.ceremonyId).toBe("security-triage");
+  });
+
+  it("publishes ceremony.service-health.execute when ceremony.service_health_discord dispatches", async () => {
+    const executor = registry.resolve("ceremony.service_health_discord")!;
+    const result = await executor.execute({
+      skill: "ceremony.service_health_discord",
+      correlationId: "corr-2",
+      replyTopic: "reply.test",
+      payload: {
+        skill: "ceremony.service_health_discord",
+        meta: { actionId: "ceremony.service_health_discord", goalId: "services.discord_connected" },
+      },
+    });
+
+    expect(result.isError).toBe(false);
+    const trigger = bus.published.find(m => m.topic === "ceremony.service-health.execute");
+    expect(trigger).toBeDefined();
+    const p = trigger!.payload as Record<string, unknown>;
+    expect(p.ceremonyId).toBe("service-health");
+    expect(p.goalId).toBe("services.discord_connected");
+  });
+
+  it("payload type is NOT 'ceremony.execute' so CeremonyPlugin treats it as an external trigger", async () => {
+    // CeremonyPlugin's .execute handler skips messages with payload.type === 'ceremony.execute'
+    // (those are its own internal cron fires, re-published to the same topic). External triggers
+    // must use a different type or they will be silently swallowed and never fire the ceremony.
+    const executor = registry.resolve("ceremony.security_triage")!;
+    await executor.execute({
+      skill: "ceremony.security_triage",
+      correlationId: "corr-3",
+      replyTopic: "reply.test",
+      payload: { skill: "ceremony.security_triage" },
+    });
+    const trigger = bus.published.find(m => m.topic === "ceremony.security-triage.execute");
+    const p = trigger!.payload as Record<string, unknown>;
+    expect(p.type).not.toBe("ceremony.execute");
+  });
+
+  it("falls back to action.id and 'unknown' goalId when meta is empty", async () => {
+    const executor = registry.resolve("ceremony.security_triage")!;
+    await executor.execute({
+      skill: "ceremony.security_triage",
+      correlationId: "corr-4",
+      replyTopic: "reply.test",
+      payload: { skill: "ceremony.security_triage" }, // no meta, no goalId
+    });
+    const trigger = bus.published.find(m => m.topic === "ceremony.security-triage.execute");
+    const p = trigger!.payload as Record<string, unknown>;
+    expect(p.actionId).toBe("ceremony.security_triage");
+    expect(p.goalId).toBe("unknown");
+  });
+
+  it("propagates correlationId on the published trigger", async () => {
+    const executor = registry.resolve("ceremony.security_triage")!;
+    await executor.execute({
+      skill: "ceremony.security_triage",
+      correlationId: "corr-trace-xyz",
+      replyTopic: "reply.test",
+      payload: { skill: "ceremony.security_triage" },
+    });
+    const trigger = bus.published.find(m => m.topic === "ceremony.security-triage.execute");
+    expect(trigger!.correlationId).toBe("corr-trace-xyz");
+  });
+
+  it("returns SkillResult.text describing the ceremony triggered", async () => {
+    const executor = registry.resolve("ceremony.security_triage")!;
+    const result = await executor.execute({
+      skill: "ceremony.security_triage",
+      correlationId: "c5",
+      replyTopic: "r",
+      payload: { skill: "ceremony.security_triage" },
+    });
+    expect(result.text).toContain("security-triage");
+    expect(result.text).toContain("ceremony");
+  });
+
+  it("uninstall clears the bus reference and reinstall is clean", () => {
+    plugin.uninstall();
+    const bus2 = makeBus();
+    const reg2 = new ExecutorRegistry();
+    const plugin2 = new CeremonySkillExecutorPlugin(reg2);
+    expect(() => plugin2.install(bus2 as never)).not.toThrow();
+  });
+});
+
+describe("CeremonySkillExecutorPlugin → CeremonyPlugin integration", () => {
+  it("trigger payload shape matches what CeremonyPlugin._fireCeremony expects", async () => {
+    // CeremonyPlugin reads the topic, splits on '.', extracts the ceremony id
+    // from parts[1..-1].join('.'), and looks it up. The executor must publish
+    // to the right topic shape — verified here so a future refactor doesn't
+    // break the contract silently.
+    const registry = new ExecutorRegistry();
+    const plugin = new CeremonySkillExecutorPlugin(registry);
+    const bus = makeBus();
+    plugin.install(bus as never);
+
+    for (const entry of CEREMONY_SKILLS) {
+      const executor = registry.resolve(entry.skill)!;
+      await executor.execute({
+        skill: entry.skill,
+        correlationId: `corr-${entry.skill}`,
+        replyTopic: "reply.test",
+        payload: { skill: entry.skill },
+      });
+
+      const expectedTopic = `ceremony.${entry.ceremonyId}.execute`;
+      const trigger = bus.published.find(m => m.topic === expectedTopic);
+      expect(trigger).toBeDefined();
+
+      // Mirror CeremonyPlugin's parse to prove the topic is decodable.
+      const parts = trigger!.topic.split(".");
+      const decodedId = parts.slice(1, -1).join(".");
+      expect(decodedId).toBe(entry.ceremonyId);
+    }
+  });
+});

--- a/src/plugins/ceremony-skill-executor-plugin.ts
+++ b/src/plugins/ceremony-skill-executor-plugin.ts
@@ -1,0 +1,132 @@
+/**
+ * CeremonySkillExecutorPlugin — registers FunctionExecutors for the GOAP-wired
+ * `ceremony.*` actions that previously had no skill-side handler.
+ *
+ * Background (issue #430): a small set of tier_0 fire-and-forget actions in
+ * `workspace/actions.yaml` exist purely to nudge an existing ceremony — they
+ * have no skillHint, no agentId, and their action id is the skill name the
+ * dispatcher tries to resolve. CeremonyPlugin already accepts external
+ * triggers on `ceremony.<id>.execute`, but nothing was bridging the GOAP
+ * action id to that topic, so SkillDispatcherPlugin dropped every dispatch
+ * with `No executor found for skill "ceremony.X"`. After PR #427 those drops
+ * also fire HIGH `platform.skills_unwired` alerts every planning cycle.
+ *
+ * Each registered executor here translates the dispatch into a single
+ * `ceremony.<id>.execute` publish and returns a successful SkillResult so
+ * ActionDispatcherPlugin records a clean outcome.
+ *
+ * Registration mapping is explicit (not derived) — action ids and ceremony
+ * ids deliberately differ in punctuation (underscores vs. dashes), and
+ * pretending the mapping is mechanical hides the contract.
+ *
+ * Install order: must run AFTER ExecutorRegistry construction and BEFORE
+ * SkillDispatcherPlugin so registrations are resolvable on first dispatch.
+ * (Same constraint as `alert-skill-executor-plugin`.)
+ */
+
+import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
+import type { ExecutorRegistry } from "../executor/executor-registry.ts";
+import type { SkillRequest, SkillResult } from "../executor/types.ts";
+import { FunctionExecutor } from "../executor/executors/function-executor.ts";
+
+/**
+ * Action id (== skill name on agent.skill.request) → ceremony id to trigger.
+ *
+ * The mapping is intentionally explicit: action ids in actions.yaml use
+ * snake_case and may carry suffixes describing the trigger condition
+ * (e.g. `_discord` for the Discord-disconnect path), while ceremony ids in
+ * `workspace/ceremonies/*.yaml` use kebab-case file-based ids.
+ */
+export const CEREMONY_SKILLS: ReadonlyArray<{
+  skill: string;
+  ceremonyId: string;
+  description: string;
+}> = [
+  {
+    skill: "ceremony.security_triage",
+    ceremonyId: "security-triage",
+    description: "Open security incidents detected — trigger security-triage ceremony",
+  },
+  {
+    skill: "ceremony.service_health_discord",
+    ceremonyId: "service-health",
+    description: "Discord bot disconnected — trigger service-health ceremony",
+  },
+];
+
+export class CeremonySkillExecutorPlugin implements Plugin {
+  readonly name = "ceremony-skill-executor";
+  readonly description = "Registers FunctionExecutors that bridge GOAP `ceremony.*` actions to ceremony.<id>.execute triggers";
+  readonly capabilities = ["ceremony-trigger", "executor-registrar"];
+
+  private bus?: EventBus;
+
+  constructor(private readonly registry: ExecutorRegistry) {}
+
+  install(bus: EventBus): void {
+    this.bus = bus;
+    for (const entry of CEREMONY_SKILLS) {
+      const executor = new FunctionExecutor(async (req) => this._execute(req, entry));
+      this.registry.register(entry.skill, executor, { priority: 5 });
+    }
+    console.log(
+      `[ceremony-skill-executor] Registered ${CEREMONY_SKILLS.length} ceremony executor(s): ${CEREMONY_SKILLS.map(c => c.skill).join(", ")}`,
+    );
+  }
+
+  uninstall(): void {
+    this.bus = undefined;
+  }
+
+  /**
+   * Translate a GOAP skill dispatch into a `ceremony.<id>.execute` bus event.
+   *
+   * The published payload deliberately carries `type: "external.trigger"`
+   * (anything other than `"ceremony.execute"`) so CeremonyPlugin's `.execute`
+   * handler treats it as an external trigger and fires the ceremony — the
+   * internal cron path uses `type: "ceremony.execute"` and is skipped to
+   * avoid double-firing.
+   */
+  private async _execute(
+    req: SkillRequest,
+    entry: { skill: string; ceremonyId: string; description: string },
+  ): Promise<SkillResult> {
+    if (!this.bus) {
+      return {
+        text: "ceremony-skill-executor not installed",
+        isError: true,
+        correlationId: req.correlationId,
+      };
+    }
+
+    const meta = (req.payload?.meta ?? {}) as Record<string, unknown>;
+    const actionId = typeof meta.actionId === "string" ? meta.actionId : entry.skill;
+    const goalId = typeof meta.goalId === "string" ? meta.goalId
+      : typeof req.payload?.goalId === "string" ? req.payload.goalId
+      : "unknown";
+
+    const executeTopic = `ceremony.${entry.ceremonyId}.execute`;
+    const triggerMsg: BusMessage = {
+      id: crypto.randomUUID(),
+      correlationId: req.correlationId,
+      topic: executeTopic,
+      timestamp: Date.now(),
+      payload: {
+        type: "external.trigger",
+        source: "goap",
+        actionId,
+        goalId,
+        skill: entry.skill,
+        ceremonyId: entry.ceremonyId,
+      },
+    };
+    this.bus.publish(executeTopic, triggerMsg);
+
+    const text = `Triggered ceremony '${entry.ceremonyId}' — ${entry.description} (action ${actionId}, goal ${goalId})`;
+    return {
+      text,
+      isError: false,
+      correlationId: req.correlationId,
+    };
+  }
+}


### PR DESCRIPTION
Partial fix for #430 — wires the 2 ceremony-scoped skills (separate PR covers pr-remediator and protomaker actions).

## Summary

- Adds `CeremonySkillExecutorPlugin` that registers FunctionExecutors for the two unwired `ceremony.*` skills.
- Each executor publishes to `ceremony.<id>.execute`, which CeremonyPlugin already handles as an external trigger and fires the matching ceremony.
- Explicit action→ceremony id mapping (snake_case actions vs. kebab-case ceremony files):
  - `ceremony.security_triage` → `security-triage`
  - `ceremony.service_health_discord` → `service-health`
- Wired into `src/index.ts` next to `alert-skill-executor` (same install-order constraints).
- Updated `validate-action-executors` doc/error text to mention the new registrar.

Pattern mirrors the alert-skill-executor-plugin from #427.

## Test plan

- [x] `bun test src/plugins/__tests__/ceremony-skill-executor-plugin.test.ts` — 10 pass
- [x] `bun test` — full suite 1002 pass
- [ ] Post-deploy: confirm `No executor found.*ceremony` drops disappear from workstacean logs
- [ ] Post-deploy: confirm next `platform.skills_unwired` startup-validator alert no longer lists these two skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a ceremony skill executor that bridges planning workflow actions to ceremony execution, enabling automated ceremony triggers (including security triage and service health monitoring) through skill-based planning.

* **Documentation**
  * Updated startup validation guidance to include the new ceremony skill executor in recommended executor-registration setup.

* **Tests**
  * Added comprehensive test coverage for ceremony skill executor functionality, including end-to-end integration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->