### PR TITLE
feat(ava): Linear board read + filing tools

### DIFF
--- a/lib/linear-client.ts
+++ b/lib/linear-client.ts
@@ -35,6 +35,34 @@ const PRIORITY_MAP: Record<LinearPriority, number> = {
  */
 const CACHE_TTL_MS = 10 * 60 * 1000;
 
+export interface IssueSummary {
+  id: string;
+  identifier: string;
+  title: string;
+  state: string;
+  priority: string;
+  assignee: string;
+  team: string;
+  url: string;
+  updatedAt: string;
+}
+
+export interface IssueDetail extends IssueSummary {
+  description: string;
+  labels: string[];
+  comments: { author: string; body: string; createdAt: string }[];
+}
+
+export interface ListIssuesFilter {
+  teamKey?: string;
+  state?: string;
+  assignedToMe?: boolean;
+  label?: string;
+  max?: number;
+}
+
+const PRIORITY_NAMES = ["No priority", "Urgent", "High", "Medium", "Low"];
+
 export interface CreateIssueInput {
   teamKey: string;
   title: string;
@@ -104,6 +132,77 @@ export class LinearClient {
       this.stateCache.set(teamId, { value: teamStates, expiresAt: now + CACHE_TTL_MS });
     }
     return teamStates.get(stateName.toLowerCase()) ?? null;
+  }
+
+  async listTeams(): Promise<{ id: string; key: string; name: string }[]> {
+    const teams = await this.sdk.teams({ first: 50 });
+    return teams.nodes.map(t => ({ id: t.id, key: t.key, name: t.name }));
+  }
+
+  /** Hydrate an SDK Issue node into the IssueSummary shape used by the API. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async toSummary(node: any): Promise<IssueSummary> {
+    const [state, assignee, team] = await Promise.all([
+      node.state,
+      node.assignee,
+      node.team,
+    ]);
+    return {
+      id: node.id,
+      identifier: node.identifier,
+      title: node.title,
+      state: state?.name ?? "",
+      priority: PRIORITY_NAMES[node.priority] ?? "Unknown",
+      assignee: assignee?.displayName ?? assignee?.name ?? "",
+      team: team?.key ?? "",
+      url: node.url,
+      updatedAt: node.updatedAt instanceof Date ? node.updatedAt.toISOString() : String(node.updatedAt),
+    };
+  }
+
+  async listIssues(filter: ListIssuesFilter = {}): Promise<IssueSummary[]> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const where: any = {};
+    if (filter.teamKey) where.team = { key: { eq: filter.teamKey } };
+    if (filter.state) where.state = { name: { eqIgnoreCase: filter.state } };
+    if (filter.assignedToMe) where.assignee = { isMe: { eq: true } };
+    if (filter.label) where.labels = { name: { eqIgnoreCase: filter.label } };
+    const issues = await this.sdk.issues({
+      filter: where,
+      first: Math.min(filter.max ?? 50, 250),
+      orderBy: "updatedAt" as never,
+    });
+    return Promise.all(issues.nodes.map(n => this.toSummary(n)));
+  }
+
+  async searchIssues(query: string, max = 25): Promise<IssueSummary[]> {
+    const issues = await this.sdk.searchIssues(query, { first: Math.min(max, 100) });
+    return Promise.all(issues.nodes.map(n => this.toSummary(n)));
+  }
+
+  /** Lookup by UUID or identifier (e.g. "ENG-123"). */
+  async getIssue(idOrKey: string): Promise<IssueDetail | null> {
+    const issue = await this.sdk.issue(idOrKey);
+    if (!issue) return null;
+    const summary = await this.toSummary(issue);
+    const [labelsConn, commentsConn] = await Promise.all([
+      issue.labels(),
+      issue.comments({ first: 50 }),
+    ]);
+    const comments = await Promise.all(commentsConn.nodes.map(async c => {
+      const user = await c.user;
+      return {
+        author: user?.displayName ?? user?.name ?? "Unknown",
+        body: c.body,
+        createdAt: c.createdAt instanceof Date ? c.createdAt.toISOString() : String(c.createdAt),
+      };
+    }));
+    return {
+      ...summary,
+      description: issue.description ?? "",
+      labels: labelsConn.nodes.map(l => l.name),
+      comments,
+    };
   }
 
   /** Drop all cached lookups. Useful for tests and after known workspace edits. */

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -23,6 +23,7 @@ import { createRoutes as observabilityRoutes } from "./observability.ts";
 import { createRoutes as operatorRoutes } from "./operator.ts";
 import { createRoutes as openaiCompatRoutes } from "./openai-compat.ts";
 import { createRoutes as googleRoutes } from "./google.ts";
+import { createRoutes as linearRoutes } from "./linear.ts";
 
 export { matchPath } from "./types.ts";
 export type { Route, ApiContext } from "./types.ts";
@@ -45,5 +46,6 @@ export function createAllRoutes(ctx: ApiContext): Route[] {
     ...operatorRoutes(ctx),
     ...openaiCompatRoutes(ctx),
     ...googleRoutes(ctx),
+    ...linearRoutes(ctx),
   ];
 }

