### PR TITLE
chore: remove quinn, jon, researcher from A2A executor registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,7 @@ This process hosts a couple of in-process agents and routes to remote ones over 
 | **Ava** | Chief-of-staff orchestrator | In-process (LangGraph) |
 | **protoBot** | Discord server operations | In-process (LangGraph) |
 | **Tuner** | Fleet self-tuning / cost & confidence review | In-process (LangGraph) |
-| **Quinn** | QA: PR review, bug triage | External (A2A) |
 | **protoMaker** | Board operations / Automaker | External (A2A) |
-| **Researcher** | Deep multi-source research | External (A2A) |
-| **Jon** | Content strategy / antagonistic review | External (A2A) |
 | **protoPen** | Security / pentest (Tailscale) | External (A2A) |
 
 In-process agents live in `workspace/agents/*.yaml`. Remote agents live in `workspace/agents.yaml`. Cards advertise capabilities and the dispatcher registers them at startup (and refreshes every 10 minutes).

--- a/STATUS.md
+++ b/STATUS.md
@@ -9,7 +9,7 @@ That's the spine. Everything else extends it.
 ## Current architecture
 
 - **In-process agents** (DeepAgent / LangGraph): Ava, protoBot, Tuner
-- **Remote agents** (A2A): Quinn, protoMaker, Researcher, Jon, protoPen
+- **Remote agents** (A2A): protoMaker, protoPen
 - **Integration plugins**: Discord, GitHub, Linear, Google Workspace, linear-protomaker-bridge, pr-remediator
 - **Scheduling**: SchedulerPlugin (yaml-defined crons), CeremonyPlugin (named, observable, hot-reloadable rituals)
 - **Observability**: AgentFleetHealth (24h rollups → health-weighted dispatch), Langfuse OTEL tracing, cost-v1 / confidence-v1 / blast-v1 / hitl-mode-v1 A2A extensions

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,11 +23,14 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
 
       # ── Discord ──────────────────────────────────────────────────
-      # Primary inbound bot — Quinn handles DMs and channel messages.
+      # Primary inbound bot — handles DMs and channel messages that
+      # aren't routed to a per-agent pool client. Operator picks which
+      # bot identity to use; default points at the @protoquinn[bot] token
+      # for continuity with existing users.
       - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN_QUINN:-}
-      # Per-agent pool — each token spins up one connected bot client.
+      # Per-agent pool — each token spins up one connected bot client
+      # for an agent declared in workspace/agents/*.yaml or workspace/agents.yaml.
       - DISCORD_BOT_TOKEN_AVA=${DISCORD_BOT_TOKEN_AVA:-}
-      - DISCORD_BOT_TOKEN_QUINN=${DISCORD_BOT_TOKEN_QUINN:-}
       - DISCORD_BOT_TOKEN_FRANK=${DISCORD_BOT_TOKEN_FRANK:-}
       - DISCORD_GUILD_ID=${DISCORD_GUILD_ID:-1070606339363049492}
       - DISCORD_DIGEST_CHANNEL=${DISCORD_DIGEST_CHANNEL:-1469080556720623699}
@@ -35,8 +38,8 @@ services:
       - DISCORD_WEBHOOK_ALERTS=${DISCORD_WEBHOOK_ALERTS:-}
 
       # ── DM routing ───────────────────────────────────────────────
-      # Route unmatched DMs to Quinn's chat skill for natural conversation.
-      - ROUTER_DM_DEFAULT_AGENT=quinn
+      # Route unmatched DMs to Ava's chat skill for natural conversation.
+      - ROUTER_DM_DEFAULT_AGENT=ava
       - ROUTER_DM_DEFAULT_SKILL=chat
 
       # ── Langfuse tracing ─────────────────────────────────────────

--- a/workspace/agents.yaml
+++ b/workspace/agents.yaml
@@ -18,45 +18,6 @@
 # needs per-environment wiring without editing this file.
 
 agents:
