### PR TITLE
fix(ceremony): honor enabled:false on initial load (closes #453)

### DIFF
--- a/src/loaders/ceremonyYamlLoader.ts
+++ b/src/loaders/ceremonyYamlLoader.ts
@@ -118,10 +118,12 @@ export class CeremonyYamlLoader {
 
     const c = raw as Record<string, unknown>;
 
-    // Disabled ceremonies are still returned (with enabled: false) so hot-reload
-    // can cancel their timers. Previously returning null here meant
-    // _reloadChangedCeremonies never saw the disabled entry and the old timer
-    // kept firing — the ceremony was "disabled" in YAML but alive in memory.
+    // Disabled ceremonies are still returned (with enabled: false). The
+    // CeremonyPlugin scheduler is responsible for filtering them — at both
+    // initial load and hot-reload — so a disabled entry never lands in the
+    // ceremony registry and external `ceremony.<id>.execute` triggers cannot
+    // resurrect it. Previously returning null here also broke hot-reload's
+    // _reloadChangedCeremonies path, which couldn't see a disappearing entry.
 
     if (typeof c.id !== "string" || !c.id) {
       console.warn(`[ceremony-loader] Skipping ${filePath} (${source}): missing required 'id' field`);

--- a/src/plugins/CeremonyPlugin.ts
+++ b/src/plugins/CeremonyPlugin.ts
@@ -254,6 +254,13 @@ export class CeremonyPlugin implements Plugin {
     const loaded = this.loader.loadMerged();
 
     for (const ceremony of loaded.ceremonies) {
+      if (ceremony.enabled === false) {
+        // Greenfield: disabled = disabled everywhere. Do not register, do not
+        // schedule, and skip state extension so external `ceremony.<id>.execute`
+        // triggers cannot resurrect the ceremony via the registry lookup.
+        console.log(`[ceremony] Skipping disabled ceremony: ${ceremony.id}`);
+        continue;
+      }
       this.ceremonies.set(ceremony.id, ceremony);
       this.stateExtension.registerCeremony(ceremony);
       this._scheduleCeremony(ceremony);
@@ -501,13 +508,16 @@ export class CeremonyPlugin implements Plugin {
           this.fileSnapshots.set(filePath, { mtime: Date.now(), size: stat });
 
           if (!existing) {
-            // New file — load and schedule
+            // New file — load and schedule (skipping disabled entries).
             const ceremonies = this.loader.loadGlobal();
             for (const ceremony of ceremonies) {
-              if (!this.ceremonies.has(ceremony.id)) {
-                this.registerCeremony(ceremony);
-                console.log(`[ceremony] Hot-loaded new ceremony: ${ceremony.id}`);
+              if (this.ceremonies.has(ceremony.id)) continue;
+              if (ceremony.enabled === false) {
+                console.log(`[ceremony] Skipping disabled ceremony: ${ceremony.id}`);
+                continue;
               }
+              this.registerCeremony(ceremony);
+              console.log(`[ceremony] Hot-loaded new ceremony: ${ceremony.id}`);
             }
           } else {
             // Changed file — reload all and reschedule changed ceremonies
@@ -524,6 +534,18 @@ export class CeremonyPlugin implements Plugin {
     const loaded = this.loader.loadMerged();
     for (const ceremony of loaded.ceremonies) {
       const existing = this.ceremonies.get(ceremony.id);
+
+      if (ceremony.enabled === false) {
+        // Flip enabled→disabled (or stayed-disabled): cancel any timer and
+        // drop from registry so external triggers cannot fire it. Greenfield:
+        // disabled = disabled everywhere.
+        if (existing) {
+          this.unregisterCeremony(ceremony.id);
+          console.log(`[ceremony] Hot-disabled ceremony: ${ceremony.id}`);
+        }
+        continue;
+      }
+
       if (!existing || JSON.stringify(existing) !== JSON.stringify(ceremony)) {
         this.ceremonies.set(ceremony.id, ceremony);
         this.stateExtension.registerCeremony(ceremony);

--- a/src/plugins/__tests__/CeremonyPlugin.test.ts
+++ b/src/plugins/__tests__/CeremonyPlugin.test.ts
@@ -58,7 +58,17 @@ enabled: true
     expect(ceremonies.some((c) => c.id === "board.health")).toBe(true);
   });
 
-  test("CeremonyPlugin loader: loads disabled ceremonies but does not schedule them", () => {
+  test("CeremonyPlugin loader: skips disabled ceremonies on initial load (#453)", () => {
+    writeCeremony(
+      "board.enabled.yaml",
+      `id: board.enabled
+name: Enabled Ceremony
+schedule: "*/30 * * * *"
+skill: board_health
+targets: [all]
+enabled: true
+`
+    );
     writeCeremony(
       "board.disabled.yaml",
       `id: board.disabled
@@ -70,12 +80,129 @@ enabled: false
 `
     );
 
-    plugin.install(bus);
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map((a) => String(a)).join(" "));
+    };
+
+    try {
+      plugin.install(bus);
+    } finally {
+      console.log = originalLog;
+    }
+
     const ceremonies = plugin.getCeremonies();
-    // Disabled ceremonies are loaded (so hot-reload can cancel timers) but not scheduled
-    const disabled = ceremonies.find((c) => c.id === "board.disabled");
-    expect(disabled).toBeDefined();
-    expect(disabled!.enabled).toBe(false);
+    const ids = ceremonies.map((c) => c.id);
+    // Disabled ceremonies must NOT enter the registry — otherwise external
+    // `ceremony.<id>.execute` triggers will fire them.
+    expect(ids).toContain("board.enabled");
+    expect(ids).not.toContain("board.disabled");
+
+    // Operators should see the skip in logs (fail-loud principle).
+    expect(
+      logs.some((l) => l.includes("Skipping disabled ceremony: board.disabled")),
+    ).toBe(true);
+
+    // Only enabled ceremonies should have a scheduled timer.
+    const timers = (plugin as unknown as { timers: Map<string, unknown> }).timers;
+    expect(timers.has("board.enabled")).toBe(true);
+    expect(timers.has("board.disabled")).toBe(false);
+  });
+
+  test("CeremonyPlugin loader: hot-reload flips enabled→disabled (cancels timer, removes from registry) (#415, #453)", async () => {
+    writeCeremony(
+      "board.flipping.yaml",
+      `id: board.flipping
+name: Flipping Ceremony
+schedule: "*/30 * * * *"
+skill: board_health
+targets: [all]
+enabled: true
+`
+    );
+
+    plugin.install(bus);
+
+    // Initially enabled and scheduled
+    const before = plugin.getCeremonies().map((c) => c.id);
+    expect(before).toContain("board.flipping");
+    let timers = (plugin as unknown as { timers: Map<string, unknown> }).timers;
+    expect(timers.has("board.flipping")).toBe(true);
+
+    // Prime hot-reload snapshot for the current (enabled) file size so the
+    // next _checkForChanges call enters the changed-file branch.
+    const pluginAny = plugin as unknown as {
+      _checkForChanges(dir: string): void;
+    };
+    pluginAny._checkForChanges(join(TEST_DIR, "ceremonies"));
+    await new Promise((r) => setTimeout(r, 5));
+
+    // Flip to disabled in YAML
+    writeCeremony(
+      "board.flipping.yaml",
+      `id: board.flipping
+name: Flipping Ceremony
+schedule: "*/30 * * * *"
+skill: board_health
+targets: [all]
+enabled: false
+`
+    );
+
+    pluginAny._checkForChanges(join(TEST_DIR, "ceremonies"));
+    await new Promise((r) => setTimeout(r, 10));
+
+    const after = plugin.getCeremonies().map((c) => c.id);
+    timers = (plugin as unknown as { timers: Map<string, unknown> }).timers;
+    expect(after).not.toContain("board.flipping");
+    expect(timers.has("board.flipping")).toBe(false);
+  });
+
+  test("CeremonyPlugin loader: hot-reload flips disabled→enabled (schedules new timer) (#453)", async () => {
+    writeCeremony(
+      "board.flipping.yaml",
+      `id: board.flipping
+name: Flipping Ceremony
+schedule: "*/30 * * * *"
+skill: board_health
+targets: [all]
+enabled: false
+`
+    );
+
+    plugin.install(bus);
+
+    // Disabled at install time — not in registry, no timer
+    expect(plugin.getCeremonies().map((c) => c.id)).not.toContain("board.flipping");
+    let timers = (plugin as unknown as { timers: Map<string, unknown> }).timers;
+    expect(timers.has("board.flipping")).toBe(false);
+
+    // Prime the hot-reload snapshot at the current (disabled) file size.
+    const pluginAny = plugin as unknown as {
+      _checkForChanges(dir: string): void;
+    };
+    pluginAny._checkForChanges(join(TEST_DIR, "ceremonies"));
+    await new Promise((r) => setTimeout(r, 5));
+
+    // Flip to enabled in YAML
+    writeCeremony(
+      "board.flipping.yaml",
+      `id: board.flipping
+name: Flipping Ceremony
+schedule: "*/30 * * * *"
+skill: board_health
+targets: [all]
+enabled: true
+`
+    );
+
+    pluginAny._checkForChanges(join(TEST_DIR, "ceremonies"));
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(plugin.getCeremonies().map((c) => c.id)).toContain("board.flipping");
+    timers = (plugin as unknown as { timers: Map<string, unknown> }).timers;
+    expect(timers.has("board.flipping")).toBe(true);
   });
 
   test("ceremony YAML: registerCeremony adds ceremony to registry", () => {


### PR DESCRIPTION
## Summary

PR #415 fixed the hot-reload path so flipping a ceremony to `enabled: false` cancelled its timer, but the initial-load path still added every YAML entry to the in-memory registry. Two consequences:

1. External `ceremony.<id>.execute` triggers (from `CeremonySkillExecutorPlugin`'s GOAP bridge) found the disabled ceremony in the registry and fired it anyway.
2. After hot-reload flipped a ceremony enabled→disabled, the entry stayed in the registry — same external-trigger leak.

This PR filters `enabled === false` at every place that lands a ceremony in the registry:
- `_loadAndScheduleAll` (initial install)
- `_checkForChanges` new-file branch (first poll after install / new YAML drop)
- `_reloadChangedCeremonies` (YAML edits)

Disabled ceremonies are still parsed by the loader (so the changed-file path can detect a flip), but they never reach the registry, never schedule a timer, and cannot be resurrected by an external trigger. Operators see `[ceremony] Skipping disabled ceremony: <id>` for each skip (fail-loud).

Greenfield: no flag, no toggle. `enabled: false` means disabled everywhere.

## Files

- `src/plugins/CeremonyPlugin.ts` — three call sites filtered + log
- `src/loaders/ceremonyYamlLoader.ts` — comment refresh
- `src/plugins/__tests__/CeremonyPlugin.test.ts` — replaced PR #415 initial-load expectation; added enabled→disabled and disabled→enabled hot-reload coverage

## Test plan

- [x] `bun test src/plugins/__tests__/CeremonyPlugin.test.ts` — 11 pass
- [x] `bun test src/loaders/__tests__/ceremonyYamlLoader.test.ts` — 13 pass
- [x] `bun test` (full suite) — 1031 pass / 0 fail

## Verification after merge + watchtower redeploy

- `docker logs workstacean | grep "Firing: service-health"` should be empty (service-health is `enabled: false` per PR #454 but still fires today)
- `docker logs workstacean | grep "Skipping disabled ceremony"` should list 3 entries: `agent-health`, `board.retro`, `service-health` (per PR #454's disabled set)
- Pick a previously-firing disabled ceremony, confirm zero `[ceremony] Firing:` log lines for it after one full cron cycle

Closes #453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where disabled ceremonies were incorrectly registered and could be executed
  * Improved hot-reload to correctly process enable/disable state changes for ceremonies when configuration updates occur during runtime
  * Enhanced ceremony exclusion logic to prevent disabled ceremonies from reaching execution paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->