### PR TITLE
fix(pr-remediator): wire 5 GOAP-dispatched skills

### DIFF
--- a/lib/plugins/pr-remediator.ts
+++ b/lib/plugins/pr-remediator.ts
@@ -907,6 +907,11 @@ export class PrRemediatorPlugin implements Plugin {
       return;
     }
 
+    // Extract hitlPolicy forwarded by PrRemediatorSkillExecutorPlugin so the
+    // fallback HITL request honours action.pr_merge_ready.meta.hitlPolicy
+    // (ttlMs: 30min, onTimeout: approve).
+    const hitlPolicy = this._extractHitlPolicy(msg);
+
     for (const pr of ready) {
       const gate = this._shouldDispatch(pr.repo, pr.number, "merge_ready");
       if (!gate.ok) {
@@ -935,7 +940,7 @@ export class PrRemediatorPlugin implements Plugin {
         // HITL so an operator can look. This is the only remaining
         // _emitHitlApproval call site.
         console.warn(`[pr-remediator] auto-merge failed ${pr.repo}#${pr.number}: ${result.error}`);
-        this._emitHitlApproval(pr, msg.correlationId, `Auto-merge failed (${result.status}): ${result.error}`);
+        this._emitHitlApproval(pr, msg.correlationId, `Auto-merge failed (${result.status}): ${result.error}`, hitlPolicy);
       }
     }
   }
@@ -1187,11 +1192,43 @@ Critical rules:
     console.warn(`[pr-remediator] ${text}`);
   }
 
