### PR TITLE
fix(pr-remediator): live CI re-check before stuck-PR HITL escalation

### DIFF
--- a/lib/plugins/pr-remediator.ts
+++ b/lib/plugins/pr-remediator.ts
@@ -241,6 +241,53 @@ interface PrDomainData {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
+/**
+ * Live CI re-check used right before a stuck-PR HITL escalation fires.
+ * Mirrors the check-runs aggregation that `src/api/github.ts`
+ * `handleGetPrPipeline` does, so the answer is consistent with the
+ * `pr_pipeline` domain — just freshly fetched at decision time so we
+ * don't escalate a PR whose CI flipped green between snapshots.
+ *
+ * Returns `null` on missing creds / network error / malformed response.
+ * Callers must treat null as "unknown" and fall through to the cached
+ * decision rather than assuming the PR is healthy.
+ */
+async function defaultFetchLiveCiStatus(
+  repo: string,
+  headSha: string,
+): Promise<"pass" | "fail" | "pending" | "none" | null> {
+  if (!getGithubToken) return null;
+  const [owner, repoName] = repo.split("/");
+  if (!owner || !repoName || !headSha) return null;
+  try {
+    const token = await getGithubToken(owner, repoName);
+    const resp = await fetch(
+      `https://api.github.com/repos/${repo}/commits/${headSha}/check-runs?per_page=50`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+        signal: AbortSignal.timeout(15_000),
+      },
+    );
+    if (!resp.ok) return null;
+    const runs = await resp.json() as {
+      total_count: number;
+      check_runs: Array<{ status: string; conclusion: string | null }>;
+    };
+    if (runs.total_count === 0) return "none";
+    if (runs.check_runs.some(r => r.status !== "completed")) return "pending";
+    if (runs.check_runs.some(r =>
+      r.conclusion === "failure" || r.conclusion === "timed_out" || r.conclusion === "action_required"
+    )) return "fail";
+    return "pass";
+  } catch {
+    return null;
+  }
+}
+
 async function ghMerge(repo: string, num: number): Promise<{ ok: boolean; status: number; error?: string }> {
   if (!getGithubToken) return { ok: false, status: 0, error: "no GitHub credentials (QUINN_APP_* or GITHUB_TOKEN)" };
   const [owner, repoName] = repo.split("/");
@@ -527,10 +574,27 @@ type BranchDriftData = {
   maxDrift: number;
 };
 
+/**
+ * Fetches the live CI status for a PR head SHA. Returns `null` when the
+ * answer is unknown (no GitHub creds, network error, malformed response)
+ * so callers can fall through to their cached-snapshot decision instead
+ * of treating "unknown" as "all clear".
+ */
+type LiveCiStatusFetcher = (
+  repo: string,
+  headSha: string,
+) => Promise<"pass" | "fail" | "pending" | "none" | null>;
+
 export class PrRemediatorPlugin implements Plugin {
   readonly name = "pr-remediator";
   readonly description = "Closes the GOAP loop on stuck PRs — auto-merges eligible titles, escalates others to HITL";
   readonly capabilities = ["pr-merge", "pr-feedback-dispatch", "hitl-emit"];
+
+  private readonly fetchLiveCiStatus: LiveCiStatusFetcher;
+
+  constructor(options: { fetchLiveCiStatus?: LiveCiStatusFetcher } = {}) {
+    this.fetchLiveCiStatus = options.fetchLiveCiStatus ?? defaultFetchLiveCiStatus;
+  }
 
   private bus?: EventBus;
   private readonly subscriptionIds: string[] = [];
@@ -686,7 +750,7 @@ export class PrRemediatorPlugin implements Plugin {
       // human unblock is required. Rate-limited by the `escalated` flag.
       if (!entry.escalated) {
         entry.escalated = true;
-        this._emitStuckHitlEscalation(repo, number, kind, entry);
+        void this._emitStuckHitlEscalation(repo, number, kind, entry);
       }
       return { ok: false, reason: `exhausted after ${entry.attempts} attempts (HITL escalated)` };
     }
@@ -712,7 +776,7 @@ export class PrRemediatorPlugin implements Plugin {
     if (entry.attempts >= MAX_ATTEMPTS_PER_PR) {
       entry.exhausted = true;
       entry.escalated = true;
-      this._emitStuckHitlEscalation(repo, number, kind, entry);
+      void this._emitStuckHitlEscalation(repo, number, kind, entry);
       return { ok: false, reason: `exhausted after ${entry.attempts} attempts (HITL escalated)` };
     }
     return { ok: true };
@@ -730,13 +794,13 @@ export class PrRemediatorPlugin implements Plugin {
    * The request goes to topic `hitl.request.pr.remediation_stuck.{correlationId}`
    * which the HITL plugin routes to its registered renderers (Discord, etc).
    */
-  private _emitStuckHitlEscalation(
+  private async _emitStuckHitlEscalation(
     repo: string,
     number: number,
     kind: RemediationKind,
     entry: InFlightEntry,
     conflictDetails?: string,
-  ): void {
+  ): Promise<void> {
     if (!this.bus) return;
 
     // Suppress escalations for PRs that have left the pipeline (closed /
@@ -752,6 +816,26 @@ export class PrRemediatorPlugin implements Plugin {
       );
       this.inFlight.delete(this._inFlightKey(repo, number, kind));
       return;
+    }
+
+    // Live CI re-check at escalation time. The cached snapshot can lag
+    // behind a recent push (snapshot interval ~2min), so a PR whose CI
+    // was failing at the last poll may have already flipped green —
+    // happens when an author pushes a fix during the dispatch window.
+    // Conflict-driven escalations carry conflictDetails from
+    // diagnose_pr_stuck and are not CI-driven, so we only short-circuit
+    // for fix_ci. Non-fail live status clears the entry and drops the
+    // alert. `null` (unknown — no creds/network error) falls through to
+    // escalate based on the cached snapshot, never silently swallows.
+    if (kind === "fix_ci" && pr.headSha) {
+      const liveStatus = await this.fetchLiveCiStatus(repo, pr.headSha);
+      if (liveStatus === "pass" || liveStatus === "pending" || liveStatus === "none") {
+        console.log(
+          `[pr-remediator] suppressing stuck HITL escalation for ${repo}#${number} — live CI status=${liveStatus} on ${pr.headSha.slice(0, 7)} (cached snapshot showed ${pr.ciStatus})`,
+        );
+        this.inFlight.delete(this._inFlightKey(repo, number, kind));
+        return;
+      }
     }
 
     const correlationId = crypto.randomUUID();
@@ -772,6 +856,7 @@ export class PrRemediatorPlugin implements Plugin {
         `**Kind**: \`${kind}\``,
         `**Attempts**: ${entry.attempts} / ${MAX_ATTEMPTS_PER_PR} over ~${durationMin} min`,
         pr ? `**Current CI**: \`${pr.ciStatus}\` · Review: \`${pr.reviewState}\` · Mergeable: \`${pr.mergeable}\`` : "",
+        pr.headSha ? `**Head SHA**: \`${pr.headSha.slice(0, 7)}\`` : "",
         `**Last correlationId**: \`${entry.correlationId}\``,
         ``,
         `The auto-remediation loop has dispatched ${kind} to Ava ${entry.attempts} times and the PR is still stuck. This is a bottleneck — either a new agent capability is needed, the root cause is outside Ava's reach, or a human merge / manual fix will break the cycle.`,
@@ -1610,7 +1695,7 @@ Do NOT ask for confirmation. Act.`;
             exhausted: true,
             escalated: true,
           };
-          this._emitStuckHitlEscalation(
+          void this._emitStuckHitlEscalation(
             pr.repo,
             pr.number,
             "update_branch",
@@ -1672,7 +1757,7 @@ Do NOT ask for confirmation. Act.`;
           exhausted: true,
           escalated: true,
         };
-        this._emitStuckHitlEscalation(pr.repo, pr.number, "update_branch", effectiveEntry, diagnosis.evidence);
+        void this._emitStuckHitlEscalation(pr.repo, pr.number, "update_branch", effectiveEntry, diagnosis.evidence);
         break;
       }
     }

--- a/src/pr-remediator.test.ts
+++ b/src/pr-remediator.test.ts
@@ -490,7 +490,8 @@ describe("PrRemediatorPlugin — world state tracking", () => {
 
     test("exhaustion emits a HITL escalation request (bottlenecks are growth opportunities)", async () => {
       const bus = new InMemoryEventBus();
-      const plugin = new PrRemediatorPlugin();
+      // Inject a deterministic live-CI fetcher: still failing → escalate.
+      const plugin = new PrRemediatorPlugin({ fetchLiveCiStatus: async () => "fail" });
       plugin.install(bus);
 
       const hitlCaptured = captureOn(bus, "hitl.request.pr.remediation_stuck.#");
@@ -557,6 +558,67 @@ describe("PrRemediatorPlugin — world state tracking", () => {
       dispatch(bus, "pr.remediate.fix_ci");
       await flushMicrotasks();
       expect(hitlCaptured.length).toBe(1);
+
+      plugin.uninstall();
+    });
+
+    test("exhaustion suppresses escalation when live CI status is now passing", async () => {
+      // Reproduces the protoBot stuck-PR alert we hit on PR #509: snapshot
+      // captured a red CI window mid-push; by the time the auto-remediator
+      // exhausted its budget, a follow-up commit had already turned CI green.
+      // The cached snapshot still showed "fail", so the alert fired anyway.
+      // The fix is a live re-check at escalation time.
+      const bus = new InMemoryEventBus();
+      const plugin = new PrRemediatorPlugin({
+        fetchLiveCiStatus: async () => "pass", // CI flipped green between snapshots
+      });
+      plugin.install(bus);
+
+      const hitlCaptured = captureOn(bus, "hitl.request.pr.remediation_stuck.#");
+      const skillCaptured = captureOn(bus, "agent.skill.request");
+
+      pushWorldState(bus, [
+        makePr({ number: 509, ciStatus: "fail", title: "feat: a2a delivery channel", readyToMerge: false }),
+      ]);
+      await flushMicrotasks();
+
+      const completeAndBackdate = async () => {
+        const latest = skillCaptured[skillCaptured.length - 1]!;
+        bus.publish(`agent.skill.response.${latest.correlationId}`, {
+          id: crypto.randomUUID(),
+          correlationId: latest.correlationId,
+          topic: `agent.skill.response.${latest.correlationId}`,
+          timestamp: Date.now(),
+          payload: { text: "done", isError: false, correlationId: latest.correlationId },
+        });
+        await flushMicrotasks();
+        const inFlight = (plugin as unknown as { inFlight: Map<string, { completedAt?: number; startedAt: number }> }).inFlight;
+        for (const entry of inFlight.values()) {
+          if (entry.completedAt) entry.completedAt -= 10 * 60 * 1000;
+          entry.startedAt -= 10 * 60 * 1000;
+        }
+      };
+
+      for (let i = 0; i < 2; i++) {
+        await completeAndBackdate();
+        dispatch(bus, "pr.remediate.fix_ci");
+        await flushMicrotasks();
+      }
+      await completeAndBackdate();
+
+      // Trigger the fourth attempt — this would normally escalate, but the
+      // injected live status returns "pass" so the alert is suppressed.
+      dispatch(bus, "pr.remediate.fix_ci");
+      // The escalation guard awaits the live fetch; one extra microtask flush
+      // before asserting.
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      expect(hitlCaptured.length).toBe(0);
+      // The exhausted in-flight entry is cleared so the loop can re-decide
+      // on the next world-state tick rather than staying stuck forever.
+      const inFlight = (plugin as unknown as { inFlight: Map<string, unknown> }).inFlight;
+      expect(inFlight.size).toBe(0);
 
       plugin.uninstall();
     });


### PR DESCRIPTION
## Summary

Stops the auto-remediator from posting stuck-PR HITL alerts whose \`Current CI\` status is stale. Adds a live re-check at escalation time: if the PR's CI is now passing/pending, suppress the alert and clear the in-flight entry so the loop can re-decide on the next world-state tick.

Also includes the head SHA (short prefix) in the alert body so the recipient can reconcile against the current commit.

## Why

Reproduced on PR #509 today: the cached \`pr_pipeline\` snapshot caught a red CI window between two pushes; by the time the remediator exhausted its budget and rendered the HITL alert, CI was already green. The alert claimed \`Current CI: fail\` when current truth was \`pass\` — protoBot flagged the PR as stuck and burned its retry budget.

\`latestPrData\` refreshes every ~2min. Any PR whose author pushes a fix during the dispatch window can hit this race. Same chokepoint-invariant pattern as #437/#444/#459/#465 — invariant lives at the verdict-handler site, falls through cleanly when state is unknowable.

## Changes

- \`lib/plugins/pr-remediator.ts\`:
  - New \`defaultFetchLiveCiStatus(repo, headSha)\` mirrors the check-runs aggregation in \`src/api/github.ts\` so cached and live answers stay consistent.
  - \`_emitStuckHitlEscalation\` is async; for \`fix_ci\` kind, awaits a live status check on the PR's head SHA. On \`pass\`/\`pending\`/\`none\`, logs the suppression with both cached and live values, clears the in-flight entry, returns. \`null\` (unknown — no GH creds / network error / 404) falls through to escalate based on the cached snapshot — never silently swallow.
  - Conflict-driven escalations (carry \`conflictDetails\` from \`diagnose_pr_stuck\`) are *not* CI-driven and skip the live check.
  - Constructor accepts an optional \`fetchLiveCiStatus\` override so tests are deterministic without hitting api.github.com. Production wiring (zero-arg) is unchanged.
  - Alert summary now includes \`**Head SHA**: \`<7-char>\`\`.
- \`src/pr-remediator.test.ts\`:
  - Existing exhaustion test injects a stub returning \`"fail"\` (still escalates as before).
  - New regression test injects \`"pass"\` and asserts no HITL fires + in-flight entry is cleared. Comment in the test calls out the protoBot/#509 incident so the next person debugging this has context.

## Test plan

- [x] \`bun test src/pr-remediator.test.ts\` — 40/40 pass (added 1 new test)
- [x] \`bun run tsc --noEmit\` clean for the touched files
- [x] Full \`bun test\` — 1073 pass (1 pre-existing failure unrelated: \`@linear/sdk\` missing on dev baseline)

## Notes

The injected fetcher pattern lets the existing test continue to work identically (it now passes a deterministic \`"fail"\` stub instead of relying on real-network behavior masking through the catch path). Future tests that want to exercise specific live-CI states can do the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CI status validation to check live results before escalating stalled pull requests to manual review
  * Escalations now suppress if CI is passing or pending, with fallback to cached status if live results are unavailable

* **Tests**
  * Updated test coverage for live CI status injection and escalation suppression scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->