### PR TITLE
fix(deep-agent): extract text from array-shaped AIMessage content (reasoning models)

### DIFF
--- a/src/executor/__tests__/deep-agent-extract-text.test.ts
+++ b/src/executor/__tests__/deep-agent-extract-text.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { extractAiText } from "../executors/deep-agent-executor.ts";
+
+describe("extractAiText", () => {
+  test("returns trimmed string content as-is", () => {
+    expect(extractAiText("  hello world  ")).toBe("hello world");
+  });
+
+  test("returns empty string for null, undefined, number, boolean, plain object", () => {
+    expect(extractAiText(null)).toBe("");
+    expect(extractAiText(undefined)).toBe("");
+    expect(extractAiText(42)).toBe("");
+    expect(extractAiText(true)).toBe("");
+    expect(extractAiText({})).toBe("");
+  });
+
+  test("extracts text from a single text-type block", () => {
+    expect(extractAiText([{ type: "text", text: "PR looks good." }])).toBe("PR looks good.");
+  });
+
+  test("skips thinking blocks and returns only text blocks (reasoning-model shape)", () => {
+    const content = [
+      { type: "thinking", thinking: "Let me check the CI..." },
+      { type: "text", text: "VERDICT: PASS — CI is green." },
+    ];
+    expect(extractAiText(content)).toBe("VERDICT: PASS — CI is green.");
+  });
+
+  test("concatenates multiple text blocks in order", () => {
+    const content = [
+      { type: "text", text: "Part 1. " },
+      { type: "thinking", thinking: "..." },
+      { type: "text", text: "Part 2." },
+    ];
+    expect(extractAiText(content)).toBe("Part 1. Part 2.");
+  });
+
+  test("ignores unknown block types", () => {
+    const content = [
+      { type: "image", url: "..." },
+      { type: "text", text: "only this" },
+      { type: "tool_use", id: "abc", name: "x" },
+    ];
+    expect(extractAiText(content)).toBe("only this");
+  });
+
+  test("returns empty string when no text blocks present (all thinking / tool calls)", () => {
+    const content = [
+      { type: "thinking", thinking: "..." },
+      { type: "tool_use", id: "abc", name: "pr_inspector" },
+    ];
+    expect(extractAiText(content)).toBe("");
+  });
+
+  test("accepts string entries inside an array", () => {
+    expect(extractAiText(["hello ", "world"])).toBe("hello world");
+  });
+});

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -18,6 +18,31 @@ import type { IExecutor, SkillRequest, SkillResult } from "../types.ts";
 
 const LANGFUSE_ENABLED = !!(process.env.LANGFUSE_PUBLIC_KEY && process.env.LANGFUSE_SECRET_KEY);
 
+/**
+ * Extract the assistant's text output from a LangChain AIMessage's `content`.
+ * Reasoning-style models (e.g. protolabs/reasoning, o3, claude with extended
+ * thinking) emit `content` as an array of typed blocks rather than a string:
+ *   [{type: "thinking", thinking: "..."}, {type: "text", text: "..."}]
+ * The text we want is the concatenation of `text`-typed blocks. Returns the
+ * trimmed result, or "" if no usable text was found.
+ */
+export function extractAiText(content: unknown): string {
+  if (typeof content === "string") return content.trim();
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const block of content) {
+    if (typeof block === "string") {
+      parts.push(block);
+      continue;
+    }
+    if (block && typeof block === "object") {
+      const b = block as Record<string, unknown>;
+      if (b.type === "text" && typeof b.text === "string") parts.push(b.text);
+    }
+  }
+  return parts.join("").trim();
+}
+
 export interface DeepAgentConfig {
   gatewayUrl?: string;
   gatewayApiKey?: string;
@@ -598,13 +623,12 @@ export class DeepAgentExecutor implements IExecutor {
       let text = "";
       for (let i = messages.length - 1; i >= 0; i--) {
         const msg = messages[i];
-        const content = msg.content;
-        if (typeof content === "string" && content.trim()) {
-          const type = msg._getType?.() ?? msg.constructor?.name ?? "";
-          if (type === "ai" || type === "AIMessage") {
-            text = content.trim();
-            break;
-          }
+        const type = msg._getType?.() ?? msg.constructor?.name ?? "";
+        if (type !== "ai" && type !== "AIMessage") continue;
+        const extracted = extractAiText(msg.content);
+        if (extracted) {
+          text = extracted;
+          break;
         }
       }
 


### PR DESCRIPTION
## Summary

The DeepAgent text extractor only handled `content: string`. Reasoning-style models (`protolabs/reasoning`, o3, Claude with extended thinking) return `content` as an **array of typed blocks**:

```
[
  { type: "thinking", thinking: "Let me check CI..." },
  { type: "text", text: "VERDICT: PASS — CI is green." },
]
```

The loop in `DeepAgentExecutor.execute()` walked the messages, checked `typeof content === "string"`, fell through, and the dispatcher logged `"No response generated."` — even though the model had produced a valid answer.

Caught during the Quinn smoke after she was switched to `protolabs/reasoning` (#535). She ran the full review, called `pr_inspector` 4× across turns, then her verdict vanished.

## Fix

Small typed helper `extractAiText(content)` that handles:
- string content (returns trimmed)
- arrays of strings (concatenates)
- arrays of typed blocks (concatenates `text`-typed, skips `thinking` / `tool_use` / etc)

## Test plan

- [x] `bun test src/executor/__tests__/deep-agent-extract-text.test.ts` — 8 pass, 0 fail
- [x] Full suite: 656 pass, 0 fail
- [ ] Manual re-smoke once #535 + this lands and main is updated: dispatch `pr_review`, confirm dispatcher logs a real verdict instead of the placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)