### PR TITLE
feat(channels): native A2A delivery channel for scheduled fires (#507)

### DIFF
--- a/docs/guides/a2a-scheduler-bridge.md
+++ b/docs/guides/a2a-scheduler-bridge.md
@@ -1,0 +1,106 @@
+---
+title: A2A scheduler bridge
+description: Use Workstacean as the scheduler for remote A2A agents like protoAgent forks.
+---
+
+Workstacean can act as a shared scheduler for one or more remote A2A agents — useful when you have N [protoAgent](https://github.com/protoLabsAI/protoAgent) forks (e.g. `gina-personal`, `gina-work`) and want a single source of truth for when each one fires its scheduled jobs.
+
+The transport is the `a2a` delivery channel on the [Scheduler](/reference/scheduler/#a2a-delivery-channel). When a schedule with `payload.channel: "a2a"` fires, `A2ADeliveryPlugin` looks up the configured target and POSTs a JSON-RPC `message/send` to that endpoint.
+
+## End-to-end wiring
+
+### 1. Configure the target in Workstacean
+
+Create `workspace/a2a.yaml`:
+
+```yaml
+targets:
+  gina-personal:
+    url: http://gina-personal:7870/a2a
+    bearer_token: ${GINA_PERSONAL_BEARER}
+```
+
+Restart Workstacean — the plugin logs `[a2a-delivery] Ready — N target(s) configured` on startup.
+
+### 2. Publish a schedule
+
+From any caller (the protoAgent `WorkstaceanScheduler` adapter does this automatically):
+
+```bash
+curl -X POST http://localhost:3000/publish \
+  -H "X-API-Key: $WORKSTACEAN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "topic": "command.schedule",
+    "payload": {
+      "action": "add",
+      "id": "gina-personal-daily",
+      "schedule": "0 9 * * 1-5",
+      "topic": "cron.gina-personal.daily",
+      "payload": {
+        "content": "morning standup summary",
+        "sender": "scheduler",
+        "channel": "a2a",
+        "agent_name": "gina-personal",
+        "scheduler_job_id": "gina-personal-daily"
+      }
+    }
+  }'
+```
+
+The four `a2a`-specific fields:
+
+- `channel: "a2a"` — selects the A2A delivery path.
+- `agent_name` — keys into `targets` in `workspace/a2a.yaml`.
+- `scheduler_job_id` — surfaced as `metadata.scheduler_job_id` so the receiver can distinguish scheduler-driven turns.
+- `content` — the user-message text sent to the agent.
+
+### 3. What the receiving agent gets
+
+At fire time, the configured A2A endpoint receives:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "<uuid>",
+  "method": "message/send",
+  "params": {
+    "message": {
+      "messageId": "<uuid>",
+      "role": "user",
+      "parts": [{ "kind": "text", "text": "morning standup summary" }],
+      "metadata": {
+        "scheduler_job_id": "gina-personal-daily",
+        "channel": "a2a",
+        "agent_name": "gina-personal"
+      }
+    }
+  }
+}
+```
+
+## Topic naming
+
+By convention, scheduled topics are `cron.<agent_name>.<job_id>`. This keeps multi-fork deployments greppable — `bus consumers | grep cron.gina-` shows every job for the `gina-*` agents at a glance.
+
+## Auth
+
+Both `bearer_token` and `api_key` are optional. Configure whichever the target requires (or both):
+
+- `bearer_token` → `Authorization: Bearer <token>`
+- `api_key` → `X-API-Key: <key>`
+
+`${ENV_VAR}` substitution is supported in any field, so secrets stay out of the YAML.
+
+## Failure modes
+
+| Scenario | Behavior |
+|----------|----------|
+| `workspace/a2a.yaml` missing | Plugin installs cleanly with 0 targets. `channel: a2a` firings drop with a loud error. |
+| `agent_name` missing on payload | Drops the firing with an error pointing at the topic. |
+| `agent_name` not in `targets` | Drops with an error naming the unconfigured agent. |
+| HTTP error on POST | Logs the status + body excerpt. The local schedule remains active and re-fires on the next cron tick. |
+
+## Why a separate channel
+
+`signal` and `cli` are *reply* channels — the scheduled fire is processed by a local skill and the *response* routes via the named channel. `a2a` is structurally different: the fired schedule is *delivered* directly to a remote endpoint, no local skill resolution. The router short-circuits when `channel === "a2a"` so the local skill resolver never sees these firings.

--- a/docs/reference/config-files.md
+++ b/docs/reference/config-files.md
@@ -89,6 +89,7 @@ Each has a `.example` counterpart — copy it to bootstrap a new deployment:
 | `workspace/projects.yaml` | `workspace/projects.yaml.example` |
 | `workspace/discord.yaml` | `workspace/discord.yaml.example` |
 | `workspace/google.yaml` | `workspace/google.yaml.example` |
+| `workspace/a2a.yaml` | `workspace/a2a.yaml.example` — outbound A2A delivery targets for the scheduler |
 | `workspace/incidents.yaml` | `workspace/incidents.yaml.example` |
 
 Schema/behavior files (`actions.yaml`, `goals.yaml`, `ceremonies/`) are tracked and committed as-is.

--- a/docs/reference/scheduler.md
+++ b/docs/reference/scheduler.md
@@ -43,7 +43,7 @@ lastFired: "2026-04-02T12:00:00.000Z"
 | `topic` | Yes | Bus topic to publish on fire (e.g., `cron.daily-weather`). |
 | `payload.content` | Yes | Message the agent receives when this fires. |
 | `payload.sender` | No | Sender identifier. Default: `cron`. |
-| `payload.channel` | No | Reply channel (`signal`, `cli`). Default: `cli`. |
+| `payload.channel` | No | Where the fired schedule is delivered. `cli` / `signal` route to local agents (with the channel as the *reply* topic). `a2a` routes to a configured remote A2A endpoint — see [A2A delivery channel](#a2a-delivery-channel). Default: `cli`. |
 | `enabled` | No | Whether this schedule is active. Default: `true`. |
 | `lastFired` | Auto | ISO timestamp of last fire. Updated by scheduler. |
 
@@ -126,6 +126,78 @@ If a schedule was missed (container was down), it fires immediately on restart. 
 - Default: system timezone (`Intl.DateTimeFormat().resolvedOptions().timeZone`)
 - Override: `timezone` field in YAML
 - Env var: `TZ` (standard, respected by most runtimes)
+
+## A2A delivery channel
+
+When `payload.channel` is `a2a`, the fired schedule is delivered to a remote A2A endpoint as a JSON-RPC `message/send` call instead of being processed by a local skill. Use this when Workstacean is acting as the scheduler for one or more remote agents (for example, [protoAgent](https://github.com/protoLabsAI/protoAgent) forks that subscribe via the `WorkstaceanScheduler` adapter).
+
+### Topic naming convention
+
+Use `cron.<agent_name>.<job_id>` so multi-fork deployments are trivially discoverable — operators can grep the topic list to see which agent is scheduling what.
+
+### Required payload fields for `a2a`
+
+| Field | Description |
+|-------|-------------|
+| `payload.channel` | Must be `"a2a"`. |
+| `payload.agent_name` | Key into the `targets` map in `workspace/a2a.yaml`. Selects the destination endpoint. |
+| `payload.scheduler_job_id` | Surfaced as `metadata.scheduler_job_id` on the outbound message so observers can tell scheduler-driven turns from user-driven ones. |
+| `payload.content` | The user-message text sent to the A2A endpoint. |
+
+### Configuration: `workspace/a2a.yaml`
+
+```yaml
+targets:
+  gina-personal:
+    url: http://gina-personal:7870/a2a
+    bearer_token: ${GINA_PERSONAL_BEARER}
+    api_key: ${GINA_PERSONAL_API_KEY}
+
+  gina-work:
+    url: http://gina-work:7871/a2a
+    bearer_token: ${GINA_WORK_BEARER}
+```
+
+Both `bearer_token` and `api_key` are optional — provide whichever the target requires. `${ENV_VAR}` substitution is supported. When the file is absent, the channel is a no-op (cron firings with `channel: a2a` are dropped with a loud error).
+
+### Example
+
+```yaml
+# workspace/crons/gina-personal-daily.yaml
+id: gina-personal-daily
+schedule: "0 9 * * 1-5"
+topic: "cron.gina-personal.daily"
+payload:
+  content: "morning standup summary"
+  sender: "scheduler"
+  channel: "a2a"
+  agent_name: "gina-personal"
+  scheduler_job_id: "gina-personal-daily"
+```
+
+When this fires at 9am on weekdays, Workstacean POSTs to `http://gina-personal:7870/a2a` with:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "<uuid>",
+  "method": "message/send",
+  "params": {
+    "message": {
+      "messageId": "<uuid>",
+      "role": "user",
+      "parts": [{ "kind": "text", "text": "morning standup summary" }],
+      "metadata": {
+        "scheduler_job_id": "gina-personal-daily",
+        "channel": "a2a",
+        "agent_name": "gina-personal"
+      }
+    }
+  }
+}
+```
+
+For the protoAgent end-to-end wiring, see the [A2A scheduler bridge guide](../guides/a2a-scheduler-bridge/).
 
 ## One-Shot Schedules
 

--- a/lib/plugins/__tests__/a2a-delivery.test.ts
+++ b/lib/plugins/__tests__/a2a-delivery.test.ts
@@ -11,7 +11,6 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import type { Server } from "bun";
 import { InMemoryEventBus } from "../../bus.ts";
 import { A2ADeliveryPlugin } from "../a2a-delivery.ts";
 
@@ -21,7 +20,7 @@ interface CapturedRequest {
   body: unknown;
 }
 
-function startSink(): { server: Server; baseUrl: string; calls: CapturedRequest[] } {
+function startSink() {
   const calls: CapturedRequest[] = [];
   const server = Bun.serve({
     port: 0, // ephemeral
@@ -63,7 +62,7 @@ async function flush(): Promise<void> {
 describe("A2ADeliveryPlugin", () => {
   let workspaceDir: string;
   let bus: InMemoryEventBus;
-  let sink: { server: Server; baseUrl: string; calls: CapturedRequest[] };
+  let sink: ReturnType<typeof startSink>;
 
   beforeEach(() => {
     workspaceDir = mkdtempSync(join(tmpdir(), "a2a-delivery-test-"));
@@ -218,6 +217,24 @@ targets:
       content: "x",
       channel: "a2a",
       agent_name: "unconfigured-agent",
+    });
+    await flush();
+
+    expect(sink.calls).toHaveLength(0);
+  });
+
+  test("drops a2a cron when expanded url is empty (e.g. unset env var)", async () => {
+    writeFileSync(join(workspaceDir, "a2a.yaml"), `
+targets:
+  agent:
+    url: \${A2A_TEST_UNSET_VAR}
+`);
+    new A2ADeliveryPlugin(workspaceDir).install(bus);
+
+    fireCron(bus, "cron.agent.x", {
+      content: "x",
+      channel: "a2a",
+      agent_name: "agent",
     });
     await flush();
 

--- a/lib/plugins/__tests__/a2a-delivery.test.ts
+++ b/lib/plugins/__tests__/a2a-delivery.test.ts
@@ -1,15 +1,17 @@
 /**
  * A2ADeliveryPlugin tests — verify channel gating, target lookup,
- * auth header forwarding, and the shape of the dispatched JSON-RPC
- * `message/send` request. The plugin only does HTTP fetch + bus
- * subscription; we inject a fetch mock to assert the outbound shape
- * without standing up an HTTP server.
+ * auth header forwarding, payload validation, and the JSON-RPC
+ * `message/send` shape.
+ *
+ * No mocks: each test stands up a real Bun.serve HTTP sink on an
+ * ephemeral port and asserts against the requests it received.
  */
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import type { Server } from "bun";
 import { InMemoryEventBus } from "../../bus.ts";
 import { A2ADeliveryPlugin } from "../a2a-delivery.ts";
 
@@ -19,24 +21,23 @@ interface CapturedRequest {
   body: unknown;
 }
 
-function makeFetchMock(status = 200): {
-  fn: typeof fetch;
-  calls: CapturedRequest[];
-} {
+function startSink(): { server: Server; baseUrl: string; calls: CapturedRequest[] } {
   const calls: CapturedRequest[] = [];
-  const fn = (async (input: string | URL | Request, init?: RequestInit) => {
-    const url = typeof input === "string" ? input : input.toString();
-    const headers: Record<string, string> = {};
-    const initHeaders = init?.headers as Record<string, string> | undefined;
-    if (initHeaders) for (const k of Object.keys(initHeaders)) headers[k] = initHeaders[k];
-    const body = init?.body ? JSON.parse(init.body as string) : undefined;
-    calls.push({ url, headers, body });
-    return new Response(JSON.stringify({ jsonrpc: "2.0", id: "1", result: {} }), {
-      status,
-      headers: { "Content-Type": "application/json" },
-    });
-  }) as typeof fetch;
-  return { fn, calls };
+  const server = Bun.serve({
+    port: 0, // ephemeral
+    async fetch(req) {
+      const headers: Record<string, string> = {};
+      req.headers.forEach((v, k) => { headers[k] = v; });
+      const text = await req.text();
+      const body = text ? JSON.parse(text) : undefined;
+      calls.push({ url: req.url, headers, body });
+      return new Response(JSON.stringify({ jsonrpc: "2.0", id: "1", result: {} }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+  });
+  return { server, baseUrl: `http://localhost:${server.port}`, calls };
 }
 
 function fireCron(
@@ -53,22 +54,25 @@ function fireCron(
   });
 }
 
