### PR TITLE
fix(linear): bundle audit findings — fail-loud, replay protection, schema validation

### DIFF
--- a/docs/integrations/linear.md
+++ b/docs/integrations/linear.md
@@ -61,7 +61,7 @@ channels:
 | Variable | Required | Description |
 |---|---|---|
 | `LINEAR_API_KEY` | For outbound | Personal API key for GraphQL mutations |
-| `LINEAR_WEBHOOK_SECRET` | For inbound | HMAC-SHA256 signing secret from Linear webhook config. Unset = verification disabled (dev mode only) |
+| `LINEAR_WEBHOOK_SECRET` | For inbound | HMAC-SHA256 signing secret from Linear webhook config. **REQUIRED** when `NODE_ENV=production` or `WORKSTACEAN_PUBLIC_BASE_URL` is set — `LinearPlugin` refuses to start without it (open-relay safety). Unset is allowed in dev only and disables signature verification. |
 | `LINEAR_WEBHOOK_PORT` | No | Webhook server port (default: `8084`) |
 
 The plugin is condition-gated on either env var being present — with neither set, it doesn't install.
@@ -80,15 +80,21 @@ The plugin is condition-gated on either env var being present — with neither s
 | `message.inbound.linear.project.created` | Project created | `projectId`, `name`, `description`, `state`, `creatorId` |
 | `message.inbound.linear.project.updated` | Project updated | same shape |
 
-Every inbound message carries `source.interface = "linear"`, `source.channelId` (team key / issue id / project id), and `reply.topic = linear.reply.{issueId}` when applicable.
+Every inbound message carries `source.interface = "linear"`, `source.channelId` (team key / issue id / project id), and `reply.topic = linear.reply.{issueId}` (with `format: "markdown"` so agents emit Linear-renderable comment bodies) when applicable.
+
+Inbound webhooks are validated against a Zod envelope schema — a malformed Linear payload is rejected with HTTP 400 before reaching the bus. Replay protection rejects events whose `webhookTimestamp` is more than 5 minutes off real time.
 
 ### Outbound (bus → Linear)
 
 | Topic | Payload | Effect |
 |---|---|---|
-| `linear.reply.{issueId}` | `{ text }` | Posts a comment on the issue |
-| `linear.update.issue.{issueId}` | `{ stateName?, priority?, assigneeId?, labelIds? }` | Mutates the issue |
-| `linear.create.issue` | `{ teamKey, title, description?, priority?, assigneeId?, labelIds?, stateName? }` | Creates a new issue; publishes result on `linear.create.issue.result.{correlationId}` |
+| `linear.reply.{issueId}` | `{ text }` | Posts a comment. Result published on `linear.reply.result.{correlationId}` |
+| `linear.update.issue.{issueId}` | `{ stateName?, priority?, assigneeId?, labelIds? }` | Mutates the issue. Result published on `linear.update.issue.result.{correlationId}` |
+| `linear.create.issue` | `{ teamKey, title, description?, priority?, assigneeId?, labelIds?, stateName? }` | Creates a new issue. Result published on `linear.create.issue.result.{correlationId}` |
+
+**Result-topic shape:** every outbound mutation publishes a `{family}.result.{correlationId}` event with `{ success: boolean, error?: string, issueId?: string }`. A `linear.reply.{issueId}` that hits a Linear rate-limit, has an empty body, or comes from a revoked API key surfaces as a `linear.reply.result.{cid}` with `success: false, error: "..."` — instead of silently swallowing the failure as the V1 plugin did.
+
+**Priority semantics:** `priority: "none"` on `linear.update.issue.*` sets Linear's "No priority" (value `0`), which is a real Linear value distinct from "leave unchanged." Pass `priority: undefined` (omit the field) to leave the existing priority untouched.
 
 ## Multi-layer conversation example
 

--- a/lib/linear-client.ts
+++ b/lib/linear-client.ts
@@ -6,9 +6,14 @@
  *
  * The SDK already handles GraphQL auth + retries + schema validation, so this
  * layer is deliberately a narrow adapter:
- *   - resolve human-friendly teamKey → teamId
- *   - resolve state name → stateId (cached per team)
+ *   - resolve human-friendly teamKey → teamId (cached with TTL)
+ *   - resolve state name → stateId (cached per team with TTL)
  *   - coerce priority strings to the 0-4 ints Linear expects
+ *
+ * Priority semantics: Linear's `0` is the literal "No priority" value, NOT
+ * "leave unchanged". Passing `priority: "none"` to updateIssue() will set the
+ * issue to No priority. Pass `priority: undefined` (omit the field) to leave
+ * priority untouched.
  */
 
 import { LinearClient as LinearSdkClient } from "@linear/sdk";
@@ -22,6 +27,13 @@ const PRIORITY_MAP: Record<LinearPriority, number> = {
   low: 4,
   none: 0,
 };