--- a/src/api/linear.ts
+++ b/src/api/linear.ts
@@ -1,0 +1,178 @@
+/**
+ * Linear API routes — back the Ava-side tools that read the Linear board on
+ * demand and (optionally) file issues / post comments.
+ *
+ * Endpoints:
+ *   GET  /api/linear/teams
+ *   GET  /api/linear/issues?team=&state=&label=&assignee=me&max=
+ *   GET  /api/linear/issues/search?q=&max=
+ *   GET  /api/linear/issues/:idOrKey
+ *   POST /api/linear/issues                   { teamKey, title, description?, priority?, labelIds?, stateName? }
+ *   POST /api/linear/issues/:id/comment       { body }
+ *
+ * Every endpoint requires LINEAR_API_KEY. Without it, returns 503 with a
+ * clear "linear plugin disabled" message so Ava's tool layer surfaces the
+ * gap rather than crashing.
+ */
+
+import type { Route, ApiContext } from "./types.ts";
+import { LinearClient, type LinearPriority } from "../../lib/linear-client.ts";
+
+let cachedClient: LinearClient | null = null;
+function getClient(): LinearClient | null {
+  const key = process.env.LINEAR_API_KEY;
+  if (!key) return null;
+  if (!cachedClient) cachedClient = new LinearClient(key);
+  return cachedClient;
+}
+
+function disabledResponse(): Response {
+  return Response.json(
+    { success: false, error: "Linear plugin disabled — LINEAR_API_KEY env var is required." },
+    { status: 503 },
+  );
+}
+
+async function withClient<T>(handler: (c: LinearClient) => Promise<T>): Promise<Response> {
+  const client = getClient();
+  if (!client) return disabledResponse();
+  try {
+    const data = await handler(client);
+    return Response.json({ success: true, data });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return Response.json({ success: false, error: msg }, { status: 500 });
+  }
+}
+
+const VALID_PRIORITIES: ReadonlySet<LinearPriority> = new Set(["urgent", "high", "medium", "low", "none"]);
+
+export function createRoutes(_ctx: ApiContext): Route[] {
+  return [
+    {
+      method: "GET",
+      path: "/api/linear/teams",
+      handler: () => withClient(async (c) => {
+        const teams = await c.listTeams();
+        return { count: teams.length, teams };
+      }),
+    },
+
+    {
+      method: "GET",
+      path: "/api/linear/issues",
+      handler: (req) => {
+        const url = new URL(req.url);
+        const team = url.searchParams.get("team") ?? undefined;
+        const state = url.searchParams.get("state") ?? undefined;
+        const label = url.searchParams.get("label") ?? undefined;
+        const assignee = url.searchParams.get("assignee");
+        const max = Math.min(parseInt(url.searchParams.get("max") ?? "50", 10) || 50, 250);
+        return withClient(async (c) => {
+          const issues = await c.listIssues({
+            teamKey: team,
+            state,
+            label,
+            assignedToMe: assignee === "me",
+            max,
+          });
+          return { count: issues.length, filter: { team, state, label, assignee, max }, issues };
+        });
+      },
+    },
+
+    {
+      method: "GET",
+      path: "/api/linear/issues/search",
+      handler: (req) => {
+        const url = new URL(req.url);
+        const q = url.searchParams.get("q") ?? "";
+        const max = Math.min(parseInt(url.searchParams.get("max") ?? "25", 10) || 25, 100);
+        if (!q.trim()) {
+          return Promise.resolve(Response.json({ success: false, error: "missing q parameter" }, { status: 400 }));
+        }
+        return withClient(async (c) => {
+          const issues = await c.searchIssues(q, max);
+          return { query: q, count: issues.length, issues };
+        });
+      },
+    },
+
+    {
+      method: "GET",
+      path: "/api/linear/issues/:idOrKey",
+      handler: (_req, params) => {
+        const idOrKey = params?.idOrKey;
+        if (!idOrKey) {
+          return Promise.resolve(Response.json({ success: false, error: "missing idOrKey" }, { status: 400 }));
+        }
+        return withClient(async (c) => {
+          const issue = await c.getIssue(idOrKey);
+          if (!issue) throw new Error(`issue ${idOrKey} not found`);
+          return issue;
+        });
+      },
+    },
+
+    {
+      method: "POST",
+      path: "/api/linear/issues",
+      handler: async (req) => {
+        let input: {
+          teamKey?: string;
+          title?: string;
+          description?: string;
+          priority?: string;
+          labelIds?: string[];
+          stateName?: string;
+        };
+        try {
+          input = await req.json() as typeof input;
+        } catch {
+          return Response.json({ success: false, error: "invalid JSON body" }, { status: 400 });
+        }
+        if (!input.teamKey || !input.title) {
+          return Response.json({ success: false, error: "teamKey and title are required" }, { status: 400 });
+        }
+        if (input.priority && !VALID_PRIORITIES.has(input.priority as LinearPriority)) {
+          return Response.json({ success: false, error: `invalid priority — must be one of urgent/high/medium/low/none` }, { status: 400 });
+        }
+        return withClient(async (c) => {
+          const id = await c.createIssue({
+            teamKey: input.teamKey!,
+            title: input.title!,
+            description: input.description,
+            priority: input.priority as LinearPriority | undefined,
+            labelIds: input.labelIds,
+            stateName: input.stateName,
+          });
+          if (!id) throw new Error(`createIssue failed — team key '${input.teamKey}' may not exist`);
+          return { id, teamKey: input.teamKey, title: input.title };
+        });
+      },
+    },
+
+    {
+      method: "POST",
+      path: "/api/linear/issues/:id/comment",
+      handler: async (req, params) => {
+        const id = params?.id;
+        if (!id) return Response.json({ success: false, error: "missing id" }, { status: 400 });
+        let input: { body?: string };
+        try {
+          input = await req.json() as typeof input;
+        } catch {
+          return Response.json({ success: false, error: "invalid JSON body" }, { status: 400 });
+        }
+        if (!input.body?.trim()) {
+          return Response.json({ success: false, error: "missing body" }, { status: 400 });
+        }
+        return withClient(async (c) => {
+          const ok = await c.addComment(id, input.body!);
+          if (!ok) throw new Error("addComment returned false");
+          return { issueId: id, posted: true };
+        });
+      },
+    },
+  ];
+}

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -457,6 +457,83 @@ function createLangChainTools(toolNames: string[], http: HttpClient, correlation
         }),
       },
     ),
