### PR TITLE
fix(tests): wrap subscribe-spy push callbacks to return void

### DIFF
--- a/src/planner/__tests__/end-to-end-loop.test.ts
+++ b/src/planner/__tests__/end-to-end-loop.test.ts
@@ -137,7 +137,7 @@ describe("GOAP end-to-end feedback loop", () => {
     // Spy on what actually reaches the executor — agent.skill.request is
     // the first downstream of the dispatcher's drop-or-publish decision.
     const skillRequests: unknown[] = [];
-    bus.subscribe("agent.skill.request", "spy", (m) => skillRequests.push(m.payload));
+    bus.subscribe("agent.skill.request", "spy", (m) => { skillRequests.push(m.payload); });
 
     // Spam-publish 100 violations of the same goal.
     for (let i = 0; i < 100; i++) {

--- a/src/plugins/action-dispatcher-plugin.test.ts
+++ b/src/plugins/action-dispatcher-plugin.test.ts
@@ -213,7 +213,7 @@ describe("ActionDispatcherPlugin", () => {
   describe("per-action cooldown (meta.cooldownMs)", () => {
     test("blocks repeat dispatches of the same action within window", async () => {
       const requests: BusMessage[] = [];
-      bus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => requests.push(m));
+      bus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => { requests.push(m); });
 
       const action = makeAction({
         id: "cooldown-action-A",
@@ -234,7 +234,7 @@ describe("ActionDispatcherPlugin", () => {
 
     test("cooldown of action A does not affect action B", async () => {
       const requests: BusMessage[] = [];
-      bus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => requests.push(m));
+      bus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => { requests.push(m); });
 
       const actionA = makeAction({
         id: "cooldown-A",
@@ -260,7 +260,7 @@ describe("ActionDispatcherPlugin", () => {
 
     test("dispatch after window expires is admitted", async () => {
       const requests: BusMessage[] = [];
-      bus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => requests.push(m));
+      bus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => { requests.push(m); });
 
       const action = makeAction({
         id: "cooldown-expire",
@@ -282,7 +282,7 @@ describe("ActionDispatcherPlugin", () => {
 
     test("absent meta.cooldownMs means no cooldown (greenfield default)", async () => {
       const requests: BusMessage[] = [];
-      bus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => requests.push(m));
+      bus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => { requests.push(m); });
 
       const action = makeAction({
         id: "no-cooldown",
@@ -300,7 +300,7 @@ describe("ActionDispatcherPlugin", () => {
 
     test("cooldownMs <= 0 is treated as no cooldown", async () => {
       const requests: BusMessage[] = [];
-      bus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => requests.push(m));
+      bus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => { requests.push(m); });
 
       const action = makeAction({
         id: "zero-cooldown",
@@ -343,7 +343,7 @@ describe("ActionDispatcherPlugin", () => {
 
     test("admits dispatch when target is registered", async () => {
       const requests: BusMessage[] = [];
-      bus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => requests.push(m));
+      bus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => { requests.push(m); });
 
       // Build a dispatcher with a registry containing the target.
       const localBus = new InMemoryEventBus();
@@ -352,7 +352,7 @@ describe("ActionDispatcherPlugin", () => {
       const guarded = new ActionDispatcherPlugin({ wipLimit: 5 }, undefined, registry as any);
       guarded.install(localBus);
       const localRequests: BusMessage[] = [];
-      localBus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => localRequests.push(m));
+      localBus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => { localRequests.push(m); });
 
       const action = makeAction({
         id: "valid-target-action",
@@ -374,7 +374,7 @@ describe("ActionDispatcherPlugin", () => {
       const guarded = new ActionDispatcherPlugin({ wipLimit: 5 }, spy as any, registry as any);
       guarded.install(localBus);
       const requests: BusMessage[] = [];
-      localBus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => requests.push(m));
+      localBus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => { requests.push(m); });
 
       const action = makeAction({
         id: "invalid-target-action",
@@ -406,7 +406,7 @@ describe("ActionDispatcherPlugin", () => {
       const guarded = new ActionDispatcherPlugin({ wipLimit: 5 }, undefined, registry as any);
       guarded.install(localBus);
       const requests: BusMessage[] = [];
-      localBus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => requests.push(m));
+      localBus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => { requests.push(m); });
 
       const action = makeAction({
         id: "mixed-action",
@@ -428,7 +428,7 @@ describe("ActionDispatcherPlugin", () => {
       const guarded = new ActionDispatcherPlugin({ wipLimit: 5 }, undefined, registry as any);
       guarded.install(localBus);
       const requests: BusMessage[] = [];
-      localBus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => requests.push(m));
+      localBus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => { requests.push(m); });
 
       const action = makeAction({
         id: "broadcast-action",
@@ -448,7 +448,7 @@ describe("ActionDispatcherPlugin", () => {
       const guarded = new ActionDispatcherPlugin({ wipLimit: 5 }, undefined, registry as any);
       guarded.install(localBus);
       const requests: BusMessage[] = [];
-      localBus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => requests.push(m));
+      localBus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => { requests.push(m); });
 
       const action = makeAction({
         id: "skill-routed-action",
@@ -464,7 +464,7 @@ describe("ActionDispatcherPlugin", () => {
       // Default `dispatcher` constructed in beforeEach has no registry — verifies
       // that absent-registry equals 'check skipped' so existing tests stay green.
       const requests: BusMessage[] = [];
-      bus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => requests.push(m));
+      bus.subscribe(TOPICS.AGENT_SKILL_REQUEST, "spy", (m) => { requests.push(m); });
 
       const action = makeAction({
         id: "no-registry-action",


### PR DESCRIPTION
## Problem

CI's \`test\` job has been failing on \`bun run tsc --noEmit\` since PR #452 shipped — 13 TS2322 errors in \`src/plugins/action-dispatcher-plugin.test.ts\` (12) and \`src/planner/__tests__/end-to-end-loop.test.ts\` (1). Each PR since has inherited + added to the pile (#452, #455, #456 all merged red on test).

The merges went through anyway because \`build-and-push\` (the workflow that actually publishes \`:dev\`) is a separate job that doesn't gate on test. So \`:dev\` kept shipping green while \`tsc --noEmit\` was returning exit 2 on the PR itself.

## Root cause

All 13 errors are the same pattern — \`Array.push()\` returns \`number\`, but \`bus.subscribe()\`'s callback expects \`void | Promise<void>\`:

\`\`\`ts
bus.subscribe(T, \"spy\", (m) => requests.push(m));
                         // ^^ returns number, callback wants void
\`\`\`

## Fix

Wrap the arrow body in a block so it returns \`void\`:

\`\`\`ts
bus.subscribe(T, \"spy\", (m) => { requests.push(m); });
\`\`\`

Applied mechanically across all 13 sites.

## Verification

\`\`\`
$ bun run tsc --noEmit
(exit 0)

$ bun test src/plugins/action-dispatcher-plugin.test.ts
19 pass / 0 fail / 36 expect() calls
\`\`\`

## Follow-up worth considering (not in this PR)

The \`test\` check being non-blocking for merge is itself a gap. A red CI on dev has meant promotion PRs could ship without a clean type-check for days. Worth either (a) making \`test\` a required check in branch protection, or (b) restructuring so \`build-and-push\` gates on \`test\`'s success. Filing separately if it surfaces again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test callback syntax for improved code consistency.

**Note:** This release contains internal testing improvements with no user-facing changes or functionality modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->