-  private _emitHitlApproval(pr: PrDomainEntry, parentCorrelationId: string, note?: string): void {
+  /**
+   * Pull `meta.hitlPolicy` from the trigger bus message. The shape comes from
+   * actions.yaml and is propagated by PrRemediatorSkillExecutorPlugin into the
+   * pr.remediate.* trigger payload. Returns undefined when not present so
+   * callers fall back to their built-in defaults.
+   */
+  private _extractHitlPolicy(msg: BusMessage): { ttlMs?: number; onTimeout?: "approve" | "reject" | "escalate" } | undefined {
+    const payload = msg.payload as { meta?: Record<string, unknown> } | undefined;
+    const meta = payload?.meta;
+    if (!meta || typeof meta !== "object") return undefined;
+    const policy = (meta as Record<string, unknown>).hitlPolicy;
+    if (!policy || typeof policy !== "object") return undefined;
+    const p = policy as Record<string, unknown>;
+    const out: { ttlMs?: number; onTimeout?: "approve" | "reject" | "escalate" } = {};
+    if (typeof p.ttlMs === "number") out.ttlMs = p.ttlMs;
+    if (p.onTimeout === "approve" || p.onTimeout === "reject" || p.onTimeout === "escalate") {
+      out.onTimeout = p.onTimeout;
+    }
+    return Object.keys(out).length > 0 ? out : undefined;
+  }
+
+  private _emitHitlApproval(
+    pr: PrDomainEntry,
+    parentCorrelationId: string,
+    note?: string,
+    hitlPolicy?: { ttlMs?: number; onTimeout?: "approve" | "reject" | "escalate" },
+  ): void {
     if (!this.bus) return;
     const correlationId = crypto.randomUUID();
     const replyTopic = `hitl.response.pr.merge.${correlationId}`;
     const devChannelId = loadProjectMetaMap().get(pr.repo)?.devChannelId;
+    // Honor action.pr_merge_ready.meta.hitlPolicy when provided (forwarded by
+    // PrRemediatorSkillExecutorPlugin via the trigger msg). Defaults match the
+    // pre-existing 30-min escalation behaviour so non-policy callers (e.g. the
+    // ghMerge fallback path) keep their semantics.
+    const ttlMs = hitlPolicy?.ttlMs ?? 30 * 60 * 1000;
+    const onTimeout = hitlPolicy?.onTimeout;
     const request: HITLRequest = {
       type: "hitl_request",
       correlationId,
@@ -1205,7 +1242,9 @@ Critical rules:
         `\nhttps://github.com/${pr.repo}/pull/${pr.number}`,
       ].filter(Boolean).join("\n"),
       options: ["approve", "reject"],
-      expiresAt: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+      expiresAt: new Date(Date.now() + ttlMs).toISOString(),
+      ttlMs,
+      ...(onTimeout ? { onTimeout } : {}),
       replyTopic,
       sourceMeta: { interface: "discord", ...(devChannelId ? { channelId: devChannelId } : {}) },
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -314,6 +314,21 @@ const pluginRegistry: PluginRegistryEntry[] = [
     },
   },
   {
+    // Registers FunctionExecutors for the five `action.pr_*` /
+    // `action.dispatch_backmerge` skills whose handlers live in
+    // PrRemediatorPlugin. Without this registrar, SkillDispatcherPlugin
+    // logged "No executor found" and the startup validator (#427) raised
+    // `platform.skills_unwired` HIGH every cycle.
+    // Same install-order constraint as alert-skill-executor: AFTER the
+    // ExecutorRegistry exists, BEFORE skill-dispatcher subscribes.
+    name: "pr-remediator-skill-executor",
+    condition: () => true,
+    factory: async () => {
+      const { PrRemediatorSkillExecutorPlugin } = await import("./plugins/pr-remediator-skill-executor-plugin.js");
+      return new PrRemediatorSkillExecutorPlugin(executorRegistry);
+    },
+  },
+  {
     // Intercepts ExecutorRegistry.resolve() to A/B test competing skill variants.
     // Must be installed AFTER registrars (agent-runtime, skill-broker) and
     // BEFORE skill-dispatcher so the hook is active when dispatches begin.

--- a/src/planner/validate-action-executors.ts
+++ b/src/planner/validate-action-executors.ts
@@ -10,7 +10,8 @@
  * gap surfaces in the operator dashboard instead of being buried in logs.
  *
  * Called once at startup AFTER all registrar plugins (agent-runtime,
- * skill-broker, alert-skill-executor, ceremony-skill-executor) have installed. Pre-existing
+ * skill-broker, alert-skill-executor, ceremony-skill-executor,
+ * pr-remediator-skill-executor) have installed. Pre-existing
  * unwired actions don't crash the process — but each one is a feature
  * request signal that the GOAP loop is dispatching into the void on
  * every planning cycle (issue #426).
@@ -45,8 +46,8 @@ export class UnwiredActionsError extends Error {
       `SkillDispatcherPlugin to silently drop the dispatch on every GOAP ` +
       `planning cycle.\n${lines.join("\n")}\n` +
       `Fix: register an executor (agent-runtime, skill-broker, alert-skill-executor, ` +
-      `ceremony-skill-executor, or a FunctionExecutor) for each skill, or remove the action from ` +
-      `workspace/actions.yaml.`,
+      `ceremony-skill-executor, pr-remediator-skill-executor, or a FunctionExecutor) ` +
+      `for each skill, or remove the action from workspace/actions.yaml.`,
     );
     this.name = "UnwiredActionsError";
     this.unwired = unwired;

--- a/src/plugins/__tests__/pr-remediator-skill-executor-plugin.test.ts
+++ b/src/plugins/__tests__/pr-remediator-skill-executor-plugin.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import {
+  PrRemediatorSkillExecutorPlugin,
+  PR_REMEDIATOR_SKILL_TOPICS,
+} from "../pr-remediator-skill-executor-plugin.ts";
+import { ExecutorRegistry } from "../../executor/executor-registry.ts";
+import type { BusMessage } from "../../../lib/types.ts";
+
+/**
+ * Minimal in-memory bus mirroring the AlertSkillExecutor test harness —
+ * captures every published message so we can assert on dispatch shape.
+ */
+function makeBus() {
+  const subs = new Map<string, Array<(msg: BusMessage) => void>>();
+  const published: BusMessage[] = [];
+  return {
+    published,
+    subscribe(topic: string, _name: string, handler: (msg: BusMessage) => void) {
+      if (!subs.has(topic)) subs.set(topic, []);
+      subs.get(topic)!.push(handler);
+      return `sub-${topic}-${Math.random()}`;
+    },
+    unsubscribe(_id: string) {},
+    publish(topic: string, msg: BusMessage) {
+      published.push(msg);
+      const handlers = subs.get(topic) ?? [];
+      for (const h of handlers) h(msg);
+    },
+    topics() { return []; },
+  };
+}
+
+describe("PrRemediatorSkillExecutorPlugin", () => {
+  let registry: ExecutorRegistry;
+  let plugin: PrRemediatorSkillExecutorPlugin;
+  let bus: ReturnType<typeof makeBus>;
+
+  beforeEach(() => {
+    registry = new ExecutorRegistry();
+    plugin = new PrRemediatorSkillExecutorPlugin(registry);
+    bus = makeBus();
+    plugin.install(bus as never);
+  });
+
+  it("registers an executor for every pr-remediator-owned skill", () => {
+    const required = [
+      "action.pr_update_branch",
+      "action.pr_merge_ready",
+      "action.pr_fix_ci",
+      "action.pr_address_feedback",
+      "action.dispatch_backmerge",
+    ];
+    for (const skill of required) {
+      expect(registry.resolve(skill)).not.toBeNull();
+    }
+  });
+
+  it("registry size matches the topic table", () => {
+    expect(registry.size).toBe(PR_REMEDIATOR_SKILL_TOPICS.length);
+  });
+
+  it("each executor publishes on its mapped pr-remediator topic", async () => {
+    for (const entry of PR_REMEDIATOR_SKILL_TOPICS) {
+      // Reset capture between iterations
+      bus.published.length = 0;
+      const executor = registry.resolve(entry.skill)!;
+      const result = await executor.execute({
+        skill: entry.skill,
+        correlationId: `corr-${entry.skill}`,
+        replyTopic: "reply.test",
+        payload: { skill: entry.skill, meta: { actionId: entry.skill, goalId: "test.goal" } },
+      });
+      expect(result.isError).toBe(false);
+      expect(result.correlationId).toBe(`corr-${entry.skill}`);
+      const triggered = bus.published.find(m => m.topic === entry.topic);
+      expect(triggered).toBeDefined();
+      expect(triggered!.correlationId).toBe(`corr-${entry.skill}`);
+    }
+  });
+
+  it("fire-and-forget: returns success synchronously and never awaits the handler", async () => {
+    // The executor must not depend on a subscriber existing — pr-remediator
+    // is a separate plugin and may be absent in dry-run / test environments.
+    const reg2 = new ExecutorRegistry();
+    const plugin2 = new PrRemediatorSkillExecutorPlugin(reg2);
+    const bus2 = makeBus(); // no subscribers
+    plugin2.install(bus2 as never);
+
+    const executor = reg2.resolve("action.pr_update_branch")!;
+    const result = await executor.execute({
+      skill: "action.pr_update_branch",
+      correlationId: "ff-1",
+      replyTopic: "reply.test",
+      payload: { skill: "action.pr_update_branch" },
+    });
+    expect(result.isError).toBe(false);
+    // The publish still happened — no subscribers, but no error either.
+    expect(bus2.published.find(m => m.topic === "pr.remediate.update_branch")).toBeDefined();
+  });
+
+  it("forwards meta (incl. hitlPolicy) into the trigger payload", async () => {
+    const executor = registry.resolve("action.pr_merge_ready")!;
+    const hitlPolicy = { ttlMs: 1_800_000, onTimeout: "approve" as const };
+    await executor.execute({
+      skill: "action.pr_merge_ready",
+      correlationId: "corr-hitl",
+      replyTopic: "reply.test",
+      payload: {
+        skill: "action.pr_merge_ready",
+        meta: {
+          systemActor: "goap",
+          actionId: "action.pr_merge_ready",
+          goalId: "pr.mergeable_flushed",
+          hitlPolicy,
+        },
+      },
+    });
+
+    const triggered = bus.published.find(m => m.topic === "pr.remediate.merge_ready");
+    expect(triggered).toBeDefined();
+    const p = triggered!.payload as { actionId?: string; goalId?: string; meta?: Record<string, unknown> };
+    expect(p.actionId).toBe("action.pr_merge_ready");
+    expect(p.goalId).toBe("pr.mergeable_flushed");
+    expect(p.meta?.hitlPolicy).toEqual(hitlPolicy);
+    expect(p.meta?.systemActor).toBe("goap");
+  });
+
+  it("propagates correlationId on the published trigger", async () => {
+    const executor = registry.resolve("action.dispatch_backmerge")!;
+    await executor.execute({
+      skill: "action.dispatch_backmerge",
+      correlationId: "trace-bm-1",
+      replyTopic: "reply.test",
+      payload: { skill: "action.dispatch_backmerge" },
+    });
+    const triggered = bus.published.find(m => m.topic === "pr.backmerge.dispatch");
+    expect(triggered!.correlationId).toBe("trace-bm-1");
+  });
+
+  it("fails loud when invoked before install (no silent swallow)", async () => {
+    const reg = new ExecutorRegistry();
+    const p = new PrRemediatorSkillExecutorPlugin(reg);
+    // Don't install — but still need to register an executor to test, so
+    // simulate the post-uninstall path.
+    const bus3 = makeBus();
+    p.install(bus3 as never);
+    const executor = reg.resolve("action.pr_fix_ci")!;
+    p.uninstall();
+    const result = await executor.execute({
+      skill: "action.pr_fix_ci",
+      correlationId: "no-bus",
+      replyTopic: "reply.test",
+      payload: { skill: "action.pr_fix_ci" },
+    });
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain("not installed");
+  });
+
+  it("uninstall clears the bus reference (re-install on fresh bus is safe)", () => {
+    plugin.uninstall();
+    const reg2 = new ExecutorRegistry();
+    const plugin2 = new PrRemediatorSkillExecutorPlugin(reg2);
+    const bus2 = makeBus();
+    expect(() => plugin2.install(bus2 as never)).not.toThrow();
+  });
+});
+
+// ── Integration: PrRemediatorPlugin reacts to dispatched skill ────────────────
+//
+// End-to-end check that the executor → bus → pr-remediator handler path is
+// wired correctly. We use the real EventBus and the real PrRemediatorPlugin so
+// the registered subscription on pr.remediate.update_branch actually receives
+// our dispatch.
+
+import { InMemoryEventBus } from "../../../lib/bus";
+import { PrRemediatorPlugin } from "../../../lib/plugins/pr-remediator";
+
+describe("PrRemediatorSkillExecutorPlugin — bus integration", () => {
+  it("dispatching action.pr_update_branch triggers PrRemediatorPlugin's handler", async () => {
+    const bus = new InMemoryEventBus();
+    const remediator = new PrRemediatorPlugin();
+    remediator.install(bus);
+
+    const reg = new ExecutorRegistry();
+    const skillExec = new PrRemediatorSkillExecutorPlugin(reg);
+    skillExec.install(bus);
+
+    // No PR data cached — handler will log "no PRs match" and return cleanly.
+    // We capture the log topic by spying on the underlying bus subscription
+    // count: the remediator subscribes to pr.remediate.update_branch in install.
+    expect(bus.topics().map(t => t.pattern)).toContain("pr.remediate.update_branch");
+
+    const executor = reg.resolve("action.pr_update_branch")!;
+    const result = await executor.execute({
+      skill: "action.pr_update_branch",
+      correlationId: "int-1",
+      replyTopic: "reply.test",
+      payload: { skill: "action.pr_update_branch" },
+    });
+    expect(result.isError).toBe(false);
+
+    remediator.uninstall();
+    skillExec.uninstall();
+  });
+
+  it("dispatching action.dispatch_backmerge reaches the backmerge subscription", async () => {
+    const bus = new InMemoryEventBus();
+    const remediator = new PrRemediatorPlugin();
+    remediator.install(bus);
+
+    const reg = new ExecutorRegistry();
+    const skillExec = new PrRemediatorSkillExecutorPlugin(reg);
+    skillExec.install(bus);
+
+    expect(bus.topics().map(t => t.pattern)).toContain("pr.backmerge.dispatch");
+
+    const executor = reg.resolve("action.dispatch_backmerge")!;
+    const result = await executor.execute({
+      skill: "action.dispatch_backmerge",
+      correlationId: "int-bm",
+      replyTopic: "reply.test",
+      payload: { skill: "action.dispatch_backmerge" },
+    });
+    expect(result.isError).toBe(false);
+
+    remediator.uninstall();
+    skillExec.uninstall();
+  });
+});

--- a/src/plugins/pr-remediator-skill-executor-plugin.ts
+++ b/src/plugins/pr-remediator-skill-executor-plugin.ts
@@ -1,0 +1,119 @@
+/**
+ * PrRemediatorSkillExecutorPlugin — registers FunctionExecutors for the five
+ * GOAP-wired `action.pr_*` and `action.dispatch_backmerge` skills whose
+ * handlers already live in `lib/plugins/pr-remediator.ts`.
+ *
+ * Without these registrations the SkillDispatcherPlugin logs
+ * "No executor found for skill action.pr_..." and drops the dispatch on
+ * every planning cycle. After PR #427 added the startup validator the same
+ * gap also raises a HIGH `platform.skills_unwired` alert each tick.
+ *
+ * The pr-remediator plugin already subscribes to its own internal trigger
+ * topics (`pr.remediate.*`, `pr.backmerge.dispatch`) — see
+ * `PrRemediatorPlugin.install()`. Each executor in this file translates a
+ * GOAP skill dispatch into a publish on the matching trigger topic and
+ * returns a successful SkillResult immediately (fire-and-forget semantics
+ * declared in actions.yaml).
+ *
+ * Routing through the bus rather than calling the plugin directly keeps the
+ * "bus is the contract" invariant — the executor never holds a reference
+ * to PrRemediatorPlugin, only to the EventBus.
+ *
+ * Install order matters: AFTER ExecutorRegistry construction and BEFORE
+ * SkillDispatcherPlugin so registrations resolve on first dispatch.
+ */
+
+import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
+import type { ExecutorRegistry } from "../executor/executor-registry.ts";
+import type { SkillRequest, SkillResult } from "../executor/types.ts";
+import { FunctionExecutor } from "../executor/executors/function-executor.ts";
+
+/**
+ * Maps each GOAP action id to the bus topic that PrRemediatorPlugin already
+ * subscribes to. Adding a new action is one line here plus the corresponding
+ * `bus.subscribe()` in pr-remediator.ts.
+ */
+export const PR_REMEDIATOR_SKILL_TOPICS: ReadonlyArray<{
+  skill: string;
+  topic: string;
+}> = [
+  { skill: "action.pr_update_branch",     topic: "pr.remediate.update_branch" },
+  { skill: "action.pr_merge_ready",       topic: "pr.remediate.merge_ready" },
+  { skill: "action.pr_fix_ci",            topic: "pr.remediate.fix_ci" },
+  { skill: "action.pr_address_feedback",  topic: "pr.remediate.address_feedback" },
+  { skill: "action.dispatch_backmerge",   topic: "pr.backmerge.dispatch" },
+];
+
+export class PrRemediatorSkillExecutorPlugin implements Plugin {
+  readonly name = "pr-remediator-skill-executor";
+  readonly description = "Registers FunctionExecutors that route GOAP `action.pr_*` skills to PrRemediatorPlugin's bus topics";
+  readonly capabilities = ["pr-remediator-dispatch", "executor-registrar"];
+
+  private bus?: EventBus;
+
+  constructor(private readonly registry: ExecutorRegistry) {}
+
+  install(bus: EventBus): void {
+    this.bus = bus;
+    for (const entry of PR_REMEDIATOR_SKILL_TOPICS) {
+      const executor = new FunctionExecutor(async (req) => this._execute(req, entry));
+      this.registry.register(entry.skill, executor, { priority: 5 });
+    }
+    console.log(
+      `[pr-remediator-skill-executor] Registered ${PR_REMEDIATOR_SKILL_TOPICS.length} executor(s): ${PR_REMEDIATOR_SKILL_TOPICS.map(e => e.skill).join(", ")}`,
+    );
+  }
+
+  uninstall(): void {
+    this.bus = undefined;
+  }
+
+  /**
+   * Translate a GOAP skill dispatch into the pr-remediator trigger event.
+   *
+   * The published payload mirrors the meta forwarded by ActionDispatcherPlugin
+   * (actionId, goalId, hitlPolicy, systemActor) so downstream handlers can
+   * honour action-level policy without a second lookup.
+   *
+   * Fire-and-forget: returns a successful SkillResult immediately. The
+   * pr-remediator handler runs asynchronously on the bus subscription.
+   * Failures inside the handler surface via its own logging and HITL
+   * escalation paths — see `_emitStuckHitlEscalation`.
+   */
+  private async _execute(
+    req: SkillRequest,
+    entry: { skill: string; topic: string },
+  ): Promise<SkillResult> {
+    if (!this.bus) {
+      // Fail fast — surface, don't swallow.
+      return {
+        text: "pr-remediator-skill-executor not installed",
+        isError: true,
+        correlationId: req.correlationId,
+      };
+    }
+
+    const meta = (req.payload?.meta ?? {}) as Record<string, unknown>;
+    const triggerMsg: BusMessage = {
+      id: crypto.randomUUID(),
+      correlationId: req.correlationId,
+      ...(req.parentId ? { parentId: req.parentId } : {}),
+      topic: entry.topic,
+      timestamp: Date.now(),
+      payload: {
+        actionId: typeof meta.actionId === "string" ? meta.actionId : entry.skill,
+        goalId: typeof meta.goalId === "string" ? meta.goalId
+          : typeof req.payload?.goalId === "string" ? req.payload.goalId
+          : undefined,
+        meta,
+      },
+    };
+    this.bus.publish(entry.topic, triggerMsg);
+
+    return {
+      text: `dispatched ${entry.skill} → ${entry.topic}`,
+      isError: false,
+      correlationId: req.correlationId,
+    };
+  }
+}

--- a/src/pr-remediator.test.ts
+++ b/src/pr-remediator.test.ts
@@ -799,3 +799,112 @@ describe("PrRemediatorPlugin — diagnose_pr_stuck", () => {
     plugin.uninstall();
   });
 });
