### PR TITLE
fix(fleet-health): filter outcomes from synthetic actors via registry whitelist (closes #459)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -422,7 +422,8 @@ const pluginRegistry: PluginRegistryEntry[] = [
     condition: () => true,
     factory: async () => {
       const { AgentFleetHealthPlugin } = await import("./plugins/agent-fleet-health-plugin.js");
-      return new AgentFleetHealthPlugin();
+      // executorRegistry wired for outcome attribution whitelist (#459).
+      return new AgentFleetHealthPlugin(executorRegistry);
     },
   },
   // Built-ins: opt-in via ENABLED_PLUGINS=echo,...

--- a/src/plugins/agent-fleet-health-plugin.test.ts
+++ b/src/plugins/agent-fleet-health-plugin.test.ts
@@ -1,8 +1,26 @@
 import { describe, test, expect, beforeEach } from "bun:test";
 import { InMemoryEventBus } from "../../lib/bus.ts";
 import { AgentFleetHealthPlugin } from "./agent-fleet-health-plugin.ts";
+import { ExecutorRegistry } from "../executor/executor-registry.ts";
+import type { IExecutor, SkillRequest, SkillResult } from "../executor/types.ts";
 import type { AutonomousOutcomePayload } from "../event-bus/payloads.ts";
 import type { BusMessage } from "../../lib/types.ts";
