### PR TITLE
fix(ceremonies): route 4 ceremonies to right skill owner, disable 3 broken

### DIFF
--- a/workspace/ceremonies/agent-health.yaml
+++ b/workspace/ceremonies/agent-health.yaml
@@ -1,12 +1,23 @@
 id: agent-health
 name: "Agent Health Check"
 description: >
-  Triggered by world engine when no agents are registered (agentCount drops to 0).
-  Calls get_world_state to confirm the failure, posts a structured alert with
-  remediation steps, and logs if Discord is unreachable.
+  DISABLED 2026-04-20 — calls skill `health_check` which no agent in the
+  fleet advertises. Every cron fire dropped at the dispatcher with
+  "No executor found for targets [all] or skill 'health_check'". Result
+  was a guaranteed FAILURE on every */15 min tick, polluting logs.
+
+  The data this ceremony was meant to surface (which agents are reachable,
+  current skill counts, last probe latency) is already collected every 60s
+  by the world-state engine via the `agent_health` domain and exposed at
+  `/api/agent-health`. No re-implementation needed — operators / Ava read
+  the snapshot directly.
+
+  Re-enable with a real skill if a periodic ANNOUNCE-to-Discord behavior
+  is wanted (e.g. wire a small `agent_health_report` skill on protobot
+  that posts the snapshot to ops). Until then, this stays off.
 schedule: "*/15 * * * *"
 skill: health_check
 targets:
   - all
 notifyChannel: ""
-enabled: true
+enabled: false

--- a/workspace/ceremonies/board.cleanup.yaml
+++ b/workspace/ceremonies/board.cleanup.yaml
@@ -1,8 +1,10 @@
 id: board.cleanup
 name: Board Cleanup
 schedule: "0 8 * * *"
+# board_audit is advertised by Quinn — broadcasting to [all] caused 404s on
+# every other agent each fire. Route to Quinn directly.
 skill: board_audit
 targets:
-  - all
+  - quinn
 notifyChannel: ""
 enabled: true

--- a/workspace/ceremonies/board.health.yaml
+++ b/workspace/ceremonies/board.health.yaml
@@ -2,7 +2,10 @@ id: board.health
 name: Board Health Check
 schedule: "*/30 * * * *"
 skill: board_health
+# Only protomaker (apps/server in protoLabsAI/ava) advertises board_health —
+# the previous targets:[all] broadcast caused 404s on quinn/jon/researcher
+# every fire because they don't have the skill.
 targets:
-  - all
+  - protomaker
 notifyChannel: ""
 enabled: true

--- a/workspace/ceremonies/board.retro.yaml
+++ b/workspace/ceremonies/board.retro.yaml
@@ -1,8 +1,12 @@
 id: board.retro
 name: Weekly Retrospective
 schedule: "0 9 * * 1"
+# DISABLED 2026-04-20 — calls skill `pattern_analysis` which no agent
+# advertises. Every Monday 09:00 fire dropped at the dispatcher with
+# "No executor found for targets [all] or skill 'pattern_analysis'".
+# Re-enable when a retrospective skill is wired (Quinn or Ava could host it).
 skill: pattern_analysis
 targets:
   - all
 notifyChannel: ""
-enabled: true
+enabled: false

--- a/workspace/ceremonies/daily-standup.yaml
+++ b/workspace/ceremonies/daily-standup.yaml
@@ -2,8 +2,12 @@ id: daily-standup
 name: "Daily Fleet Standup"
 description: "Morning ceremony: board summary, active ceremonies, open PRs"
 schedule: "0 9 * * 1-5"
+# board_audit lives on Quinn (not Ava). Ava advertises chat / goal_proposal /
+# diagnose_pr_stuck / debug_ci_failures / fleet_incident_response /
+# downshift_models / investigate_orphaned_skills / issue_triage. Quinn is the
+# QA agent and the canonical board auditor.
 skill: board_audit
 targets:
-  - ava
+  - quinn
 notifyChannel: "1469195643590541353"
 enabled: true

--- a/workspace/ceremonies/health-check.yaml
+++ b/workspace/ceremonies/health-check.yaml
@@ -2,8 +2,13 @@ id: health_check
 name: "Service Health Check"
 description: "Triggered by world engine when a service domain collection fails. Investigates and reports the health status of fleet infrastructure dependencies."
 schedule: "0 */6 * * *"
+# board_audit lives on Quinn (not Ava) — same fix as daily-standup. The name
+# of this ceremony is misleading: it dispatches a board audit, not a service
+# health check. Service-health domain data already comes from world-state
+# polling; if a real periodic service health REPORT is wanted, wire a new
+# skill on protobot or Quinn.
 skill: board_audit
 targets:
-  - ava
+  - quinn
 notifyChannel: ""
 enabled: true

--- a/workspace/ceremonies/service-health.yaml
+++ b/workspace/ceremonies/service-health.yaml
@@ -1,13 +1,21 @@
 id: service-health
 name: "Service Health Recovery"
 description: >
-  Triggered by world engine when a critical service (Discord bot or LLM gateway)
-  becomes unavailable. Calls get_world_state to confirm the failure, posts a
-  structured alert to the Discord alerts channel with remediation steps, and
-  falls back to logging if Discord itself is unreachable.
+  DISABLED 2026-04-20 — calls skill `health_check` which no agent in the
+  fleet advertises (same gap as agent-health.yaml). Every 4-hour cron fire
+  dropped at the dispatcher.
+
+  The data this ceremony was meant to surface (Discord bot reachability,
+  LLM gateway availability) is already collected every 60s by the
+  world-state engine via the `services` domain and exposed at
+  `/api/services`.
+
+  Re-enable with a real skill if a periodic ANNOUNCE-to-Discord behavior
+  is wanted (e.g. wire a small `service_health_report` skill on protobot
+  that posts the snapshot to ops). Until then, this stays off.
 schedule: "0 */4 * * *"
 skill: health_check
 targets:
   - all
 notifyChannel: ""
-enabled: true
+enabled: false


### PR DESCRIPTION
Audit of all 10 \`workspace/ceremonies/*.yaml\` against the live agent skill registry surfaced 7 with skill-target mismatches that fail every fire.

## Routed (4)
| Ceremony | Skill | Was | Now |
|---|---|---|---|
| board.cleanup | board_audit | targets:[all] | targets:[quinn] |
| board.health | board_health | targets:[all] | targets:[protomaker] |
| daily-standup | board_audit | targets:[ava] | targets:[quinn] |
| health-check | board_audit | targets:[ava] | targets:[quinn] |

\`board_audit\` lives on Quinn (not Ava). \`board_health\` lives on protomaker.

## Disabled (3)
| Ceremony | Skill | Why |
|---|---|---|
| agent-health | health_check | No agent advertises health_check |
| board.retro | pattern_analysis | No agent advertises pattern_analysis |
| service-health | health_check | Same as agent-health; data already in /api/services |

## Caveat — disable bug

Per #453, \`enabled: false\` is not honored on initial ceremony load (only on hot-reload). So the 3 disabled here will still fire and fail until #453 lands. Their failures are logs-only (no Discord, no skill executor side effects), so this is non-blocking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled three automated health-check ceremonies (`agent-health`, `board.retro`, `service-health`) to resolve configuration issues.
  * Updated ceremony routing to target specific agents instead of all agents for improved reliability (`daily-standup`, `health-check`, `board.cleanup`, `board.health`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->