+
+// ── hitlPolicy propagation ───────────────────────────────────────────────────
+//
+// action.pr_merge_ready in workspace/actions.yaml declares
+//   meta.hitlPolicy: { ttlMs: 1800000, onTimeout: approve }
+// The PrRemediatorSkillExecutorPlugin forwards meta into the trigger payload
+// on `pr.remediate.merge_ready`. _handleMergeReady extracts it via
+// _extractHitlPolicy and applies it to the HITL request raised when ghMerge
+// fails. This test exercises _emitHitlApproval directly via the same
+// `as unknown as` cast pattern used by the diagnose_pr_stuck tests.
+
+describe("PrRemediatorPlugin — hitlPolicy", () => {
+  type PluginPrivate = {
+    _emitHitlApproval(
+      pr: PrEntry,
+      parentCorrelationId: string,
+      note?: string,
+      hitlPolicy?: { ttlMs?: number; onTimeout?: "approve" | "reject" | "escalate" },
+    ): void;
+    _extractHitlPolicy(msg: BusMessage): { ttlMs?: number; onTimeout?: "approve" | "reject" | "escalate" } | undefined;
+  };
+  function privateOf(plugin: PrRemediatorPlugin): PluginPrivate {
+    return plugin as unknown as PluginPrivate;
+  }
+
+  test("_emitHitlApproval honours hitlPolicy onTimeout=approve and ttlMs", async () => {
+    const bus = new InMemoryEventBus();
+    const plugin = new PrRemediatorPlugin();
+    plugin.install(bus);
+
+    const captured = captureOn(bus, "hitl.request.pr.merge.#");
+    const pr = makePr({ number: 555 });
+    const before = Date.now();
+    privateOf(plugin)._emitHitlApproval(pr, crypto.randomUUID(), "test fallback", {
+      ttlMs: 1_800_000,
+      onTimeout: "approve",
+    });
+    await flushMicrotasks();
+    expect(captured.length).toBe(1);
+    const req = captured[0]!.payload as HITLRequest;
+    expect(req.onTimeout).toBe("approve");
+    expect(req.ttlMs).toBe(1_800_000);
+    const expiresAtMs = Date.parse(req.expiresAt);
+    // Expiry should be ~30 min in the future (allow generous tolerance for CI).
+    expect(expiresAtMs - before).toBeGreaterThanOrEqual(1_800_000 - 1000);
+    expect(expiresAtMs - before).toBeLessThanOrEqual(1_800_000 + 5000);
+
+    plugin.uninstall();
+  });
+
+  test("_emitHitlApproval falls back to 30min escalation when no policy passed", async () => {
+    const bus = new InMemoryEventBus();
+    const plugin = new PrRemediatorPlugin();
+    plugin.install(bus);
+
+    const captured = captureOn(bus, "hitl.request.pr.merge.#");
+    privateOf(plugin)._emitHitlApproval(makePr({ number: 556 }), crypto.randomUUID(), "no-policy");
+    await flushMicrotasks();
+    const req = captured[0]!.payload as HITLRequest;
+    expect(req.onTimeout).toBeUndefined(); // → escalate behaviour in HITLPlugin
+    expect(req.ttlMs).toBe(30 * 60 * 1000);
+
+    plugin.uninstall();
+  });
+
+  test("_extractHitlPolicy parses meta.hitlPolicy from a trigger msg", () => {
+    const plugin = new PrRemediatorPlugin();
+    const policy = privateOf(plugin)._extractHitlPolicy({
+      id: "x",
+      correlationId: "y",
+      topic: "pr.remediate.merge_ready",
+      timestamp: Date.now(),
+      payload: {
+        meta: {
+          hitlPolicy: { ttlMs: 1_800_000, onTimeout: "approve" },
+        },
+      },
+    });
+    expect(policy).toEqual({ ttlMs: 1_800_000, onTimeout: "approve" });
+  });
+
+  test("_extractHitlPolicy returns undefined when meta.hitlPolicy is missing", () => {
+    const plugin = new PrRemediatorPlugin();
+    const policy = privateOf(plugin)._extractHitlPolicy({
+      id: "x",
+      correlationId: "y",
+      topic: "pr.remediate.merge_ready",
+      timestamp: Date.now(),
+      payload: { meta: {} },
+    });
+    expect(policy).toBeUndefined();
+  });
+
+  test("_extractHitlPolicy ignores unknown onTimeout values", () => {
+    const plugin = new PrRemediatorPlugin();
+    const policy = privateOf(plugin)._extractHitlPolicy({
+      id: "x",
+      correlationId: "y",
+      topic: "pr.remediate.merge_ready",
+      timestamp: Date.now(),
+      payload: {
+        meta: {
+          hitlPolicy: { ttlMs: 1000, onTimeout: "bogus" },
+        },
+      },
+    });
+    expect(policy).toEqual({ ttlMs: 1000 });
+  });
+});


### PR DESCRIPTION
Partial fix for #430 — wires the 5 pr-remediator-owned skills (separate PR will cover ceremony + protomaker actions).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PR merge approvals now support configurable expiration and timeout policies, allowing operators to define how long approval requests remain active.
  * Pull request automation skills are now properly registered and executable in the system.

* **Documentation**
  * Updated validation error messages to reference newly registered skill executors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->