### PR TITLE
fix(ava): rename web_search → searxng_search to match runtime tool name

### DIFF
--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -53,7 +53,7 @@ systemPrompt: |
   - **get_incidents** — Open security/operational incidents.
   - **get_cost_summary** — Per-agent/skill cost: tokens, duration, dollars.
   - **get_confidence_summary** — Per-agent/skill calibration metrics.
-  - **web_search** — Quick web search. For deep research, delegate to Researcher.
+  - **searxng_search** — Quick web search via SearXNG. For deep research, delegate to Researcher.
 
   ### Write / Act
   - **manage_board** — Create or update features on the protoMaker board.
@@ -187,7 +187,7 @@ tools:
   - get_incidents
   - get_cost_summary
   - get_confidence_summary
-  - web_search
+  - searxng_search
   # ── Write / Act ────────────────────────────────────────────────────
   - manage_board
   - create_github_issue


### PR DESCRIPTION
## Symptom

Ava, asked directly to list her tools, says: *\"I don't have a \`searxng_search\` or \`web_search\` tool in my current toolkit.\"* — and at startup the runtime warns:

\`\`\`
[agent-runtime] WARNING: agent ava declares unknown tools: web_search
\`\`\`

## Root cause

PR #411 (feat: upgrade web_search → searxng_search) renamed the tool in code (\`src/agent-runtime/tools/bus-tools.ts:393\` registers it as \`searxng_search\`) but \`workspace/agents/ava.yaml\` still declared the old name in two places (description block + tools list). Result: the agent-runtime can't bind a tool that doesn't exist under that name, and Ava has no search capability at all.

## Fix

Two-line rename in \`workspace/agents/ava.yaml\`. Workspace is bind-mounted so a workstacean restart picks it up — no image rebuild needed.

## Test plan

- [ ] After merge + workstacean restart: \`docker logs workstacean | grep \"unknown tools\" | grep ava\` should be empty
- [ ] Ask Ava (\`POST :3000/v1/chat/completions\` with \`model: \"ava\"\`) to list her tools — \`searxng_search\` should appear
- [ ] Ask Ava to do a quick web search — should run via \`searxng_search\` instead of recommending delegation to Researcher

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated search tool naming to explicitly identify SearXNG as the provider for quick web searches. Deep research requests continue to be delegated to the Researcher tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->