### PR TITLE
fix(agents): drop overscoped subscribesTo from protomaker entry

### DIFF
--- a/workspace/agents.yaml
+++ b/workspace/agents.yaml
@@ -81,14 +81,18 @@ agents:
   # bug_triage, onboard_project, provision_discord, plan, plan_resume).
   # Auth: AVA_API_KEY (the same Ava-app key used for HTTP /api/* — protoMaker
   # validates X-API-Key against its per-app key table).
+  #
+  # No subscribesTo: protoMaker is reached via explicit GOAP `targets:
+  # [protomaker]` dispatches (board_health, auto_mode, bug_triage etc.) — it
+  # is not a broadcast inbound listener. Quinn already subscribes to GitHub
+  # inbound and triages on protoMaker's behalf via `bug_triage`; adding a
+  # second subscriber here would duplicate dispatch with no extra value.
   - name: protomaker
     url: http://automaker-server:3008/a2a
     auth:
       scheme: apiKey
       credentialsEnv: AVA_API_KEY
     streaming: false
-    subscribesTo:
-      - message.inbound.github.#
 
   # protopen — security/pentest/RF recon. Remote via Tailscale
   # (PROTOPEN_BASE_URL defaults to http://steamdeck:7870 in homelab-iac).


### PR DESCRIPTION
Cleans up #433. Companion to protoLabsAI/protoMaker#3503.

## What

Remove \`subscribesTo: message.inbound.github.#\` from the \`protomaker\` agent registration. Comment block now explains why protoMaker is action-target-only and not a broadcast subscriber.

## Why

#433 (protomaker A2A registration) copy-pasted quinn's pattern, which included broadcast subscription to GitHub inbound. That was wrong:

- protoMaker is reached via explicit GOAP \`targets: [protomaker]\` dispatches (\`action.protomaker_triage_blocked\`, \`action.protomaker_start_auto_mode\`)
- Quinn already subscribes to GitHub inbound and dispatches \`bug_triage\` on protoMaker's behalf
- Having both subscribe to the same broadcast doubles the firing path

This isn't the root cause of the duplicate-triage spam (filed as protoLabsAI/protoMaker#3503 — Quinn's handler isn't idempotent), but it removes one extra contributing path while we wait for the protoMaker-side fix.

## Test plan

- [ ] After merge + redeploy, world-state \`agents.protomaker\` should still be reachable (target-based dispatch path is unchanged)
- [ ] \`docker logs workstacean | grep \"Dispatching.*targets: protomaker\"\` should still fire on \`action.protomaker_*\` GOAP cycles
- [ ] No new entries from broadcast \`message.inbound.github.#\` should hit the protomaker A2AExecutor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated protomaker agent configuration and dispatch behavior.

* **Documentation**
  * Added clarifying comments to agent registry configuration explaining how the protomaker agent is invoked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->