### PR TITLE
fix(goap): disable 4 more action.* loops — same no-cooldown bug as #436

### DIFF
--- a/workspace/actions.yaml
+++ b/workspace/actions.yaml
@@ -585,23 +585,25 @@ actions:
     meta:
       fireAndForget: true
 
-  - id: action.fleet_downshift_models
-    goalId: fleet.cost_under_budget
-    tier: tier_0
-    priority: 30
-    cost: 1
-    name: "Downshift to cheaper models on low-blast skills when fleet spend exceeds budget"
-    preconditions:
-      - path: "extensions.agent_fleet_health_available"
-        operator: eq
-        value: true
-      - path: "domains.agent_fleet_health.data.totalCostUsd1d"
-        operator: gt
-        value: 50
-    effects: []
-    meta:
-      skillHint: downshift_models
-      fireAndForget: true
+  # DISABLED 2026-04-20 — same no-cooldown loop bug as #436. Re-fires every
+  # GOAP cycle while fleet.cost_under_budget is violated. Tracking: #437.
+  # - id: action.fleet_downshift_models
+  #   goalId: fleet.cost_under_budget
+  #   tier: tier_0
+  #   priority: 30
+  #   cost: 1
+  #   name: "Downshift to cheaper models on low-blast skills when fleet spend exceeds budget"
+  #   preconditions:
+  #     - path: "extensions.agent_fleet_health_available"
+  #       operator: eq
+  #       value: true
+  #     - path: "domains.agent_fleet_health.data.totalCostUsd1d"
+  #       operator: gt
+  #       value: 50
+  #   effects: []
+  #   meta:
+  #     skillHint: downshift_models
+  #     fireAndForget: true
 
   # ── Skill orphan detection (Arc 8.5) ──────────────────────────────
 
@@ -622,24 +624,29 @@ actions:
     meta:
       fireAndForget: true
 
-  - id: action.fleet_investigate_orphaned_skills
-    goalId: fleet.no_skill_orphaned
-    tier: tier_0
-    priority: 30
-    cost: 1
-    name: "Dispatch Ava to investigate orphaned skills and diagnose capability regression"
-    preconditions:
-      - path: "extensions.agent_fleet_health_available"
-        operator: eq
-        value: true
-      - path: "domains.agent_fleet_health.data.orphanedSkillCount"
-        operator: gt
-        value: 0
-    effects: []
-    meta:
-      skillHint: investigate_orphaned_skills
-      agentId: ava
-      fireAndForget: true
+  # DISABLED 2026-04-20 — confirmed Discord spam source. No cooldown means
+  # Ava re-investigates orphaned skills every GOAP cycle (~3s) while the
+  # goal stays violated, posting a new diagnosis to Discord ops each time.
+  # Observed: 8+ near-identical "Orphaned Skill Investigation Complete"
+  # posts in 1 min on 2026-04-20T07:28-07:31. Tracking: #437.
+  # - id: action.fleet_investigate_orphaned_skills
+  #   goalId: fleet.no_skill_orphaned
+  #   tier: tier_0
+  #   priority: 30
+  #   cost: 1
+  #   name: "Dispatch Ava to investigate orphaned skills and diagnose capability regression"
+  #   preconditions:
+  #     - path: "extensions.agent_fleet_health_available"
+  #       operator: eq
+  #       value: true
+  #     - path: "domains.agent_fleet_health.data.orphanedSkillCount"
+  #       operator: gt
+  #       value: 0
+  #   effects: []
+  #   meta:
+  #     skillHint: investigate_orphaned_skills
+  #     agentId: ava
+  #     fireAndForget: true
 
   # ── Issue Zero — triage open GitHub issues ────────────────────────
   #
@@ -664,24 +671,27 @@ actions:
     meta:
       fireAndForget: true
 
-  - id: action.issues_triage_critical
-    goalId: issues.zero_critical
-    tier: tier_0
-    priority: 80
-    cost: 1
-    name: "Dispatch Ava to triage critical GitHub issues"
-    preconditions:
-      - path: "extensions.github_issues_available"
-        operator: eq
-        value: true
-      - path: "domains.github_issues.data.criticalOpen"
-        operator: gt
-        value: 0
-    effects: []
-    meta:
-      skillHint: issue_triage
-      agentId: ava
-      fireAndForget: true
+  # DISABLED 2026-04-20 — same loop pattern as #436. ~447 fires in 30 min
+  # observed today. Each fire dispatches Ava to triage every open critical
+  # issue again, with no idempotency check. Tracking: #437.
+  # - id: action.issues_triage_critical
+  #   goalId: issues.zero_critical
+  #   tier: tier_0
+  #   priority: 80
+  #   cost: 1
+  #   name: "Dispatch Ava to triage critical GitHub issues"
+  #   preconditions:
+  #     - path: "extensions.github_issues_available"
+  #       operator: eq
+  #       value: true
+  #     - path: "domains.github_issues.data.criticalOpen"
+  #       operator: gt
+  #       value: 0
+  #   effects: []
+  #   meta:
+  #     skillHint: issue_triage
+  #     agentId: ava
+  #     fireAndForget: true
 
   - id: alert.issues_bugs
     goalId: issues.zero_bugs
