### PR TITLE
fix(storage): deterministic TTL tests via injected clock (#504)

### DIFF
--- a/src/storage/__tests__/push-notification-store.test.ts
+++ b/src/storage/__tests__/push-notification-store.test.ts
@@ -112,23 +112,26 @@ describe("SqlitePushNotificationStore — persistence", () => {
 });
 
 describe("SqlitePushNotificationStore — TTL eviction", () => {
+  // TTL behavior is exercised against a virtual clock so the tests are
+  // deterministic — no sleep races, no sub-ms timing assumptions.
+  let now = 1_000_000;
+  const clock = () => now;
+
+  beforeEach(() => { now = 1_000_000; });
+
   test("expired configs are filtered from load() even before GC runs", async () => {
-    // ttl=1ms means everything expires almost immediately. Wait 5ms to
-    // be sure we're past the expiry boundary, then load() should return
-    // empty without any explicit purge call.
-    const store = new SqlitePushNotificationStore(dbPath, { ttlMs: 1 });
+    const store = new SqlitePushNotificationStore(dbPath, { ttlMs: 1000, clock });
     await store.save("task-1", makeConfig({ url: "https://expired.example.com/cb" }));
-    await new Promise(r => setTimeout(r, 5));
-    const loaded = await store.load("task-1");
-    expect(loaded).toEqual([]);
+    now += 5000;
+    expect(await store.load("task-1")).toEqual([]);
     store.close();
   });
 
   test("expired configs are GC'd from the table on the next save() call", async () => {
-    const store = new SqlitePushNotificationStore(dbPath, { ttlMs: 1 });
+    const store = new SqlitePushNotificationStore(dbPath, { ttlMs: 1000, clock });
     await store.save("task-old", makeConfig({ url: "https://expired.example.com/cb" }));
     expect(store.size()).toBe(1);
-    await new Promise(r => setTimeout(r, 5));
+    now += 5000;
     // Saving a fresh entry triggers opportunistic purge of the old row.
     await store.save("task-new", makeConfig({ url: "https://fresh.example.com/cb" }));
     expect(store.size()).toBe(1); // only the fresh row survived
@@ -136,23 +139,22 @@ describe("SqlitePushNotificationStore — TTL eviction", () => {
   });
 
   test("ttlMs=0 means no expiry", async () => {
-    const store = new SqlitePushNotificationStore(dbPath, { ttlMs: 0 });
+    const store = new SqlitePushNotificationStore(dbPath, { ttlMs: 0, clock });
     await store.save("task-1", makeConfig({ url: "https://forever.example.com/cb" }));
-    await new Promise(r => setTimeout(r, 10));
-    const loaded = await store.load("task-1");
-    expect(loaded).toHaveLength(1);
+    now += 1_000_000_000;
+    expect(await store.load("task-1")).toHaveLength(1);
     store.close();
   });
 
   test("cold-start purge clears stale rows before they reach load()", async () => {
-    const first = new SqlitePushNotificationStore(dbPath, { ttlMs: 1 });
+    const first = new SqlitePushNotificationStore(dbPath, { ttlMs: 1000, clock });
     await first.save("task-stale", makeConfig({ url: "https://stale.example.com/cb" }));
     first.close();
-    await new Promise(r => setTimeout(r, 5));
+    now += 5000;
 
     // Reopen — _init() runs the cold-start purge, so the stale row is
     // gone before the first load().
-    const second = new SqlitePushNotificationStore(dbPath, { ttlMs: 1 });
+    const second = new SqlitePushNotificationStore(dbPath, { ttlMs: 1000, clock });
     expect(second.size()).toBe(0);
     second.close();
   });

--- a/src/storage/push-notification-store.ts
+++ b/src/storage/push-notification-store.ts
@@ -51,10 +51,15 @@ export class SqlitePushNotificationStore implements PushNotificationStore {
   private db: Database | null = null;
   private readonly dbPath: string;
   private readonly ttlMs: number;
+  private readonly clock: () => number;
 
-  constructor(dbPath: string, options: { ttlMs?: number } = {}) {
+  constructor(
+    dbPath: string,
+    options: { ttlMs?: number; clock?: () => number } = {},
+  ) {
     this.dbPath = resolve(dbPath);
     this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.clock = options.clock ?? Date.now;
     this._init();
   }
 
@@ -90,7 +95,7 @@ export class SqlitePushNotificationStore implements PushNotificationStore {
   async save(taskId: string, config: PushNotificationConfig): Promise<void> {
     if (!this.db) return;
     const configId = config.id ?? "";
-    const now = Date.now();
+    const now = this.clock();
     const expiresAt = this.ttlMs > 0 ? now + this.ttlMs : null;
     try {
       this.db.run(
@@ -115,7 +120,7 @@ export class SqlitePushNotificationStore implements PushNotificationStore {
   async load(taskId: string): Promise<PushNotificationConfig[]> {
     if (!this.db) return [];
     try {
-      const now = Date.now();
+      const now = this.clock();
       const rows = this.db
         .query<Row, [string, number]>(
           `SELECT task_id, config_id, config_json, created_at, expires_at
@@ -166,7 +171,7 @@ export class SqlitePushNotificationStore implements PushNotificationStore {
     this.db = null;
   }
 
-  private _purgeExpired(cutoff: number = Date.now()): void {
+  private _purgeExpired(cutoff: number = this.clock()): void {
     if (!this.db) return;
     try {
       this.db.run(


### PR DESCRIPTION
## Summary

- Inject a `clock` option into `SqlitePushNotificationStore` so TTL tests use virtual time instead of real-time sleeps.
- Threads the same clock through `save`, `load`, and `_purgeExpired` so all expiry boundaries are deterministic.
- Production callers default to `Date.now` — no behavior change.

Closes #504.

## Why

The flaky test (`expired configs are GC'd from the table on the next save() call`) relied on `setTimeout(5)` between sub-ms TTL boundaries. On busy CI runners that race could fail in ~7ms (see linked failing run in #504). Virtual time removes the race entirely.

## Test plan

- [x] `bun test src/storage/__tests__/push-notification-store.test.ts` — 12/12 pass
- [x] Ran 5 consecutive iterations, all green, all ~120-150ms
- [x] Verified the lone external caller (`src/api/a2a-server.ts:333`) does not pass options, so the new field is additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved push notification expiration behavior tests by replacing real-time delays with a deterministic virtual clock system, enabling more reliable TTL validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->