### PR TITLE
chore(protobot): switch model to protolabs/reasoning

### DIFF
--- a/workspace/agents/protobot.yaml
+++ b/workspace/agents/protobot.yaml
@@ -12,7 +12,7 @@
 name: protobot
 role: devops
 
-model: claude-sonnet-4-6
+model: protolabs/reasoning
 
 systemPrompt: |
   You are protoBot, the Discord operations agent for protoLabs.


### PR DESCRIPTION
## Summary

Completes the fleet-wide swap to gateway-native reasoning. Same rationale as #535 (Quinn) and #542 (Ava): `claude-sonnet-4-6` 401s at the gateway because the Anthropic key isn't set there and no fallback alias is registered.

protobot is the last in-process agent on a `claude-*` model — after this lands, all three (Quinn, Ava, protobot) run on `protolabs/reasoning`.

## Test plan

- [x] Container restart loads `protobot (devops, model: protolabs/reasoning)`.
- [ ] After deploy: a protobot dispatch (deploy / infra ceremony) returns content instead of a 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the configured AI model for protoBot from `claude-sonnet-4-6` to `protolabs/reasoning`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/543?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->