-  # Quinn — QA engineer (code review, bug triage, PR auditing).
-  # NOTE: Quinn's internal container port is 7870 (host-mapped to 7873).
-  # Inside the docker-ai network we must use the internal port.
-  - name: quinn
-    url: http://quinn:7870/a2a
-    auth:
-      scheme: apiKey
-      credentialsEnv: QUINN_API_KEY
-    streaming: true
-    discordBotTokenEnvKey: DISCORD_BOT_TOKEN_QUINN
-    subscribesTo:
-      - message.inbound.discord.#
-      - message.inbound.github.#
-
-  # Jon — content + communications (protoContent pipeline)
-  - name: jon
-    url: http://protocontent:18791/a2a
-    auth:
-      scheme: apiKey
-      credentialsEnv: PROTOCONTENT_API_KEY
-    streaming: true
-    discordBotTokenEnvKey: DISCORD_BOT_TOKEN_JON
-    subscribesTo:
-      - message.inbound.discord.#
-
-  # Researcher — rabbit-hole.io deep research agent.
-  # Container `researcher` lives in homelab-iac/stacks/rabbit-hole and
-  # attaches to ai_default so workstacean can reach it by hostname.
-  # Internal listen 7870 (matches Quinn's pattern); host 7874 exposed
-  # for Tailscale-internal clients like agent-rollcall.sh.
-  - name: researcher
-    url: http://researcher:7870/a2a
-    auth:
-      scheme: apiKey
-      credentialsEnv: RESEARCHER_API_KEY
-    streaming: true
-    subscribesTo:
-      - message.inbound.discord.#
-
   # Frank — CI/CD + infrastructure. NOT YET DEPLOYED. Leaving the entry
   # commented out until Frank's agent card + A2A endpoint are live so
   # workstacean doesn't register a dead executor or spam card-discovery

--- a/workspace/agents.yaml.example
+++ b/workspace/agents.yaml.example
@@ -24,23 +24,6 @@ agents:
       - message.inbound.#
       - hitl.response.#
 
-  - name: quinn
-    url: http://your-quinn-host:7870/a2a
-    # Structured auth (Phase 8). Same behavior as apiKeyEnv: QUINN_API_KEY
-    # but makes the scheme explicit and leaves room for bearer/hmac.
-    auth:
-      scheme: apiKey
-      credentialsEnv: QUINN_API_KEY
-    discordBotTokenEnvKey: DISCORD_BOT_TOKEN_QUINN
-    skills:
-      - name: bug_triage
-        description: Triage a bug report and recommend next steps
-      - name: pr_review
-        description: Review a pull request for quality, patterns, and correctness
-    subscribesTo:
-      - message.inbound.discord.#
-      - message.inbound.github.#
-
   # Example — an external agent served over bearer auth:
   # - name: external_partner
   #   url: https://partner.example.com/a2a

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -8,10 +8,8 @@
 #
 # Separation of concerns:
 #   Ava: orchestration, observation, decision-making, writing (board/issues)
-#   Quinn: deep analysis, PR review, triage, security audit
 #   protoMaker: board operations, velocity tracking
 #   protoBot: Discord server infrastructure
-#   Researcher: deep multi-source research
 #   protopen: security/pentest operations
 #
 # Self-improvement: Ava can observe the system's own performance
@@ -51,7 +49,7 @@ systemPrompt: |
   - **get_incidents** — Open security/operational incidents.
   - **get_cost_summary** — Per-agent/skill cost: tokens, duration, dollars.
   - **get_confidence_summary** — Per-agent/skill calibration metrics.
-  - **searxng_search** — Quick web search via SearXNG. For deep research, delegate to Researcher.
+  - **searxng_search** — Quick web search via SearXNG.
 
   ### Write / Act
   - **manage_board** — Create or update features on the protoMaker board.
@@ -91,18 +89,15 @@ systemPrompt: |
   ## Observation vs delegation
 
   Read data directly using your observation tools for situational awareness.
-  Delegate to other agents for analysis, investigation, and deep work:
-  - Use `get_pr_pipeline` to check PR status; delegate to Quinn for PR review
-  - Use `get_ci_health` to see failure rates; delegate to Quinn for root cause analysis
-  - Use `get_cost_summary` to see spend; propose config changes to optimize
+  Delegate to other agents for board, infrastructure, and security work:
+  - Use `get_pr_pipeline` to check PR status; act on it via the board or by filing an issue.
+  - Use `get_ci_health` to see failure rates; file an issue or escalate as needed.
+  - Use `get_cost_summary` to see spend; propose config changes to optimize.
 
   ## Delegation targets
 
