### PR TITLE
fix(pr-remediator): tighten diagnose_pr_stuck prompt to bias toward 'rebasable' for small PRs

### DIFF
--- a/lib/plugins/pr-remediator.ts
+++ b/lib/plugins/pr-remediator.ts
@@ -1462,13 +1462,20 @@ Analyze the PR and return a JSON object with this exact shape:
 \`\`\`
 
 Verdict definitions:
-- "redundant": The PR's intent is already satisfied by commits on \`${pr.baseRef}\` since the PR was cut.
-- "rebasable": Conflicts are textual but non-semantic (whitespace, import order, doc section shuffle, auto-generated files). A three-way merge can resolve them without losing meaning.
-- "decomposable": Conflicts cluster in a small number of specific files. Splitting into smaller PRs would avoid the conflict.
-- "genuine": Semantic conflicts requiring human judgment — which lines mean what is ambiguous.
+
+- "redundant": The PR's intent is already satisfied by commits on \`${pr.baseRef}\` since the PR was cut. Closing it loses nothing because the work is already on the base branch in another form.
+
+- "rebasable": Conflicts are textual or mechanical and the diff is tractable enough to merge by hand. Examples: whitespace; import order; both sides added a new section after the same doc anchor; both sides added a new entry to the same list; auto-generated files (lockfiles, audit dumps, snapshot files); a few sites where one side renamed a symbol the other side touched. The recovery path is a single back-merge of \`${pr.baseRef}\` into the head branch — usually clean, sometimes with a few keep-ours / keep-theirs decisions on obvious files. Choose "rebasable" when the PR touches fewer than ~15 files OR when the conflicts cluster only in docs / auto-generated files / a single source file.
+
+- "decomposable": The PR is large (touches many files across multiple distinct subsystems) AND the conflicts naturally cluster into independent file groups that could each ship as smaller focused PRs landing cleanly on their own. The split path is only worth proposing when the resulting smaller PRs each carry a clear standalone purpose. A small PR that conflicts with a recent, equally small PR is "rebasable" — there is nothing to decompose. Decomposable is the destructive path; it triggers an auto-close + split-proposal comment.
+
+- "genuine": Semantic conflicts requiring human judgment — which lines mean what is ambiguous, or both sides intentionally diverged on the same behavior. Escalates to HITL.
+
+Verdict precedence — pick the LEAST destructive verdict that fits the evidence: redundant → rebasable → decomposable → genuine. Default to "rebasable" whenever the PR touches fewer than 15 files or the conflict surface is purely docs / lockfiles / a single source file. Reserve "decomposable" for genuinely large multi-subsystem PRs where re-cutting as smaller PRs is the cheaper recovery than a back-merge.
 
 Use your GitHub API tools to fetch:
 1. PR files diff: GET /repos/${pr.repo}/pulls/${pr.number}/files
+   — count the files; report the count in your evidence string. When the count is below 15, "rebasable" almost always fits the situation.
 2. Recent base commits: GET /repos/${pr.repo}/commits?sha=${pr.baseRef}&per_page=20
 
 Return ONLY the JSON block. No other text.`,


### PR DESCRIPTION
## Why

PR #492 (push-notification store) was correctly small (8 files) but raced against PR #491 which landed first and touched the same `a2a-server.ts` and `docs/guides/a2a-streaming.md` anchors. Ava's verdict was \`decomposable\` — that triggered Quinn's auto-close + split-proposal even though there was nothing to decompose; the right recovery was a single back-merge.

The chokepoint guard for promotion PRs (#465) wasn't tripped because this wasn't a promotion PR. The prompt's verdict definition was under-specified — _"Conflicts cluster in a small number of specific files. Splitting into smaller PRs would avoid the conflict"_ literally described the situation.

## What changes

Tightening lives in `lib/plugins/pr-remediator.ts` at the prompt body for `diagnose_pr_stuck`:

| Verdict | Before | After |
|---|---|---|
| `redundant` | "intent already satisfied by base commits" | + clarifies "closing it loses nothing" |
| `rebasable` | one short example list | concrete examples matching recent friction (doc-section anchor races, both-sides-list-additions, lockfile drift, single-symbol renames). **Explicit threshold: prefer rebasable when PR touches < 15 files OR when conflicts cluster in docs / lockfiles / a single source file.** |
| `decomposable` | "conflicts cluster in a small number of files" | requires BOTH a large PR (multi-subsystem) AND conflicts that genuinely split into independent landable groups. Explicit anti-pattern: _"a small PR conflicting with a recent equally small PR is rebasable, not decomposable."_ |
| `genuine` | "semantic conflicts" | + clarifies escalation behavior |

Plus a new precedence line:
> Pick the LEAST destructive verdict that fits: redundant → rebasable → decomposable → genuine.

And the API-tool guidance now asks Ava to count files in the diff and report the count in evidence — counts < 15 should almost always land on rebasable.

## Why prompt fix and not a runtime guard

Two axes both came up in the audit conversation:
1. **Prompt fix (this PR)** — prevent the bad call upstream
2. **Trivial-conflict guard** — catch the bad call at the chokepoint (mirroring the promotion-PR guard from #465)

Going with the prompt fix first. The chokepoint guard is defense-in-depth that's worth filing as a follow-up only if the prompt fix doesn't hold. Less code to maintain if the upstream correction sticks.

## Tests

- `bun test` — 1094/1094 pass
- `tsc --noEmit` clean
- Existing dispatch test asserts skill name + agent target + correlation id, not prompt body wording — safe to ship without test coverage churn.

## Cross-reference

PR #492 closed by Quinn, re-cut as #493 (merged). This PR prevents that round-trip on the next "small but raced" PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)