### PR TITLE
fix(pr-remediator): never auto-close promotion PRs on decomposable verdict

### DIFF
--- a/lib/plugins/pr-remediator.ts
+++ b/lib/plugins/pr-remediator.ts
@@ -226,6 +226,7 @@ interface PrDomainEntry {
   headSha: string;
   author: string;
   baseRef: string;
+  headRef?: string;
   mergeable: "clean" | "dirty" | "blocked" | "unknown";
   ciStatus: "pass" | "fail" | "pending" | "none";
   reviewState: "approved" | "changes_requested" | "pending" | "none";
@@ -377,6 +378,31 @@ function isAutoApproveClass(pr: PrDomainEntry): boolean {
   for (const prefix of AUTO_APPROVE_TITLE_PREFIXES) {
     if (lower.startsWith(prefix)) return true;
   }
+  return false;
+}
+
+/**
+ * Promotion PR detector — used as a guard at every destructive verdict site
+ * (right now just `decomposable`, but the chokepoint pattern is the same as
+ * #437/#444/#459: refuse a destructive verb against a release-pipeline branch).
+ *
+ * A promotion PR is one where:
+ *   - the head branch is `dev` or `staging`, OR
+ *   - the base branch is `main` or `staging`, OR
+ *   - the title starts with `Promote` or `promote:` (case-insensitive).
+ *
+ * Conflicts on a promotion always reflect drift between branches, never
+ * "clusters that could be split" — splitting a 17-PR promotion makes no
+ * sense. The recovery is a back-merge, not a close+decompose.
+ */
+const PROTECTED_HEAD_REFS = new Set(["dev", "staging"]);
+const PROTECTED_BASE_REFS = new Set(["main", "staging"]);
+
+function isPromotionPr(pr: { headRef?: string; baseRef: string; title: string }): boolean {
+  if (pr.headRef && PROTECTED_HEAD_REFS.has(pr.headRef)) return true;
+  if (PROTECTED_BASE_REFS.has(pr.baseRef)) return true;
+  const lower = pr.title.toLowerCase();
+  if (lower.startsWith("promote:") || lower.startsWith("promote ")) return true;
   return false;
 }
 
@@ -1416,6 +1442,7 @@ Critical rules:
 PR: ${pr.repo}#${pr.number} — ${pr.title}
 Author: ${pr.author}
 Base branch: ${pr.baseRef}
+Head branch: ${pr.headRef ?? "(unknown)"}
 Head SHA: ${pr.headSha}
 Mergeable: ${pr.mergeable}
 CI Status: ${pr.ciStatus}
@@ -1550,6 +1577,45 @@ Do NOT ask for confirmation. Act.`;
       }
 
       case "decomposable": {
+        // Defense-in-depth guard (mirrors #437/#444/#459): refuse to apply a
+        // destructive verdict — close+propose-split — to a release-pipeline
+        // PR. A 17-PR promotion can't be "decomposed"; conflicts always
+        // reflect drift between branches and the recovery is a back-merge.
+        // If Ava's prompt drifts and returns decomposable for a promotion
+        // anyway, the chokepoint catches it.
+        if (isPromotionPr(pr)) {
+          console.warn(
+            `[pr-remediator] PROMOTION GUARD: refusing decomposable verdict on protected PR ${prKey} ` +
+              `(head=${pr.headRef ?? "unknown"} base=${pr.baseRef} title="${pr.title}"). ` +
+              `Promotion conflicts indicate drift, not need-to-decompose. Escalating to HITL.`,
+          );
+          const ubKey = this._inFlightKey(pr.repo, pr.number, "update_branch");
+          const entry = this.inFlight.get(ubKey);
+          if (entry) {
+            entry.exhausted = true;
+            entry.escalated = true;
+          }
+          const effectiveEntry: InFlightEntry = entry ?? {
+            kind: "update_branch",
+            startedAt: Date.now() - DIAGNOSE_AFTER_ATTEMPTS * IN_FLIGHT_TTL_MS,
+            correlationId: parentCorrelationId,
+            attempts: DIAGNOSE_AFTER_ATTEMPTS,
+            exhausted: true,
+            escalated: true,
+          };
+          this._emitStuckHitlEscalation(
+            pr.repo,
+            pr.number,
+            "update_branch",
+            effectiveEntry,
+            `Promotion-PR guard tripped: Ava returned \`decomposable\` for a release-pipeline PR ` +
+              `(head=\`${pr.headRef ?? "unknown"}\` base=\`${pr.baseRef}\`). ` +
+              `Recovery is a back-merge of \`${pr.baseRef}\` into \`${pr.headRef ?? "head"}\`, not a split. ` +
+              `Original evidence: ${diagnosis.evidence}`,
+          );
+          break;
+        }
+
         const fileList = diagnosis.conflictingFiles?.length
           ? diagnosis.conflictingFiles.map((f) => `- \`${f}\``).join("\n")
           : "See diagnosis evidence above.";

