### PR TITLE
feat(agents): register protomaker A2A agent

### DIFF
--- a/workspace/agents.yaml
+++ b/workspace/agents.yaml
@@ -74,6 +74,22 @@ agents:
   #     - message.inbound.discord.#
   #     - message.inbound.github.#
 
+  # protoMaker — Automaker-server agent (apps/server in protoLabsAI/ava).
+  # Hosts the project board, auto-mode runtime, and feature/PR pipeline.
+  # Reached on the docker-ai network as automaker-server:3008/a2a; advertises
+  # 10 skills (chat, sitrep, manage_feature, auto_mode, board_health,
+  # bug_triage, onboard_project, provision_discord, plan, plan_resume).
+  # Auth: AVA_API_KEY (the same Ava-app key used for HTTP /api/* — protoMaker
+  # validates X-API-Key against its per-app key table).
+  - name: protomaker
+    url: http://automaker-server:3008/a2a
+    auth:
+      scheme: apiKey
+      credentialsEnv: AVA_API_KEY
+    streaming: false
+    subscribesTo:
+      - message.inbound.github.#
+
   # protopen — security/pentest/RF recon. Remote via Tailscale
   # (PROTOPEN_BASE_URL defaults to http://steamdeck:7870 in homelab-iac).
   # Serves the legacy /.well-known/agent.json path; advertises streaming:true.


### PR DESCRIPTION
Closes the protomaker portion of #430 (the final 2 of the 9 unwired actions surfaced by #427's validator).

## What & why

The two unwired actions targeting protomaker:

- \`action.protomaker_triage_blocked\` → skill \`board_health\`
- \`action.protomaker_start_auto_mode\` → skill \`auto_mode\`

were dropping because no agent named \`protomaker\` was registered, even though the protoMaker A2A surface (\`automaker-server:3008/a2a\`) has been live and advertising both skills (plus 8 more) for a while.

## Verification

\`\`\`bash
# From inside the workstacean container:
curl -s -H \"X-API-Key: \$AVA_API_KEY\" -X POST http://automaker-server:3008/a2a \\
  -H 'Content-Type: application/json' \\
  -d '{\"jsonrpc\":\"2.0\",\"id\":\"test\",\"method\":\"message/send\",\"params\":{\"message\":{\"role\":\"user\",\"parts\":[{\"kind\":\"text\",\"text\":\"sitrep\"}]}}}'
# → {\"jsonrpc\":\"2.0\",\"id\":\"test\",\"result\":{\"id\":\"...\",\"status\":{\"state\":\"completed\"},\"artifacts\":[...]}}
\`\`\`

Card available at \`http://automaker-server:3008/.well-known/agent-card.json\` lists all 10 skills.

## Test plan

- [ ] After merge + redeploy, \`docker logs workstacean | grep \"agent-card discovery\"\` should show successful card fetch for \`protomaker\`
- [ ] \`docker logs workstacean | grep \"No executor found.*protomaker\"\` should be empty
- [ ] World-state \`domains.agent_health.data.agents.protomaker\` should report \`reachable: true\` with all 10 skills
- [ ] Validator (#427) should drop \`action.protomaker_triage_blocked\` / \`action.protomaker_start_auto_mode\` from its unwired list