+
+/** Minimal executor stub — just satisfies the IExecutor shape for registry wiring. */
+class StubExecutor implements IExecutor {
+  readonly type = "stub";
+  async execute(_req: SkillRequest): Promise<SkillResult> {
+    return { text: "", isError: false, correlationId: "" };
+  }
+}
+
+const makeRegistry = (agentNames: string[]): ExecutorRegistry => {
+  const reg = new ExecutorRegistry();
+  for (const name of agentNames) {
+    reg.register("noop", new StubExecutor(), { agentName: name });
+  }
+  return reg;
+};
 
 const makeOutcomeMsg = (payload: Partial<AutonomousOutcomePayload> & { systemActor: string; skill: string }): BusMessage => ({
   id: crypto.randomUUID(),
@@ -279,6 +297,130 @@ describe("AgentFleetHealthPlugin", () => {
 
     const snapshot = plugin.getFleetHealth();
     expect(snapshot.orphanedSkillCount).toBe(0);
+  });
+
+  // ── #459: synthetic-actor whitelist via ExecutorRegistry ─────────────────
+  describe("synthetic actor filtering (#459)", () => {
+    let wlBus: InMemoryEventBus;
+    let wlPlugin: AgentFleetHealthPlugin;
+
+    beforeEach(() => {
+      wlBus = new InMemoryEventBus();
+      const registry = makeRegistry(["ava", "quinn", "protomaker"]);
+      wlPlugin = new AgentFleetHealthPlugin(registry);
+      wlPlugin.install(wlBus);
+    });
+
+    test("outcome from a registered agent lands in agents[]", async () => {
+      wlBus.publish("autonomous.outcome.completed", makeOutcomeMsg({
+        systemActor: "quinn", skill: "triage", success: true, durationMs: 100,
+      }));
+      await new Promise(r => setTimeout(r, 10));
+
+      const snap = wlPlugin.getFleetHealth();
+      expect(snap.agents).toHaveLength(1);
+      expect(snap.agents[0].agentName).toBe("quinn");
+      expect(snap.systemActors).toHaveLength(0);
+    });
+
+    test("outcome from auto-triage-sweep does NOT pollute agents[]", async () => {
+      wlBus.publish("autonomous.outcome.failed", makeOutcomeMsg({
+        systemActor: "auto-triage-sweep", skill: "bug_triage", success: false, durationMs: 200,
+      }));
+      await new Promise(r => setTimeout(r, 10));
+
+      const snap = wlPlugin.getFleetHealth();
+      expect(snap.agents).toHaveLength(0);
+      expect(snap.systemActors).toHaveLength(1);
+      expect(snap.systemActors[0].systemActor).toBe("auto-triage-sweep");
+      expect(snap.systemActors[0].failureCount).toBe(1);
+    });
+
+    test("outcome from pr-remediator does NOT pollute agents[]", async () => {
+      wlBus.publish("autonomous.outcome.failed", makeOutcomeMsg({
+        systemActor: "pr-remediator", skill: "bug_triage", success: false, durationMs: 500,
+      }));
+      await new Promise(r => setTimeout(r, 10));
+
+      const snap = wlPlugin.getFleetHealth();
+      expect(snap.agents).toHaveLength(0);
+      expect(snap.agents.find(a => a.agentName === "pr-remediator")).toBeUndefined();
+      expect(snap.systemActors.find(s => s.systemActor === "pr-remediator")).toBeDefined();
+    });
+
+    test("agentCount after mixed outcomes = count of real agents only", async () => {
+      // Real agents
+      wlBus.publish("autonomous.outcome.completed", makeOutcomeMsg({
+        systemActor: "ava", skill: "plan", success: true, durationMs: 100,
+      }));
+      wlBus.publish("autonomous.outcome.failed", makeOutcomeMsg({
+        systemActor: "quinn", skill: "sweep", success: false, durationMs: 100,
+      }));
+      // Synthetic / plugin actors
+      wlBus.publish("autonomous.outcome.failed", makeOutcomeMsg({
+        systemActor: "pr-remediator", skill: "bug_triage", success: false, durationMs: 100,
+      }));
+      wlBus.publish("autonomous.outcome.failed", makeOutcomeMsg({
+        systemActor: "auto-triage-sweep", skill: "bug_triage", success: false, durationMs: 100,
+      }));
+      wlBus.publish("autonomous.outcome.failed", makeOutcomeMsg({
+        systemActor: "user", skill: "chat", success: false, durationMs: 100,
+      }));
+      await new Promise(r => setTimeout(r, 10));
+
+      const snap = wlPlugin.getFleetHealth();
+      expect(snap.agents).toHaveLength(2);
+      expect(new Set(snap.agents.map(a => a.agentName))).toEqual(new Set(["ava", "quinn"]));
+      expect(snap.systemActors).toHaveLength(3);
+      expect(new Set(snap.systemActors.map(s => s.systemActor))).toEqual(
+        new Set(["pr-remediator", "auto-triage-sweep", "user"]),
+      );
+    });
+
+    test("maxFailureRate1h is not inflated by synthetic-actor failures", async () => {
+      // One real agent with full success in 1h
+      wlBus.publish("autonomous.outcome.completed", makeOutcomeMsg({
+        systemActor: "ava", skill: "plan", success: true, durationMs: 100,
+      }));
+      // Synthetic actor with 100% failure — must not leak into maxFailureRate1h
+      wlBus.publish("autonomous.outcome.failed", makeOutcomeMsg({
+        systemActor: "pr-remediator", skill: "bug_triage", success: false, durationMs: 100,
+      }));
+      await new Promise(r => setTimeout(r, 10));
+
+      const snap = wlPlugin.getFleetHealth();
+      expect(snap.maxFailureRate1h).toBe(0);
+    });
+
+    test("orphanedSkillCount excludes synthetic-actor-only skills", async () => {
+      // Real agent has a successful "plan" skill
+      wlBus.publish("autonomous.outcome.completed", makeOutcomeMsg({
+        systemActor: "ava", skill: "plan", success: true, durationMs: 100,
+      }));
+      // Synthetic actor fails a skill nobody else runs — shouldn't count as orphaned
+      wlBus.publish("autonomous.outcome.failed", makeOutcomeMsg({
+        systemActor: "pr-remediator", skill: "bug_triage", success: false, durationMs: 100,
+      }));
+      await new Promise(r => setTimeout(r, 10));
+
+      const snap = wlPlugin.getFleetHealth();
+      expect(snap.orphanedSkillCount).toBe(0);
+    });
+
+    test("with empty registry, all actors are filtered to systemActors[]", async () => {
+      const emptyBus = new InMemoryEventBus();
+      const emptyPlugin = new AgentFleetHealthPlugin(new ExecutorRegistry());
+      emptyPlugin.install(emptyBus);
+
+      emptyBus.publish("autonomous.outcome.completed", makeOutcomeMsg({
+        systemActor: "ava", skill: "plan", success: true, durationMs: 100,
+      }));
+      await new Promise(r => setTimeout(r, 10));
+
+      const snap = emptyPlugin.getFleetHealth();
+      expect(snap.agents).toHaveLength(0);
+      expect(snap.systemActors).toHaveLength(1);
+    });
   });
 
   test("uninstall cleans up subscription", () => {

--- a/src/plugins/agent-fleet-health-plugin.ts
+++ b/src/plugins/agent-fleet-health-plugin.ts
@@ -10,10 +10,21 @@
  *
  * Inbound topics:
  *   autonomous.outcome.#  — every autonomous task terminal state
+ *
+ * Outcome attribution (issue #459):
+ *   Outcome `systemActor` values are whitelisted against the live
+ *   ExecutorRegistry before being recorded under the per-agent window.
+ *   Unknown actors (plugin names like `pr-remediator`, synthetic labels like
+ *   `auto-triage-sweep`, `goap`, `user`) are routed to a separate
+ *   `systemActors[]` bucket in the snapshot so they don't pollute agentCount,
+ *   reachableCount, orphanedSkillCount, or maxFailureRate1h. Same chokepoint
+ *   discipline as the ActionDispatcher cooldown (#437) and registry guard
+ *   (#444): invariants belong at the point an outcome is written.
  */
 
 import type { Plugin, EventBus } from "../../lib/types.ts";
 import type { AutonomousOutcomePayload } from "../event-bus/payloads.ts";
+import type { ExecutorRegistry } from "../executor/executor-registry.ts";
 import { MODEL_RATES } from "../../lib/types/budget.ts";
 
 const WINDOW_MS = 24 * 60 * 60 * 1_000; // 24 hours
@@ -67,6 +78,21 @@ export interface AgentFleetMetrics {
   failureRate1h: number;
 }
 
+/**
+ * Outcome attribution for a systemActor that is NOT a registered A2A or
+ * DeepAgent executor. Tracked separately so dashboards + GOAP selectors can
+ * see that traffic without treating it as agent health signal.
+ *
+ * Examples: `goap`, `pr-remediator`, `auto-triage-sweep`, `outcome-analysis`,
+ * `ceremony.*`. These are plugin / subsystem labels, not agents.
+ */
+export interface SystemActorOutcomeSummary {
+  systemActor: string;
+  totalOutcomes: number;
+  successCount: number;
+  failureCount: number;
+}
+
 export interface FleetHealthSnapshot {
   agents: AgentFleetMetrics[];
   /** Always 24 — documents the rolling window. */
@@ -79,12 +105,21 @@ export interface FleetHealthSnapshot {
   /** Sum of all LLM costs across all agents over the 24h window (USD). Used by fleet.cost_under_budget (Arc 8.3). */
   totalCostUsd1d: number;
   /**
-   * Count of skills seen in any outcome in the 24h window that have had
+   * Count of skills seen in any agent outcome in the 24h window that have had
    * no successful execution during that window. > 0 signals capability
-   * regression — a skill is active but consistently failing.
+   * regression — a skill is active but consistently failing. Only counts
+   * outcomes recorded against REAL agents; synthetic-actor outcomes are
+   * excluded so plugin failures don't inflate the orphan count (#459).
    * Used by fleet.no_skill_orphaned (Arc 8.5).
    */
   orphanedSkillCount: number;
+  /**
+   * Outcomes attributed to systemActor values that are NOT registered
+   * executors — plugin / subsystem labels like `pr-remediator`,
+   * `auto-triage-sweep`, `goap`. Kept separate so agentCount and the fleet
+   * health metrics reflect the real agent fleet (#459).
+   */
+  systemActors: SystemActorOutcomeSummary[];
   collectedAt: number;
 }
 
@@ -98,8 +133,25 @@ export class AgentFleetHealthPlugin implements Plugin {
 
   private bus?: EventBus;
   private readonly subscriptionIds: string[] = [];
-  /** Per-agent rolling window. Keys are systemActor values. */
+  /** Per-agent rolling window. Keys are systemActor values that match a registered executor. */
   private readonly agentWindows = new Map<string, OutcomeRecord[]>();
+  /** Per-systemActor rolling window for names NOT in the ExecutorRegistry. */
+  private readonly systemActorWindows = new Map<string, OutcomeRecord[]>();
+  /** Synthetic actors seen since last startup — used for the one-time warn. */
+  private readonly seenSyntheticActors = new Set<string>();
+
+  constructor(
+    /**
+     * ExecutorRegistry handle for outcome-attribution whitelist (issue #459).
+     * When set, every inbound outcome's `systemActor` is checked against the
+     * live registry before being aggregated into `agents[]`. Absent-from-
+     * registry actors land in a separate `systemActors[]` bucket. When the
+     * registry is not wired (test fixtures that only exercise aggregation
+     * math), every actor is treated as an agent — preserving pre-#459 shape
+     * for legacy tests until they opt in.
+     */
+    private readonly executorRegistry?: ExecutorRegistry,
+  ) {}
 
   install(bus: EventBus): void {
     this.bus = bus;
@@ -132,6 +184,8 @@ export class AgentFleetHealthPlugin implements Plugin {
     const agents: AgentFleetMetrics[] = [];
 
     // Per-skill: track whether any success exists in the window.
+    // Only real agents contribute — synthetic-actor failures shouldn't
+    // flag a skill as orphaned (#459).
     const skillSeenInWindow = new Set<string>();
     const skillHasSuccessInWindow = new Set<string>();
 
@@ -196,7 +250,30 @@ export class AgentFleetHealthPlugin implements Plugin {
       if (!skillHasSuccessInWindow.has(skill)) orphanedSkillCount++;
     }
 
-    return { agents, windowHours: 24, maxFailureRate1h, totalCostUsd1d, orphanedSkillCount, collectedAt: now };
+    // Prune + summarize synthetic-actor buckets.
+    const systemActors: SystemActorOutcomeSummary[] = [];
+    for (const [actor, records] of this.systemActorWindows) {
+      const fresh = records.filter(r => r.timestamp >= cutoff);
+      this.systemActorWindows.set(actor, fresh);
+      if (fresh.length === 0) continue;
+      const successCount = fresh.filter(r => r.success).length;
+      systemActors.push({
+        systemActor: actor,
+        totalOutcomes: fresh.length,
+        successCount,
+        failureCount: fresh.length - successCount,
+      });
+    }
+
+    return {
+      agents,
+      windowHours: 24,
+      maxFailureRate1h,
+      totalCostUsd1d,
+      orphanedSkillCount,
+      systemActors,
+      collectedAt: now,
+    };
   }
 
   // ── Private ─────────────────────────────────────────────────────────────────
@@ -217,9 +294,43 @@ export class AgentFleetHealthPlugin implements Plugin {
       failureReason: p.success ? undefined : (p.taskState ?? "failed"),
     };
 
-    const existing = this.agentWindows.get(p.systemActor) ?? [];
+    if (this._isRegisteredAgent(p.systemActor)) {
+      const existing = this.agentWindows.get(p.systemActor) ?? [];
+      existing.push(record);
+      this.agentWindows.set(p.systemActor, existing);
+      return;
+    }
+
+    // Synthetic actor: plugin / subsystem label that isn't a real executor.
+    // Log once per distinct actor so operators can see what's being filtered
+    // without flooding on every outcome.
+    if (!this.seenSyntheticActors.has(p.systemActor)) {
+      this.seenSyntheticActors.add(p.systemActor);
+      console.warn(
+        `[agent-fleet-health] synthetic_actor_filtered systemActor=${p.systemActor} ` +
+          `skill=${p.skill} — not in ExecutorRegistry; aggregating under systemActors[] ` +
+          `instead of agents[]. Fix source so it doesn't masquerade as an agent.`,
+      );
+    }
+    const existing = this.systemActorWindows.get(p.systemActor) ?? [];
     existing.push(record);
-    this.agentWindows.set(p.systemActor, existing);
+    this.systemActorWindows.set(p.systemActor, existing);
+  }
+
+  /**
+   * Returns true when `actor` is a registered executor agentName.
+   *
+   * No registry wired → every actor is treated as an agent (preserves
+   * pre-#459 aggregation shape for legacy tests that don't need the guard).
+   * Empty registry → nothing is an agent; all outcomes go to systemActors[].
+   */
+  private _isRegisteredAgent(actor: string): boolean {
+    if (!this.executorRegistry) return true;
+    const known = this.executorRegistry
+      .list()
+      .map(r => r.agentName)
+      .filter((n): n is string => typeof n === "string" && n.length > 0);
+    return known.includes(actor);
   }
 }
 


### PR DESCRIPTION
## Summary

- `AgentFleetHealthPlugin` now takes an optional `ExecutorRegistry` (mirrors the #455 wiring on `ActionDispatcherPlugin`).
- On each inbound `autonomous.outcome.*`, the outcome's `systemActor` is checked against `executorRegistry.list().map(r => r.agentName)`. Registered agents feed `agents[]` (unchanged shape); everything else (`pr-remediator`, `auto-triage-sweep`, `goap`, `user`, ...) routes to a separate `systemActors[]` bucket so it doesn't pollute `agentCount`, `maxFailureRate1h`, or `orphanedSkillCount`.
- First time a synthetic actor is observed, a loud one-time `console.warn` names the actor + skill (fail-fast-and-loud, per policy). No flag — unconditional once the registry is wired. Same chokepoint discipline as #437 (cooldown) and #444 (target registry guard); third instance of the pattern — updated pattern memory to reflect the shape.

## Scope note on `_default`

`_default` is a label in `/api/agent-health` (driven by the ExecutorRegistry — registrations with no `agentName`). The fleet-health plugin keys on outcome `systemActor`, not registry `agentName`. No publisher in the repo sends `systemActor: "_default"`, so it never reaches `agents[]` here. If it ever did, the new whitelist would route it to `systemActors[]` — the correct outcome. No filter on `_default` was added in this PR because there's nothing to filter.

## Test plan

- [x] `bun test src/plugins/agent-fleet-health-plugin.test.ts` — 25/25 pass
- [x] `bun test` — 1038/1038 pass
- [x] New tests:
  - Outcome from a registered agent (`quinn`) → counts in `agents[]`
  - Outcome from `auto-triage-sweep` → routes to `systemActors[]`, no `agents[]` entry
  - Outcome from `pr-remediator` → routes to `systemActors[]`, no `agents[]` entry
  - Mixed real + synthetic outcomes → `agents[]` length == count of real agents (2 of 5)
  - Synthetic-actor failures don't inflate `maxFailureRate1h`
  - Synthetic-actor-only skills don't orphan themselves (`orphanedSkillCount == 0`)
  - Empty registry → everything goes to `systemActors[]`
- [ ] **Post-deploy verification** — after this merges + deploys, confirm Ava's fleet sitrep no longer lists `pr-remediator` / `auto-triage-sweep` / `user` as agents:
  ```
  curl -s -X POST http://localhost:3000/v1/chat/completions \
    -H 'Content-Type: application/json' \
    -d '{"model":"ava","messages":[{"role":"user","content":"fleet sitrep"}]}'
  ```

## Cross-references

- Closes #459
- Related mitigations: #437 (cooldown — closed by #452), #444 (registry guard — closed by #455)
- Symptom report: protoLabsAI/protoMaker#3532

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fleet health snapshots now include a dedicated `systemActors` bucket to track synthetic and unregistered actors separately from registered agents.

* **Bug Fixes**
  * System actor outcomes no longer inflate agent-based health metrics such as failure rates and orphaned skill counts.

* **Tests**
  * Added comprehensive test coverage for synthetic actor filtering, whitelist validation, and behavior with mixed real and synthetic actors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->