--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -115,6 +115,7 @@ export function createRoutes(ctx: ApiContext): Route[] {
       repo: string; number: number; title: string; headSha: string;
       author: string;
       baseRef: string;
+      headRef: string;
       mergeable: "clean" | "dirty" | "blocked" | "unknown";
       ciStatus: "pass" | "fail" | "pending" | "none";
       reviewState: "approved" | "changes_requested" | "pending" | "none";
@@ -130,7 +131,7 @@ export function createRoutes(ctx: ApiContext): Route[] {
     for (const repo of repoList) {
       type PrListItem = {
         number: number; title: string; updated_at: string; draft: boolean;
-        head: { sha: string };
+        head: { sha: string; ref: string };
         base: { ref: string };
         user: { login: string } | null;
         labels: Array<{ name: string }>;
@@ -233,6 +234,7 @@ export function createRoutes(ctx: ApiContext): Route[] {
           repo, number: pr.number, title: pr.title, headSha: pr.head.sha,
           author: pr.user?.login ?? "unknown",
           baseRef: pr.base.ref,
+          headRef: pr.head.ref,
           mergeable, ciStatus, reviewState,
           isDraft: pr.draft,
           readyToMerge,

--- a/src/pr-remediator.test.ts
+++ b/src/pr-remediator.test.ts
@@ -24,6 +24,7 @@ interface PrEntry {
   headSha: string;
   author: string;
   baseRef: string;
+  headRef?: string;
   mergeable: "clean" | "dirty" | "blocked" | "unknown";
   ciStatus: "pass" | "fail" | "pending" | "none";
   reviewState: "approved" | "changes_requested" | "pending" | "none";
@@ -39,7 +40,8 @@ function makePr(overrides: Partial<PrEntry> = {}): PrEntry {
     title: "feat: widget",
     headSha: "abc1234",
     author: "alice",
-    baseRef: "main",
+    baseRef: "dev",
+    headRef: "feature/x",
     mergeable: "clean",
     ciStatus: "pass",
     reviewState: "approved",
@@ -795,6 +797,184 @@ describe("PrRemediatorPlugin — diagnose_pr_stuck", () => {
 
     // Malformed response falls back to genuine → HITL
     expect(hitlCaptured.length).toBeGreaterThan(0);
+
+    plugin.uninstall();
+  });
+
+  // ── Promotion-PR guard (issue #465) ────────────────────────────────────────
+  //
+  // A `decomposable` verdict on a release-pipeline PR (head ∈ {dev,staging} or
+  // base ∈ {main,staging} or title starts "Promote") is structurally wrong:
+  // the conflict is drift between branches, not within commits, so a back-merge
+  // is the recovery, not a split. Guard at the chokepoint refuses the verdict
+  // and escalates to HITL — same defense-in-depth pattern as #437/#444/#459.
+
+  test("decomposable verdict on a refactor PR (head=feature/x, base=dev) still closes", async () => {
+    const bus = new InMemoryEventBus();
+    const plugin = new PrRemediatorPlugin();
+    plugin.install(bus);
+
+    pushWorldState(bus, [
+      makePr({ number: 101, headRef: "feature/x", baseRef: "dev", mergeable: "dirty", readyToMerge: false }),
+    ]);
+
+    const hitlCaptured = captureOn(bus, "hitl.request.pr.remediation_stuck.#");
+    const skillCaptured = captureOn(bus, "agent.skill.request");
+
+    const pr = makePr({
+      number: 101,
+      headRef: "feature/x",
+      baseRef: "dev",
+      mergeable: "dirty",
+      readyToMerge: false,
+    });
+    privateOf(plugin)._dispatchDiagnose(pr, crypto.randomUUID());
+    await flushMicrotasks();
+
+    const cid = skillCaptured[0]!.correlationId;
+    bus.publish(`agent.skill.response.${cid}`, {
+      id: crypto.randomUUID(),
+      correlationId: cid,
+      topic: `agent.skill.response.${cid}`,
+      timestamp: Date.now(),
+      payload: {
+        text:
+          '```json\n{"verdict":"decomposable","evidence":"conflicts cluster in src/auth.ts and src/api.ts","conflictingFiles":["src/auth.ts","src/api.ts"]}\n```',
+      },
+    });
+    await flushMicrotasks();
+
+    // Refactor PR — guard does NOT trip; the close path runs (silently fails
+    // without GH creds in tests, but importantly does not escalate to HITL).
+    expect(hitlCaptured.length).toBe(0);
+
+    plugin.uninstall();
+  });
+
+  test("decomposable verdict on dev→main promotion PR escalates to HITL, does NOT close", async () => {
+    const bus = new InMemoryEventBus();
+    const plugin = new PrRemediatorPlugin();
+    plugin.install(bus);
+
+    pushWorldState(bus, [
+      makePr({ number: 463, headRef: "dev", baseRef: "main", title: "Promote v0.7.22 to main", mergeable: "dirty", readyToMerge: false }),
+    ]);
+
+    const hitlCaptured = captureOn(bus, "hitl.request.pr.remediation_stuck.#");
+    const skillCaptured = captureOn(bus, "agent.skill.request");
+
+    const pr = makePr({
+      number: 463,
+      headRef: "dev",
+      baseRef: "main",
+      title: "Promote v0.7.22 to main",
+      mergeable: "dirty",
+      readyToMerge: false,
+    });
+    privateOf(plugin)._dispatchDiagnose(pr, crypto.randomUUID());
+    await flushMicrotasks();
+
+    const cid = skillCaptured[0]!.correlationId;
+    bus.publish(`agent.skill.response.${cid}`, {
+      id: crypto.randomUUID(),
+      correlationId: cid,
+      topic: `agent.skill.response.${cid}`,
+      timestamp: Date.now(),
+      payload: {
+        text:
+          '```json\n{"verdict":"decomposable","evidence":"conflicts cluster in 4 files","conflictingFiles":["a.ts","b.ts","c.ts","d.ts"]}\n```',
+      },
+    });
+    await flushMicrotasks();
+
+    // Promotion PR — guard MUST trip and escalate to HITL.
+    expect(hitlCaptured.length).toBe(1);
+    const req = hitlCaptured[0]!.payload as HITLRequest;
+    expect(req.title).toContain("#463");
+    expect(req.summary).toContain("Promotion-PR guard");
+    expect(req.summary).toContain("back-merge");
+
+    plugin.uninstall();
+  });
+
+  test("decomposable verdict on staging→main promotion PR escalates to HITL", async () => {
+    const bus = new InMemoryEventBus();
+    const plugin = new PrRemediatorPlugin();
+    plugin.install(bus);
+
+    pushWorldState(bus, [
+      makePr({ number: 470, headRef: "staging", baseRef: "main", mergeable: "dirty", readyToMerge: false }),
+    ]);
+
+    const hitlCaptured = captureOn(bus, "hitl.request.pr.remediation_stuck.#");
+    const skillCaptured = captureOn(bus, "agent.skill.request");
+
+    const pr = makePr({
+      number: 470,
+      headRef: "staging",
+      baseRef: "main",
+      mergeable: "dirty",
+      readyToMerge: false,
+    });
+    privateOf(plugin)._dispatchDiagnose(pr, crypto.randomUUID());
+    await flushMicrotasks();
+
+    const cid = skillCaptured[0]!.correlationId;
+    bus.publish(`agent.skill.response.${cid}`, {
+      id: crypto.randomUUID(),
+      correlationId: cid,
+      topic: `agent.skill.response.${cid}`,
+      timestamp: Date.now(),
+      payload: {
+        text:
+          '```json\n{"verdict":"decomposable","evidence":"clusters in 3 files","conflictingFiles":["x.ts","y.ts","z.ts"]}\n```',
+      },
+    });
+    await flushMicrotasks();
+
+    expect(hitlCaptured.length).toBe(1);
+    const req = hitlCaptured[0]!.payload as HITLRequest;
+    expect(req.summary).toContain("staging");
+
+    plugin.uninstall();
+  });
+
+  test("decomposable verdict on dev→staging promotion PR escalates to HITL", async () => {
+    const bus = new InMemoryEventBus();
+    const plugin = new PrRemediatorPlugin();
+    plugin.install(bus);
+
+    pushWorldState(bus, [
+      makePr({ number: 471, headRef: "dev", baseRef: "staging", mergeable: "dirty", readyToMerge: false }),
+    ]);
+
+    const hitlCaptured = captureOn(bus, "hitl.request.pr.remediation_stuck.#");
+    const skillCaptured = captureOn(bus, "agent.skill.request");
+
+    const pr = makePr({
+      number: 471,
+      headRef: "dev",
+      baseRef: "staging",
+      mergeable: "dirty",
+      readyToMerge: false,
+    });
+    privateOf(plugin)._dispatchDiagnose(pr, crypto.randomUUID());
+    await flushMicrotasks();
+
+    const cid = skillCaptured[0]!.correlationId;
+    bus.publish(`agent.skill.response.${cid}`, {
+      id: crypto.randomUUID(),
+      correlationId: cid,
+      topic: `agent.skill.response.${cid}`,
+      timestamp: Date.now(),
+      payload: {
+        text:
+          '```json\n{"verdict":"decomposable","evidence":"clusters in 2 files","conflictingFiles":["a.ts","b.ts"]}\n```',
+      },
+    });
+    await flushMicrotasks();
+
+    expect(hitlCaptured.length).toBe(1);
 
     plugin.uninstall();
   });

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -269,10 +269,13 @@ skills:
     systemPromptOverride: |
       You are a PR conflict diagnostician. Analyze the given PR and return ONLY a JSON verdict.
 
+      Promotion-PR rule (apply first, before anything else):
+      When the PR is a promotion — head branch is `dev` or `staging`, OR base branch is `main` or `staging`, OR title starts with `Promote` / `promote:` — the verdict is always `rebasable`. Drift between branches is fixed with a back-merge of the base into the head. Apply this even when conflicts cluster in a small number of files; splitting wouldn't reduce drift, because the conflict is between branches, not within the PR's commits.
+
       The four verdicts:
       - "redundant": PR intent already satisfied by commits on the base branch since the PR was cut. Evidence: find base commits implementing the same change.
-      - "rebasable": Conflicts are textual but non-semantic — whitespace, import order, doc section shuffle, auto-generated files. A three-way merge can resolve them without losing semantic meaning.
-      - "decomposable": Conflicts cluster in a small number of specific files. Splitting the PR into smaller, focused PRs would avoid the conflict entirely.
+      - "rebasable": Conflicts are textual but non-semantic — whitespace, import order, doc section shuffle, auto-generated files. A three-way merge can resolve them without losing semantic meaning. (Also the verdict for any promotion PR per the rule above.)
+      - "decomposable": Conflicts cluster in a small number of specific files. Splitting the PR into smaller, focused PRs would avoid the conflict entirely. (Never applies to promotion PRs.)
       - "genuine": Semantic conflicts requiring human judgment — which lines are correct is ambiguous and cannot be resolved mechanically.
 
       Respond with ONLY this JSON structure (inside a json code block):


### PR DESCRIPTION
Closes #465.

## Motivation

PR #463 (the v0.7.22 dev→main promotion bundling 17 already-merged PRs) was auto-closed yesterday by `protoquinn[bot]` with this comment:

> **Auto-remediation verdict: decomposable** — closing and proposing a split.
>
> This PR has merge conflicts that cluster into distinct file groups. Rather than attempting a complex merge, the recommended path is to split this PR into smaller, focused PRs — one per file cluster.
>
> **Conflicting file clusters:**
> - `src/services/a2a/agentCard.ts`
> - `src/services/fleet-health/collector.ts`
> - `src/services/ceremonies/loader.ts`
> - `package.json`
>
> **Evidence:** This dev→main promotion PR bundles 3 independent concerns ... Splitting into separate PRs per feature area would isolate the conflicting files and allow each to merge independently.

That's a **structurally wrong policy for a promotion PR**. The work is already split across the 17 PRs being promoted; the conflicts are drift between dev and main, not need-to-decompose. Recovery is `rebasable` (back-merge), not split.

## Two-layer fix

### Layer A — `workspace/agents/ava.yaml` `diagnose_pr_stuck` prompt

Promotion-PR rule is now stated **first**, above the four verdict definitions, in positive framing per the no-negative-reinforcement memory:

> When the PR is a promotion — head branch is `dev` or `staging`, OR base branch is `main` or `staging`, OR title starts with `Promote` / `promote:` — the verdict is always `rebasable`. Drift between branches is fixed with a back-merge of the base into the head. Apply this even when conflicts cluster in a small number of files; splitting wouldn't reduce drift, because the conflict is between branches, not within the PR's commits.

The dispatch payload to Ava also gains a `Head branch:` line so she has the field to apply the rule to.

### Layer B — `lib/plugins/pr-remediator.ts` chokepoint guard

```ts
// before
case "decomposable": {
  // ... post comment, ghClosePr ...
}

// after
case "decomposable": {
  if (isPromotionPr(pr)) {
    console.warn(`PROMOTION GUARD: refusing decomposable verdict on protected PR ${prKey} ` +
                 `(head=${pr.headRef} base=${pr.baseRef} title="${pr.title}"). ` +
                 `Promotion conflicts indicate drift, not need-to-decompose. Escalating to HITL.`);
    this._emitStuckHitlEscalation(pr.repo, pr.number, "update_branch", entry, evidence);
    break;
  }
  // ... existing post comment, ghClosePr ...
}
```

`isPromotionPr()` returns true when `headRef ∈ {dev, staging}` OR `baseRef ∈ {main, staging}` OR title starts `promote:` / `promote `. `PrDomainEntry` gains an optional `headRef` field; `src/api/github.ts` surfaces `pr.head.ref` in the `pr_pipeline` domain so the guard can see it.

This is the same defense-in-depth shape as #437 (cooldown), #444 (target registry), and #459 (synthetic actor filter): invariants belong at the action-site chokepoint, not at the planner. A drifting prompt cannot close a release-pipeline PR.

## Tests

`src/pr-remediator.test.ts` adds 4 new cases inside the `diagnose_pr_stuck` describe block:

- (a) decomposable verdict on a refactor PR (head=`feature/x`, base=`dev`) → still closes (no HITL)
- (b) decomposable verdict on dev→main promotion PR → does NOT close, escalates to HITL with `Promotion-PR guard` reason in the summary
- (c) decomposable verdict on staging→main promotion PR → escalates to HITL
- (d) decomposable verdict on dev→staging promotion PR → escalates to HITL

Full suite: **1047/1047 pass**.

## Verification plan

- [ ] Open a synthetic conflict-bearing dev→main PR (e.g. add a debug commit on main touching a file dev also changed).
- [ ] Wait for `pr-remediator` to dispatch `diagnose_pr_stuck` after 2 update-branch 422s.
- [ ] Expect: `PROMOTION GUARD` warn line in logs, HITL request emitted, **PR remains OPEN**.
- [ ] `gh pr view <id> --json closedBy --jq .closedBy.login` should never be `protoquinn[bot]` for any PR with `base: main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented promotion pull request detection using branch naming patterns and title prefixes (e.g., "Promote")
  * Escalates promotion PRs to human review instead of attempting automatic decomposition

* **Improvements**
  * Enhanced PR diagnostics display with head branch reference information
  * Added protective measures for release and staging branch merge operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->