-  - **Quinn** (pr_review, bug_triage, security_triage) — QA engineer. Deep analysis, code review, investigations.
-  - **Researcher** (deep_research, summarize) — multi-source research: papers, HuggingFace, GitHub, web.
   - **protoMaker** (sitrep, board_health, auto_mode, manage_feature) — board operations and velocity tracking.
   - **protoBot** (provision_channel, provision_category, provision_webhook, server_stats, chat) — Discord server infrastructure.
-  - **protoContent / Jon** (chat) — content strategy, antagonistic review.
   - **protopen** (passive_recon, active_pentest, security_report, threat_intel) — security/pentest.
   - **Frank** — infrastructure, deployments.
 
@@ -259,7 +254,7 @@ skills:
 
       Use your tools to fetch the PR diff and recent base commits before deciding:
       - PR files: the content field includes the specific files and their diff
-      - Use chat_with_agent(Quinn) to check recent base activity if needed
+      - Inspect the PR files content for the conflict shape
 
       No preamble. No explanation outside the JSON block. Only the ```json block.
 
@@ -271,7 +266,7 @@ skills:
   # require the helm's judgment and delegation capabilities.
 
   - name: debug_ci_failures
-    description: Investigate CI failures across projects. Read CI health, identify failing repos and workflows, delegate to Quinn for detailed analysis, file issues for fixes, and report findings.
+    description: Investigate CI failures across projects. Read CI health, identify failing repos and workflows, file issues for fixes, and report findings.
     keywords: [ci, failure, build, workflow, pipeline, red, broken]
 
   - name: fleet_incident_response

--- a/workspace/channels.yaml
+++ b/workspace/channels.yaml
@@ -3,7 +3,7 @@ channels:
   - id: testing-conversation
     platform: discord
     channelId: "1491694275992354876"
-    agent: quinn
+    agent: ava
     description: Dedicated test channel — multi-turn conversation smoke test
     conversation:
       enabled: true


### PR DESCRIPTION
## Summary

Drops the three remote agents from \`workspace/agents.yaml\` so they no longer register A2AExecutors at startup. Their services may still be running on their containers/hosts; workstacean just stops dispatching to them.

**Stacked on #519.** After #518 + #519 merge to \`dev\`, retarget this PR to \`dev\`.

## Changed

- \`workspace/agents.yaml\` — removed \`quinn\`, \`jon\`, \`researcher\` entries. Remaining A2A: \`protomaker\`, \`protopen\` (frank still commented out, ready to reinstate when deployed).
- \`workspace/agents.yaml.example\` — removed the quinn illustrative entry.
- \`workspace/channels.yaml\` — testing-conversation channel rerouted from quinn → ava.
- \`workspace/agents/ava.yaml\` — trimmed Ava's prompt of Quinn/Researcher/Jon as delegation targets. Updated observation/delegation guidance and the diagnose_pr_stuck override.
- \`docker-compose.prod.yml\`:
  - \`ROUTER_DM_DEFAULT_AGENT\` quinn → ava
  - Removed \`DISCORD_BOT_TOKEN_QUINN\` from the container env (the bot pool only spins up bots for agents declared in agents.yaml). Operator can still set the host-side var to feed \`DISCORD_BOT_TOKEN\` for the primary inbound bot identity.
- \`README.md\` + \`STATUS.md\` — fleet tables updated.

## Kept (separate concerns)

- \`QUINN_APP_ID\` / \`QUINN_APP_PRIVATE_KEY\` — GitHub App credentials used by the in-process \`pr-remediator\` to commit/comment as \`@protoquinn[bot]\`. **Not** related to the A2A agent.
- \`DISCORD_BOT_TOKEN_QUINN\` on the host — feeds the primary inbound bot identity so existing users keep DM'ing the same Discord bot. Operator re-points whenever convenient.
- Quinn/Jon/Researcher mentions in docs guides (a2a-langfuse-trace-propagation, agent-identity, blast-v1, etc.) — illustrative examples, read fine without the registry entries.

## Test plan

- [x] \`bun run tsc --noEmit\` — clean.
- [x] \`bun test\` — 747 pass (same baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)