### PR TITLE
fix(pr-inspector): surface GitHub failures, add timeouts, handle GraphQL errors

### DIFF
--- a/src/api/pr-inspector.ts
+++ b/src/api/pr-inspector.ts
@@ -49,6 +49,9 @@ function parseRepo(repo: string): { owner: string; name: string } | null {
   return { owner: owner!, name: name! };
 }
 
+/** Per-request timeout for GitHub calls. Beyond this, treat as a failed inspection. */
+const GH_FETCH_TIMEOUT_MS = 15_000;
+
 async function ghFetch(
   owner: string,
   name: string,
@@ -59,6 +62,7 @@ async function ghFetch(
   const token = await getGithubToken(owner, name);
   return fetch(url, {
     ...init,
+    signal: init.signal ?? AbortSignal.timeout(GH_FETCH_TIMEOUT_MS),
     headers: {
       ...(init.headers ?? {}),
       Authorization: `Bearer ${token}`,
@@ -75,7 +79,7 @@ async function listOpen(owner: string, name: string): Promise<string> {
     name,
     `https://api.github.com/repos/${owner}/${name}/pulls?state=open&per_page=30`,
   );
-  if (!resp.ok) return `Error listing PRs: ${resp.status} ${await resp.text()}`;
+  if (!resp.ok) throw new Error(`GitHub API error listing PRs: ${resp.status} ${await resp.text()}`);
   const prs = (await resp.json()) as Array<{
     number: number;
     title: string;
@@ -94,7 +98,7 @@ async function listOpen(owner: string, name: string): Promise<string> {
 
 async function checkCi(owner: string, name: string, pr: number): Promise<string> {
   const prResp = await ghFetch(owner, name, `https://api.github.com/repos/${owner}/${name}/pulls/${pr}`);
-  if (!prResp.ok) return `Error fetching PR#${pr}: ${prResp.status} ${await prResp.text()}`;
+  if (!prResp.ok) throw new Error(`GitHub API error fetching PR#${pr}: ${prResp.status} ${await prResp.text()}`);
   const { head } = (await prResp.json()) as { head: { sha: string } };
 
   const checksResp = await ghFetch(
@@ -102,7 +106,7 @@ async function checkCi(owner: string, name: string, pr: number): Promise<string>
     name,
     `https://api.github.com/repos/${owner}/${name}/commits/${head.sha}/check-runs?per_page=50`,
   );
-  if (!checksResp.ok) return `Error fetching check-runs: ${checksResp.status} ${await checksResp.text()}`;
+  if (!checksResp.ok) throw new Error(`GitHub API error fetching check-runs: ${checksResp.status} ${await checksResp.text()}`);
   const { check_runs } = (await checksResp.json()) as {
     check_runs: Array<{ name: string; status: string; conclusion: string | null }>;
   };
@@ -134,8 +138,9 @@ async function coderabbitThreads(owner: string, name: string, pr: number): Promi
     method: "POST",
     body: JSON.stringify({ query, variables: { owner, name, pr } }),
   });
-  if (!resp.ok) return `Error fetching review threads: ${resp.status} ${await resp.text()}`;
+  if (!resp.ok) throw new Error(`GitHub API error fetching review threads: ${resp.status} ${await resp.text()}`);
   const data = (await resp.json()) as {
+    errors?: Array<{ message: string }>;
     data?: {
       repository?: {
         pullRequest?: {
@@ -151,6 +156,9 @@ async function coderabbitThreads(owner: string, name: string, pr: number): Promi
       };
     };
   };
+  if (data.errors?.length) {
+    throw new Error(`GraphQL error fetching review threads: ${data.errors.map((e) => e.message).join("; ")}`);
+  }
   const threads = data?.data?.repository?.pullRequest?.reviewThreads?.nodes ?? [];
   const unresolved = threads.filter((t) => !t.isResolved);
   if (unresolved.length === 0) return `No unresolved review threads on PR#${pr}.`;
@@ -169,16 +177,17 @@ async function coderabbitThreads(owner: string, name: string, pr: number): Promi
 }
 
 async function diffSummary(owner: string, name: string, pr: number): Promise<string> {
-  if (!getGithubToken) return "Error: no GitHub credentials";
+  if (!getGithubToken) throw new Error("no GitHub credentials (QUINN_APP_* or GITHUB_TOKEN)");
   const token = await getGithubToken(owner, name);
   const resp = await fetch(`https://api.github.com/repos/${owner}/${name}/pulls/${pr}`, {
+    signal: AbortSignal.timeout(GH_FETCH_TIMEOUT_MS),
     headers: {
       Authorization: `Bearer ${token}`,
       Accept: "application/vnd.github.v3.diff",
       "User-Agent": "protoquinn",
     },
   });
-  if (!resp.ok) return `Error fetching diff: ${resp.status} ${await resp.text()}`;
+  if (!resp.ok) throw new Error(`GitHub API error fetching diff: ${resp.status} ${await resp.text()}`);
   const diff = await resp.text();
   const lines = diff.split("\n");
   const truncated = lines.length > 200;
@@ -204,7 +213,7 @@ async function submitReview(
       headers: { "Content-Type": "application/json" },
     },
   );
-  if (!resp.ok) return `Error submitting review: ${resp.status} ${await resp.text()}`;
+  if (!resp.ok) throw new Error(`GitHub API error submitting review: ${resp.status} ${await resp.text()}`);
   const label = event === "APPROVE" ? "Approved" : event === "REQUEST_CHANGES" ? "Requested changes on" : "Commented on";
   return `${label} PR#${pr} in ${owner}/${name}.`;
 }


### PR DESCRIPTION
## Summary

Follow-up to #529 fixing three Major CodeRabbit findings on `src/api/pr-inspector.ts`:

- **Add 15s timeouts** to outbound GitHub fetches (`ghFetch` + the direct fetch in `diffSummary`). Without this, a hung GitHub API would stall the inspect route indefinitely.
- **Throw on GitHub HTTP failures** instead of returning `"Error..."` strings. The route now responds `success: false` when GitHub returns 4xx/5xx — previously every action returned `success: true` with the error stuffed into `data.result`, so the pr-remediator verdict loop couldn't distinguish a real review from a swallowed failure.
- **Handle GraphQL `errors[]`** in `coderabbitThreads`. The query previously only checked `resp.ok`, falling back to "no unresolved review threads" when the query itself errored (e.g. permissions, invalid repo).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 648 pass, 0 fail
- [ ] Smoke: `curl POST /api/pr/inspect` with action=check_ci against a bad PR returns `success: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)