### PR TITLE
fix(tests): drop project-schema mock leak (closes #480)

### DIFF
--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -63,11 +63,18 @@ function findComplete(published: BusMessage[]): BusMessage | undefined {
 }
 
 // ── Mock state (shared across mock.module factories) ──────────────────────────
+//
+// We deliberately do NOT mock `../lib/project-schema.ts`. `mock.module()`
+// replacements in Bun's test runner persist for the entire process and bleed
+// into other test files run in the same `bun test` invocation — when
+// tests/project-schema.test.ts runs after this file in the same process, it
+// would pick up the mocked `validateProjectEntry` (which returned the wrong
+// success shape) and 12 tests would fail intermittently in CI. Tracked as #480.
+// The real schema is fast and pure; tests construct payloads that satisfy it.
 
 const _mocks = {
   makeGitHubAuth: null as unknown,
   createDriveFolder: null as unknown,
-  validateProjectEntry: null as unknown,
 };
 
 mock.module("../lib/github-auth.ts", () => ({
@@ -78,11 +85,6 @@ mock.module("../lib/plugins/google.ts", () => ({
   createDriveFolder: (...args: unknown[]) => (_mocks.createDriveFolder as (...a: unknown[]) => unknown)(...args),
   getGoogleAccessToken: () => Promise.resolve(null),
   GooglePlugin: class {},
-}));
-
-mock.module("../lib/project-schema.ts", () => ({
-  validateProjectEntry: (...args: unknown[]) => (_mocks.validateProjectEntry as (...a: unknown[]) => unknown)(...args),
-  parseProjectsYaml: () => ({ projects: [] }),
 }));
 
 // Import the plugin AFTER mock.module calls
@@ -126,7 +128,6 @@ describe("OnboardingPlugin — Step 1: validate", () => {
     setEnv();
     _mocks.makeGitHubAuth = mock(() => () => Promise.resolve("ghp_test"));
     _mocks.createDriveFolder = mock(() => Promise.resolve(null));
-    _mocks.validateProjectEntry = mock(() => ({ ok: true, errors: [] }));
   });
 
   afterEach(() => {
@@ -195,7 +196,6 @@ describe("OnboardingPlugin — Step 2: idempotency", () => {
     setEnv();
     _mocks.makeGitHubAuth = mock(() => () => Promise.resolve("ghp_test"));
     _mocks.createDriveFolder = mock(() => Promise.resolve(null));
-    _mocks.validateProjectEntry = mock(() => ({ ok: true, errors: [] }));
   });
 
   afterEach(() => {
@@ -244,7 +244,6 @@ describe("OnboardingPlugin — Step 3: GitHub webhook", () => {
     workspaceDir = mkdtempSync(join(tmpdir(), "onboard-test-"));
     setEnv();
     _mocks.createDriveFolder = mock(() => Promise.resolve(null));
-    _mocks.validateProjectEntry = mock(() => ({ ok: true, errors: [] }));
   });
 
   afterEach(() => {
@@ -356,7 +355,6 @@ describe("OnboardingPlugin — Step 4: Drive folder", () => {
     workspaceDir = mkdtempSync(join(tmpdir(), "onboard-test-"));
     setEnv();
     _mocks.makeGitHubAuth = mock(() => null);
-    _mocks.validateProjectEntry = mock(() => ({ ok: true, errors: [] }));
   });
 
   afterEach(() => {
@@ -436,7 +434,6 @@ describe("OnboardingPlugin — Step 5: projects.yaml write", () => {
     setEnv();
     _mocks.makeGitHubAuth = mock(() => null);
     _mocks.createDriveFolder = mock(() => Promise.resolve(null));
-    _mocks.validateProjectEntry = mock(() => ({ ok: true, errors: [] }));
   });
 
   afterEach(() => {
@@ -524,7 +521,6 @@ describe("OnboardingPlugin — Full pipeline", () => {
     setEnv();
     _mocks.makeGitHubAuth = mock(() => null);
     _mocks.createDriveFolder = mock(() => Promise.resolve(null));
-    _mocks.validateProjectEntry = mock(() => ({ ok: true, errors: [] }));
   });
 
   afterEach(() => {
@@ -583,7 +579,6 @@ describe("OnboardingPlugin — Idempotency (full run twice)", () => {
     setEnv();
     _mocks.makeGitHubAuth = mock(() => null);
     _mocks.createDriveFolder = mock(() => Promise.resolve(null));
-    _mocks.validateProjectEntry = mock(() => ({ ok: true, errors: [] }));
   });
 
   afterEach(() => {
@@ -624,7 +619,6 @@ describe("OnboardingPlugin — Error handling", () => {
     setEnv();
     _mocks.makeGitHubAuth = mock(() => null);
     _mocks.createDriveFolder = mock(() => Promise.resolve(null));
-    _mocks.validateProjectEntry = mock(() => ({ ok: true, errors: [] }));
   });
 
   afterEach(() => {
@@ -633,13 +627,20 @@ describe("OnboardingPlugin — Error handling", () => {
   });
 
   test("fatal step error (projects.yaml schema fail) aborts pipeline", async () => {
-    _mocks.validateProjectEntry = mock(() => ({ ok: false, errors: ["slug is required"] }));
-
+    // Construct a request whose constructed entry will fail the real
+    // ProjectEntrySchema. ProjectDiscordChannelSchema is union(string, object{
+    // channelId, webhook? }); a bare numeric `dev` value satisfies neither
+    // branch, so projects_yaml step rejects with a schema error.
     const plugin = new OnboardingPlugin(workspaceDir);
     const { bus, published } = makeTestBus();
     plugin.install(bus);
 
-    bus.publish("message.inbound.onboard", makeBusMsg({ slug: "fatal-test", title: "Fatal", github: "o/r" }));
+    bus.publish("message.inbound.onboard", makeBusMsg({
+      slug: "fatal-test",
+      title: "Fatal",
+      github: "o/r",
+      discord: { dev: 12345 as unknown as string },
+    }));
     await new Promise(r => setTimeout(r, 150));
 
     const reply = findReply(published);


### PR DESCRIPTION
## Root cause

`tests/onboarding.test.ts` mocked `../lib/project-schema.ts` via `mock.module(...)`. **Bun's `mock.module()` replacements persist for the entire test process** — when `tests/project-schema.test.ts` ran in the same `bun test` invocation (file-discovery order varies between runs), it picked up the mocked `validateProjectEntry` instead of the real schema-backed one.

The mock returned `{ ok: true, errors: [] }` — missing the `entry` field that the real success branch carries. So the 12 tests in project-schema.test.ts that destructure `result.entry.*` would crash with `TypeError: undefined is not an object` — the exact failure pattern the audit flagged across PRs #468, #478, #479, #486 in CI.

Failure was deterministic in CI (file-load order + memory pressure made the leak reproduce consistently) and never reproduced locally. The audit hypothesis ("zod parallel race / module-state mutation") was on the right track — it's the latter, specifically `mock.module` cross-file leak.

## Fix

- Removed `mock.module("../lib/project-schema.ts", ...)` and the `validateProjectEntry` field from the shared `_mocks` state
- Removed the per-test `_mocks.validateProjectEntry = mock(...)` setups
- Replaced the "fatal step error (projects.yaml schema fail)" test with a payload that genuinely fails the real schema (`discord.dev: 12345 as unknown as string` — a number satisfies neither branch of `ProjectDiscordChannelSchema`'s `union(string, object)`). Same pipeline branch exercised, real validation now.
- Comment block documents the mock-leak hazard so a future maintainer doesn't reintroduce it.

The other two `mock.module()` calls in this file (`github-auth`, `google`) stay — they don't have other test files importing them with assertions on the return shape, so they're not a leak source.

## Verification

- 5 consecutive `bun test` runs locally → all 1080/1080 pass, 0 fail
- Type-check clean
- The "fatal" test still asserts `step: "projects_yaml"` — same pipeline path, real-schema-driven instead of mock-driven

## Test plan
- [x] `bun test` 5x consecutive — clean
- [x] `tsc --noEmit` clean
- [ ] CI: 5 consecutive PR runs all green (post-merge tracking)
- [ ] No occurrence of the flake on the next 7 days of merge activity

Closes #480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test validation by removing mocks and enforcing real schema validation checks, ensuring tests more accurately reflect production behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->