### PR TITLE
chore(workspace): enable Gmail INBOX + primary Calendar in google.yaml

### DIFF
--- a/workspace/google.yaml
+++ b/workspace/google.yaml
@@ -3,13 +3,13 @@ drive:
   templateFolderId: ""  # per-project folder template (optional)
 
 calendar:
-  orgCalendarId: ""             # shared org calendar for milestones/deadlines
-  pollIntervalMinutes: 60       # how often to check for upcoming events
+  orgCalendarId: "primary"      # the authenticated user's primary calendar
+  pollIntervalMinutes: 15       # how often to check for upcoming events
 
 gmail:
-  watchLabels: []               # Gmail labels to monitor for inbound routing
+  watchLabels: ["INBOX"]        # poll the entire inbox; Gmail's INBOX label covers everything not archived
   pollIntervalMinutes: 5        # how often to poll for new messages
-  routingRules: []              # label → skillHint mappings
+  routingRules: []              # label → skillHint mappings (none yet — every inbound becomes a chat skill)
   # routingRules example:
   # - label: "bug-report"
   #   skillHint: bug_triage


### PR DESCRIPTION
Activates the now-fully-wired Google Workspace integration on the standard inbox/calendar surface. Hot-reloaded by `GooglePlugin` — no restart needed once this lands and the volume-mounted file updates.

## Diff

```yaml
calendar:
-  orgCalendarId: ""             # shared org calendar for milestones/deadlines
-  pollIntervalMinutes: 60
+  orgCalendarId: "primary"      # the authenticated user's primary calendar
+  pollIntervalMinutes: 15

gmail:
-  watchLabels: []
+  watchLabels: ["INBOX"]
```

## Why now

- PR #495 wired `GooglePlugin` into the registry
- homelab-iac PR #13 piped the OAuth env through to the container
- PR #496 wired Gmail into channels.yaml + bus topics + reply path
- `GOOGLE_REFRESH_TOKEN` is in Infisical

All four pieces are in place. This config flip is what actually starts polling.

## What lands when this merges

- Gmail poller fetches every unread INBOX email every 5 min
- Each email publishes `message.inbound.google.gmail.inbox.{threadId}`
- RouterPlugin matches the `google-gmail-inbox` channel → dispatches to Ava
- Ava replies → `google.gmail.reply.{threadId}` → posted as a threaded Gmail reply

## What's intentionally NOT in this PR

- `routingRules` left empty — every inbound mail goes through the channel-routed `chat` skill. Per-label specialty routing (`bug-report` → `bug_triage` etc.) can be added later without touching the default path.
- Drive `orgFolderId` / `templateFolderId` left empty — onboarding doesn't need them yet.

## Sync between repo + container

The deployed container bind-mounts `workspace/` from this repo (`/home/josh/dev/protoWorkstacean/workspace:/workspace`), so the file is already live on the box (I edited it earlier in the session for hot-reload validation, then reverted local + re-applied on this branch for clean git history). After this PR merges, the repo state and the live state are aligned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Calendar synchronization now targets the authenticated user's primary calendar instead of a shared calendar configuration.
  * Event polling frequency increased from 60 to 15 minutes, enabling faster calendar synchronization.
  * Gmail monitoring now exclusively watches the INBOX label for improved focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->