### PR TITLE
feat(ava): pull-mode Gmail/Calendar tools (read + draft only)

### DIFF
--- a/src/api/google.ts
+++ b/src/api/google.ts
@@ -1,0 +1,394 @@
+/**
+ * Google Workspace API routes — back the Ava-side tools that read Gmail
+ * and Calendar on demand and create draft replies (no auto-send).
+ *
+ * Endpoints:
+ *   GET  /api/google/gmail/list-unread?label=INBOX&max=20
+ *   GET  /api/google/gmail/search?q=from:foo&max=20
+ *   GET  /api/google/gmail/thread/:threadId
+ *   POST /api/google/gmail/draft   { threadId, body, to?, subject?, inReplyTo?, references? }
+ *   GET  /api/google/calendar/upcoming?days=7&calendarId=primary
+ *   GET  /api/google/calendar/event/:eventId?calendarId=primary
+ *
+ * Every endpoint requires the GooglePlugin's OAuth credentials
+ * (GOOGLE_CLIENT_ID / SECRET / REFRESH_TOKEN). When unset, returns 503
+ * with a clear "google plugin disabled" message so Ava's tool layer can
+ * surface the gap without crashing.
+ *
+ * Ava is a pull-mode reader/drafter: she calls these when explicitly
+ * asked. Drafts are NOT sent — they land in the user's Drafts folder for
+ * manual review and send.
+ */
+
+import type { Route, ApiContext } from "./types.ts";
+import { getGoogleAccessToken } from "../../lib/plugins/google/auth.ts";
+
+function disabledResponse(): Response {
+  return Response.json(
+    {
+      success: false,
+      error: "Google Workspace plugin disabled — GOOGLE_CLIENT_ID/SECRET/REFRESH_TOKEN env vars are required.",
+    },
+    { status: 503 },
+  );
+}
+
+async function withToken<T>(handler: (token: string) => Promise<T>): Promise<Response> {
+  const token = await getGoogleAccessToken();
+  if (!token) return disabledResponse();
+  try {
+    const data = await handler(token);
+    return Response.json({ success: true, data });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return Response.json({ success: false, error: msg }, { status: 500 });
+  }
+}
+
+/** Decode Gmail's URL-safe base64 payload to UTF-8 text. */
+function decodeBody(data: string | undefined): string {
+  if (!data) return "";
+  return Buffer.from(data.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8");
+}
+
+interface GmailMessageHeader { name: string; value: string }
+interface GmailMessage {
+  id: string;
+  threadId: string;
+  payload?: {
+    headers?: GmailMessageHeader[];
+    body?: { data?: string };
+    parts?: { mimeType: string; body?: { data?: string } }[];
+  };
+  snippet?: string;
+}
+
+function header(headers: GmailMessageHeader[] | undefined, name: string): string {
+  return headers?.find(h => h.name.toLowerCase() === name.toLowerCase())?.value ?? "";
+}
+
+function extractBody(msg: GmailMessage): string {
+  const parts = msg.payload?.parts ?? [];
+  const plain = parts.find(p => p.mimeType === "text/plain");
+  return decodeBody(plain?.body?.data ?? msg.payload?.body?.data);
+}
+
+/** Compact summary used by list endpoints. */
+function summaryOf(msg: GmailMessage) {
+  const headers = msg.payload?.headers;
+  return {
+    messageId: msg.id,
+    threadId: msg.threadId,
+    from: header(headers, "From"),
+    to: header(headers, "To"),
+    subject: header(headers, "Subject"),
+    date: header(headers, "Date"),
+    snippet: (msg.snippet ?? "").slice(0, 200),
+  };
+}
+
+async function fetchMessages(token: string, ids: { id: string }[]): Promise<GmailMessage[]> {
+  const out: GmailMessage[] = [];
+  for (const { id } of ids) {
+    const resp = await fetch(`https://gmail.googleapis.com/gmail/v1/users/me/messages/${id}?format=metadata&metadataHeaders=From&metadataHeaders=To&metadataHeaders=Subject&metadataHeaders=Date`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!resp.ok) continue;
+    out.push(await resp.json() as GmailMessage);
+  }
+  return out;
+}
+
+/** Base64URL encode (no padding) — Gmail draft / send body shape. */
+function base64url(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export function createRoutes(_ctx: ApiContext): Route[] {
+  return [
+    // ── Gmail: list unread ───────────────────────────────────────────────
+    {
+      method: "GET",
+      path: "/api/google/gmail/list-unread",
+      handler: async (req) => {
+        const url = new URL(req.url);
+        const label = url.searchParams.get("label") ?? "INBOX";
+        const max = Math.min(parseInt(url.searchParams.get("max") ?? "20", 10) || 20, 100);
+        return withToken(async (token) => {
+          const query = `label:${label.replace(/\s+/g, "-")} is:unread`;
+          const listUrl = new URL("https://gmail.googleapis.com/gmail/v1/users/me/messages");
+          listUrl.searchParams.set("q", query);
+          listUrl.searchParams.set("maxResults", String(max));
+          const listResp = await fetch(listUrl.toString(), {
+            headers: { Authorization: `Bearer ${token}` },
+            signal: AbortSignal.timeout(15_000),
+          });
+          if (!listResp.ok) throw new Error(`Gmail list failed: ${listResp.status}`);
+          const listData = await listResp.json() as { messages?: { id: string }[] };
+          const messages = await fetchMessages(token, listData.messages ?? []);
+          return { label, count: messages.length, messages: messages.map(summaryOf) };
+        });
+      },
+    },
+
+    // ── Gmail: search ────────────────────────────────────────────────────
+    {
+      method: "GET",
+      path: "/api/google/gmail/search",
+      handler: async (req) => {
+        const url = new URL(req.url);
+        const q = url.searchParams.get("q") ?? "";
+        const max = Math.min(parseInt(url.searchParams.get("max") ?? "20", 10) || 20, 100);
+        if (!q.trim()) {
+          return Response.json({ success: false, error: "missing q parameter" }, { status: 400 });
+        }
+        return withToken(async (token) => {
+          const listUrl = new URL("https://gmail.googleapis.com/gmail/v1/users/me/messages");
+          listUrl.searchParams.set("q", q);
+          listUrl.searchParams.set("maxResults", String(max));
+          const listResp = await fetch(listUrl.toString(), {
+            headers: { Authorization: `Bearer ${token}` },
+            signal: AbortSignal.timeout(15_000),
+          });
+          if (!listResp.ok) throw new Error(`Gmail search failed: ${listResp.status}`);
+          const listData = await listResp.json() as { messages?: { id: string }[] };
+          const messages = await fetchMessages(token, listData.messages ?? []);
+          return { query: q, count: messages.length, messages: messages.map(summaryOf) };
+        });
+      },
+    },
+
+    // ── Gmail: get full thread ───────────────────────────────────────────
+    {
+      method: "GET",
+      path: "/api/google/gmail/thread/:threadId",
+      handler: async (_req, params) => {
+        const threadId = params?.threadId;
+        if (!threadId) {
+          return Response.json({ success: false, error: "missing threadId" }, { status: 400 });
+        }
+        return withToken(async (token) => {
+          const resp = await fetch(`https://gmail.googleapis.com/gmail/v1/users/me/threads/${threadId}?format=full`, {
+            headers: { Authorization: `Bearer ${token}` },
+            signal: AbortSignal.timeout(15_000),
+          });
+          if (!resp.ok) throw new Error(`Gmail thread fetch failed: ${resp.status}`);
+          const data = await resp.json() as { messages?: GmailMessage[] };
+          const messages = (data.messages ?? []).map(m => ({
+            messageId: m.id,
+            threadId: m.threadId,
+            from: header(m.payload?.headers, "From"),
+            to: header(m.payload?.headers, "To"),
+            subject: header(m.payload?.headers, "Subject"),
+            date: header(m.payload?.headers, "Date"),
+            messageIdHeader: header(m.payload?.headers, "Message-ID"),
+            references: header(m.payload?.headers, "References"),
+            snippet: (m.snippet ?? "").slice(0, 200),
+            body: extractBody(m).slice(0, 8_000),
+          }));
+          return { threadId, count: messages.length, messages };
+        });
+      },
+    },
+
+    // ── Gmail: create draft ──────────────────────────────────────────────
+    // Drafts go to Drafts folder. They are NOT sent. Operator reviews + sends.
+    {
+      method: "POST",
+      path: "/api/google/gmail/draft",
+      handler: async (req) => {
+        let input: {
+          threadId?: string;
+          body?: string;
+          to?: string;
+          subject?: string;
+          inReplyTo?: string;
+          references?: string;
+        };
+        try {
+          input = await req.json() as typeof input;
+        } catch {
+          return Response.json({ success: false, error: "invalid JSON body" }, { status: 400 });
+        }
+        if (!input.body?.trim()) {
+          return Response.json({ success: false, error: "missing body" }, { status: 400 });
+        }
+        return withToken(async (token) => {
+          // If threadId is set but headers aren't provided, fetch them so the
+          // draft threads correctly in Gmail's UI.
+          let to = input.to ?? "";
+          let subject = input.subject ?? "";
+          let inReplyTo = input.inReplyTo ?? "";
+          let references = input.references ?? "";
+          if (input.threadId && (!to || !subject || !inReplyTo)) {
+            const threadResp = await fetch(`https://gmail.googleapis.com/gmail/v1/users/me/threads/${input.threadId}?format=metadata&metadataHeaders=From&metadataHeaders=Subject&metadataHeaders=Message-ID&metadataHeaders=References`, {
+              headers: { Authorization: `Bearer ${token}` },
+              signal: AbortSignal.timeout(15_000),
+            });
+            if (threadResp.ok) {
+              const data = await threadResp.json() as { messages?: GmailMessage[] };
+              const last = data.messages?.[data.messages.length - 1];
+              const h = last?.payload?.headers;
+              if (h) {
+                if (!to) to = header(h, "From");
+                if (!subject) {
+                  const s = header(h, "Subject");
+                  subject = s.startsWith("Re:") ? s : `Re: ${s}`;
+                }
+                if (!inReplyTo) inReplyTo = header(h, "Message-ID");
+                if (!references) {
+                  const refs = header(h, "References");
+                  const mid = header(h, "Message-ID");
+                  references = [refs, mid].filter(Boolean).join(" ");
+                }
+              }
+            }
+          }
+          if (!to) {
+            throw new Error("draft missing recipient — provide `to` or a `threadId` we can resolve from");
+          }
+
+          const headers: string[] = [
+            `To: ${to}`,
+            `Subject: ${subject || "(no subject)"}`,
+          ];
+          if (inReplyTo) headers.push(`In-Reply-To: ${inReplyTo}`);
+          if (references) headers.push(`References: ${references}`);
+          headers.push("Content-Type: text/plain; charset=utf-8");
+          headers.push("MIME-Version: 1.0");
+          const raw = headers.join("\r\n") + "\r\n\r\n" + input.body;
+          const encoded = base64url(Buffer.from(raw, "utf-8"));
+
+          const draftResp = await fetch("https://gmail.googleapis.com/gmail/v1/users/me/drafts", {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${token}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              message: input.threadId
+                ? { raw: encoded, threadId: input.threadId }
+                : { raw: encoded },
+            }),
+            signal: AbortSignal.timeout(15_000),
+          });
+          if (!draftResp.ok) {
+            const errText = await draftResp.text().catch(() => "");
+            throw new Error(`Gmail draft create failed: ${draftResp.status} ${errText.slice(0, 200)}`);
+          }
+          const draft = await draftResp.json() as { id?: string; message?: { id?: string; threadId?: string } };
+          return {
+            draftId: draft.id,
+            messageId: draft.message?.id,
+            threadId: draft.message?.threadId,
+            to,
+            subject,
+            // Sentinel field so callers (and Ava) know to surface "review and send manually."
+            sent: false,
+          };
+        });
+      },
+    },
+
+    // ── Calendar: upcoming events ────────────────────────────────────────
+    {
+      method: "GET",
+      path: "/api/google/calendar/upcoming",
+      handler: async (req) => {
+        const url = new URL(req.url);
+        const days = Math.min(parseInt(url.searchParams.get("days") ?? "7", 10) || 7, 90);
+        const calendarId = url.searchParams.get("calendarId") ?? "primary";
+        return withToken(async (token) => {
+          const now = new Date();
+          const horizon = new Date(now.getTime() + days * 24 * 60 * 60 * 1_000);
+          const evtUrl = new URL(
+            `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events`,
+          );
+          evtUrl.searchParams.set("timeMin", now.toISOString());
+          evtUrl.searchParams.set("timeMax", horizon.toISOString());
+          evtUrl.searchParams.set("singleEvents", "true");
+          evtUrl.searchParams.set("orderBy", "startTime");
+          evtUrl.searchParams.set("maxResults", "50");
+          const resp = await fetch(evtUrl.toString(), {
+            headers: { Authorization: `Bearer ${token}` },
+            signal: AbortSignal.timeout(15_000),
+          });
+          if (!resp.ok) throw new Error(`Calendar list failed: ${resp.status}`);
+          const data = await resp.json() as {
+            items?: {
+              id: string;
+              summary?: string;
+              start?: { dateTime?: string; date?: string };
+              end?: { dateTime?: string; date?: string };
+              attendees?: { email: string; displayName?: string }[];
+              location?: string;
+              htmlLink?: string;
+            }[];
+          };
+          const events = (data.items ?? []).map(e => ({
+            id: e.id,
+            title: e.summary ?? "(No title)",
+            start: e.start?.dateTime ?? e.start?.date ?? "",
+            end: e.end?.dateTime ?? e.end?.date ?? "",
+            attendees: (e.attendees ?? []).map(a => a.email),
+            location: e.location ?? "",
+            link: e.htmlLink ?? "",
+          }));
+          return { calendarId, days, count: events.length, events };
+        });
+      },
+    },
+
+    // ── Calendar: event detail ───────────────────────────────────────────
+    {
+      method: "GET",
+      path: "/api/google/calendar/event/:eventId",
+      handler: async (req, params) => {
+        const url = new URL(req.url);
+        const eventId = params?.eventId;
+        const calendarId = url.searchParams.get("calendarId") ?? "primary";
+        if (!eventId) {
+          return Response.json({ success: false, error: "missing eventId" }, { status: 400 });
+        }
+        return withToken(async (token) => {
+          const evtUrl = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`;
+          const resp = await fetch(evtUrl, {
+            headers: { Authorization: `Bearer ${token}` },
+            signal: AbortSignal.timeout(15_000),
+          });
+          if (!resp.ok) throw new Error(`Calendar event fetch failed: ${resp.status}`);
+          const e = await resp.json() as {
+            id: string;
+            summary?: string;
+            description?: string;
+            start?: { dateTime?: string; date?: string };
+            end?: { dateTime?: string; date?: string };
+            attendees?: { email: string; displayName?: string; responseStatus?: string }[];
+            location?: string;
+            htmlLink?: string;
+            organizer?: { email?: string; displayName?: string };
+          };
+          return {
+            id: e.id,
+            title: e.summary ?? "(No title)",
+            description: e.description ?? "",
+            start: e.start?.dateTime ?? e.start?.date ?? "",
+            end: e.end?.dateTime ?? e.end?.date ?? "",
+            attendees: (e.attendees ?? []).map(a => ({
+              email: a.email,
+              name: a.displayName ?? "",
+              status: a.responseStatus ?? "",
+            })),
+            location: e.location ?? "",
+            link: e.htmlLink ?? "",
+            organizer: e.organizer ? {
+              email: e.organizer.email ?? "",
+              name: e.organizer.displayName ?? "",
+            } : null,
+          };
+        });
+      },
+    },
+  ];
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -22,6 +22,7 @@ import { createRoutes as widgetsRoutes } from "./widgets.ts";
 import { createRoutes as observabilityRoutes } from "./observability.ts";
 import { createRoutes as operatorRoutes } from "./operator.ts";
 import { createRoutes as openaiCompatRoutes } from "./openai-compat.ts";
+import { createRoutes as googleRoutes } from "./google.ts";
 
 export { matchPath } from "./types.ts";
 export type { Route, ApiContext } from "./types.ts";
@@ -43,5 +44,6 @@ export function createAllRoutes(ctx: ApiContext): Route[] {
     ...observabilityRoutes(ctx),
     ...operatorRoutes(ctx),
     ...openaiCompatRoutes(ctx),
+    ...googleRoutes(ctx),
   ];
 }

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -368,6 +368,95 @@ function createLangChainTools(toolNames: string[], http: HttpClient, correlation
         }),
       },
     ),
+    // ── Google Workspace (pull-mode reader/drafter — no auto-send) ───────────
+    gmail_list_unread: tool(
+      async (input) => {
+        const url = new URL("/api/google/gmail/list-unread", "http://x");
+        if (input.label) url.searchParams.set("label", input.label);
+        if (input.max) url.searchParams.set("max", String(input.max));
+        return JSON.stringify(await http.get(url.pathname + url.search));
+      },
+      {
+        name: "gmail_list_unread",
+        description: "List unread Gmail messages in a label (default INBOX). Use when the operator asks 'what's in my inbox?'.",
+        schema: z.object({
+          label: z.string().optional().describe("Gmail label (default INBOX)"),
+          max: z.number().optional().describe("Max results (default 20, max 100)"),
+        }),
+      },
+    ),
+    gmail_search: tool(
+      async (input) => {
+        const url = new URL("/api/google/gmail/search", "http://x");
+        url.searchParams.set("q", input.query);
+        if (input.max) url.searchParams.set("max", String(input.max));
+        return JSON.stringify(await http.get(url.pathname + url.search));
+      },
+      {
+        name: "gmail_search",
+        description: "Search Gmail with native Gmail query syntax (from:, subject:, after:, has:attachment, etc.).",
+        schema: z.object({
+          query: z.string().describe("Gmail search query"),
+          max: z.number().optional().describe("Max results (default 20, max 100)"),
+        }),
+      },
+    ),
+    gmail_get_thread: tool(
+      async (input) => JSON.stringify(await http.get(`/api/google/gmail/thread/${encodeURIComponent(input.threadId)}`)),
+      {
+        name: "gmail_get_thread",
+        description: "Read the full message history of a Gmail thread. Returns headers and bodies for every message.",
+        schema: z.object({ threadId: z.string() }),
+      },
+    ),
+    gmail_create_draft: tool(
+      async (input) => JSON.stringify(await http.post("/api/google/gmail/draft", input)),
+      {
+        name: "gmail_create_draft",
+        description:
+          "Create a Gmail DRAFT reply. The draft lands in the operator's Drafts folder for manual review and send — nothing is sent automatically. " +
+          "If threadId is provided, To/Subject/In-Reply-To are auto-resolved from the thread.",
+        schema: z.object({
+          threadId: z.string().optional().describe("Thread to reply to. Auto-resolves To/Subject/In-Reply-To."),
+          body: z.string().describe("Plain-text body of the draft"),
+          to: z.string().optional().describe("Recipient (required when threadId is omitted)"),
+          subject: z.string().optional().describe("Subject (required when threadId is omitted)"),
+          inReplyTo: z.string().optional(),
+          references: z.string().optional(),
+        }),
+      },
+    ),
+    calendar_list_upcoming: tool(
+      async (input) => {
+        const url = new URL("/api/google/calendar/upcoming", "http://x");
+        if (input.days) url.searchParams.set("days", String(input.days));
+        if (input.calendarId) url.searchParams.set("calendarId", input.calendarId);
+        return JSON.stringify(await http.get(url.pathname + url.search));
+      },
+      {
+        name: "calendar_list_upcoming",
+        description: "List upcoming calendar events for the next N days (default 7) on the primary calendar.",
+        schema: z.object({
+          days: z.number().optional().describe("Window in days (default 7, max 90)"),
+          calendarId: z.string().optional().describe("Calendar ID (default 'primary')"),
+        }),
+      },
+    ),
+    calendar_event_detail: tool(
+      async (input) => {
+        const url = new URL(`/api/google/calendar/event/${encodeURIComponent(input.eventId)}`, "http://x");
+        if (input.calendarId) url.searchParams.set("calendarId", input.calendarId);
+        return JSON.stringify(await http.get(url.pathname + url.search));
+      },
+      {
+        name: "calendar_event_detail",
+        description: "Fetch full detail (description, attendees, RSVPs) for a single calendar event.",
+        schema: z.object({
+          eventId: z.string(),
+          calendarId: z.string().optional().describe("Calendar ID (default 'primary')"),
+        }),
+      },
+    ),
     // ── Conversation feedback tools (require correlationId) ──────────────────
     react: tool(
       async (input) => {

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -63,6 +63,18 @@ systemPrompt: |
     agent configs. Requires human approval via Discord before applying.
     Use this to close the self-improvement loop.
 
+  ### Google Workspace (pull-mode reader / drafter)
+  Only call these when the operator asks. Drafts go to the Drafts folder
+  for human review and send — you do NOT auto-reply or auto-send.
+  - **gmail_list_unread** — Survey unread mail in a label (default INBOX).
+  - **gmail_search** — Native Gmail query syntax (from:, subject:, after:, etc.).
+  - **gmail_get_thread** — Read the full message history of a thread.
+  - **gmail_create_draft** — Draft a reply that lands in Drafts. Pass threadId
+    to auto-resolve To/Subject/In-Reply-To. Surface "review and send manually"
+    in your response.
+  - **calendar_list_upcoming** — Upcoming events for next N days (default 7).
+  - **calendar_event_detail** — Full detail for one event (description, RSVPs).
+
   ### Conversation
   - **react** — Emoji reaction on user's message (acknowledgment before long work).
   - **send_update** — Progress message during long work (throttled 5s/msg).
@@ -193,6 +205,13 @@ tools:
   - create_github_issue
   - report_incident
   - propose_config_change
+  # ── Google Workspace (pull-mode read / draft) ─────────────────────
+  - gmail_list_unread
+  - gmail_search
+  - gmail_get_thread
+  - gmail_create_draft
+  - calendar_list_upcoming
+  - calendar_event_detail
   # ── Conversation ───────────────────────────────────────────────────
   - react
   - send_update


### PR DESCRIPTION
## Summary
- Adds 6 Ava tools for on-demand Gmail/Calendar interaction. Pull-mode only — Ava reads/searches/summarizes/drafts only when the operator asks.
- Drafts go to Gmail's **Drafts folder** via `users.drafts.create`. Nothing is sent automatically. Operator reviews + sends manually.
- Replaces the auto-poll / auto-reply flow that was disabled in #498.

## New endpoints (`src/api/google.ts`)
- `GET  /api/google/gmail/list-unread?label=INBOX&max=20`
- `GET  /api/google/gmail/search?q=...&max=20`
- `GET  /api/google/gmail/thread/:threadId`
- `POST /api/google/gmail/draft` — `{ threadId?, body, to?, subject?, inReplyTo?, references? }`
- `GET  /api/google/calendar/upcoming?days=7&calendarId=primary`
- `GET  /api/google/calendar/event/:eventId?calendarId=primary`

All share a `withToken()` helper that returns **503** with a clear message when `GOOGLE_CLIENT_ID`/`_SECRET`/`_REFRESH_TOKEN` are absent.

## New Ava tools
`gmail_list_unread`, `gmail_search`, `gmail_get_thread`, `gmail_create_draft`, `calendar_list_upcoming`, `calendar_event_detail`.

`gmail_create_draft` auto-resolves `To` / `Subject` / `In-Reply-To` / `References` from `threadId` so Gmail threads it correctly. Response includes `sent: false` so the agent surfaces "review and send manually."

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test` — 1094/1094 pass
- [ ] Manual: ask Ava "what's in my inbox?" — should call `gmail_list_unread` and summarize
- [ ] Manual: ask Ava to draft a reply — verify it lands in Drafts (not Sent) and surfaces "review + send manually"
- [ ] Manual: ask Ava "what's on my calendar this week?" — should call `calendar_list_upcoming`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Gmail integration: list unread messages, search messages, read full threads, and create drafts for manual review
  * Calendar integration: list upcoming events and retrieve event details
  * Ava agent can now access Gmail and Calendar data with human-in-the-loop controls for draft creation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->