@@ -700,24 +710,27 @@ actions:
     meta:
       fireAndForget: true
 
-  - id: action.issues_triage_bugs
-    goalId: issues.zero_bugs
-    tier: tier_0
-    priority: 35
-    cost: 1
-    name: "Dispatch Ava to triage open bug issues"
-    preconditions:
-      - path: "extensions.github_issues_available"
-        operator: eq
-        value: true
-      - path: "domains.github_issues.data.bugOpen"
-        operator: gt
-        value: 0
-    effects: []
-    meta:
-      skillHint: issue_triage
-      agentId: ava
-      fireAndForget: true
+  # DISABLED 2026-04-20 — same loop pattern as #436. ~447 fires in 30 min
+  # observed today. Each fire dispatches Ava to triage every open bug,
+  # cascading into duplicate board features (downstream of #3503). Tracking: #437.
+  # - id: action.issues_triage_bugs
+  #   goalId: issues.zero_bugs
+  #   tier: tier_0
+  #   priority: 35
+  #   cost: 1
+  #   name: "Dispatch Ava to triage open bug issues"
+  #   preconditions:
+  #     - path: "extensions.github_issues_available"
+  #       operator: eq
+  #       value: true
+  #     - path: "domains.github_issues.data.bugOpen"
+  #       operator: gt
+  #       value: 0
+  #   effects: []
+  #   meta:
+  #     skillHint: issue_triage
+  #     agentId: ava
+  #     fireAndForget: true
 
   - id: alert.issues_total_high
     goalId: issues.total_low


### PR DESCRIPTION
Stopgap. Tracking proper fix in #437.

## Symptom

After #436 disabled \`action.fleet_incident_response\`, observed Discord-ops spam from 4 more action.* dispatches sharing the same architectural bug:

| Action | Skill dispatched | Symptom today |
|--------|-----------------|---------------|
| \`action.fleet_investigate_orphaned_skills\` | Ava → \`investigate_orphaned_skills\` | 8+ near-identical \"Orphaned Skill Investigation Complete\" Discord posts in 1 min on 2026-04-20T07:28-07:31 |
| \`action.issues_triage_critical\` | Ava → \`issue_triage\` | ~447 fires in 30 min — Ava re-triaged the same critical issues every cycle |
| \`action.issues_triage_bugs\` | Ava → \`issue_triage\` | ~447 fires in 30 min — compounds with the upstream protoMaker#3503 idempotency bug |
| \`action.fleet_downshift_models\` | Ava → \`downshift_models\` | Same pattern, fires when fleet spend exceeds budget |

## Same root cause as #436

All four have \`effects: []\` and no \`meta.cooldownMs\`. So GOAP correctly identifies the goal as still violated on the next planning cycle (~3s later) and re-fires. The dispatched skill runs a fresh investigation/triage, posts a fresh report — repeat forever.

## Mitigation

Comment out all four in \`workspace/actions.yaml\`. Already applied live via direct edit + \`docker restart workstacean\` — Discord ops went silent within seconds and stayed silent for 15+ min. This PR commits the change.

## What this loses (temporarily)

- Ava no longer auto-investigates orphaned skills (operator must trigger manually)
- New critical/bug GitHub issues won't auto-triage on filing (operator must invoke Ava with \`issue_triage\` skill)
- Fleet-wide cost overruns won't trigger model downshift

These are real autonomy losses. Reinstate when #437 ships either:
1. Action-level \`meta.cooldownMs\` honored by the dispatcher
2. \`effects\` field that satisfies the goal for a TTL window
3. Skill-side idempotency (Ava checks \"did I just do this\" before acting)

## The 24 alert.* siblings

\`alert.*\` actions share the exact same bug but aren't impacting Discord today because \`DISCORD_WEBHOOK_ALERTS\` is unset → WorldEngineAlertPlugin drops them silently. They still cost CPU (601 fires/30min on the worst ones). #437's fix will cover both layers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Disabled automated fleet cost optimization
  * Disabled automated skill orphaning investigation
  * Disabled automated critical and bug issue triage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->