### PR TITLE
feat(github): auto-dispatch pr_review on PR opened/synchronize

### DIFF
--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -493,6 +493,17 @@ export class GitHubPlugin implements Plugin {
       }
     }
 
+    // ── Auto-review path: pull_request opened/synchronize ─────────────────────
+    // Every opened/synchronized PR triggers Quinn's pr_review skill — no
+    // @mention required. PRs are trusted by virtue of being in our repo;
+    // Quinn's pr_inspector + system prompt do the gating on what to actually
+    // verdict. Dedup'd via recentDispatches so a fast-updating branch doesn't
+    // flood the bus.
+    if (event === "pull_request" && (payload.action === "opened" || payload.action === "synchronize")) {
+      this._handleAutoReview(event, payload, ctx, bus);
+      return;
+    }
+
     // ── @mention path (existing, unchanged) ──────────────────────────────────
     if (!ctx.body.toLowerCase().includes(config.mentionHandle.toLowerCase())) return;
 
@@ -566,6 +577,72 @@ export class GitHubPlugin implements Plugin {
   /** Tracks recently-dispatched (owner/repo#number) to suppress duplicate webhook deliveries. */
   private recentDispatches = new Map<string, number>();
   private static readonly DEDUP_WINDOW_MS = 60_000;
+
+  private _handleAutoReview(
+    event: string,
+    payload: Record<string, unknown>,
+    ctx: GitHubEventContext,
+    bus: EventBus,
+  ): void {
+    const action = payload.action as string;
+    const dedupKey = `pr-review:${ctx.owner}/${ctx.repo}#${ctx.number}`;
+    const lastDispatched = this.recentDispatches.get(dedupKey);
+    if (lastDispatched && Date.now() - lastDispatched < GitHubPlugin.DEDUP_WINDOW_MS) {
+      console.log(`[github] Auto-review: skipping duplicate ${dedupKey} (dispatched ${Date.now() - lastDispatched}ms ago)`);
+      return;
+    }
+    this.recentDispatches.set(dedupKey, Date.now());
+
+    const pr = payload.pull_request as Record<string, unknown>;
+    const isDraft = pr?.draft as boolean;
+    if (isDraft) {
+      console.log(`[github] Auto-review: skipping draft PR ${ctx.owner}/${ctx.repo}#${ctx.number}`);
+      return;
+    }
+
+    const correlationId = crypto.randomUUID();
+    pendingComments.set(correlationId, { owner: ctx.owner, repo: ctx.repo, number: ctx.number });
+
+    const content = [
+      `Auto-review — pull_request.${action} on ${ctx.owner}/${ctx.repo}#${ctx.number}`,
+      `Title: ${ctx.title}`,
+      `Author: @${ctx.author}`,
+      `URL: ${ctx.url}`,
+      ``,
+      `Use pr_inspector with repo="${ctx.owner}/${ctx.repo}" and pr_number=${ctx.number} to pull CI status, the diff, and any unresolved review threads. Issue your verdict (PASS / WARN / FAIL) via review_approve / review_comment / review_request_changes.`,
+      ``,
+      ctx.body,
+    ].join("\n");
+
+    const topic = `message.inbound.github.${ctx.owner}.${ctx.repo}.${event}.${ctx.number}`;
+    const replyTopic = `message.outbound.github.${ctx.owner}.${ctx.repo}.${ctx.number}`;
+
+    bus.publish(topic, {
+      id: `${event}-${action}-${ctx.owner}-${ctx.repo}-${ctx.number}-${correlationId.slice(0, 8)}`,
+      correlationId,
+      topic,
+      timestamp: Date.now(),
+      payload: {
+        sender: ctx.author,
+        channel: `${ctx.owner}/${ctx.repo}#${ctx.number}`,
+        content,
+        skillHint: "pr_review",
+        github: {
+          event,
+          action,
+          owner: ctx.owner,
+          repo: ctx.repo,
+          number: ctx.number,
+          title: ctx.title,
+          url: ctx.url,
+        },
+      },
+      source: { interface: "github" as const },
+      reply: { topic: replyTopic },
+    });
+
+    console.log(`[github] Auto-review: ${ctx.owner}/${ctx.repo}#${ctx.number} (${action}) → pr_review`);
+  }
 
   private _handleAutoTriage(
     event: string,


### PR DESCRIPTION
## Summary

Phase 2 of Quinn's absorption (Phase 1 was #529, smoke-fix was #536). Every opened or synchronized PR now triggers Quinn's `pr_review` skill — no `@protoquinn` mention required.

Mirrors the existing `_handleAutoTriage` path (`issues.opened` → `bug_triage`) for the PR side:
- Fires on `pull_request.opened` and `pull_request.synchronize`
- Skips drafts
- 60s dedup window via the existing `recentDispatches` map (so a fast-rebase loop doesn't flood the bus)
- Bypasses the `@mention` + `admin` gates — PRs are trusted by virtue of landing in our repos; Quinn's `pr_inspector` + system prompt gate the actual verdict
- Same bus topic shape as the existing path (`message.inbound.github.{owner}.{repo}.pull_request.{number}` with `skillHint: "pr_review"`), so router + skill-dispatcher need no changes

## Test plan

- [x] `bun test` — 648 pass, 0 fail
- [x] `bun run typecheck` clean
- [ ] After merge + deploy: open a PR in protoLabsAI/protoWorkstacean, confirm Quinn reacts (eyes + verdict review) without any mention

🤖 Generated with [Claude Code](https://claude.com/claude-code)