### PR TITLE
fix(goap): disable fleet_agent_stuck loop — fires every cycle, no dedup

### DIFF
--- a/workspace/actions.yaml
+++ b/workspace/actions.yaml
@@ -498,40 +498,49 @@ actions:
   # incident, page on-call, and pause auto-routing to the stuck
   # agent until its failure rate falls below 50%.
 
-  - id: alert.fleet_agent_stuck
-    goalId: fleet.no_agent_stuck
-    tier: tier_0
-    priority: 20
-    cost: 0
-    name: "Alert when an agent's 1h failure rate exceeds 50%"
-    preconditions:
-      - path: "extensions.agent_fleet_health_available"
-        operator: eq
-        value: true
-      - path: "domains.agent_fleet_health.data.maxFailureRate1h"
-        operator: gt
-        value: 0.5
-    effects: []
-    meta:
-      fireAndForget: true
-
-  - id: action.fleet_incident_response
-    goalId: fleet.no_agent_stuck
-    tier: tier_0
-    priority: 30
-    cost: 1
-    name: "Dispatch Ava to open incident, page on-call, and pause routing for stuck agent"
-    preconditions:
-      - path: "extensions.agent_fleet_health_available"
-        operator: eq
-        value: true
-      - path: "domains.agent_fleet_health.data.maxFailureRate1h"
-        operator: gt
-        value: 0.5
-    effects: []
-    meta:
-      skillHint: fleet_incident_response
-      fireAndForget: true
+  # DISABLED 2026-04-20 — both actions had no cooldown and no `effects`,
+  # so GOAP re-fired them every planning cycle while the goal stayed
+  # violated. Result: 7+ duplicate INC-* incidents filed in seconds plus
+  # Discord alert spam (observed: INC-003 through INC-009 in ~30s,
+  # auto-triage-sweep stuck loop). Reinstate after a dedup/cooldown is
+  # added on the action side AND Ava's fleet_incident_response skill
+  # checks for an existing open incident before filing a new one.
+  # Tracking: protoLabsAI/protoWorkstacean#TBD
+  #
+  # - id: alert.fleet_agent_stuck
+  #   goalId: fleet.no_agent_stuck
+  #   tier: tier_0
+  #   priority: 20
+  #   cost: 0
+  #   name: "Alert when an agent's 1h failure rate exceeds 50%"
+  #   preconditions:
+  #     - path: "extensions.agent_fleet_health_available"
+  #       operator: eq
+  #       value: true
+  #     - path: "domains.agent_fleet_health.data.maxFailureRate1h"
+  #       operator: gt
+  #       value: 0.5
+  #   effects: []
+  #   meta:
+  #     fireAndForget: true
+  #
+  # - id: action.fleet_incident_response
+  #   goalId: fleet.no_agent_stuck
+  #   tier: tier_0
+  #   priority: 30
+  #   cost: 1
+  #   name: "Dispatch Ava to open incident, page on-call, and pause routing for stuck agent"
+  #   preconditions:
+  #     - path: "extensions.agent_fleet_health_available"
+  #       operator: eq
+  #       value: true
+  #     - path: "domains.agent_fleet_health.data.maxFailureRate1h"
+  #       operator: gt
+  #       value: 0.5
+  #   effects: []
+  #   meta:
+  #     skillHint: fleet_incident_response
+  #     fireAndForget: true
 
   # ── HITL routing health ───────────────────────────────────────────
   #


### PR DESCRIPTION
Stops the duplicate-incident spam loop observed today. See companion issue for the proper fix.

## Symptom

When \`auto-triage-sweep\`'s 1h failure rate on \`bug_triage\` hit 100% (cascading from the non-idempotent handler in protoLabsAI/protoMaker#3503), Ava filed **INC-003 through INC-009 in ~30 seconds** and Discord got 7+ duplicate \"agent stuck\" posts. Each cycle of the GOAP planner re-fired both actions on goal \`fleet.no_agent_stuck\`.

## Root cause

Both actions:
- \`alert.fleet_agent_stuck\`
- \`action.fleet_incident_response\`

…have **\`effects: []\` and no cooldown**. So GOAP correctly identifies the goal as still violated on the next cycle and re-fires both. The pause-routing side effect succeeds but the rolling 1h failure rate metric doesn't drop immediately, so the goal stays violated and the loop continues.

## Mitigation

Comment out both actions in \`workspace/actions.yaml\`. Already applied live via direct edit + \`docker restart workstacean\` (workspace is bind-mounted) — Discord spam stopped within seconds. This PR commits the change for the next watchtower-redeploy.

## What this loses

While disabled, the system won't:
- Post a Discord alert when an agent's failure rate exceeds 50% (operators must check world-state directly)
- Auto-file an incident or pause routing to a stuck agent

These are valuable behaviors — we want them back, just not in a tight loop. See follow-up issue for the proper fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automated fleet agent health monitoring and incident response actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->