+
+/**
+ * Cache TTL for team-id and state-name lookups. Linear teams + workflow
+ * states rarely change, but a process-lifetime cache risks holding stale
+ * mappings across a workspace re-org. 10 min strikes a reasonable balance.
+ */
+const CACHE_TTL_MS = 10 * 60 * 1000;
 
 export interface CreateIssueInput {
   teamKey: string;
@@ -40,36 +52,47 @@ export interface UpdateIssueInput {
   labelIds?: string[];
 }
 
+export type UpdateIssueResult =
+  | { success: true }
+  | { success: false; reason: string };
+
+interface CacheEntry<V> { value: V; expiresAt: number; }
+
 export class LinearClient {
   private readonly sdk: LinearSdkClient;
-  private teamIdCache = new Map<string, string>();
-  private stateCache = new Map<string, Map<string, string>>();
+  private teamIdCache = new Map<string, CacheEntry<string>>();
+  private stateCache = new Map<string, CacheEntry<Map<string, string>>>();
 
   constructor(apiKey: string) {
     this.sdk = new LinearSdkClient({ apiKey });
   }
 
   /**
-   * Resolve a team key (e.g. "ENG") to its UUID. Cached — Linear team keys
-   * are stable strings, so a process-lifetime cache is safe.
+   * Resolve a team key (e.g. "ENG") to its UUID. Cached with TTL — Linear
+   * team keys are stable, but the cache TTL bounds drift after a re-org.
    */
   async resolveTeamId(teamKey: string): Promise<string | null> {
+    const now = Date.now();
     const cached = this.teamIdCache.get(teamKey);
-    if (cached) return cached;
+    if (cached && cached.expiresAt > now) return cached.value;
     const teams = await this.sdk.teams({ filter: { key: { eq: teamKey } }, first: 1 });
     const team = teams.nodes[0];
     if (!team) return null;
-    this.teamIdCache.set(teamKey, team.id);
+    this.teamIdCache.set(teamKey, { value: team.id, expiresAt: now + CACHE_TTL_MS });
     return team.id;
   }
 
   /**
    * Resolve a state name (e.g. "In Progress") to its UUID within a team.
-   * Case-insensitive. Cached per team.
+   * Case-insensitive. Cached per team with TTL.
    */
   async resolveStateId(teamId: string, stateName: string): Promise<string | null> {
-    let teamStates = this.stateCache.get(teamId);
-    if (!teamStates) {
+    const now = Date.now();
+    const cached = this.stateCache.get(teamId);
+    let teamStates: Map<string, string>;
+    if (cached && cached.expiresAt > now) {
+      teamStates = cached.value;
+    } else {
       teamStates = new Map();
       const states = await this.sdk.workflowStates({
         filter: { team: { id: { eq: teamId } } },
@@ -78,9 +101,15 @@ export class LinearClient {
       for (const s of states.nodes) {
         teamStates.set(s.name.toLowerCase(), s.id);
       }
-      this.stateCache.set(teamId, teamStates);
+      this.stateCache.set(teamId, { value: teamStates, expiresAt: now + CACHE_TTL_MS });
     }
     return teamStates.get(stateName.toLowerCase()) ?? null;
+  }
+
+  /** Drop all cached lookups. Useful for tests and after known workspace edits. */
+  invalidateCache(): void {
+    this.teamIdCache.clear();
+    this.stateCache.clear();
   }
 
   /** Post a comment on an issue. Returns true on success. */
@@ -95,7 +124,7 @@ export class LinearClient {
     if (!teamId) return null;
 
     const stateId = input.stateName ? await this.resolveStateId(teamId, input.stateName) : undefined;
-    const priorityInt = input.priority ? PRIORITY_MAP[input.priority] : undefined;
+    const priorityInt = input.priority !== undefined ? PRIORITY_MAP[input.priority] : undefined;
 
     const result = await this.sdk.createIssue({
       teamId,
@@ -111,24 +140,46 @@ export class LinearClient {
     return issue?.id ?? null;
   }
 
-  /** Update an issue's state/priority/assignee/labels. Returns true on success. */
-  async updateIssue(issueId: string, input: UpdateIssueInput): Promise<boolean> {
+  /**
+   * Update an issue. Returns a tagged result so the caller can distinguish
+   * "no fields to update" from "API call failed" — both used to come back as
+   * a bare `false` and were indistinguishable.
+   *
+   * `priority: "none"` sets Linear's "No priority" (value 0). Pass undefined
+   * (omit the field) to leave the existing priority untouched.
+   */
+  async updateIssue(issueId: string, input: UpdateIssueInput): Promise<UpdateIssueResult> {
     const update: Record<string, unknown> = {};
-    if (input.priority) update.priority = PRIORITY_MAP[input.priority];
-    if (input.assigneeId) update.assigneeId = input.assigneeId;
-    if (input.labelIds) update.labelIds = input.labelIds;
+    // !== undefined so the explicit "none" → 0 mapping reaches Linear,
+    // matching the documented semantics.
+    if (input.priority !== undefined) update.priority = PRIORITY_MAP[input.priority];
+    if (input.assigneeId !== undefined) update.assigneeId = input.assigneeId;
+    if (input.labelIds !== undefined) update.labelIds = input.labelIds;
 
     if (input.stateName) {
       const issue = await this.sdk.issue(issueId);
       const teamId = (await issue.team)?.id;
-      if (teamId) {
-        const stateId = await this.resolveStateId(teamId, input.stateName);
-        if (stateId) update.stateId = stateId;
+      if (!teamId) {
+        return { success: false, reason: `issue ${issueId} has no team` };
       }
+      const stateId = await this.resolveStateId(teamId, input.stateName);
+      if (!stateId) {
+        return {
+          success: false,
+          reason: `state name '${input.stateName}' not found on team ${teamId}`,
+        };
+      }
+      update.stateId = stateId;
     }
 
-    if (Object.keys(update).length === 0) return false;
+    if (Object.keys(update).length === 0) {
+      return { success: false, reason: "no fields supplied to update" };
+    }
+
     const result = await this.sdk.updateIssue(issueId, update);
-    return Boolean(result.success);
+    if (!result.success) {
+      return { success: false, reason: "Linear updateIssue mutation returned success=false" };
+    }
+    return { success: true };
   }
 }

--- a/lib/plugins/__tests__/linear-protomaker-bridge.test.ts
+++ b/lib/plugins/__tests__/linear-protomaker-bridge.test.ts
@@ -149,26 +149,25 @@ mappings:
     expect(dispatched).toHaveLength(0);
   });
 
-  test("malformed mapping entries are skipped, valid ones still load", () => {
+  test("malformed mapping entry rejects the WHOLE file (fail-loud config)", () => {
+    // V2 behavior change: a typo in any one mapping now invalidates the whole
+    // file rather than partially loading it. That's a clearer signal —
+    // operator sees a loud schema error instead of confused silent-drop on
+    // the entry they expected to fire. Per the audit's "fail loud on config" finding.
     writeMappings(`
 mappings:
   - linearTeamKey: ENG
-    # missing protoMakerProjectSlug + triggerLabel — should be skipped
+    # missing protoMakerProjectSlug + triggerLabel
   - linearTeamKey: DESIGN
     protoMakerProjectSlug: design-system
     triggerLabel: board
 `);
     installPlugin();
 
-    // ENG is malformed and should not match
+    // Neither entry loads — the whole file failed schema validation.
     publishIssueCreated(bus, makeIssuePayload({ teamKey: "ENG" }));
-    expect(dispatched).toHaveLength(0);
-
-    // DESIGN with the trigger label fires correctly
     publishIssueCreated(bus, makeIssuePayload({ teamKey: "DESIGN" }));
-    expect(dispatched).toHaveLength(1);
-    const meta = (dispatched[0].payload as { meta: Record<string, unknown> }).meta;
-    expect(meta.protoMakerProjectSlug).toBe("design-system");
+    expect(dispatched).toHaveLength(0);
   });
 
   test("missing required Linear fields short-circuit (no crash, no dispatch)", () => {

--- a/lib/plugins/__tests__/linear.test.ts
+++ b/lib/plugins/__tests__/linear.test.ts
@@ -1,13 +1,11 @@
 /**
- * LinearPlugin tests — inbound webhook → bus publish, outbound bus → LinearClient,
- * HMAC verification, and dedup. Exercises the plugin's shape translation without
- * starting a real HTTP server (we call the internal handler directly via a
- * minimal harness) so tests run fast and are hermetic.
+ * LinearPlugin tests — inbound shape translation, outbound subscriber result
+ * topics, HMAC verification, schema validation, replay window, dedup.
  *
- * We don't spin up Bun.serve — install() has HTTP wiring side effects we can't
- * easily disable, so these tests reach into the plugin by calling the private
- * _handleWebhook and _wireOutbound methods directly through an `as unknown as`
- * cast. Same pattern used in the pr-remediator tests.
+ * We don't spin up Bun.serve here — install() has HTTP wiring side effects
+ * that complicate hermetic tests, so we reach into the plugin via private
+ * `_handleWebhook` and `_wireOutbound` through an `as unknown as` cast. Same
+ * pattern as pr-remediator tests.
  */
 
 import { describe, test, expect, beforeEach } from "bun:test";
@@ -15,6 +13,7 @@ import { createHmac } from "node:crypto";
 import { InMemoryEventBus } from "../../bus.ts";
 import { LinearPlugin } from "../linear.ts";
 import type { BusMessage } from "../../types.ts";
+import type { UpdateIssueResult } from "../../linear-client.ts";
 
 interface LinearPrivate {
   _handleWebhook(payload: unknown, bus: InMemoryEventBus): Promise<void>;
@@ -25,12 +24,11 @@ function priv(plugin: LinearPlugin): LinearPrivate {
   return plugin as unknown as LinearPrivate;
 }
 
-// Minimal stand-in for LinearClient — records calls so outbound tests assert
-// that the correct SDK method was invoked with the right arguments.
 interface MockCall {
   method: string;
   args: unknown[];
 }
+
 function makeMockClient(overrides: Record<string, (...args: unknown[]) => unknown> = {}) {
   const calls: MockCall[] = [];
   const record = (method: string) => (...args: unknown[]) => {
@@ -39,7 +37,7 @@ function makeMockClient(overrides: Record<string, (...args: unknown[]) => unknow
     if (impl) return impl(...args);
     if (method === "createIssue") return Promise.resolve("new-issue-id");
     if (method === "addComment") return Promise.resolve(true);
-    if (method === "updateIssue") return Promise.resolve(true);
+    if (method === "updateIssue") return Promise.resolve({ success: true } as UpdateIssueResult);
     return Promise.resolve(null);
   };
   return {
@@ -56,6 +54,11 @@ function collectBus(bus: InMemoryEventBus, pattern: string): BusMessage[] {
   return collected;
 }
 
+// Wrap a payload as a Linear webhook envelope (post-Zod-parse shape).
+function envelope(action: "create" | "update" | "remove", type: string, data: Record<string, unknown>) {
+  return { action, type, data };
+}
+
 describe("LinearPlugin — inbound webhooks", () => {
   let bus: InMemoryEventBus;
   let plugin: LinearPlugin;
@@ -67,25 +70,21 @@ describe("LinearPlugin — inbound webhooks", () => {
 
   test("Issue create → publishes message.inbound.linear.issue.created with correct shape", async () => {
     const collected = collectBus(bus, "message.inbound.linear.issue.#");
-    await priv(plugin)._handleWebhook({
-      action: "create",
-      type: "Issue",
-      data: {
-        id: "issue-uuid-1",
-        identifier: "ENG-42",
-        title: "Add Linear plugin",
-        description: "Build outbound + inbound bridges",
-        priority: 2,
-        priorityLabel: "High",
-        state: { id: "state-1", name: "Todo", type: "unstarted" },
-        team: { id: "team-1", key: "ENG", name: "Engineering" },
-        project: { id: "project-1", name: "Integrations" },
-        assignee: { id: "user-1", name: "Josh" },
-        creator: { id: "user-1", name: "Josh" },
-        labels: [{ id: "label-1", name: "backend" }],
-        url: "https://linear.app/foo/issue/ENG-42",
-      },
-    }, bus);
+    await priv(plugin)._handleWebhook(envelope("create", "Issue", {
+      id: "issue-uuid-1",
+      identifier: "ENG-42",
+      title: "Add Linear plugin",
+      description: "Build outbound + inbound bridges",
+      priority: 2,
+      priorityLabel: "High",
+      state: { id: "state-1", name: "Todo", type: "unstarted" },
+      team: { id: "team-1", key: "ENG", name: "Engineering" },
+      project: { id: "project-1", name: "Integrations" },
+      assignee: { id: "user-1", name: "Josh" },
+      creator: { id: "user-1", name: "Josh" },
+      labels: [{ id: "label-1", name: "backend" }],
+      url: "https://linear.app/foo/issue/ENG-42",
+    }), bus);
 
     expect(collected).toHaveLength(1);
     const msg = collected[0];
@@ -103,51 +102,47 @@ describe("LinearPlugin — inbound webhooks", () => {
     expect(msg.source?.interface).toBe("linear");
     expect(msg.source?.channelId).toBe("ENG");
     expect(msg.reply?.topic).toBe("linear.reply.issue-uuid-1");
+    // Comment bodies render markdown in Linear; reply.format must reflect that
+    // so downstream agents emit markdown rather than a JSON envelope.
+    expect(msg.reply?.format).toBe("markdown");
   });
 
-  test("Issue update → publishes message.inbound.linear.issue.updated", async () => {
+  test("Issue update / remove → topic suffix matches action", async () => {
     const collected = collectBus(bus, "message.inbound.linear.issue.#");
-    await priv(plugin)._handleWebhook({
-      action: "update",
-      type: "Issue",
-      data: {
-        id: "issue-uuid-2",
-        title: "Title",
-        team: { id: "team-1", key: "ENG", name: "Engineering" },
-      },
-    }, bus);
-    expect(collected).toHaveLength(1);
+    await priv(plugin)._handleWebhook(envelope("update", "Issue", {
+      id: "issue-uuid-2",
+      title: "Title",
+      team: { id: "team-1", key: "ENG", name: "Engineering" },
+    }), bus);
+    await priv(plugin)._handleWebhook(envelope("remove", "Issue", {
+      id: "issue-uuid-3",
+      title: "Gone",
+    }), bus);
+    expect(collected).toHaveLength(2);
     expect(collected[0].topic).toBe("message.inbound.linear.issue.updated");
+    expect(collected[1].topic).toBe("message.inbound.linear.issue.removed");
   });
 
-  test("Issue remove → publishes message.inbound.linear.issue.removed", async () => {
+  test("Issue payload missing required fields → schema rejects, no publish", async () => {
     const collected = collectBus(bus, "message.inbound.linear.issue.#");
-    await priv(plugin)._handleWebhook({
-      action: "remove",
-      type: "Issue",
-      data: { id: "issue-uuid-3", title: "Gone" },
-    }, bus);
-    expect(collected).toHaveLength(1);
-    expect(collected[0].topic).toBe("message.inbound.linear.issue.removed");
+    // Issue.title is required by the schema — omit it
+    await priv(plugin)._handleWebhook(envelope("create", "Issue", { id: "x" }), bus);
+    expect(collected).toHaveLength(0);
   });
 
-  test("Comment create → publishes message.inbound.linear.comment.created with issue context", async () => {
+  test("Comment create → publishes with issue context + markdown reply format", async () => {
     const collected = collectBus(bus, "message.inbound.linear.comment.#");
-    await priv(plugin)._handleWebhook({
-      action: "create",
-      type: "Comment",
-      data: {
-        id: "comment-uuid-1",
-        body: "Can Ava take a look at this?",
-        user: { id: "user-2", name: "Alice" },
-        issue: {
-          id: "issue-uuid-1",
-          identifier: "ENG-42",
-          title: "Add Linear plugin",
-          team: { id: "team-1", key: "ENG" },
-        },
+    await priv(plugin)._handleWebhook(envelope("create", "Comment", {
+      id: "comment-uuid-1",
+      body: "Can Ava take a look at this?",
+      user: { id: "user-2", name: "Alice" },
+      issue: {
+        id: "issue-uuid-1",
+        identifier: "ENG-42",
+        title: "Add Linear plugin",
+        team: { id: "team-1", key: "ENG" },
       },
-    }, bus);
+    }), bus);
 
     expect(collected).toHaveLength(1);
     const msg = collected[0];
@@ -158,31 +153,24 @@ describe("LinearPlugin — inbound webhooks", () => {
     expect(p.teamKey).toBe("ENG");
     expect(msg.source?.channelId).toBe("ENG");
     expect(msg.reply?.topic).toBe("linear.reply.issue-uuid-1");
+    expect(msg.reply?.format).toBe("markdown");
   });
 
   test("Project create → publishes message.inbound.linear.project.created", async () => {
     const collected = collectBus(bus, "message.inbound.linear.project.#");
-    await priv(plugin)._handleWebhook({
-      action: "create",
-      type: "Project",
-      data: {
-        id: "project-uuid-1",
-        name: "Q2 Roadmap",
-        description: "What we're building",
-        state: "started",
-      },
-    }, bus);
+    await priv(plugin)._handleWebhook(envelope("create", "Project", {
+      id: "project-uuid-1",
+      name: "Q2 Roadmap",
+      description: "What we're building",
+      state: "started",
+    }), bus);
     expect(collected).toHaveLength(1);
     expect(collected[0].topic).toBe("message.inbound.linear.project.created");
   });
 
-  test("unknown envelope type is silently dropped (no publish)", async () => {
+  test("unknown envelope type is dropped (no publish, logged as a warning)", async () => {
     const collected = collectBus(bus, "message.inbound.linear.#");
-    await priv(plugin)._handleWebhook({
-      action: "create",
-      type: "Reaction",
-      data: { id: "r-1" },
-    }, bus);
+    await priv(plugin)._handleWebhook(envelope("create", "Reaction", { id: "r-1" }), bus);
     expect(collected).toHaveLength(0);
   });
 
@@ -194,15 +182,15 @@ describe("LinearPlugin — inbound webhooks", () => {
       [3, "medium"],
       [4, "low"],
       [undefined, "none"],
-      [99, "none"], // unexpected → none, never crashes
+      [99, "none"],
     ];
     for (const [input, expected] of cases) {
       const collected = collectBus(bus, "message.inbound.linear.issue.#");
-      await priv(plugin)._handleWebhook({
-        action: "create",
-        type: "Issue",
-        data: { id: `p-${input}`, title: "t", priority: input },
-      }, bus);
+      await priv(plugin)._handleWebhook(envelope("create", "Issue", {
+        id: `p-${input}`,
+        title: "t",
+        priority: input,
+      }), bus);
       const p = collected[collected.length - 1].payload as Record<string, unknown>;
       expect(p.priority).toBe(expected);
     }
@@ -218,9 +206,12 @@ describe("LinearPlugin — outbound subscribers", () => {
     plugin = new LinearPlugin();
   });
 
-  test("linear.reply.{issueId} → calls client.addComment(issueId, body)", async () => {
+  test("linear.reply.{issueId} → calls client.addComment AND publishes success result", async () => {
     const client = makeMockClient();
     priv(plugin)._wireOutbound(bus, client);
+
+    const results: BusMessage[] = [];
+    bus.subscribe("linear.reply.result.#", "test", (m) => { results.push(m); });
 
     bus.publish("linear.reply.issue-123", {
       id: crypto.randomUUID(),
@@ -229,18 +220,25 @@ describe("LinearPlugin — outbound subscribers", () => {
       timestamp: Date.now(),
       payload: { text: "Reply from Ava" },
     });
-
-    // The subscriber is async; wait for microtasks to drain
     await new Promise(r => setTimeout(r, 10));
 
     expect(client.calls).toHaveLength(1);
     expect(client.calls[0].method).toBe("addComment");
     expect(client.calls[0].args).toEqual(["issue-123", "Reply from Ava"]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].topic).toBe("linear.reply.result.cid-1");
+    const p = results[0].payload as Record<string, unknown>;
+    expect(p.success).toBe(true);
+    expect(p.issueId).toBe("issue-123");
   });
 
-  test("linear.reply.* with empty body is skipped (no client call)", async () => {
+  test("linear.reply.* with empty body → result publishes failure, no API call", async () => {
     const client = makeMockClient();
     priv(plugin)._wireOutbound(bus, client);
+
+    const results: BusMessage[] = [];
+    bus.subscribe("linear.reply.result.#", "test", (m) => { results.push(m); });
 
     bus.publish("linear.reply.issue-123", {
       id: crypto.randomUUID(),
@@ -252,11 +250,84 @@ describe("LinearPlugin — outbound subscribers", () => {
     await new Promise(r => setTimeout(r, 10));
 
     expect(client.calls).toHaveLength(0);
+    expect(results).toHaveLength(1);
+    const p = results[0].payload as Record<string, unknown>;
+    expect(p.success).toBe(false);
+    expect(p.error).toBe("empty body");
   });
 
-  test("linear.update.issue.{issueId} → calls client.updateIssue with payload", async () => {
+  test("linear.reply.* when addComment throws → result captures the exception message", async () => {
+    const client = makeMockClient({
+      addComment: () => Promise.reject(new Error("rate-limited")),
+    });
+    priv(plugin)._wireOutbound(bus, client);
+
+    const results: BusMessage[] = [];
+    bus.subscribe("linear.reply.result.#", "test", (m) => { results.push(m); });
+
+    bus.publish("linear.reply.issue-x", {
+      id: crypto.randomUUID(),
+      correlationId: "cid-throw",
+      topic: "linear.reply.issue-x",
+      timestamp: Date.now(),
+      payload: { text: "hi" },
+    });
+    await new Promise(r => setTimeout(r, 10));
+
+    expect(results).toHaveLength(1);
+    const p = results[0].payload as Record<string, unknown>;
+    expect(p.success).toBe(false);
+    expect(p.error).toBe("rate-limited");
+  });
+
+  test("linear.reply.* when addComment returns false → result.success=false with reason", async () => {
+    const client = makeMockClient({
+      addComment: () => Promise.resolve(false),
+    });
+    priv(plugin)._wireOutbound(bus, client);
+
+    const results: BusMessage[] = [];
+    bus.subscribe("linear.reply.result.#", "test", (m) => { results.push(m); });
+
+    bus.publish("linear.reply.issue-x", {
+      id: crypto.randomUUID(),
+      correlationId: "cid-false",
+      topic: "linear.reply.issue-x",
+      timestamp: Date.now(),
+      payload: { text: "hi" },
+    });
+    await new Promise(r => setTimeout(r, 10));
+
+    expect(results).toHaveLength(1);
+    const p = results[0].payload as Record<string, unknown>;
+    expect(p.success).toBe(false);
+    expect(String(p.error)).toContain("returned false");
+  });
+
+  test("linear.reply.result.* events are NOT re-processed by the reply subscriber", async () => {
+    // Without the result-topic guard the subscriber would loop on its own
+    // emissions — this regression test pins the guard down.
     const client = makeMockClient();
     priv(plugin)._wireOutbound(bus, client);
+
+    bus.publish("linear.reply.result.someCid", {
+      id: crypto.randomUUID(),
+      correlationId: "someCid",
+      topic: "linear.reply.result.someCid",
+      timestamp: Date.now(),
+      payload: { success: true, issueId: "x" },
+    });
+    await new Promise(r => setTimeout(r, 10));
+
+    expect(client.calls).toHaveLength(0);
+  });
+
+  test("linear.update.issue.{issueId} → calls client.updateIssue AND publishes result", async () => {
+    const client = makeMockClient();
+    priv(plugin)._wireOutbound(bus, client);
+
+    const results: BusMessage[] = [];
+    bus.subscribe("linear.update.issue.result.#", "test", (m) => { results.push(m); });
 
     bus.publish("linear.update.issue.issue-456", {
       id: crypto.randomUUID(),
@@ -271,9 +342,35 @@ describe("LinearPlugin — outbound subscribers", () => {
     expect(client.calls[0].method).toBe("updateIssue");
     expect(client.calls[0].args[0]).toBe("issue-456");
     expect(client.calls[0].args[1]).toEqual({ stateName: "Done", priority: "low" });
+    expect(results).toHaveLength(1);
+    expect((results[0].payload as Record<string, unknown>).success).toBe(true);
   });
 
-  test("linear.create.issue → calls client.createIssue and publishes result back", async () => {
+  test("linear.update.issue.{issueId} when updateIssue returns failure → result carries reason", async () => {
+    const client = makeMockClient({
+      updateIssue: () => Promise.resolve({ success: false, reason: "no fields supplied to update" } as UpdateIssueResult),
+    });
+    priv(plugin)._wireOutbound(bus, client);
+
+    const results: BusMessage[] = [];
+    bus.subscribe("linear.update.issue.result.#", "test", (m) => { results.push(m); });
+
+    bus.publish("linear.update.issue.issue-789", {
+      id: crypto.randomUUID(),
+      correlationId: "cid-empty-update",
+      topic: "linear.update.issue.issue-789",
+      timestamp: Date.now(),
+      payload: {},
+    });
+    await new Promise(r => setTimeout(r, 10));
+
+    expect(results).toHaveLength(1);
+    const p = results[0].payload as Record<string, unknown>;
+    expect(p.success).toBe(false);
+    expect(p.error).toBe("no fields supplied to update");
+  });
+
+  test("linear.create.issue → calls client.createIssue and publishes success result", async () => {
     const client = makeMockClient({
       createIssue: () => Promise.resolve("brand-new-id"),
     });
@@ -300,7 +397,10 @@ describe("LinearPlugin — outbound subscribers", () => {
     expect(p.issueId).toBe("brand-new-id");
   });
 
-  test("linear.create.issue missing teamKey → skipped, no client call, no result publish", async () => {
+  test("linear.create.issue missing teamKey → publishes failure result with explanation", async () => {
+    // Behavior change from V1: missing required fields now publish a failure
+    // result (so the caller knows what went wrong) instead of silently
+    // dropping. Per the audit's fail-loud finding.
     const client = makeMockClient();
     priv(plugin)._wireOutbound(bus, client);
 
@@ -317,27 +417,137 @@ describe("LinearPlugin — outbound subscribers", () => {
     await new Promise(r => setTimeout(r, 10));
 
     expect(client.calls).toHaveLength(0);
-    expect(results).toHaveLength(0);
+    expect(results).toHaveLength(1);
+    const p = results[0].payload as Record<string, unknown>;
+    expect(p.success).toBe(false);
+    expect(String(p.error)).toContain("teamKey");
+  });
+
+  test("linear.create.issue when teamKey is unknown → publishes failure with helpful error", async () => {
+    const client = makeMockClient({
+      createIssue: () => Promise.resolve(null),
+    });
+    priv(plugin)._wireOutbound(bus, client);
+
+    const results: BusMessage[] = [];
+    bus.subscribe("linear.create.issue.result.#", "test", (m) => { results.push(m); });
+
+    bus.publish("linear.create.issue", {
+      id: crypto.randomUUID(),
+      correlationId: "cid-unknown-team",
+      topic: "linear.create.issue",
+      timestamp: Date.now(),
+      payload: { teamKey: "DOES-NOT-EXIST", title: "x" },
+    });
+    await new Promise(r => setTimeout(r, 10));
+
+    expect(results).toHaveLength(1);
+    const p = results[0].payload as Record<string, unknown>;
+    expect(p.success).toBe(false);
+    expect(String(p.error)).toContain("DOES-NOT-EXIST");
+  });
+
+  test("subscriber result-topic without correlationId is a silent no-op (no infinite loop)", async () => {
+    // publishResult skips when no correlationId — a publisher that doesn't
+    // ask for confirmation shouldn't get one.
+    const client = makeMockClient();
+    priv(plugin)._wireOutbound(bus, client);
+
+    const results: BusMessage[] = [];
+    bus.subscribe("linear.reply.result.#", "test", (m) => { results.push(m); });
+
+    bus.publish("linear.reply.no-cid-issue", {
+      id: crypto.randomUUID(),
+      correlationId: "",
+      topic: "linear.reply.no-cid-issue",
+      timestamp: Date.now(),
+      payload: { text: "hi" },
+    });
+    await new Promise(r => setTimeout(r, 10));
+
+    expect(client.calls).toHaveLength(1); // API call still happened
+    expect(results).toHaveLength(0); // but no result topic published
   });
 });
 
 describe("LinearPlugin — HMAC signature verification", () => {
-  // The verify function lives as a module-internal helper. We re-derive the
-  // expected digest the same way the plugin does and assert that an independent
-  // signing of the body with the same secret matches.
-  test("matching HMAC-SHA256 over raw body is accepted; tampered body is rejected", () => {
+  test("matching HMAC-SHA256 over raw body produces expected hex digest shape", () => {
     const body = Buffer.from('{"action":"create","type":"Issue","data":{"id":"x"}}', "utf-8");
     const secret = "test-secret";
     const correctSig = createHmac("sha256", secret).update(body).digest("hex");
-    const expectedBadSig = createHmac("sha256", secret).update(Buffer.from("tampered")).digest("hex");
+    const tamperedSig = createHmac("sha256", secret).update(Buffer.from("tampered")).digest("hex");
 
-    // Verify the digest shape (hex, 64 chars) so any future format change
-    // surfaces here rather than in a cryptic HTTP 401.
     expect(correctSig).toHaveLength(64);
-    expect(correctSig).not.toBe(expectedBadSig);
+    expect(correctSig).not.toBe(tamperedSig);
 
-    // Independent recomputation — sanity-check the algorithm choice
     const roundTrip = createHmac("sha256", secret).update(body).digest("hex");
     expect(roundTrip).toBe(correctSig);
+  });
+});
+
+describe("LinearPlugin — install-time production safety", () => {
+  // The plugin refuses to start an unauthenticated webhook receiver in a
+  // production-like env (NODE_ENV=production OR WORKSTACEAN_PUBLIC_BASE_URL
+  // set). Cuts the open-relay footgun.
+
+  let origNodeEnv: string | undefined;
+  let origPublicBase: string | undefined;
+  let origSecret: string | undefined;
+
+  beforeEach(() => {
+    origNodeEnv = process.env.NODE_ENV;
+    origPublicBase = process.env.WORKSTACEAN_PUBLIC_BASE_URL;
+    origSecret = process.env.LINEAR_WEBHOOK_SECRET;
+    delete process.env.LINEAR_WEBHOOK_SECRET;
+  });
+
+  function restore() {
+    if (origNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = origNodeEnv;
+    if (origPublicBase === undefined) delete process.env.WORKSTACEAN_PUBLIC_BASE_URL;
+    else process.env.WORKSTACEAN_PUBLIC_BASE_URL = origPublicBase;
+    if (origSecret === undefined) delete process.env.LINEAR_WEBHOOK_SECRET;
+    else process.env.LINEAR_WEBHOOK_SECRET = origSecret;
+  }
+
+  test("install throws when NODE_ENV=production AND no LINEAR_WEBHOOK_SECRET", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.WORKSTACEAN_PUBLIC_BASE_URL;
+    const plugin = new LinearPlugin();
+    const bus = new InMemoryEventBus();
+    try {
+      expect(() => plugin.install(bus)).toThrow(/LINEAR_WEBHOOK_SECRET is required/);
+    } finally {
+      restore();
+    }
+  });
+
+  test("install throws when WORKSTACEAN_PUBLIC_BASE_URL is set AND no LINEAR_WEBHOOK_SECRET", () => {
+    delete process.env.NODE_ENV;
+    process.env.WORKSTACEAN_PUBLIC_BASE_URL = "https://ava.example.com";
+    const plugin = new LinearPlugin();
+    const bus = new InMemoryEventBus();
+    try {
+      expect(() => plugin.install(bus)).toThrow(/LINEAR_WEBHOOK_SECRET is required/);
+    } finally {
+      restore();
+    }
+  });
+
+  test("install does NOT throw in dev (NODE_ENV unset, no public base) without a secret", () => {
+    // We don't actually want to start a Bun.serve — so we'll set the secret
+    // to satisfy the production-safety check first to prove the inverse.
+    delete process.env.NODE_ENV;
+    delete process.env.WORKSTACEAN_PUBLIC_BASE_URL;
+    process.env.LINEAR_WEBHOOK_SECRET = "test-secret";
+    const plugin = new LinearPlugin();
+    const bus = new InMemoryEventBus();
+    try {
+      // install is allowed; uninstall stops the started server.
+      expect(() => plugin.install(bus)).not.toThrow();
+      plugin.uninstall();
+    } finally {
+      restore();
+    }
   });
 });

--- a/lib/plugins/linear-protomaker-bridge.ts
+++ b/lib/plugins/linear-protomaker-bridge.ts
@@ -40,18 +40,21 @@
 import { existsSync, readFileSync, watchFile } from "node:fs";
 import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
+import { z } from "zod";
 import type { EventBus, BusMessage, Plugin } from "../types.ts";
 
-interface LinearBoardMapping {
-  linearTeamKey: string;
-  protoMakerProjectSlug: string;
+const LinearBoardMappingSchema = z.object({
+  linearTeamKey: z.string().min(1),
+  protoMakerProjectSlug: z.string().min(1),
   /** Label that gates filing. Issue must carry this label to fire. */
-  triggerLabel: string;
-}
+  triggerLabel: z.string().min(1),
+});
 
-interface LinearBoardMappingsFile {
-  mappings?: LinearBoardMapping[];
-}
+const LinearBoardMappingsFileSchema = z.object({
+  mappings: z.array(LinearBoardMappingSchema).optional(),
+});
+
+type LinearBoardMapping = z.infer<typeof LinearBoardMappingSchema>;
 
 interface LinearIssuePayload {
   issueId: string;
@@ -115,29 +118,29 @@ export class LinearProtoMakerBridgePlugin implements Plugin {
       return;
     }
     try {
-      const parsed = parseYaml(readFileSync(path, "utf8")) as LinearBoardMappingsFile;
-      const next: LinearBoardMapping[] = [];
-      for (const m of parsed.mappings ?? []) {
-        if (!m.linearTeamKey || !m.protoMakerProjectSlug || !m.triggerLabel) {
-          console.warn(
-            `[linear-protomaker-bridge] mapping missing required fields, skipping: ${JSON.stringify(m)}`,
-          );
-          continue;
-        }
-        next.push({
-          linearTeamKey: m.linearTeamKey,
-          protoMakerProjectSlug: m.protoMakerProjectSlug,
-          triggerLabel: m.triggerLabel,
-        });
+      const raw = parseYaml(readFileSync(path, "utf8"));
+      const fileParsed = LinearBoardMappingsFileSchema.safeParse(raw);
+      if (!fileParsed.success) {
+        const issues = fileParsed.error.issues
+          .map(i => `${i.path.join(".")}: ${i.message}`)
+          .join("; ");
+        console.error(`[linear-protomaker-bridge] mappings file failed schema — ${issues}. Keeping prior mappings.`);
+        return;
       }
+      // Per-entry validation already happened via the array schema above —
+      // any malformed entry would have failed the safeParse, so we'd never
+      // see partial mappings. This means an operator typo in one entry now
+      // rejects the whole file rather than silently filtering it. That's
+      // intentional fail-loud for config — clearer signal than a partial
+      // load + warning.
+      const next = fileParsed.data.mappings ?? [];
       this.mappings = next;
       console.log(
         `[linear-protomaker-bridge] reloaded ${next.length} mapping(s) from ${path}`,
       );
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      console.error(`[linear-protomaker-bridge] failed to parse ${path}: ${msg}`);
-      // Keep prior mappings on parse error — fail-soft hot reload.
+      console.error(`[linear-protomaker-bridge] failed to parse ${path}: ${msg}. Keeping prior mappings.`);
     }
   }
 
@@ -196,7 +199,8 @@ export class LinearProtoMakerBridgePlugin implements Plugin {
       },
       reply: {
         topic: replyTopic,
-        format: "structured",
+        // Linear comment bodies render markdown.
+        format: "markdown",
       },
       source: { interface: "linear" as const },
     });

--- a/lib/plugins/linear.ts
+++ b/lib/plugins/linear.ts
@@ -2,95 +2,126 @@
  * LinearPlugin — Linear webhooks in, outbound Linear mutations out.
  *
  * Inbound:
- *   POST /webhooks/linear → verifies HMAC-SHA256 signature → dedups by
- *   delivery id → publishes one of:
+ *   POST /webhooks/linear → verifies HMAC-SHA256 signature → enforces freshness
+ *   window → validates payload via Zod → dedups by delivery id → publishes one of:
  *     message.inbound.linear.issue.{created|updated|removed}
  *     message.inbound.linear.comment.{created|updated|removed}
  *     message.inbound.linear.project.{created|updated|removed}
  *
- * RouterPlugin already subscribes to `message.inbound.#` and translates to
- * `agent.skill.request` — Linear channels configured in
- * workspace/channels.yaml (platform: linear, teamKey / issueId / projectId)
- * route to the appropriate agent + skill.
+ *   The HTTP 200 is returned AFTER the bus publish completes, so a publish
+ *   failure surfaces as a 5xx that Linear will retry on.
  *
  * Outbound:
- *   linear.reply.{issueId}        → post comment (payload: { text })
- *   linear.update.issue.{issueId} → mutate issue (payload: { stateName?,
- *                                   priority?, assigneeId?, labelIds? })
+ *   linear.reply.{issueId}         → post comment (payload: { text })
+ *                                    Result published on
+ *                                    linear.reply.result.{correlationId}
+ *   linear.update.issue.{issueId}  → mutate issue (payload: { stateName?,
+ *                                    priority?, assigneeId?, labelIds? })
+ *                                    Result published on
+ *                                    linear.update.issue.result.{correlationId}
  *   linear.create.issue            → createIssue (payload: { teamKey, title,
- *                                   description?, priority?, assigneeId?,
- *                                   labelIds?, stateName? })
- *                                   Result published back on
- *                                   linear.create.issue.result.{correlationId}
+ *                                    description?, priority?, assigneeId?,
+ *                                    labelIds?, stateName? })
+ *                                    Result published on
+ *                                    linear.create.issue.result.{correlationId}
  *
  * Env vars:
  *   LINEAR_API_KEY         Personal API key for outbound mutations (optional;
  *                          without it only inbound webhooks work)
  *   LINEAR_WEBHOOK_SECRET  HMAC-SHA256 signing secret from Linear webhook
- *                          config (optional in dev — unset disables verification)
+ *                          config. REQUIRED in production-like envs (when
+ *                          NODE_ENV=production OR WORKSTACEAN_PUBLIC_BASE_URL
+ *                          is set). Without it in dev the receiver runs
+ *                          unauthenticated and logs loudly.
  *   LINEAR_WEBHOOK_PORT    Port for the webhook server (default: 8084)
  */
 
 import { createHmac, timingSafeEqual } from "node:crypto";
+import { z } from "zod";
 import type { EventBus, BusMessage, Plugin } from "../types.ts";
 import { LinearClient, type LinearPriority } from "../linear-client.ts";
 
-// ── Linear webhook payload shapes ────────────────────────────────────────────
+// ── Limits ───────────────────────────────────────────────────────────────────
+
+/** Reject webhook bodies larger than this — Linear's docs cap webhook size at ~1 MB. */
+const MAX_BODY_BYTES = 1_048_576;
+
+/**
+ * Reject webhook events whose `webhookTimestamp` is older than this. Cuts the
+ * replay-attack window when a signed body leaks. Linear's webhookTimestamp is
+ * the server-side fire time in ms.
+ */
+const FRESHNESS_WINDOW_MS = 5 * 60 * 1000;
+
+// ── Linear webhook payload schemas ───────────────────────────────────────────
 // Linear sends a single envelope shape for all resource types with a discriminant
-// `type` field. We only model the fields we actually publish downstream; any
-// extra fields flow through untouched via the raw payload.
+// `type` field. We model the fields we publish downstream and validate the
+// envelope at the boundary so a Linear API drift produces a loud 4xx instead of
+// undefined fields silently flowing through to agents.
 
-interface LinearWebhookIssueData {
-  id: string;
-  identifier?: string;
-  title: string;
-  description?: string;
-  priority?: number;
-  priorityLabel?: string;
-  state?: { id: string; name: string; type?: string };
-  team?: { id: string; key: string; name: string };
-  assignee?: { id: string; name: string; email?: string };
-  creator?: { id: string; name: string; email?: string };
-  project?: { id: string; name: string };
-  labels?: Array<{ id: string; name: string }>;
-  url?: string;
-}
+const LinearIssueDataSchema = z.object({
+  id: z.string(),
+  identifier: z.string().optional(),
+  title: z.string(),
+  description: z.string().optional(),
+  priority: z.number().optional(),
+  priorityLabel: z.string().optional(),
+  state: z.object({ id: z.string(), name: z.string(), type: z.string().optional() }).optional(),
+  team: z.object({ id: z.string(), key: z.string(), name: z.string() }).optional(),
+  assignee: z.object({ id: z.string(), name: z.string(), email: z.string().optional() }).optional(),
+  creator: z.object({ id: z.string(), name: z.string(), email: z.string().optional() }).optional(),
+  project: z.object({ id: z.string(), name: z.string() }).optional(),
+  labels: z.array(z.object({ id: z.string(), name: z.string() })).optional(),
+  url: z.string().optional(),
+});
 
-interface LinearWebhookCommentData {
-  id: string;
-  body: string;
-  user?: { id: string; name: string; email?: string };
-  issue?: { id: string; identifier?: string; title?: string; team?: { id: string; key: string } };
-  url?: string;
-}
+const LinearCommentDataSchema = z.object({
+  id: z.string(),
+  body: z.string(),
+  user: z.object({ id: z.string(), name: z.string(), email: z.string().optional() }).optional(),
+  issue: z.object({
+    id: z.string(),
+    identifier: z.string().optional(),
+    title: z.string().optional(),
+    team: z.object({ id: z.string(), key: z.string() }).optional(),
+  }).optional(),
+  url: z.string().optional(),
+});
 
-interface LinearWebhookProjectData {
-  id: string;
-  name: string;
-  description?: string;
-  state?: string;
-  creator?: { id: string; name: string };
-  url?: string;
-}
+const LinearProjectDataSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  state: z.string().optional(),
+  creator: z.object({ id: z.string(), name: z.string() }).optional(),
+  url: z.string().optional(),
+});
 
-type LinearWebhookData = LinearWebhookIssueData | LinearWebhookCommentData | LinearWebhookProjectData;
+/** Action verbs Linear emits across all resource types. */
+const LINEAR_ACTIONS = ["create", "update", "remove"] as const;
 
-interface LinearWebhookEnvelope {
-  action: "create" | "update" | "remove";
-  type: "Issue" | "Comment" | "Project" | string;
-  data: LinearWebhookData;
-  createdAt?: string;
-  organizationId?: string;
-  webhookTimestamp?: number;
-  webhookId?: string;
-}
+const LinearWebhookEnvelopeSchema = z.object({
+  action: z.enum(LINEAR_ACTIONS),
+  type: z.string(),
+  data: z.record(z.string(), z.unknown()),
+  createdAt: z.string().optional(),
+  organizationId: z.string().optional(),
+  webhookTimestamp: z.number().optional(),
+  webhookId: z.string().optional(),
+});
+
+type LinearWebhookEnvelope = z.infer<typeof LinearWebhookEnvelopeSchema>;
+type LinearIssueData = z.infer<typeof LinearIssueDataSchema>;
+type LinearCommentData = z.infer<typeof LinearCommentDataSchema>;
+type LinearProjectData = z.infer<typeof LinearProjectDataSchema>;
 
 // ── Signature verification ───────────────────────────────────────────────────
 
 function verifyLinearSignature(body: Buffer, signature: string, secret: string): boolean {
-  // Linear signs requests with HMAC-SHA256 over the raw body; the `linear-signature`
-  // header is the hex digest. timingSafeEqual throws on length mismatch — catch
-  // to return false rather than surfacing an error to the caller.
+  // Linear signs requests with HMAC-SHA256 over the raw body; the
+  // `linear-signature` header (case-insensitive) is the hex digest.
+  // timingSafeEqual throws on length mismatch — catch to return false rather
+  // than surfacing an error to the caller.
   const expected = createHmac("sha256", secret).update(body).digest("hex");
   try {
     return timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
@@ -100,9 +131,7 @@ function verifyLinearSignature(body: Buffer, signature: string, secret: string):
 }
 
 // ── Deduplication ring buffer ────────────────────────────────────────────────
-// Linear retries on non-2xx. Standard ring-buffer dedup — last 10k IDs
-// in-memory, evicted FIFO. Keyed on the webhook envelope's webhookTimestamp +
-// data.id when present; falls back to a stable hash of the body.
+// Linear retries on non-2xx. Last 10k IDs in-memory, evicted FIFO.
 
 class DeliveryDedup {
   private seen = new Set<string>();
@@ -137,6 +166,17 @@ function priorityToString(p?: number): LinearPriority {
   }
 }
 
+/**
+ * Detect production-like environments. When true, we refuse to start without
+ * a webhook secret — an unauthenticated public-facing webhook receiver is a
+ * footgun that lets anyone inject `message.inbound.linear.*` events.
+ */
+function isProductionLike(): boolean {
+  if (process.env.NODE_ENV === "production") return true;
+  if (process.env.WORKSTACEAN_PUBLIC_BASE_URL) return true;
+  return false;
+}
+
 // ── Plugin ────────────────────────────────────────────────────────────────────
 
 export class LinearPlugin implements Plugin {
@@ -152,7 +192,16 @@ export class LinearPlugin implements Plugin {
     const port = parseInt(process.env.LINEAR_WEBHOOK_PORT ?? "8084", 10);
 
     if (!webhookSecret) {
-      console.warn("[linear] LINEAR_WEBHOOK_SECRET not set — signature verification disabled (dev mode)");
+      if (isProductionLike()) {
+        // Fail-loud rather than silently exposing an open webhook receiver in
+        // a production-like env.
+        throw new Error(
+          "[linear] LINEAR_WEBHOOK_SECRET is required when NODE_ENV=production " +
+          "or WORKSTACEAN_PUBLIC_BASE_URL is set. Refusing to start an " +
+          "unauthenticated webhook receiver in production.",
+        );
+      }
+      console.warn("[linear] LINEAR_WEBHOOK_SECRET not set — signature verification disabled (dev only)");
     }
 
     const dedup = new DeliveryDedup();
@@ -161,48 +210,94 @@ export class LinearPlugin implements Plugin {
     if (client) this._wireOutbound(bus, client);
     else console.warn("[linear] LINEAR_API_KEY not set — outbound Linear mutations disabled");
 
-    this.server = Bun.serve({
-      port,
-      fetch: async (req) => {
-        const url = new URL(req.url);
-        if (url.pathname !== "/webhooks/linear") return new Response("Not found", { status: 404 });
-        if (req.method !== "POST") return new Response("Method not allowed", { status: 405 });
+    try {
+      this.server = Bun.serve({
+        port,
+        fetch: async (req) => {
+          const url = new URL(req.url);
+          if (url.pathname !== "/webhooks/linear") return new Response("Not found", { status: 404 });
+          if (req.method !== "POST") return new Response("Method not allowed", { status: 405 });
 
-        const bodyBuffer = Buffer.from(await req.arrayBuffer());
-
-        if (webhookSecret) {
-          const sig = req.headers.get("linear-signature") ?? "";
-          if (!verifyLinearSignature(bodyBuffer, sig, webhookSecret)) {
-            console.warn("[linear] Invalid webhook signature — request rejected");
-            return new Response("Unauthorized", { status: 401 });
+          // Body-size cap: reject before fully buffering when content-length
+          // declares too much. Linear's documented webhook size limit is ~1 MB.
+          const declaredLen = parseInt(req.headers.get("content-length") ?? "0", 10);
+          if (declaredLen > MAX_BODY_BYTES) {
+            return new Response("Payload too large", { status: 413 });
           }
-        }
+          const bodyBuffer = Buffer.from(await req.arrayBuffer());
+          if (bodyBuffer.length > MAX_BODY_BYTES) {
+            return new Response("Payload too large", { status: 413 });
+          }
 
-        let payload: LinearWebhookEnvelope;
-        try {
-          payload = JSON.parse(bodyBuffer.toString("utf-8")) as LinearWebhookEnvelope;
-        } catch {
-          return new Response("Bad request", { status: 400 });
-        }
+          if (webhookSecret) {
+            const sig = req.headers.get("linear-signature") ?? "";
+            if (!verifyLinearSignature(bodyBuffer, sig, webhookSecret)) {
+              console.warn("[linear] Invalid webhook signature — request rejected");
+              return new Response("Unauthorized", { status: 401 });
+            }
+          }
 
-        // Dedup key — prefer webhookId; fall back to (type, data.id, webhookTimestamp)
-        // so retries of the same event are collapsed even when Linear's id
-        // rotation behavior differs.
-        const dedupKey = payload.webhookId
-          ?? `${payload.type}:${payload.data?.id ?? "?"}:${payload.webhookTimestamp ?? 0}`;
-        if (dedup.isDuplicate(dedupKey)) {
-          return new Response("Already processed", { status: 200 });
-        }
+          let raw: unknown;
+          try {
+            raw = JSON.parse(bodyBuffer.toString("utf-8"));
+          } catch {
+            return new Response("Bad request: malformed JSON", { status: 400 });
+          }
 
-        // Fire and forget — Linear expects a 2xx within seconds; downstream
-        // bus handlers can take their time.
-        this._handleWebhook(payload, bus).catch(err => {
-          console.error("[linear] Webhook handler error:", err);
-        });
+          const parsed = LinearWebhookEnvelopeSchema.safeParse(raw);
+          if (!parsed.success) {
+            const issues = parsed.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; ");
+            console.warn(`[linear] Webhook envelope failed schema validation — ${issues}`);
+            return new Response(`Bad request: ${issues}`, { status: 400 });
+          }
+          const payload = parsed.data;
 
-        return new Response("OK", { status: 200 });
-      },
-    });
+          // Replay protection: reject events older than the freshness window.
+          // Linear's webhookTimestamp is server-side fire time (ms). Skipped
+          // when absent so we don't break against payloads predating the field.
+          if (payload.webhookTimestamp != null) {
+            const age = Date.now() - payload.webhookTimestamp;
+            if (age > FRESHNESS_WINDOW_MS || age < -FRESHNESS_WINDOW_MS) {
+              console.warn(
+                `[linear] Webhook timestamp outside freshness window ` +
+                `(age=${age}ms, max=${FRESHNESS_WINDOW_MS}ms) — request rejected`,
+              );
+              return new Response("Stale webhook timestamp", { status: 400 });
+            }
+          }
+
+          // Dedup key — prefer webhookId; fall back to (type, data.id, webhookTimestamp).
+          const dataId = typeof payload.data.id === "string" ? payload.data.id : "?";
+          const dedupKey = payload.webhookId
+            ?? `${payload.type}:${dataId}:${payload.webhookTimestamp ?? 0}`;
+          if (dedup.isDuplicate(dedupKey)) {
+            return new Response("Already processed", { status: 200 });
+          }
+
+          // Await the handler so a publish failure surfaces as a 5xx and
+          // Linear retries. Bus publish is microseconds; agents take their
+          // time AFTER receiving the message via separate subscribers, so
+          // this doesn't block on agent work.
+          try {
+            await this._handleWebhook(payload, bus);
+          } catch (err) {
+            console.error("[linear] Webhook handler error — returning 500 for retry:", err);
+            return new Response("Internal handler error", { status: 500 });
+          }
+
+          return new Response("OK", { status: 200 });
+        },
+      });
+    } catch (err) {
+      // Server start failed (port in use, perms, etc.). Fail-loud but don't
+      // block the whole process — outbound subscribers are still useful.
+      console.error(
+        `[linear] Failed to start webhook server on :${port} — inbound disabled. Outbound mutations remain active. Error:`,
+        err,
+      );
+      this.server = null;
+      return;
+    }
 
     console.log(`[linear] Webhook receiver on :${port}/webhooks/linear`);
   }
@@ -212,32 +307,47 @@ export class LinearPlugin implements Plugin {
     this.server = null;
   }
 
-  private _handleWebhook(payload: LinearWebhookEnvelope, bus: EventBus): Promise<void> {
-    const actionMap: Record<LinearWebhookEnvelope["action"], string> = {
+  private async _handleWebhook(payload: LinearWebhookEnvelope, bus: EventBus): Promise<void> {
+    const actionMap: Record<typeof LINEAR_ACTIONS[number], string> = {
       create: "created",
       update: "updated",
       remove: "removed",
     };
     const action = actionMap[payload.action];
-    if (!action) return Promise.resolve();
 
     if (payload.type === "Issue") {
-      return this._publishIssue(payload.data as LinearWebhookIssueData, action, bus);
+      const issueParsed = LinearIssueDataSchema.safeParse(payload.data);
+      if (!issueParsed.success) {
+        console.warn(`[linear] Issue payload failed schema — dropping. ${issueParsed.error.issues.map(i => i.message).join("; ")}`);
+        return;
+      }
+      this._publishIssue(issueParsed.data, action, bus);
+      return;
     }
     if (payload.type === "Comment") {
-      return this._publishComment(payload.data as LinearWebhookCommentData, action, bus);
+      const commentParsed = LinearCommentDataSchema.safeParse(payload.data);
+      if (!commentParsed.success) {
+        console.warn(`[linear] Comment payload failed schema — dropping. ${commentParsed.error.issues.map(i => i.message).join("; ")}`);
+        return;
+      }
+      this._publishComment(commentParsed.data, action, bus);
+      return;
     }
     if (payload.type === "Project") {
-      return this._publishProject(payload.data as LinearWebhookProjectData, action, bus);
+      const projectParsed = LinearProjectDataSchema.safeParse(payload.data);
+      if (!projectParsed.success) {
+        console.warn(`[linear] Project payload failed schema — dropping. ${projectParsed.error.issues.map(i => i.message).join("; ")}`);
+        return;
+      }
+      this._publishProject(projectParsed.data, action, bus);
+      return;
     }
-    // Unknown envelope type — log once and drop. Linear adds new resource
-    // types over time; we don't want to spam the bus with shapes consumers
-    // aren't ready for.
-    console.log(`[linear] Unhandled webhook type "${payload.type}" — ignoring`);
-    return Promise.resolve();
+    // Unknown envelope type — log loudly + drop. Linear adds new resource
+    // types over time; fail visibly so we know to extend the plugin.
+    console.warn(`[linear] Unhandled webhook type "${payload.type}" — dropping (extend LinearPlugin to support)`);
   }
 
-  private _publishIssue(issue: LinearWebhookIssueData, action: string, bus: EventBus): Promise<void> {
+  private _publishIssue(issue: LinearIssueData, action: string, bus: EventBus): void {
     const topic = `message.inbound.linear.issue.${action}`;
     const correlationId = `linear-${issue.id}`;
     bus.publish(topic, {
@@ -268,22 +378,22 @@ export class LinearPlugin implements Plugin {
       },
       source: {
         interface: "linear" as const,
-        // Use teamKey as the channel identifier — channels.yaml entries
-        // declare per-team agents, per-issue agents, or per-project agents,
-        // and RouterPlugin resolves channel → agent using any of these.
+        // teamKey is the channel identifier — channels.yaml entries declare
+        // per-team agents (or per-issue / per-project), and RouterPlugin
+        // resolves channel → agent.
         channelId: issue.team?.key ?? issue.id,
         userId: issue.creator?.id,
       },
       reply: {
         topic: `linear.reply.${issue.id}`,
-        format: "structured",
+        // Linear comment bodies render markdown.
+        format: "markdown",
       },
     });
     console.log(`[linear] issue.${action} ${issue.identifier ?? issue.id} "${issue.title}"`);
-    return Promise.resolve();
   }
 
-  private _publishComment(comment: LinearWebhookCommentData, action: string, bus: EventBus): Promise<void> {
+  private _publishComment(comment: LinearCommentData, action: string, bus: EventBus): void {
     const topic = `message.inbound.linear.comment.${action}`;
     const issueId = comment.issue?.id ?? "";
     const correlationId = `linear-${issueId}`;
@@ -311,14 +421,13 @@ export class LinearPlugin implements Plugin {
       },
       reply: {
         topic: `linear.reply.${issueId}`,
-        format: "structured",
+        format: "markdown",
       },
     });
     console.log(`[linear] comment.${action} on ${comment.issue?.identifier ?? issueId}`);
-    return Promise.resolve();
   }
 
-  private _publishProject(project: LinearWebhookProjectData, action: string, bus: EventBus): Promise<void> {
+  private _publishProject(project: LinearProjectData, action: string, bus: EventBus): void {
     const topic = `message.inbound.linear.project.${action}`;
     const correlationId = `linear-project-${project.id}`;
     bus.publish(topic, {
@@ -342,47 +451,103 @@ export class LinearPlugin implements Plugin {
       },
     });
     console.log(`[linear] project.${action} "${project.name}" (${project.id})`);
-    return Promise.resolve();
   }
 
   // ── Outbound ───────────────────────────────────────────────────────────────
+  //
+  // Every outbound mutation publishes a result topic
+  // `linear.{verb}.result.{correlationId}` carrying { success, error?, ... }
+  // so callers (agents) can confirm their action landed instead of silently
+  // assuming success.
 
   private _wireOutbound(bus: EventBus, client: LinearClient): void {
     // linear.reply.{issueId} — post a comment using the standard
     // reply-on-topic convention agents already know.
     bus.subscribe("linear.reply.#", "linear-outbound", async (msg: BusMessage) => {
       const topic = msg.topic ?? "";
+      // Result topics from this family must not re-enter this subscriber.
+      if (topic.startsWith("linear.reply.result.")) return;
       const issueId = topic.startsWith("linear.reply.") ? topic.slice("linear.reply.".length) : "";
       if (!issueId) {
-        console.warn("[linear] linear.reply.* missing issueId in topic — skipping");
+        publishResult(bus, msg.correlationId, "linear.reply.result", {
+          success: false,
+          error: "missing issueId in topic",
+        });
         return;
       }
       const payload = (msg.payload ?? {}) as { text?: string; content?: string; summary?: string };
       const body = payload.text ?? payload.content ?? payload.summary ?? "";
       if (!body) {
-        console.warn(`[linear] linear.reply.${issueId} has empty body — skipping`);
+        publishResult(bus, msg.correlationId, "linear.reply.result", {
+          success: false,
+          issueId,
+          error: "empty body",
+        });
         return;
       }
-      const ok = await client.addComment(issueId, body);
-      if (ok) console.log(`[linear] Comment posted on issue ${issueId}`);
-      else console.warn(`[linear] Failed to post comment on issue ${issueId}`);
+      try {
+        const ok = await client.addComment(issueId, body);
+        publishResult(bus, msg.correlationId, "linear.reply.result", {
+          success: ok,
+          issueId,
+          error: ok ? undefined : "client.addComment returned false",
+        });
+        if (ok) console.log(`[linear] Comment posted on issue ${issueId}`);
+        else console.warn(`[linear] Failed to post comment on issue ${issueId}`);
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        publishResult(bus, msg.correlationId, "linear.reply.result", {
+          success: false,
+          issueId,
+          error: errMsg,
+        });
+        console.error(`[linear] Comment exception on issue ${issueId}: ${errMsg}`);
+      }
     });
 
     // linear.update.issue.{issueId} — state / priority / assignee / labels
     bus.subscribe("linear.update.issue.#", "linear-outbound", async (msg: BusMessage) => {
       const topic = msg.topic ?? "";
+      // Result topics are linear.update.issue.result.{correlationId} — skip
+      // to avoid re-entering this subscriber.
+      if (topic.startsWith("linear.update.issue.result.")) return;
       const issueId = topic.startsWith("linear.update.issue.")
         ? topic.slice("linear.update.issue.".length)
         : "";
-      if (!issueId) return;
+      if (!issueId) {
+        publishResult(bus, msg.correlationId, "linear.update.issue.result", {
+          success: false,
+          error: "missing issueId in topic",
+        });
+        return;
+      }
       const payload = (msg.payload ?? {}) as {
         stateName?: string;
         priority?: LinearPriority;
         assigneeId?: string;
         labelIds?: string[];
       };
-      const ok = await client.updateIssue(issueId, payload);
-      if (ok) console.log(`[linear] Issue ${issueId} updated: ${JSON.stringify(payload)}`);
+      try {
+        const result = await client.updateIssue(issueId, payload);
+        publishResult(bus, msg.correlationId, "linear.update.issue.result", {
+          success: result.success,
+          issueId,
+          error: result.success ? undefined : result.reason,
+        });
+        if (result.success) {
+          console.log(`[linear] Issue ${issueId} updated: ${JSON.stringify(payload)}`);
+        } else {
+          console.warn(`[linear] Issue ${issueId} update skipped: ${result.reason}`);
+        }
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        publishResult(bus, msg.correlationId, "linear.update.issue.result", {
+          success: false,
+          issueId,
+          error: errMsg,
+        });
+        console.error(`[linear] Issue ${issueId} update exception: ${errMsg}`);
+      }
     });
 
     // linear.create.issue — creates in the named team and publishes the new
@@ -399,30 +564,59 @@ export class LinearPlugin implements Plugin {
         stateName?: string;
       };
       if (!payload.teamKey || !payload.title) {
+        publishResult(bus, msg.correlationId, "linear.create.issue.result", {
+          success: false,
+          error: "missing teamKey or title",
+        });
         console.warn("[linear] linear.create.issue missing teamKey or title — skipping");
         return;
       }
-      const newId = await client.createIssue({
-        teamKey: payload.teamKey,
-        title: payload.title,
-        description: payload.description,
-        priority: payload.priority,
-        assigneeId: payload.assigneeId,
-        labelIds: payload.labelIds,
-        stateName: payload.stateName,
-      });
-      if (msg.correlationId) {
-        const resultTopic = `linear.create.issue.result.${msg.correlationId}`;
-        bus.publish(resultTopic, {
-          id: crypto.randomUUID(),
-          correlationId: msg.correlationId,
-          topic: resultTopic,
-          timestamp: Date.now(),
-          payload: { success: newId !== null, issueId: newId },
+      try {
+        const newId = await client.createIssue({
+          teamKey: payload.teamKey,
+          title: payload.title,
+          description: payload.description,
+          priority: payload.priority,
+          assigneeId: payload.assigneeId,
+          labelIds: payload.labelIds,
+          stateName: payload.stateName,
         });
+        publishResult(bus, msg.correlationId, "linear.create.issue.result", {
+          success: newId !== null,
+          issueId: newId,
+          error: newId === null ? `team '${payload.teamKey}' not found or createIssue failed` : undefined,
+        });
+        if (newId) console.log(`[linear] Created issue ${newId} in team ${payload.teamKey}`);
+        else console.warn(`[linear] Failed to create issue in team ${payload.teamKey}`);
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        publishResult(bus, msg.correlationId, "linear.create.issue.result", {
+          success: false,
+          error: errMsg,
+        });
+        console.error(`[linear] Create issue exception in team ${payload.teamKey}: ${errMsg}`);
       }
-      if (newId) console.log(`[linear] Created issue ${newId} in team ${payload.teamKey}`);
-      else console.warn(`[linear] Failed to create issue in team ${payload.teamKey}`);
     });
   }
+}
+
+/**
+ * Publish a `{family}.{correlationId}` result event when a correlationId is
+ * set. No-op without one (caller didn't ask for confirmation).
+ */
+function publishResult(
+  bus: EventBus,
+  correlationId: string | undefined,
+  family: string,
+  payload: Record<string, unknown>,
+): void {
+  if (!correlationId) return;
+  const topic = `${family}.${correlationId}`;
+  bus.publish(topic, {
+    id: crypto.randomUUID(),
+    correlationId,
+    topic,
+    timestamp: Date.now(),
+    payload,
+  });
 }


### PR DESCRIPTION
Bundles **all 4 ship-blockers** and **8 of 10 should-fix** findings from the LinearPlugin audit into a single PR. Diff is +780 / −316 across 6 files.

## What this fixes (severity from the audit)

### 🔴 Ship-blockers
1. **Webhook handler errors swallowed after 200 OK** → now awaits handler before responding; failure becomes 500 → Linear retries.
2. **Outbound API failures swallowed** → every mutation now publishes a `linear.{verb}.result.{correlationId}` event with `{ success, error?, issueId? }`.
3. **`reply.format: "structured"` on Linear comments** → now `"markdown"` (correct for Linear).
4. **No replay-attack protection** → reject events whose `webhookTimestamp` is more than 5 min off real time.

### 🟡 Should-fix
5. **Empty webhook secret silently opens endpoint** → refuse to start when `NODE_ENV=production` OR `WORKSTACEAN_PUBLIC_BASE_URL` is set without `LINEAR_WEBHOOK_SECRET`.
6. **Action / type silent drops** → unknown envelope types log loudly (warn, not info); schema validates the action enum upstream.
7. **`as` casts on raw JSON** → Zod `LinearWebhookEnvelopeSchema` + per-resource `LinearIssueDataSchema`/`LinearCommentDataSchema`/`LinearProjectDataSchema` parse at the boundary.
8. **Body size unbounded** → 1 MB cap (matches Linear's documented limit), 413 on overrun.
10. **`updateIssue` early-returns on empty diff** → returns tagged `UpdateIssueResult { success: false, reason: string }` so the result topic carries a real explanation.
11. **Server start failure not handled** → catches Bun.serve throw, logs loudly, leaves outbound subscribers active.
12. **`priority: "none"` ambiguity** → semantics documented (it sets Linear's "No priority" value 0, which is real and distinct from "leave unchanged"). `if (priority)` truthy check replaced with `!== undefined`.
13. **Cache invalidation gap** → `teamIdCache` and `stateCache` get a 10-min TTL; new `invalidateCache()` helper for tests/known-edits.

### Bridge plugin
- **Mappings yaml Zod-validated** as a whole — operator typos now reject the whole file with a schema error instead of silently filtering one entry.
- **`reply.format: "markdown"`** for the manage_feature dispatch.

## Tests

\`\`\`
1080/1080 pass (was 1071 — +9 net new linear tests, replaced 2 outdated)
\`\`\`

New coverage:
- Production-safety throw on missing secret (NODE_ENV=production, WORKSTACEAN_PUBLIC_BASE_URL set, dev allowed)
- Result-topic publish on success / failure / exception / empty body / missing fields for reply, update, create
- Result-topic re-entry guard (regression)
- Schema rejection drops bad payloads without publishing
- Existing tests updated where behavior changed

## Deliberately deferred

- **Outbound rate limiting** (audit #9) — needs queue + back-off, separate PR.
- **Structured tracing / Langfuse spans** (audit #14) — codebase-wide pattern, should land with the other plugins together.
- **Topic shape consistency** across reply/update/create families (audit #18) — breaking change; defer until #482 (protoMaker board lifecycle events) forces a wire-protocol revision anyway.
- **Bridge "filing failed" notification** (audit #15) — has the plumbing now (result topics) but no subscriber wired; defer until needed.

## Behavior changes worth flagging for review

- `linear.create.issue` with missing `teamKey`/`title` used to silently drop. Now publishes a `linear.create.issue.result.{cid}` with `success: false, error: "missing teamKey or title"`.
- `linear.reply.{issueId}` with empty body used to silently drop. Now publishes `linear.reply.result.{cid}` with `success: false, error: "empty body"`.
- `linear-board-mappings.yaml` with one bad entry used to load the rest with a warning. Now rejects the whole file with a schema error and keeps the prior in-memory state.
- Plugin install in production-like env without secret used to start an open relay with a warning. Now throws and refuses to start.

These are intentional fail-loud upgrades per the project's `feedback_fail_fast_and_loud` rule.

## Test plan
- [x] \`bun test\` — 1080/1080 pass
- [x] \`tsc --noEmit\` clean
- [ ] On \`:dev\`: verify boot log shows \`[linear] Webhook receiver on :8084/webhooks/linear\`
- [ ] Send a Linear webhook with a valid secret → \`message.inbound.linear.issue.created\` lands on bus
- [ ] Send a webhook with a tampered body → 401
- [ ] Send a webhook with a stale (>5min) timestamp → 400
- [ ] Send a webhook with malformed JSON → 400 with schema error
- [ ] Publish \`linear.reply.{issueId}\` with valid text → comment appears AND \`linear.reply.result.{cid}\` fires with \`success: true\`
- [ ] Publish \`linear.reply.{issueId}\` with no body → result fires with \`success: false, error: "empty body"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added result event topics for mutation operations that provide success/failure details and error information

* **Bug Fixes**
  * Corrected priority handling to properly distinguish between "no priority" and undefined values
  * Enhanced webhook validation with payload size limits, JSON parsing, and timestamp freshness verification

* **Documentation**
  * Updated Linear integration documentation with mandatory webhook secret requirements and validation behavior specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->