### PR TITLE
feat(linear): Linear → protoMaker board bridge plugin (label-triggered, auto-file)

### DIFF
--- a/docs/integrations/linear.md
+++ b/docs/integrations/linear.md
@@ -116,6 +116,63 @@ LinearPlugin outbound subscriber  → client.addComment(issueId, text)
 Comment appears on the Linear issue.
 ```
 
-## Decoupled protoMaker integration
+## Linear → protoMaker board bridge
 
-Want Linear issues to become features on the protoMaker board? Write a tiny plugin that subscribes to `message.inbound.linear.issue.created` and publishes `agent.skill.request` with `skill: "manage_feature"` — `LinearPlugin` doesn't need to know about protoMaker, and protoMaker doesn't need to know about Linear. That's the bus contract doing its job.
+`LinearProtoMakerBridgePlugin` (`lib/plugins/linear-protomaker-bridge.ts`) wires inbound Linear issues into the protoMaker board with no direct dependency on either side — pure bus contract. It's installed unconditionally and is a no-op until `workspace/linear-board-mappings.yaml` exists.
+
+### Configuration
+
+Copy `workspace/linear-board-mappings.yaml.example` to `workspace/linear-board-mappings.yaml` and edit:
+
+```yaml
+mappings:
+  - linearTeamKey: "ENG"
+    protoMakerProjectSlug: "engineering"
+    triggerLabel: "board"
+  - linearTeamKey: "DESIGN"
+    protoMakerProjectSlug: "design-system"
+    triggerLabel: "board"
+```
+
+Each mapping says: when an inbound Linear issue from `linearTeamKey` carries `triggerLabel`, file it as a feature on `protoMakerProjectSlug` via the `manage_feature` skill. Issues without the label drop straight through (RouterPlugin's chat path still handles them per `channels.yaml`).
+
+The mapping file is hot-reloaded at a 5-second interval — add or remove routes without a restart.
+
+### Flow
+
+```
+User creates Linear issue with the "board" label
+  ↓
+LinearPlugin publishes:           message.inbound.linear.issue.created
+  ↓                               { teamKey: "ENG", labels: ["board"], ... }
+  ↓
+LinearProtoMakerBridgePlugin matches the team + label and publishes:
+  agent.skill.request {
+    skill:   "manage_feature",
+    targets: ["protomaker"],
+    content: "Create a feature on project 'engineering' ...",
+    meta:    { sourceLinearIssueId, sourceLinearIdentifier, ... },
+    reply:   { topic: "linear.reply.{issueId}" }
+  }
+  ↓
+SkillDispatcherPlugin routes to protoMaker, which creates the board feature
+  ↓
+ProtoMaker's response is published on linear.reply.{issueId}
+  ↓
+LinearPlugin outbound subscriber comments on the Linear issue:
+  "Filed on board as feature ENG-XXX..."
+```
+
+### Filing close-the-loop is done; "feature done" close-the-loop is deferred
+
+When the protoMaker board feature later transitions to **done**, ideally a comment is posted back on the Linear issue. This isn't yet wired — there's no bus event today for board feature lifecycle (only skill-completion events from `SkillDispatcherPlugin`).
+
+Once protoMaker emits a `protomaker.feature.completed` (or similar) event on the bus, adding the done-loop is a ~10-line subscriber here that maps `featureId → linearIssueId` and publishes `linear.reply.{linearIssueId}` with the completion text.
+
+### What this plugin doesn't do
+
+- Doesn't import from `lib/plugins/linear.ts`.
+- Doesn't import from anything protoMaker-specific.
+- Doesn't reach Linear or protoMaker over the network — every operation is a bus publish.
+
+That's the no-cross-plugin-dependency contract.

--- a/lib/plugins/__tests__/linear-protomaker-bridge.test.ts
+++ b/lib/plugins/__tests__/linear-protomaker-bridge.test.ts
@@ -1,0 +1,248 @@
+/**
+ * LinearProtoMakerBridge tests — verify label gating, mapping resolution,
+ * and the shape of the dispatched manage_feature request. The plugin
+ * itself doesn't reach Linear or protoMaker; everything goes through the
+ * bus.
+ *
+ * We construct mappings via a temp workspace directory rather than
+ * exposing the loader, so the tests exercise the same yaml-parse path
+ * production uses.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { InMemoryEventBus } from "../../bus.ts";
+import { LinearProtoMakerBridgePlugin } from "../linear-protomaker-bridge.ts";
+import type { BusMessage } from "../../types.ts";
+
+function makeIssuePayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    issueId: "issue-uuid-1",
+    identifier: "ENG-42",
+    title: "Add Linear plugin",
+    description: "Some details",
+    priority: "high",
+    teamKey: "ENG",
+    labels: ["board"],
+    url: "https://linear.app/foo/issue/ENG-42",
+    creatorName: "Josh",
+    ...overrides,
+  };
+}
+
+function publishIssueCreated(bus: InMemoryEventBus, payload: Record<string, unknown>): void {
+  bus.publish("message.inbound.linear.issue.created", {
+    id: crypto.randomUUID(),
+    correlationId: `linear-${payload.issueId}`,
+    topic: "message.inbound.linear.issue.created",
+    timestamp: Date.now(),
+    payload,
+    source: { interface: "linear" as const, channelId: payload.teamKey as string },
+    reply: { topic: `linear.reply.${payload.issueId}`, format: "structured" as const },
+  });
+}
+
+describe("LinearProtoMakerBridgePlugin", () => {
+  let workspaceDir: string;
+  let bus: InMemoryEventBus;
+  let plugin: LinearProtoMakerBridgePlugin;
+  let dispatched: BusMessage[];
+
+  beforeEach(() => {
+    workspaceDir = mkdtempSync(join(tmpdir(), "linear-bridge-test-"));
+    bus = new InMemoryEventBus();
+    dispatched = [];
+    bus.subscribe("agent.skill.request", "test-collector", (m) => { dispatched.push(m); });
+  });
+
+  afterEach(() => {
+    plugin?.uninstall();
+    rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  function writeMappings(yaml: string): void {
+    writeFileSync(join(workspaceDir, "linear-board-mappings.yaml"), yaml);
+  }
+
+  function installPlugin(): void {
+    plugin = new LinearProtoMakerBridgePlugin(workspaceDir);
+    plugin.install(bus);
+  }
+
+  test("issue with matching team + trigger label dispatches manage_feature", () => {
+    writeMappings(`
+mappings:
+  - linearTeamKey: ENG
+    protoMakerProjectSlug: engineering
+    triggerLabel: board
+`);
+    installPlugin();
+    publishIssueCreated(bus, makeIssuePayload());
+
+    expect(dispatched).toHaveLength(1);
+    const msg = dispatched[0];
+    const p = msg.payload as Record<string, unknown>;
+    expect(p.skill).toBe("manage_feature");
+    expect(p.targets).toEqual(["protomaker"]);
+    expect(typeof p.content).toBe("string");
+    expect(p.content as string).toContain("Title: Add Linear plugin");
+    expect(p.content as string).toContain("project 'engineering'");
+    expect(p.content as string).toContain("ENG-42");
+
+    const meta = p.meta as Record<string, unknown>;
+    expect(meta.sourceLinearIssueId).toBe("issue-uuid-1");
+    expect(meta.sourceLinearIdentifier).toBe("ENG-42");
+    expect(meta.protoMakerProjectSlug).toBe("engineering");
+    expect(meta.via).toBe("linear-protomaker-bridge");
+
+    // Reply routes through Linear's outbound subscriber so the operator
+    // sees the filing confirmation as a Linear comment.
+    expect(msg.reply?.topic).toBe("linear.reply.issue-uuid-1");
+  });
+
+  test("issue without trigger label is ignored even when team matches", () => {
+    writeMappings(`
+mappings:
+  - linearTeamKey: ENG
+    protoMakerProjectSlug: engineering
+    triggerLabel: board
+`);
+    installPlugin();
+    publishIssueCreated(bus, makeIssuePayload({ labels: ["bug", "frontend"] }));
+
+    expect(dispatched).toHaveLength(0);
+  });
+
+  test("issue with no labels is ignored", () => {
+    writeMappings(`
+mappings:
+  - linearTeamKey: ENG
+    protoMakerProjectSlug: engineering
+    triggerLabel: board
+`);
+    installPlugin();
+    publishIssueCreated(bus, makeIssuePayload({ labels: [] }));
+
+    expect(dispatched).toHaveLength(0);
+  });
+
+  test("issue from unmapped team is ignored", () => {
+    writeMappings(`
+mappings:
+  - linearTeamKey: ENG
+    protoMakerProjectSlug: engineering
+    triggerLabel: board
+`);
+    installPlugin();
+    publishIssueCreated(bus, makeIssuePayload({ teamKey: "OTHER" }));
+
+    expect(dispatched).toHaveLength(0);
+  });
+
+  test("no mappings file → bridge is a silent no-op", () => {
+    // Don't write any mapping file
+    installPlugin();
+    publishIssueCreated(bus, makeIssuePayload());
+
+    expect(dispatched).toHaveLength(0);
+  });
+
+  test("malformed mapping entries are skipped, valid ones still load", () => {
+    writeMappings(`
+mappings:
+  - linearTeamKey: ENG
+    # missing protoMakerProjectSlug + triggerLabel — should be skipped
+  - linearTeamKey: DESIGN
+    protoMakerProjectSlug: design-system
+    triggerLabel: board
+`);
+    installPlugin();
+
+    // ENG is malformed and should not match
+    publishIssueCreated(bus, makeIssuePayload({ teamKey: "ENG" }));
+    expect(dispatched).toHaveLength(0);
+
+    // DESIGN with the trigger label fires correctly
+    publishIssueCreated(bus, makeIssuePayload({ teamKey: "DESIGN" }));
+    expect(dispatched).toHaveLength(1);
+    const meta = (dispatched[0].payload as { meta: Record<string, unknown> }).meta;
+    expect(meta.protoMakerProjectSlug).toBe("design-system");
+  });
+
+  test("missing required Linear fields short-circuit (no crash, no dispatch)", () => {
+    writeMappings(`
+mappings:
+  - linearTeamKey: ENG
+    protoMakerProjectSlug: engineering
+    triggerLabel: board
+`);
+    installPlugin();
+
+    // No issueId
+    publishIssueCreated(bus, makeIssuePayload({ issueId: undefined }));
+    // No teamKey
+    publishIssueCreated(bus, makeIssuePayload({ teamKey: undefined }));
+    // No title
+    publishIssueCreated(bus, makeIssuePayload({ title: undefined }));
+
+    expect(dispatched).toHaveLength(0);
+  });
+
+  test("multiple mappings — each team routes to its own project", () => {
+    writeMappings(`
+mappings:
+  - linearTeamKey: ENG
+    protoMakerProjectSlug: engineering
+    triggerLabel: board
+  - linearTeamKey: DESIGN
+    protoMakerProjectSlug: design-system
+    triggerLabel: board
+`);
+    installPlugin();
+
+    publishIssueCreated(bus, makeIssuePayload({ teamKey: "ENG", issueId: "i-1" }));
+    publishIssueCreated(bus, makeIssuePayload({ teamKey: "DESIGN", issueId: "i-2" }));
+
+    expect(dispatched).toHaveLength(2);
+    const projects = dispatched.map(d => (d.payload as { meta: Record<string, unknown> }).meta.protoMakerProjectSlug);
+    expect(projects.sort()).toEqual(["design-system", "engineering"]);
+  });
+
+  test("priority and creator pass through into the manage_feature content", () => {
+    writeMappings(`
+mappings:
+  - linearTeamKey: ENG
+    protoMakerProjectSlug: engineering
+    triggerLabel: board
+`);
+    installPlugin();
+
+    publishIssueCreated(bus, makeIssuePayload({
+      priority: "urgent",
+      creatorName: "Alice",
+    }));
+
+    expect(dispatched).toHaveLength(1);
+    const content = (dispatched[0].payload as { content: string }).content;
+    expect(content).toContain("Priority: urgent");
+    expect(content).toContain("Filed by: Alice");
+  });
+
+  test("priority 'none' is suppressed in the content (avoids noise)", () => {
+    writeMappings(`
+mappings:
+  - linearTeamKey: ENG
+    protoMakerProjectSlug: engineering
+    triggerLabel: board
+`);
+    installPlugin();
+
+    publishIssueCreated(bus, makeIssuePayload({ priority: "none" }));
+
+    expect(dispatched).toHaveLength(1);
+    const content = (dispatched[0].payload as { content: string }).content;
+    expect(content).not.toContain("Priority:");
+  });
+});

--- a/lib/plugins/linear-protomaker-bridge.ts
+++ b/lib/plugins/linear-protomaker-bridge.ts
@@ -1,0 +1,208 @@
+/**
+ * LinearProtoMakerBridge — translates Linear issue events into protoMaker
+ * board feature creations, with no direct dependency on either the Linear
+ * plugin or the protoMaker integration. Pure bus contract.
+ *
+ * Inbound:
+ *   message.inbound.linear.issue.created (published by LinearPlugin)
+ *
+ * Outbound:
+ *   agent.skill.request — skill: manage_feature, targets: [protomaker],
+ *   reply.topic: linear.reply.{linearIssueId} so protoMaker's response
+ *   becomes a Linear comment automatically via LinearPlugin's outbound
+ *   subscriber. Filing close-the-loop ships in the same dispatch — no
+ *   bridge-side state needed.
+ *
+ * Configuration:
+ *   workspace/linear-board-mappings.yaml declares which Linear team feeds
+ *   into which protoMaker project, and which label gates filing:
+ *
+ *     mappings:
+ *       - linearTeamKey: "ENG"
+ *         protoMakerProjectSlug: "engineering"
+ *         triggerLabel: "board"
+ *       - linearTeamKey: "DESIGN"
+ *         protoMakerProjectSlug: "design-system"
+ *         triggerLabel: "board"
+ *
+ *   Issues without the trigger label are dropped here — RouterPlugin still
+ *   handles the chat path via workspace/channels.yaml independently.
+ *
+ * Done close-the-loop (deferred):
+ *   Posting a "feature completed" comment when the protoMaker board moves
+ *   the feature to done is not yet wired — there's no bus event today for
+ *   board-state lifecycle. When protoMaker emits a board feature
+ *   completed event, add a single subscriber here that maps featureId →
+ *   linearIssueId (which we'd need to start tracking) and publishes
+ *   linear.reply.{linearIssueId}. Tracked separately.
+ */
+
+import { existsSync, readFileSync, watchFile } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import type { EventBus, BusMessage, Plugin } from "../types.ts";
+
+interface LinearBoardMapping {
+  linearTeamKey: string;
+  protoMakerProjectSlug: string;
+  /** Label that gates filing. Issue must carry this label to fire. */
+  triggerLabel: string;
+}
+
+interface LinearBoardMappingsFile {
+  mappings?: LinearBoardMapping[];
+}
+
+interface LinearIssuePayload {
+  issueId: string;
+  identifier?: string;
+  title: string;
+  description?: string;
+  content?: string;
+  priority?: string;
+  teamKey?: string;
+  projectName?: string;
+  labels?: string[];
+  url?: string;
+  creatorName?: string;
+}
+
+export class LinearProtoMakerBridgePlugin implements Plugin {
+  readonly name = "linear-protomaker-bridge";
+  readonly description =
+    "Linear issue → protoMaker board feature bridge (label-triggered, auto-file)";
+  readonly capabilities = ["linear-protomaker-bridge"];
+
+  private readonly workspaceDir: string;
+  private readonly subscriptionIds: string[] = [];
+  private mappings: LinearBoardMapping[] = [];
+
+  constructor(workspaceDir: string) {
+    this.workspaceDir = workspaceDir;
+  }
+
+  install(bus: EventBus): void {
+    this._loadMappings();
+    const mappingsPath = join(this.workspaceDir, "linear-board-mappings.yaml");
+    if (existsSync(mappingsPath)) {
+      // Hot-reload — operator can adjust trigger labels / project routes
+      // without a process restart.
+      watchFile(mappingsPath, { interval: 5_000 }, () => this._loadMappings());
+    }
+
+    const subId = bus.subscribe(
+      "message.inbound.linear.issue.created",
+      this.name,
+      (msg: BusMessage) => this._handleIssueCreated(bus, msg),
+    );
+    this.subscriptionIds.push(subId);
+
+    console.log(
+      `[linear-protomaker-bridge] installed with ${this.mappings.length} mapping(s)`,
+    );
+  }
+
+  uninstall(): void {
+    // Bus subscriptions are owned by the bus; nothing to actively cancel
+    // here beyond clearing local state.
+    this.subscriptionIds.length = 0;
+  }
+
+  private _loadMappings(): void {
+    const path = join(this.workspaceDir, "linear-board-mappings.yaml");
+    if (!existsSync(path)) {
+      this.mappings = [];
+      return;
+    }
+    try {
+      const parsed = parseYaml(readFileSync(path, "utf8")) as LinearBoardMappingsFile;
+      const next: LinearBoardMapping[] = [];
+      for (const m of parsed.mappings ?? []) {
+        if (!m.linearTeamKey || !m.protoMakerProjectSlug || !m.triggerLabel) {
+          console.warn(
+            `[linear-protomaker-bridge] mapping missing required fields, skipping: ${JSON.stringify(m)}`,
+          );
+          continue;
+        }
+        next.push({
+          linearTeamKey: m.linearTeamKey,
+          protoMakerProjectSlug: m.protoMakerProjectSlug,
+          triggerLabel: m.triggerLabel,
+        });
+      }
+      this.mappings = next;
+      console.log(
+        `[linear-protomaker-bridge] reloaded ${next.length} mapping(s) from ${path}`,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[linear-protomaker-bridge] failed to parse ${path}: ${msg}`);
+      // Keep prior mappings on parse error — fail-soft hot reload.
+    }
+  }
+
+  private _handleIssueCreated(bus: EventBus, msg: BusMessage): void {
+    const payload = (msg.payload ?? {}) as LinearIssuePayload;
+    if (!payload.issueId || !payload.teamKey || !payload.title) return;
+
+    const mapping = this.mappings.find(m => m.linearTeamKey === payload.teamKey);
+    if (!mapping) return;
+
+    const labels = payload.labels ?? [];
+    if (!labels.includes(mapping.triggerLabel)) {
+      console.log(
+        `[linear-protomaker-bridge] ${payload.identifier ?? payload.issueId} skipped — no '${mapping.triggerLabel}' label (has: ${labels.join(", ") || "none"})`,
+      );
+      return;
+    }
+
+    // Route protoMaker's response through Linear's outbound subscriber so
+    // the operator sees the filing confirmation as a Linear comment with
+    // zero bridge-side state.
+    const replyTopic = `linear.reply.${payload.issueId}`;
+
+    const description = payload.description ?? "";
+    const content =
+      `Create a feature on the protoMaker board for project '${mapping.protoMakerProjectSlug}'.\n\n` +
+      `Title: ${payload.title}\n\n` +
+      `Description:\n${description || "(none provided)"}\n\n` +
+      `Source: Linear issue ${payload.identifier ?? payload.issueId}` +
+      (payload.url ? ` (${payload.url})` : "") +
+      (payload.priority && payload.priority !== "none" ? `\nPriority: ${payload.priority}` : "") +
+      (payload.creatorName ? `\nFiled by: ${payload.creatorName}` : "");
+
+    const correlationId = `linear-bridge-${payload.issueId}`;
+    bus.publish("agent.skill.request", {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic: "agent.skill.request",
+      timestamp: Date.now(),
+      payload: {
+        skill: "manage_feature",
+        content,
+        targets: ["protomaker"],
+        meta: {
+          // Preserve enough Linear context for protoMaker handlers (or
+          // future audit) to reconstruct the source without going through
+          // the bus archive.
+          sourceLinearIssueId: payload.issueId,
+          sourceLinearIdentifier: payload.identifier,
+          sourceLinearTeamKey: payload.teamKey,
+          sourceLinearUrl: payload.url,
+          sourceLinearPriority: payload.priority,
+          protoMakerProjectSlug: mapping.protoMakerProjectSlug,
+          via: "linear-protomaker-bridge",
+        },
+      },
+      reply: {
+        topic: replyTopic,
+        format: "structured",
+      },
+      source: { interface: "linear" as const },
+    });
+
+    console.log(
+      `[linear-protomaker-bridge] ${payload.identifier ?? payload.issueId} → manage_feature for project '${mapping.protoMakerProjectSlug}' (reply → ${replyTopic})`,
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,6 +243,19 @@ const pluginRegistry: PluginRegistryEntry[] = [
     },
   },
   {
+    // Linear → protoMaker board feature bridge. No-op when
+    // workspace/linear-board-mappings.yaml is absent or empty, so it's
+    // safe to install unconditionally.
+    name: "linear-protomaker-bridge",
+    condition: () => true,
+    factory: async () => {
+      const { LinearProtoMakerBridgePlugin } = await import(
+        "../lib/plugins/linear-protomaker-bridge"
+      );
+      return new LinearProtoMakerBridgePlugin(workspaceDir);
+    },
+  },
+  {
     name: "onboarding",
     condition: () => true,
     factory: async () => {

--- a/workspace/linear-board-mappings.yaml.example
+++ b/workspace/linear-board-mappings.yaml.example
@@ -1,0 +1,24 @@
+# LinearProtoMakerBridgePlugin configuration.
+#
+# Each mapping declares: when an inbound Linear issue from `linearTeamKey`
+# carries `triggerLabel`, file it as a feature on `protoMakerProjectSlug`
+# via the `manage_feature` skill. ProtoMaker's response is routed back as
+# a comment on the originating Linear issue.
+#
+# Issues without the trigger label are dropped here — RouterPlugin still
+# handles the chat path via workspace/channels.yaml independently.
+#
+# Hot-reload: watched at 5s interval. Add / remove mappings without a
+# restart.
+#
+# Copy this file to `linear-board-mappings.yaml` and edit. The bridge is
+# a no-op without it.
+
+mappings:
+  - linearTeamKey: "ENG"
+    protoMakerProjectSlug: "engineering"
+    triggerLabel: "board"
+
+  - linearTeamKey: "DESIGN"
+    protoMakerProjectSlug: "design-system"
+    triggerLabel: "board"


### PR DESCRIPTION
Continuation of the Linear track. Bridges inbound Linear issues into protoMaker board features with no direct dependency on either side — pure bus contract, exactly what you described as the design goal.

## Bus flow

\`\`\`
User creates Linear issue with the "board" label
  ↓
LinearPlugin (#478) publishes:    message.inbound.linear.issue.created
  ↓                               { teamKey: "ENG", labels: ["board"], ... }
  ↓
LinearProtoMakerBridge matches and publishes:
  agent.skill.request {
    skill:   "manage_feature",
    targets: ["protomaker"],
    content: "Create a feature on project 'engineering' ...",
    meta:    { sourceLinearIssueId, sourceLinearIdentifier, ... },
    reply:   { topic: "linear.reply.{issueId}" }
  }
  ↓
SkillDispatcher → protoMaker creates the board feature
  ↓
ProtoMaker reply published on:    linear.reply.{issueId}
  ↓
LinearPlugin outbound subscriber  → comments on the Linear issue:
                                    "Filed on board as feature ENG-XXX..."
\`\`\`

Filing close-the-loop happens automatically via the \`reply.topic\` plumbing — **no bridge-side state, no persistence, no race conditions.**

## Configuration

Operator drops a \`workspace/linear-board-mappings.yaml\` (template provided as \`.example\`):

\`\`\`yaml
mappings:
  - linearTeamKey: "ENG"
    protoMakerProjectSlug: "engineering"
    triggerLabel: "board"
  - linearTeamKey: "DESIGN"
    protoMakerProjectSlug: "design-system"
    triggerLabel: "board"
\`\`\`

Hot-reloaded at 5s interval. Without this file the bridge is a no-op. Issues without the trigger label drop through to the chat path (handled by \`RouterPlugin\` + \`channels.yaml\` independently).

## What this PR deliberately doesn't do

- **Done close-the-loop** — when the protoMaker board feature later moves to "done", post a comment on Linear. Not yet wired because there's no bus event for board-feature lifecycle today (only skill-completion events from \`SkillDispatcherPlugin\`). When protoMaker emits a \`protomaker.feature.completed\` event, this becomes a ~10 line subscriber here. Worth filing as a separate platform issue against protoMaker.
- **Reverse direction** — protoMaker board operations creating Linear issues. Different use case, separate plugin.
- **HITL gate** — auto-file is intentional per the configured triggerLabel design (the label IS the gate; the operator decides which Linear issues are "board-worthy" by labeling them).

## Files

| File | LOC | Purpose |
|---|---|---|
| \`lib/plugins/linear-protomaker-bridge.ts\` | ~210 | Subscriber + dispatcher + yaml hot-reload |
| \`lib/plugins/__tests__/linear-protomaker-bridge.test.ts\` | ~250 | 10 tests — label gating, multi-team routing, malformed mappings, missing fields, priority passthrough |
| \`workspace/linear-board-mappings.yaml.example\` | +24 | Copy + edit template |
| \`src/index.ts\` | +13 | Plugin registered unconditionally (no-op without mappings file) |
| \`docs/integrations/linear.md\` | +61 | Bridge section + flow diagram |

## Test plan
- [x] \`bun test\` — 1082/1082 pass (+10 new)
- [x] \`tsc --noEmit\` clean
- [ ] Drop \`linear-board-mappings.yaml\` on \`:dev\`, label a Linear issue \`board\`, verify protoMaker creates the feature + comment posts back on Linear
- [ ] Verify no-op behavior when mappings file is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Linear-to-protoMaker bridge that automatically routes Linear issues to protoMaker boards based on configurable team and label mappings, with hot-reload support.

* **Documentation**
  * Added bridge documentation including configuration examples and control flow specifications.

* **Tests**
  * Added comprehensive test suite covering bridge functionality, mappings, routing, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->