### PR TITLE
fix(storage): close save() race in SqlitePushNotificationStore (#504)

### DIFF
--- a/src/storage/push-notification-store.ts
+++ b/src/storage/push-notification-store.ts
@@ -102,9 +102,11 @@ export class SqlitePushNotificationStore implements PushNotificationStore {
            expires_at  = excluded.expires_at`,
         [taskId, configId, JSON.stringify(config), now, expiresAt],
       );
-      // Opportunistic GC — keeps the table from growing unboundedly without
-      // a separate sweep job. Bounded by index lookup so it's cheap.
-      this._purgeExpired();
+      // Opportunistic GC — pass the captured `now` so the row we just
+      // inserted (expires_at = now + ttlMs) cannot be purged in the same
+      // call when ttlMs is small enough that Date.now() advances past it
+      // between INSERT and DELETE.
+      this._purgeExpired(now);
     } catch (err) {
       console.error(`[push-store] save() failed for task ${taskId.slice(0, 8)}…:`, err);
     }
@@ -164,12 +166,12 @@ export class SqlitePushNotificationStore implements PushNotificationStore {
     this.db = null;
   }
 
-  private _purgeExpired(): void {
+  private _purgeExpired(cutoff: number = Date.now()): void {
     if (!this.db) return;
     try {
       this.db.run(
         `DELETE FROM push_notifications WHERE expires_at IS NOT NULL AND expires_at <= ?`,
-        [Date.now()],
+        [cutoff],
       );
     } catch {
       // GC failure is non-fatal — table just gets a bit bigger.


### PR DESCRIPTION
Closes #504.

## Root cause
\`save()\` captures \`now = Date.now()\` for the row's \`expires_at\`, then immediately runs \`_purgeExpired()\` which calls \`Date.now()\` *again*. When \`ttlMs\` is small (the test uses \`ttlMs=1\`), the clock can advance past \`now + ttlMs\` between INSERT and DELETE — and the row we just inserted gets purged in the same call.

Repro on the test that flaked on PR #503:
\`\`\`
save("task-old")        // expires_at = T0 + 1
sleep 5ms
save("task-new")        // expires_at = T1 + 1
  → INSERT row T1
  → DELETE WHERE expires_at <= T1+δ
  → row T1 deleted along with T0 → size == 0
\`\`\`

## Fix
\`_purgeExpired(cutoff?: number)\` accepts an explicit cutoff, defaulting to \`Date.now()\`. \`save()\` passes the captured \`now\`, so the row it just inserted (\`expires_at = now + ttlMs > now\`) is provably outside the purge window.

Cold-start purge in \`_init()\` keeps the default \`Date.now()\`.

## Test plan
- [x] Ran the previously-failing test 5x — 0 failures
- [x] Full suite — 1094/1094 pass
- [x] \`bunx tsc --noEmit\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized internal cleanup routines for improved performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->