-// Bus dispatch is synchronous-publish + async-handler — the plugin's
-// handler awaits a fetch, so tests need a microtask flush.
+// Plugin handler awaits a real fetch; tests need a microtask flush plus
+// time for the request to reach the local server.
 async function flush(): Promise<void> {
-  await new Promise(r => setTimeout(r, 5));
+  await new Promise(r => setTimeout(r, 25));
 }
 
 describe("A2ADeliveryPlugin", () => {
   let workspaceDir: string;
   let bus: InMemoryEventBus;
+  let sink: { server: Server; baseUrl: string; calls: CapturedRequest[] };
 
   beforeEach(() => {
     workspaceDir = mkdtempSync(join(tmpdir(), "a2a-delivery-test-"));
     bus = new InMemoryEventBus();
+    sink = startSink();
   });
 
   afterEach(() => {
+    sink.server.stop(true);
     rmSync(workspaceDir, { recursive: true, force: true });
   });
 
@@ -76,12 +80,10 @@ describe("A2ADeliveryPlugin", () => {
     writeFileSync(join(workspaceDir, "a2a.yaml"), `
 targets:
   gina-personal:
-    url: http://gina-personal:7870/a2a
+    url: ${sink.baseUrl}/a2a
     bearer_token: secret-bearer
 `);
-    const { fn, calls } = makeFetchMock();
-    const plugin = new A2ADeliveryPlugin(workspaceDir, { fetch: fn });
-    plugin.install(bus);
+    new A2ADeliveryPlugin(workspaceDir).install(bus);
 
     fireCron(bus, "cron.gina-personal.daily", {
       content: "morning standup",
@@ -91,12 +93,12 @@ targets:
     });
     await flush();
 
-    expect(calls).toHaveLength(1);
-    expect(calls[0].url).toBe("http://gina-personal:7870/a2a");
-    expect(calls[0].headers["Authorization"]).toBe("Bearer secret-bearer");
-    expect(calls[0].headers["Content-Type"]).toBe("application/json");
+    expect(sink.calls).toHaveLength(1);
+    expect(sink.calls[0].url).toBe(`${sink.baseUrl}/a2a`);
+    expect(sink.calls[0].headers["authorization"]).toBe("Bearer secret-bearer");
+    expect(sink.calls[0].headers["content-type"]).toBe("application/json");
 
-    const body = calls[0].body as {
+    const body = sink.calls[0].body as {
       jsonrpc: string;
       method: string;
       params: { message: { role: string; parts: Array<{ kind: string; text: string }>; metadata: Record<string, unknown> } };
@@ -116,11 +118,10 @@ targets:
     writeFileSync(join(workspaceDir, "a2a.yaml"), `
 targets:
   gina:
-    url: http://gina:7870/a2a
+    url: ${sink.baseUrl}/a2a
     api_key: my-key
 `);
-    const { fn, calls } = makeFetchMock();
-    new A2ADeliveryPlugin(workspaceDir, { fetch: fn }).install(bus);
+    new A2ADeliveryPlugin(workspaceDir).install(bus);
 
     fireCron(bus, "cron.gina.daily", {
       content: "ping",
@@ -129,75 +130,89 @@ targets:
     });
     await flush();
 
-    expect(calls[0].headers["X-API-Key"]).toBe("my-key");
-    expect(calls[0].headers["Authorization"]).toBeUndefined();
+    expect(sink.calls[0].headers["x-api-key"]).toBe("my-key");
+    expect(sink.calls[0].headers["authorization"]).toBeUndefined();
   });
 
   test("expands ${ENV_VAR} in url and auth fields", async () => {
     process.env.A2A_TEST_BEARER = "env-bearer-value";
-    process.env.A2A_TEST_HOST = "env-host";
-    writeFileSync(join(workspaceDir, "a2a.yaml"), `
+    process.env.A2A_TEST_PORT = String(sink.server.port);
+    try {
+      writeFileSync(join(workspaceDir, "a2a.yaml"), `
 targets:
   agent:
-    url: http://\${A2A_TEST_HOST}:7870/a2a
+    url: http://localhost:\${A2A_TEST_PORT}/a2a
     bearer_token: \${A2A_TEST_BEARER}
 `);
-    const { fn, calls } = makeFetchMock();
-    new A2ADeliveryPlugin(workspaceDir, { fetch: fn }).install(bus);
+      new A2ADeliveryPlugin(workspaceDir).install(bus);
 
-    fireCron(bus, "cron.agent.x", {
-      content: "x",
-      channel: "a2a",
-      agent_name: "agent",
-    });
-    await flush();
+      fireCron(bus, "cron.agent.x", {
+        content: "x",
+        channel: "a2a",
+        agent_name: "agent",
+      });
+      await flush();
 
-    expect(calls[0].url).toBe("http://env-host:7870/a2a");
-    expect(calls[0].headers["Authorization"]).toBe("Bearer env-bearer-value");
-
-    delete process.env.A2A_TEST_BEARER;
-    delete process.env.A2A_TEST_HOST;
+      expect(sink.calls[0].url).toBe(`${sink.baseUrl}/a2a`);
+      expect(sink.calls[0].headers["authorization"]).toBe("Bearer env-bearer-value");
+    } finally {
+      delete process.env.A2A_TEST_BEARER;
+      delete process.env.A2A_TEST_PORT;
+    }
   });
 
   test("ignores cron events without channel=a2a", async () => {
     writeFileSync(join(workspaceDir, "a2a.yaml"), `
 targets:
   gina:
-    url: http://gina:7870/a2a
+    url: ${sink.baseUrl}/a2a
 `);
-    const { fn, calls } = makeFetchMock();
-    new A2ADeliveryPlugin(workspaceDir, { fetch: fn }).install(bus);
+    new A2ADeliveryPlugin(workspaceDir).install(bus);
 
     fireCron(bus, "cron.gina.daily", { content: "x", channel: "signal", agent_name: "gina" });
     fireCron(bus, "cron.gina.other", { content: "x" }); // no channel
     await flush();
 
-    expect(calls).toHaveLength(0);
+    expect(sink.calls).toHaveLength(0);
   });
 
-  test("drops a2a cron with no agent_name (loud error)", async () => {
+  test("drops a2a cron with missing or non-string content", async () => {
     writeFileSync(join(workspaceDir, "a2a.yaml"), `
 targets:
   gina:
-    url: http://gina:7870/a2a
+    url: ${sink.baseUrl}/a2a
 `);
-    const { fn, calls } = makeFetchMock();
-    new A2ADeliveryPlugin(workspaceDir, { fetch: fn }).install(bus);
+    new A2ADeliveryPlugin(workspaceDir).install(bus);
+
+    fireCron(bus, "cron.gina.no-content", { channel: "a2a", agent_name: "gina" });
+    fireCron(bus, "cron.gina.empty-content", { channel: "a2a", agent_name: "gina", content: "   " });
+    fireCron(bus, "cron.gina.numeric", { channel: "a2a", agent_name: "gina", content: 42 });
+    await flush();
+
+    expect(sink.calls).toHaveLength(0);
+  });
+
+  test("drops a2a cron with no agent_name", async () => {
+    writeFileSync(join(workspaceDir, "a2a.yaml"), `
+targets:
+  gina:
+    url: ${sink.baseUrl}/a2a
+`);
+    new A2ADeliveryPlugin(workspaceDir).install(bus);
 
     fireCron(bus, "cron.unknown", { content: "x", channel: "a2a" });
     await flush();
 
-    expect(calls).toHaveLength(0);
+    expect(sink.calls).toHaveLength(0);
   });
 
   test("drops a2a cron when agent_name has no configured target", async () => {
     writeFileSync(join(workspaceDir, "a2a.yaml"), `
 targets:
   configured-agent:
-    url: http://configured:7870/a2a
+    url: ${sink.baseUrl}/a2a
 `);
-    const { fn, calls } = makeFetchMock();
-    new A2ADeliveryPlugin(workspaceDir, { fetch: fn }).install(bus);
+    new A2ADeliveryPlugin(workspaceDir).install(bus);
 
     fireCron(bus, "cron.unconfigured.x", {
       content: "x",
@@ -206,17 +221,36 @@ targets:
     });
     await flush();
 
-    expect(calls).toHaveLength(0);
+    expect(sink.calls).toHaveLength(0);
   });
 
   test("missing a2a.yaml is a no-op (plugin still installs cleanly)", async () => {
-    const { fn, calls } = makeFetchMock();
-    const plugin = new A2ADeliveryPlugin(workspaceDir, { fetch: fn });
+    const plugin = new A2ADeliveryPlugin(workspaceDir);
     plugin.install(bus); // no a2a.yaml in workspaceDir
 
     fireCron(bus, "cron.x", { content: "x", channel: "a2a", agent_name: "anything" });
     await flush();
 
-    expect(calls).toHaveLength(0);
+    expect(sink.calls).toHaveLength(0);
+  });
+
+  test("uninstall unsubscribes — no deliveries fire after teardown", async () => {
+    writeFileSync(join(workspaceDir, "a2a.yaml"), `
+targets:
+  gina:
+    url: ${sink.baseUrl}/a2a
+`);
+    const plugin = new A2ADeliveryPlugin(workspaceDir);
+    plugin.install(bus);
+    plugin.uninstall();
+
+    fireCron(bus, "cron.gina.daily", {
+      content: "x",
+      channel: "a2a",
+      agent_name: "gina",
+    });
+    await flush();
+
+    expect(sink.calls).toHaveLength(0);
   });
 });

--- a/lib/plugins/__tests__/a2a-delivery.test.ts
+++ b/lib/plugins/__tests__/a2a-delivery.test.ts
@@ -20,7 +20,7 @@ interface CapturedRequest {
   body: unknown;
 }
 
-function startSink() {
+function startSink(opts: { responseBody?: () => unknown } = {}) {
   const calls: CapturedRequest[] = [];
   const server = Bun.serve({
     port: 0, // ephemeral
@@ -30,7 +30,8 @@ function startSink() {
       const text = await req.text();
       const body = text ? JSON.parse(text) : undefined;
       calls.push({ url: req.url, headers, body });
-      return new Response(JSON.stringify({ jsonrpc: "2.0", id: "1", result: {} }), {
+      const respBody = opts.responseBody ? opts.responseBody() : { jsonrpc: "2.0", id: "1", result: {} };
+      return new Response(JSON.stringify(respBody), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
@@ -249,6 +250,56 @@ targets:
     await flush();
 
     expect(sink.calls).toHaveLength(0);
+  });
+
+  test("rejects non-string url in YAML (e.g. url: 1234)", async () => {
+    writeFileSync(join(workspaceDir, "a2a.yaml"), `
+targets:
+  agent:
+    url: 1234
+    bearer_token: ok
+`);
+    new A2ADeliveryPlugin(workspaceDir).install(bus);
+
+    fireCron(bus, "cron.agent.x", {
+      content: "x",
+      channel: "a2a",
+      agent_name: "agent",
+    });
+    await flush();
+
+    expect(sink.calls).toHaveLength(0);
+  });
+
+  test("treats JSON-RPC HTTP-200-with-error body as a delivery failure", async () => {
+    sink.server.stop(true);
+    sink = startSink({
+      responseBody: () => ({
+        jsonrpc: "2.0",
+        id: "1",
+        error: { code: -32601, message: "Method not found" },
+      }),
+    });
+    writeFileSync(join(workspaceDir, "a2a.yaml"), `
+targets:
+  gina:
+    url: ${sink.baseUrl}/a2a
+`);
+    new A2ADeliveryPlugin(workspaceDir).install(bus);
+
+    fireCron(bus, "cron.gina.x", {
+      content: "x",
+      channel: "a2a",
+      agent_name: "gina",
+    });
+    await flush();
+
+    // Request was sent (the sink saw it) but delivery is logged as failed.
+    expect(sink.calls).toHaveLength(1);
+    // Plugin doesn't expose status — the assertion is implicit via the
+    // error log; production observers can grep `[a2a-delivery] Delivery
+    // failed`. Asserting the request shape is enough to confirm the
+    // happy path was attempted.
   });
 
   test("uninstall unsubscribes — no deliveries fire after teardown", async () => {

--- a/lib/plugins/__tests__/a2a-delivery.test.ts
+++ b/lib/plugins/__tests__/a2a-delivery.test.ts
@@ -1,0 +1,222 @@
+/**
+ * A2ADeliveryPlugin tests — verify channel gating, target lookup,
+ * auth header forwarding, and the shape of the dispatched JSON-RPC
+ * `message/send` request. The plugin only does HTTP fetch + bus
+ * subscription; we inject a fetch mock to assert the outbound shape
+ * without standing up an HTTP server.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { InMemoryEventBus } from "../../bus.ts";
+import { A2ADeliveryPlugin } from "../a2a-delivery.ts";
+
+interface CapturedRequest {
+  url: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+function makeFetchMock(status = 200): {
+  fn: typeof fetch;
+  calls: CapturedRequest[];
+} {
+  const calls: CapturedRequest[] = [];
+  const fn = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const headers: Record<string, string> = {};
+    const initHeaders = init?.headers as Record<string, string> | undefined;
+    if (initHeaders) for (const k of Object.keys(initHeaders)) headers[k] = initHeaders[k];
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+    calls.push({ url, headers, body });
+    return new Response(JSON.stringify({ jsonrpc: "2.0", id: "1", result: {} }), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+  return { fn, calls };
+}
+
+function fireCron(
+  bus: InMemoryEventBus,
+  topic: string,
+  payload: Record<string, unknown>,
+): void {
+  bus.publish(topic, {
+    id: crypto.randomUUID(),
+    correlationId: crypto.randomUUID(),
+    topic,
+    timestamp: Date.now(),
+    payload,
+  });
+}
+
+// Bus dispatch is synchronous-publish + async-handler — the plugin's
+// handler awaits a fetch, so tests need a microtask flush.
+async function flush(): Promise<void> {
+  await new Promise(r => setTimeout(r, 5));
+}
+
+describe("A2ADeliveryPlugin", () => {
+  let workspaceDir: string;
+  let bus: InMemoryEventBus;
+
+  beforeEach(() => {
+    workspaceDir = mkdtempSync(join(tmpdir(), "a2a-delivery-test-"));
+    bus = new InMemoryEventBus();
+  });
+
+  afterEach(() => {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  test("delivers JSON-RPC message/send when channel=a2a and target is configured", async () => {
+    writeFileSync(join(workspaceDir, "a2a.yaml"), `
+targets:
+  gina-personal:
+    url: http://gina-personal:7870/a2a
+    bearer_token: secret-bearer
+`);
+    const { fn, calls } = makeFetchMock();
+    const plugin = new A2ADeliveryPlugin(workspaceDir, { fetch: fn });
+    plugin.install(bus);
+
+    fireCron(bus, "cron.gina-personal.daily", {
+      content: "morning standup",
+      channel: "a2a",
+      agent_name: "gina-personal",
+      scheduler_job_id: "gina-personal-daily",
+    });
+    await flush();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("http://gina-personal:7870/a2a");
+    expect(calls[0].headers["Authorization"]).toBe("Bearer secret-bearer");
+    expect(calls[0].headers["Content-Type"]).toBe("application/json");
+
+    const body = calls[0].body as {
+      jsonrpc: string;
+      method: string;
+      params: { message: { role: string; parts: Array<{ kind: string; text: string }>; metadata: Record<string, unknown> } };
+    };
+    expect(body.jsonrpc).toBe("2.0");
+    expect(body.method).toBe("message/send");
+    expect(body.params.message.role).toBe("user");
+    expect(body.params.message.parts[0]).toEqual({ kind: "text", text: "morning standup" });
+    expect(body.params.message.metadata).toEqual({
+      scheduler_job_id: "gina-personal-daily",
+      channel: "a2a",
+      agent_name: "gina-personal",
+    });
+  });
+
+  test("forwards X-API-Key when api_key is configured", async () => {
+    writeFileSync(join(workspaceDir, "a2a.yaml"), `
+targets:
+  gina:
+    url: http://gina:7870/a2a
+    api_key: my-key
+`);
+    const { fn, calls } = makeFetchMock();
+    new A2ADeliveryPlugin(workspaceDir, { fetch: fn }).install(bus);
+
+    fireCron(bus, "cron.gina.daily", {
+      content: "ping",
+      channel: "a2a",
+      agent_name: "gina",
+    });
+    await flush();
+
+    expect(calls[0].headers["X-API-Key"]).toBe("my-key");
+    expect(calls[0].headers["Authorization"]).toBeUndefined();
+  });
+
+  test("expands ${ENV_VAR} in url and auth fields", async () => {
+    process.env.A2A_TEST_BEARER = "env-bearer-value";
+    process.env.A2A_TEST_HOST = "env-host";
+    writeFileSync(join(workspaceDir, "a2a.yaml"), `
+targets:
+  agent:
+    url: http://\${A2A_TEST_HOST}:7870/a2a
+    bearer_token: \${A2A_TEST_BEARER}
+`);
+    const { fn, calls } = makeFetchMock();
+    new A2ADeliveryPlugin(workspaceDir, { fetch: fn }).install(bus);
+
+    fireCron(bus, "cron.agent.x", {
+      content: "x",
+      channel: "a2a",
+      agent_name: "agent",
+    });
+    await flush();
+
+    expect(calls[0].url).toBe("http://env-host:7870/a2a");
+    expect(calls[0].headers["Authorization"]).toBe("Bearer env-bearer-value");
+
+    delete process.env.A2A_TEST_BEARER;
+    delete process.env.A2A_TEST_HOST;
+  });
+
+  test("ignores cron events without channel=a2a", async () => {
+    writeFileSync(join(workspaceDir, "a2a.yaml"), `
+targets:
+  gina:
+    url: http://gina:7870/a2a
+`);
+    const { fn, calls } = makeFetchMock();
+    new A2ADeliveryPlugin(workspaceDir, { fetch: fn }).install(bus);
+
+    fireCron(bus, "cron.gina.daily", { content: "x", channel: "signal", agent_name: "gina" });
+    fireCron(bus, "cron.gina.other", { content: "x" }); // no channel
+    await flush();
+
+    expect(calls).toHaveLength(0);
+  });
+
+  test("drops a2a cron with no agent_name (loud error)", async () => {
+    writeFileSync(join(workspaceDir, "a2a.yaml"), `
+targets:
+  gina:
+    url: http://gina:7870/a2a
+`);
+    const { fn, calls } = makeFetchMock();
+    new A2ADeliveryPlugin(workspaceDir, { fetch: fn }).install(bus);
+
+    fireCron(bus, "cron.unknown", { content: "x", channel: "a2a" });
+    await flush();
+
+    expect(calls).toHaveLength(0);
+  });
+
+  test("drops a2a cron when agent_name has no configured target", async () => {
+    writeFileSync(join(workspaceDir, "a2a.yaml"), `
+targets:
+  configured-agent:
+    url: http://configured:7870/a2a
+`);
+    const { fn, calls } = makeFetchMock();
+    new A2ADeliveryPlugin(workspaceDir, { fetch: fn }).install(bus);
+
+    fireCron(bus, "cron.unconfigured.x", {
+      content: "x",
+      channel: "a2a",
+      agent_name: "unconfigured-agent",
+    });
+    await flush();
+
+    expect(calls).toHaveLength(0);
+  });
+
+  test("missing a2a.yaml is a no-op (plugin still installs cleanly)", async () => {
+    const { fn, calls } = makeFetchMock();
+    const plugin = new A2ADeliveryPlugin(workspaceDir, { fetch: fn });
+    plugin.install(bus); // no a2a.yaml in workspaceDir
+
+    fireCron(bus, "cron.x", { content: "x", channel: "a2a", agent_name: "anything" });
+    await flush();
+
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/lib/plugins/a2a-delivery.ts
+++ b/lib/plugins/a2a-delivery.ts
@@ -37,9 +37,23 @@ interface CronPayloadForA2A {
 const ENV_VAR = /\$\{([A-Z0-9_]+)\}/g;
 const REQUEST_TIMEOUT_MS = 15_000;
 
-function expandEnv(value: string | undefined): string | undefined {
-  if (!value) return value;
+function expandEnv(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
   return value.replace(ENV_VAR, (_, name) => process.env[name] ?? "");
+}
+
+function parseJsonRpcError(text: string): string | null {
+  if (!text) return null;
+  try {
+    const body = JSON.parse(text) as { error?: { code?: number; message?: string } };
+    if (body && typeof body === "object" && body.error) {
+      const { code, message } = body.error;
+      return `${code ?? "?"}: ${message ?? "(no message)"}`;
+    }
+  } catch {
+    // Non-JSON 200 responses aren't errors per se — just skip the check.
+  }
+  return null;
 }
 
 export class A2ADeliveryPlugin implements Plugin {
@@ -157,9 +171,15 @@ export class A2ADeliveryPlugin implements Plugin {
         body: JSON.stringify(body),
         signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       });
+      const text = await res.text().catch(() => "");
       if (!res.ok) {
-        const text = await res.text().catch(() => "");
         throw new Error(`HTTP ${res.status} ${res.statusText}: ${text.slice(0, 200)}`);
+      }
+      // JSON-RPC 2.0 servers can return HTTP 200 with an `error` body.
+      // Surface that as a delivery failure rather than logging success.
+      const rpcError = parseJsonRpcError(text);
+      if (rpcError) {
+        throw new Error(`JSON-RPC error: ${rpcError}`);
       }
       console.log(
         `[a2a-delivery] Delivered cron "${msg.topic}" → ${agentName} (${url})`,

--- a/lib/plugins/a2a-delivery.ts
+++ b/lib/plugins/a2a-delivery.ts
@@ -1,0 +1,156 @@
+/**
+ * A2ADeliveryPlugin — delivers cron-fired schedules with `payload.channel:
+ * "a2a"` to remote A2A endpoints (e.g. protoAgent forks). Acts as the
+ * outbound counterpart to the local skill-resolver path that signal/cli
+ * channels go through.
+ *
+ * Flow:
+ *   SchedulerPlugin fires → publishes cron.<topic> with channel: "a2a"
+ *     → A2ADeliveryPlugin subscribes cron.# → looks up targets[agent_name]
+ *       → POSTs JSON-RPC message/send to target.url
+ *
+ * Config: workspace/a2a.yaml — `targets` map keyed by agent_name.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import * as YAML from "yaml";
+import type { Plugin, EventBus, BusMessage } from "../types";
+
+interface A2ATarget {
+  url: string;
+  bearer_token?: string;
+  api_key?: string;
+}
+
+interface A2AConfig {
+  targets?: Record<string, A2ATarget>;
+}
+
+interface CronPayloadForA2A {
+  content: string;
+  channel?: string;
+  agent_name?: string;
+  scheduler_job_id?: string;
+  [key: string]: unknown;
+}
+
+const ENV_VAR = /\$\{([A-Z0-9_]+)\}/g;
+
+function expandEnv(value: string | undefined): string | undefined {
+  if (!value) return value;
+  return value.replace(ENV_VAR, (_, name) => process.env[name] ?? "");
+}
+
+export class A2ADeliveryPlugin implements Plugin {
+  name = "a2a-delivery";
+  description = "Delivers cron schedules with channel: 'a2a' to remote A2A endpoints";
+  capabilities: string[] = ["a2a", "outbound", "scheduler-delivery"];
+
+  private bus: EventBus | null = null;
+  private targets: Record<string, A2ATarget> = {};
+  private readonly configPath: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(workspaceDir: string, options: { fetch?: typeof fetch } = {}) {
+    this.configPath = join(resolve(workspaceDir), "a2a.yaml");
+    this.fetchImpl = options.fetch ?? fetch;
+  }
+
+  install(bus: EventBus): void {
+    this.bus = bus;
+    this._loadConfig();
+
+    bus.subscribe("cron.#", this.name, (msg: BusMessage) => {
+      void this._handle(msg);
+    });
+
+    const count = Object.keys(this.targets).length;
+    console.log(`[a2a-delivery] Ready — ${count} target(s) configured`);
+  }
+
+  uninstall(): void {
+    this.bus = null;
+  }
+
+  private _loadConfig(): void {
+    if (!existsSync(this.configPath)) {
+      this.targets = {};
+      return;
+    }
+    try {
+      const raw = readFileSync(this.configPath, "utf-8");
+      const parsed = YAML.parse(raw) as A2AConfig | null;
+      this.targets = parsed?.targets ?? {};
+    } catch (err) {
+      console.error(`[a2a-delivery] Failed to load ${this.configPath}:`, err);
+      this.targets = {};
+    }
+  }
+
+  private async _handle(msg: BusMessage): Promise<void> {
+    const payload = msg.payload as CronPayloadForA2A | undefined;
+    if (!payload || payload.channel !== "a2a") return;
+
+    const agentName = payload.agent_name;
+    if (!agentName) {
+      console.error(
+        `[a2a-delivery] cron "${msg.topic}" channel=a2a but payload.agent_name is missing — drop`,
+      );
+      return;
+    }
+
+    const target = this.targets[agentName];
+    if (!target) {
+      console.error(
+        `[a2a-delivery] cron "${msg.topic}" agent_name="${agentName}" has no configured target in ${this.configPath} — drop`,
+      );
+      return;
+    }
+
+    const url = expandEnv(target.url) ?? "";
+    const bearer = expandEnv(target.bearer_token);
+    const apiKey = expandEnv(target.api_key);
+
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (bearer) headers["Authorization"] = `Bearer ${bearer}`;
+    if (apiKey) headers["X-API-Key"] = apiKey;
+
+    const body = {
+      jsonrpc: "2.0" as const,
+      id: crypto.randomUUID(),
+      method: "message/send",
+      params: {
+        message: {
+          messageId: crypto.randomUUID(),
+          role: "user",
+          parts: [{ kind: "text", text: payload.content }],
+          metadata: {
+            scheduler_job_id: payload.scheduler_job_id,
+            channel: "a2a",
+            agent_name: agentName,
+          },
+        },
+      },
+    };
+
+    try {
+      const res = await this.fetchImpl(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`HTTP ${res.status} ${res.statusText}: ${text.slice(0, 200)}`);
+      }
+      console.log(
+        `[a2a-delivery] Delivered cron "${msg.topic}" → ${agentName} (${url})`,
+      );
+    } catch (err) {
+      console.error(
+        `[a2a-delivery] Delivery failed for cron "${msg.topic}" → ${agentName} (${url}):`,
+        err,
+      );
+    }
+  }
+}

--- a/lib/plugins/a2a-delivery.ts
+++ b/lib/plugins/a2a-delivery.ts
@@ -47,20 +47,19 @@ export class A2ADeliveryPlugin implements Plugin {
   capabilities: string[] = ["a2a", "outbound", "scheduler-delivery"];
 
   private bus: EventBus | null = null;
+  private subscriptionId: string | null = null;
   private targets: Record<string, A2ATarget> = {};
   private readonly configPath: string;
-  private readonly fetchImpl: typeof fetch;
 
-  constructor(workspaceDir: string, options: { fetch?: typeof fetch } = {}) {
+  constructor(workspaceDir: string) {
     this.configPath = join(resolve(workspaceDir), "a2a.yaml");
-    this.fetchImpl = options.fetch ?? fetch;
   }
 
   install(bus: EventBus): void {
     this.bus = bus;
     this._loadConfig();
 
-    bus.subscribe("cron.#", this.name, (msg: BusMessage) => {
+    this.subscriptionId = bus.subscribe("cron.#", this.name, (msg: BusMessage) => {
       void this._handle(msg);
     });
 
@@ -69,6 +68,10 @@ export class A2ADeliveryPlugin implements Plugin {
   }
 
   uninstall(): void {
+    if (this.bus && this.subscriptionId) {
+      this.bus.unsubscribe(this.subscriptionId);
+    }
+    this.subscriptionId = null;
     this.bus = null;
   }
 
@@ -90,6 +93,13 @@ export class A2ADeliveryPlugin implements Plugin {
   private async _handle(msg: BusMessage): Promise<void> {
     const payload = msg.payload as CronPayloadForA2A | undefined;
     if (!payload || payload.channel !== "a2a") return;
+
+    if (typeof payload.content !== "string" || payload.content.trim() === "") {
+      console.error(
+        `[a2a-delivery] cron "${msg.topic}" channel=a2a but payload.content is missing or not a non-empty string — drop`,
+      );
+      return;
+    }
 
     const agentName = payload.agent_name;
     if (!agentName) {
@@ -134,7 +144,7 @@ export class A2ADeliveryPlugin implements Plugin {
     };
 
     try {
-      const res = await this.fetchImpl(url, {
+      const res = await fetch(url, {
         method: "POST",
         headers,
         body: JSON.stringify(body),

--- a/lib/plugins/a2a-delivery.ts
+++ b/lib/plugins/a2a-delivery.ts
@@ -35,6 +35,7 @@ interface CronPayloadForA2A {
 }
 
 const ENV_VAR = /\$\{([A-Z0-9_]+)\}/g;
+const REQUEST_TIMEOUT_MS = 15_000;
 
 function expandEnv(value: string | undefined): string | undefined {
   if (!value) return value;
@@ -117,7 +118,13 @@ export class A2ADeliveryPlugin implements Plugin {
       return;
     }
 
-    const url = expandEnv(target.url) ?? "";
+    const url = (expandEnv(target.url) ?? "").trim();
+    if (!url) {
+      console.error(
+        `[a2a-delivery] cron "${msg.topic}" agent_name="${agentName}" has empty url after env expansion (raw="${target.url}") — drop`,
+      );
+      return;
+    }
     const bearer = expandEnv(target.bearer_token);
     const apiKey = expandEnv(target.api_key);
 
@@ -148,6 +155,7 @@ export class A2ADeliveryPlugin implements Plugin {
         method: "POST",
         headers,
         body: JSON.stringify(body),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       });
       if (!res.ok) {
         const text = await res.text().catch(() => "");

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { LoggerPlugin } from "../lib/plugins/logger";
 import { CLIPlugin } from "../lib/plugins/cli";
 import { SignalPlugin } from "../lib/plugins/signal";
 import { SchedulerPlugin } from "../lib/plugins/scheduler";
+import { A2ADeliveryPlugin } from "../lib/plugins/a2a-delivery";
 import { ActionRegistry } from "./planner/action-registry";
 import type { Plugin, } from "../lib/types";
 import type { Action } from "./planner/types/action";
@@ -154,6 +155,7 @@ const corePlugins: Plugin[] = [
   new CLIPlugin(),
   new SignalPlugin(),
   new SchedulerPlugin(dataDir),
+  new A2ADeliveryPlugin(workspaceDir),
 ];
 
 for (const plugin of corePlugins) {

--- a/src/router/router-plugin.ts
+++ b/src/router/router-plugin.ts
@@ -279,6 +279,10 @@ export class RouterPlugin implements Plugin {
     const channel = payload.channel ?? "cli";
     const recipient = payload.recipient;
 
+    // a2a is a delivery channel handled by A2ADeliveryPlugin — the router's
+    // skill-resolver path is for local agent dispatch only.
+    if (channel === "a2a") return;
+
     const match = this.resolver.resolve(skillHint, content);
 
     if (!match) {

--- a/workspace/a2a.yaml.example
+++ b/workspace/a2a.yaml.example
@@ -1,0 +1,23 @@
+# A2A outbound delivery — targets for `payload.channel: "a2a"` schedules.
+#
+# Workstacean acts as the scheduler for one or more remote A2A agents
+# (e.g. protoAgent forks). When a schedule fires with channel: "a2a",
+# A2ADeliveryPlugin looks up `targets[payload.agent_name]` and POSTs a
+# JSON-RPC `message/send` to the configured URL.
+#
+# The protoAgent `WorkstaceanScheduler` adapter already publishes the
+# canonical payload shape (channel, agent_name, scheduler_job_id) — see
+# https://protolabsai.github.io/protoWorkstacean/guides/a2a-scheduler-bridge/
+#
+# Auth: configure either bearer_token, api_key, or both. Env-var
+# expansion is supported via `${VAR_NAME}`.
+
+targets:
+  # gina-personal:
+  #   url: http://gina-personal:7870/a2a
+  #   bearer_token: ${GINA_PERSONAL_BEARER}
+  #   api_key: ${GINA_PERSONAL_API_KEY}
+  #
+  # gina-work:
+  #   url: http://gina-work:7871/a2a
+  #   bearer_token: ${GINA_WORK_BEARER}


### PR DESCRIPTION
## Summary

- Adds `payload.channel: "a2a"` as a first-class scheduler delivery target. Workstacean POSTs JSON-RPC `message/send` to the configured remote A2A endpoint when a matching schedule fires.
- New `A2ADeliveryPlugin` (always-on, no-op when `workspace/a2a.yaml` absent) — subscribes to `cron.#`, intercepts `channel: "a2a"`, looks up `targets[payload.agent_name]`, forwards bearer / X-API-Key auth, attaches `metadata: {scheduler_job_id, channel, agent_name}`.
- Router short-circuits in `_handleCron` when `channel === "a2a"` so the local skill resolver never sees these firings — `a2a` is a delivery channel, not a reply channel.

Closes #507. Companion to protoLabsAI/protoAgent#156 (the publish side).

## Files

- `workspace/a2a.yaml.example` — `targets` map keyed by `agent_name`, env-var expansion supported
- `lib/plugins/a2a-delivery.ts` + 7 unit tests
- `src/router/router-plugin.ts` — short-circuit on `channel === "a2a"`
- `src/index.ts` — wire the plugin into core plugins
- `docs/reference/scheduler.md` — new "A2A delivery channel" section
- `docs/guides/a2a-scheduler-bridge.md` — end-to-end how-to
- `docs/reference/config-files.md` — list `a2a.yaml` in user-overlay table

## Acceptance criteria (from #507)

- [x] `payload.channel: "a2a"` is accepted by the scheduler.
- [x] Workstacean POSTs `message/send` to the configured A2A endpoint when a matching schedule fires.
- [x] Bearer / X-API-Key auth headers are forwarded from target config.
- [x] Fired message includes `metadata: {scheduler_job_id, channel: "a2a", agent_name}`.
- [x] Routing is per-agent so one Workstacean install can serve N protoAgents.
- [x] Docs updated (reference + new how-to guide).

## Test plan

- [x] `bun test lib/plugins/__tests__/a2a-delivery.test.ts` — 7/7 pass (request shape, bearer + X-API-Key, env-var expansion, channel gating, missing agent_name, missing target, missing config)
- [x] `bun test src/router` — 30/30 pass; the `channel: "a2a"` short-circuit doesn't affect existing cron paths
- [x] Full `bun test` — 1080 pass total (1 pre-existing fail unrelated: `@linear/sdk` not in node_modules on this branch baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds A2A (agent-to-agent) delivery for scheduled jobs: cron firings can be routed to configured remote endpoints via JSON-RPC, bypassing local skill handling; supports env-var substitution and bearer-token/API-key auth; failures are logged and schedules remain active.

* **Documentation**
  * New A2A scheduler guide, example workspace A2A config, and scheduler/config docs updated with topic naming, payload, auth, and failure behaviors.

* **Tests**
  * Integration tests covering cron-to-HTTP delivery, auth headers, payload shape, env-var expansion, and teardown/unsubscribe behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->