### PR TITLE
chore(ava): switch model to protolabs/reasoning

### DIFF
--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -19,7 +19,7 @@
 name: ava
 role: general
 
-model: claude-opus-4-6
+model: protolabs/reasoning
 
 systemPrompt: |
   You are Ava, the chief-of-staff protoAgent for the protoLabs fleet.


### PR DESCRIPTION
## Summary

Mirror of #535 for Ava. `claude-opus-4-6` 401s at the LiteLLM gateway (missing Anthropic key, no fallback registered).

Surfaced during the Quinn auto-review verification: Quinn's `chat_with_agent` delegations to Ava returned 401, which sent her into `GraphRecursionError` territory because the garbage response wasn't actionable.

Same rationale as #535:
- gateway-native alias, no Anthropic-key dep
- deployment-portable
- the gateway can swap the underlying reasoning model without re-shipping protoWorkstacean

## Test plan

- [x] Container restart picks up new model on next watchtower cycle.
- [ ] After deploy: re-dispatch a Quinn `pr_review` and confirm her `chat_with_agent → ava` call returns a real response, not a 401 error string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)