### PR TITLE
feat(github): re-review trigger via pull_request.review_requested

### DIFF
--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -199,7 +199,11 @@ function extractContext(event: string, payload: Record<string, unknown>): GitHub
     };
   }
 
-  if (event === "pull_request" && (payload.action === "opened" || payload.action === "synchronize")) {
+  if (event === "pull_request" && (
+    payload.action === "opened" ||
+    payload.action === "synchronize" ||
+    payload.action === "review_requested"
+  )) {
     const pr = payload.pull_request as Record<string, unknown>;
     return {
       owner, repo: repoName,
@@ -500,7 +504,20 @@ export class GitHubPlugin implements Plugin {
     // verdict. Dedup'd via recentDispatches so a fast-updating branch doesn't
     // flood the bus.
     if (event === "pull_request" && (payload.action === "opened" || payload.action === "synchronize")) {
-      this._handleAutoReview(event, payload, ctx, bus);
+      this._handleAutoReview(event, payload, ctx, bus, { skipDedup: false });
+      return;
+    }
+
+    // ── Re-review path: pull_request review_requested for @protoquinn[bot] ────
+    // Native GitHub "Re-request review" button → Quinn re-reviews. Bypasses
+    // dedup because the human is explicitly asking. Other review_requested
+    // events (for human reviewers) are ignored.
+    if (event === "pull_request" && payload.action === "review_requested") {
+      const reviewer = payload.requested_reviewer as Record<string, unknown> | undefined;
+      const login = (reviewer?.login as string | undefined)?.toLowerCase();
+      if (login === "protoquinn" || login === "protoquinn[bot]") {
+        this._handleAutoReview(event, payload, ctx, bus, { skipDedup: true });
+      }
       return;
     }
 
@@ -583,13 +600,16 @@ export class GitHubPlugin implements Plugin {
     payload: Record<string, unknown>,
     ctx: GitHubEventContext,
     bus: EventBus,
+    opts: { skipDedup: boolean } = { skipDedup: false },
   ): void {
     const action = payload.action as string;
     const dedupKey = `pr-review:${ctx.owner}/${ctx.repo}#${ctx.number}`;
-    const lastDispatched = this.recentDispatches.get(dedupKey);
-    if (lastDispatched && Date.now() - lastDispatched < GitHubPlugin.DEDUP_WINDOW_MS) {
-      console.log(`[github] Auto-review: skipping duplicate ${dedupKey} (dispatched ${Date.now() - lastDispatched}ms ago)`);
-      return;
+    if (!opts.skipDedup) {
+      const lastDispatched = this.recentDispatches.get(dedupKey);
+      if (lastDispatched && Date.now() - lastDispatched < GitHubPlugin.DEDUP_WINDOW_MS) {
+        console.log(`[github] Auto-review: skipping duplicate ${dedupKey} (dispatched ${Date.now() - lastDispatched}ms ago)`);
+        return;
+      }
     }
     this.recentDispatches.set(dedupKey, Date.now());
 


### PR DESCRIPTION
## Summary

Closes the gap surfaced when **escape-from-qud#103** got stuck on a stale `CHANGES_REQUESTED` — the dev had no native way to ask Quinn for a fresh review, and admin-merge couldn't override the repository ruleset.

The native UX in GitHub is the **"Re-request review"** button. It fires `pull_request.review_requested`. We now handle it: when the requested reviewer is `@protoquinn[bot]`, dispatch `pr_review` with the dedup window bypassed (the human is explicitly asking — no point in 60s dedup against an earlier auto-dispatch).

### Flow now

1. Dev pushes a fix
2. (`synchronize` should already re-trigger from #537 — investigation for why #103's didn't is a separate task)
3. Dev clicks **Re-request review** on Quinn
4. `pull_request.review_requested` webhook → `_handleAutoReview` (skipDedup=true) → Quinn re-reviews
5. Her APPROVED replaces the stale CHANGES_REQUESTED → block lifts

### Code

- `extractContext`: extended to cover `review_requested` action (same shape as opened/synchronize)
- Main flow: new branch checks `requested_reviewer.login` against `protoquinn` / `protoquinn[bot]` (case-insensitive); other review_requested events for human reviewers are ignored
- `_handleAutoReview`: takes `opts: { skipDedup: boolean }`; default `false` preserves opened/synchronize behavior

## Test plan

- [x] `bun test` — 656 pass, 0 fail
- [x] `bun run typecheck` clean
- [ ] After deploy: dev clicks "Re-request review" on Quinn, confirm Quinn re-reviews + posts a fresh verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)