+    // ── Linear (board read + filing write) ───────────────────────────────────
+    linear_list_teams: tool(
+      async () => JSON.stringify(await http.get("/api/linear/teams")),
+      { name: "linear_list_teams", description: "List all Linear teams (id, key, name).", schema: z.object({}) },
+    ),
+    linear_list_issues: tool(
+      async (input) => {
+        const url = new URL("/api/linear/issues", "http://x");
+        if (input.team) url.searchParams.set("team", input.team);
+        if (input.state) url.searchParams.set("state", input.state);
+        if (input.label) url.searchParams.set("label", input.label);
+        if (input.assignee) url.searchParams.set("assignee", input.assignee);
+        if (input.max) url.searchParams.set("max", String(input.max));
+        return JSON.stringify(await http.get(url.pathname + url.search));
+      },
+      {
+        name: "linear_list_issues",
+        description: "List Linear issues with optional filters. Use to answer 'how many open issues?' or 'what's in the ENG backlog?'.",
+        schema: z.object({
+          team: z.string().optional().describe("Team key (e.g. ENG)"),
+          state: z.string().optional().describe("Workflow state name (e.g. 'In Progress', 'Backlog')"),
+          label: z.string().optional().describe("Label name"),
+          assignee: z.string().optional().describe("Set 'me' to filter to issues assigned to the API key holder"),
+          max: z.number().optional().describe("Max results (default 50, max 250)"),
+        }),
+      },
+    ),
+    linear_search_issues: tool(
+      async (input) => {
+        const url = new URL("/api/linear/issues/search", "http://x");
+        url.searchParams.set("q", input.query);
+        if (input.max) url.searchParams.set("max", String(input.max));
+        return JSON.stringify(await http.get(url.pathname + url.search));
+      },
+      {
+        name: "linear_search_issues",
+        description: "Full-text search across Linear issues.",
+        schema: z.object({
+          query: z.string(),
+          max: z.number().optional().describe("Max results (default 25, max 100)"),
+        }),
+      },
+    ),
+    linear_get_issue: tool(
+      async (input) => JSON.stringify(await http.get(`/api/linear/issues/${encodeURIComponent(input.idOrKey)}`)),
+      {
+        name: "linear_get_issue",
+        description: "Read one Linear issue with full description, labels, and comment history. Accepts UUID or identifier (e.g. 'ENG-123').",
+        schema: z.object({ idOrKey: z.string() }),
+      },
+    ),
+    linear_create_issue: tool(
+      async (input) => JSON.stringify(await http.post("/api/linear/issues", input)),
+      {
+        name: "linear_create_issue",
+        description: "File a new Linear issue. Use when the operator asks to create one explicitly.",
+        schema: z.object({
+          teamKey: z.string().describe("Team key (e.g. ENG)"),
+          title: z.string(),
+          description: z.string().optional(),
+          priority: z.enum(["urgent", "high", "medium", "low", "none"]).optional(),
+          labelIds: z.array(z.string()).optional(),
+          stateName: z.string().optional().describe("Workflow state name (default: team's default backlog)"),
+        }),
+      },
+    ),
+    linear_add_comment: tool(
+      async (input) => JSON.stringify(await http.post(`/api/linear/issues/${encodeURIComponent(input.issueId)}/comment`, { body: input.body })),
+      {
+        name: "linear_add_comment",
+        description: "Post a comment to a Linear issue.",
+        schema: z.object({
+          issueId: z.string().describe("Issue UUID (use linear_get_issue to resolve identifier → UUID first if needed)"),
+          body: z.string(),
+        }),
+      },
+    ),
     // ── Conversation feedback tools (require correlationId) ──────────────────
     react: tool(
       async (input) => {

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -75,6 +75,16 @@ systemPrompt: |
   - **calendar_list_upcoming** — Upcoming events for next N days (default 7).
   - **calendar_event_detail** — Full detail for one event (description, RSVPs).
 
+  ### Linear (board read + filing)
+  - **linear_list_teams** — Discover team keys (ENG, etc.).
+  - **linear_list_issues** — Filter by team, state, label, or `assignee=me`.
+    Use to answer "how many open issues?" or "what's in the backlog?".
+  - **linear_search_issues** — Full-text search.
+  - **linear_get_issue** — Full detail + comment history. Accepts UUID or
+    identifier (e.g. ENG-123).
+  - **linear_create_issue** — File a new issue (only when explicitly asked).
+  - **linear_add_comment** — Post a comment on an issue.
+
   ### Conversation
   - **react** — Emoji reaction on user's message (acknowledgment before long work).
   - **send_update** — Progress message during long work (throttled 5s/msg).
@@ -212,6 +222,13 @@ tools:
   - gmail_create_draft
   - calendar_list_upcoming
   - calendar_event_detail
+  # ── Linear (board read + filing) ──────────────────────────────────
+  - linear_list_teams
+  - linear_list_issues
+  - linear_search_issues
+  - linear_get_issue
+  - linear_create_issue
+  - linear_add_comment
   # ── Conversation ───────────────────────────────────────────────────
   - react
   - send_update


### PR DESCRIPTION
## Summary
- 6 new Ava tools for Linear: list teams, list/search/read issues, create issue, add comment.
- Reads on every call; writes (create/comment) only when explicitly asked.
- Same shape as the Google tools (#499): pull-mode, X-API-Key gated, 503s with a clear message when \`LINEAR_API_KEY\` is unset.

## New endpoints (\`src/api/linear.ts\`)
- \`GET  /api/linear/teams\`
- \`GET  /api/linear/issues?team=&state=&label=&assignee=me&max=\`
- \`GET  /api/linear/issues/search?q=&max=\`
- \`GET  /api/linear/issues/:idOrKey\` (UUID or \`ENG-123\`)
- \`POST /api/linear/issues\` — \`{ teamKey, title, description?, priority?, labelIds?, stateName? }\`
- \`POST /api/linear/issues/:id/comment\`

## New Ava tools
\`linear_list_teams\`, \`linear_list_issues\`, \`linear_search_issues\`, \`linear_get_issue\`, \`linear_create_issue\`, \`linear_add_comment\`.

## LinearClient additions
Extended with \`listTeams\`, \`listIssues\`, \`searchIssues\`, \`getIssue\` so SDK coupling stays in one place and the read path shares cache + auth with the existing write path.

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun test\` — 1094/1094 pass
- [ ] Post-merge: ask Ava "how many open Linear issues?" — should call \`linear_list_issues\` and summarize
- [ ] Post-merge: ask Ava to read a specific issue — should call \`linear_get_issue\` and surface comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Linear workspace management with team and issue listing capabilities
  * Added full-text issue search and detailed issue retrieval with comment history
  * Enabled issue creation and comment functionality
  * Extended AI agent with Linear tools for streamlined workflow automation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->