### PR TITLE
chore(google): disable Gmail/Calendar polling + Gmail auto-reply (revert wrong direction from #496/#497)

### DIFF
--- a/lib/plugins/google.ts
+++ b/lib/plugins/google.ts
@@ -93,7 +93,11 @@ export class GooglePlugin implements Plugin {
     this.drive.start(bus);
     this.docs.start(bus);
     this.gmail.start(bus);
-    this.gmailOutbound.start(bus);
+    // Gmail outbound (auto-reply on `google.gmail.reply.#`) intentionally
+    // NOT started. Ava is a pull-mode drafter — she reads / summarizes /
+    // drafts replies when asked, via Gmail tools that create DRAFTS for
+    // human review and send. Auto-reply path stays in code so it's ready
+    // when/if a deliberately-opt-in send flow is wired later.
     this.calendar.start(bus);
     this.tokenRefresher.start();
 
@@ -140,7 +144,7 @@ export class GooglePlugin implements Plugin {
     this.drive.stop();
     this.docs.stop();
     this.gmail.stop();
-    this.gmailOutbound.stop();
+    // gmailOutbound was never started in install() — see comment there.
     this.calendar.stop();
     this.tokenRefresher?.stop();
     unwatchFile(join(this.workspaceDir, "google.yaml"));

--- a/workspace/channels.yaml
+++ b/workspace/channels.yaml
@@ -34,16 +34,14 @@ channels:
   #   description: Quinn owns this specific ticket end-to-end
 
   # ── Google Gmail ───────────────────────────────────────────────────────────
-  # GooglePlugin polls labels listed in workspace/google.yaml and publishes
-  # message.inbound.google.gmail.{labelSlug}.{threadId}. ChannelRegistry
-  # matches the labelSlug segment (lowercase, non-alphanumeric → "-").
-  # `channelId` here is the LABEL NAME — not the slug — and the registry
-  # normalizes it during indexing.
-  - id: google-gmail-inbox
-    platform: google
-    channelId: "INBOX"
-    agent: ava
-    description: Every email landing in the user's primary inbox routes to Ava as a chat
-    conversation:
-      enabled: true
-      timeoutMs: 1800000   # 30 min — email replies can take a while
+  # Gmail is intentionally NOT registered as an inbound-routing channel here.
+  # Ava is a pull-mode reader/drafter — she reads / summarizes / drafts
+  # replies when explicitly asked, via Gmail tools. She does NOT auto-reply
+  # to inbound emails. The `google` platform is supported by the registry
+  # (ChannelRegistry.byGoogleGmailLabel + findByTopic) so this entry shape
+  # is ready when/if a label-scoped auto-route is desired in the future:
+  #
+  # - id: google-gmail-INBOX
+  #   platform: google
+  #   channelId: "INBOX"
+  #   agent: ava

--- a/workspace/google.yaml
+++ b/workspace/google.yaml
@@ -2,16 +2,21 @@ drive:
   orgFolderId: ""       # root org Drive folder — shared across all projects
   templateFolderId: ""  # per-project folder template (optional)
 
+# Gmail + Calendar polling intentionally disabled.
+#
+# Ava is a pull-mode reader/drafter: she reads / summarizes / drafts
+# replies when explicitly asked, via Gmail tools. She does NOT auto-reply
+# to inbound emails or react to calendar events on a schedule.
+#
+# To re-enable polling at some point, set watchLabels / orgCalendarId
+# below — the GooglePlugin will start the relevant pollers on the next
+# 1-second hot-reload of this file.
+
 calendar:
-  orgCalendarId: "primary"      # the authenticated user's primary calendar
-  pollIntervalMinutes: 15       # how often to check for upcoming events
+  orgCalendarId: ""             # empty → calendar polling disabled
+  pollIntervalMinutes: 60
 
 gmail:
-  watchLabels: ["INBOX"]        # poll the entire inbox; Gmail's INBOX label covers everything not archived
-  pollIntervalMinutes: 5        # how often to poll for new messages
-  routingRules: []              # label → skillHint mappings (none yet — every inbound becomes a chat skill)
-  # routingRules example:
-  # - label: "bug-report"
-  #   skillHint: bug_triage
-  # - label: "gtm-request"
-  #   skillHint: content_strategy
+  watchLabels: []               # empty → inbox polling disabled
+  pollIntervalMinutes: 5
+  routingRules: []


### PR DESCRIPTION
Reverses the auto-flow shipped in #496 + #497. The intended pattern is **Ava as a pull-mode reader/drafter** — she reads / summarizes / drafts replies when explicitly asked, via Gmail tools that create DRAFTS for human review and send. Auto-polling the inbox and auto-replying on every inbound was the wrong direction.

## What changes

| File | Change |
|---|---|
| `workspace/google.yaml` | `watchLabels: []` (Gmail polling off), `orgCalendarId: ""` (Calendar polling off). Header comment documents intent so the next operator doesn't accidentally re-enable. |
| `workspace/channels.yaml` | Drop the `google-gmail-inbox` channel route. Replaced with a commented-out template so the registry shape stays documented for a future deliberate route. |
| `lib/plugins/google.ts` | Comment out `this.gmailOutbound.start(bus)`. Subscriber code in `google/gmail.ts` stays intact so the path can be re-wired when an explicit Ava-tool "send-this-draft" flow is built. **No subscription = no auto-reply, even if some other code accidentally publishes to `google.gmail.reply.{threadId}`.** |

## What's intact

- GooglePlugin still installs, OAuth tokens still refresh
- Drive + Docs outbound subscribers still listen (those don't have an "auto-reply" failure mode)
- Gmail handler code still works — calling `start()` with `watchLabels` populated would resume polling identically to before
- ChannelRegistry still recognizes `platform: google` entries when someone wants to re-enable label-scoped routing

## Live container

The bind-mounted `workspace/google.yaml` hot-reloads within 1s of this merge. Active poller stops mid-cycle. Discord-style auto-routing of inbound emails ceases immediately.

## Next move (separate PR — NOT in this one)

Add Gmail tools to Ava's toolkit so she can:
- `gmail_list_unread(label?, max?)` — survey what's in the inbox
- `gmail_get_thread(threadId)` — read a conversation in full
- `gmail_search(query)` — Gmail search
- `gmail_create_draft(threadId, body)` — draft a reply that lands in the Drafts folder for human review (Gmail API: `users.drafts.create`)

These are pull-mode — Ava only invokes them when asked in chat.

## Tests

`bun test` — 1094/1094 pass. Type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Disabled Gmail inbound message routing
  * Disabled automated Google Calendar event polling
  * Reduced Google Calendar polling frequency from 15 to 60 minutes
  * Removed Gmail auto-reply functionality from plugin execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->