### PR TITLE
feat(linear): accept Agent SDK + past-tense webhook envelopes

### DIFF
--- a/lib/plugins/__tests__/linear.test.ts
+++ b/lib/plugins/__tests__/linear.test.ts
@@ -55,8 +55,18 @@ function collectBus(bus: InMemoryEventBus, pattern: string): BusMessage[] {
 }
 
 // Wrap a payload as a Linear webhook envelope (post-Zod-parse shape).
-function envelope(action: "create" | "update" | "remove", type: string, data: Record<string, unknown>) {
+function envelope(action: string, type: string, data: Record<string, unknown>) {
   return { action, type, data };
+}
+
+// AppUserNotification envelope — body in `notification`, action is camelCase verb.
+function notificationEnvelope(action: string, notification: Record<string, unknown>) {
+  return { action, type: "AppUserNotification", notification };
+}
+
+// AgentSessionEvent envelope — body in `agentSession`, optional `agentActivity`.
+function agentSessionEnvelope(action: string, agentSession: Record<string, unknown>, agentActivity?: Record<string, unknown>) {
+  return { action, type: "AgentSessionEvent", agentSession, agentActivity };
 }
 
 describe("LinearPlugin — inbound webhooks", () => {
@@ -171,6 +181,100 @@ describe("LinearPlugin — inbound webhooks", () => {
   test("unknown envelope type is dropped (no publish, logged as a warning)", async () => {
     const collected = collectBus(bus, "message.inbound.linear.#");
     await priv(plugin)._handleWebhook(envelope("create", "Reaction", { id: "r-1" }), bus);
+    expect(collected).toHaveLength(0);
+  });
+
+  test("past-tense action ('created') normalizes to the same topic suffix as 'create'", async () => {
+    const collected = collectBus(bus, "message.inbound.linear.issue.#");
+    await priv(plugin)._handleWebhook(envelope("created", "Issue", {
+      id: "issue-uuid-past-tense",
+      title: "Past-tense action",
+      team: { id: "team-1", key: "ENG", name: "Engineering" },
+    }), bus);
+    await priv(plugin)._handleWebhook(envelope("updated", "Issue", {
+      id: "issue-uuid-updated",
+      title: "Updated",
+      team: { id: "team-1", key: "ENG", name: "Engineering" },
+    }), bus);
+    await priv(plugin)._handleWebhook(envelope("removed", "Issue", {
+      id: "issue-uuid-removed",
+      title: "Removed",
+    }), bus);
+    expect(collected).toHaveLength(3);
+    expect(collected[0].topic).toBe("message.inbound.linear.issue.created");
+    expect(collected[1].topic).toBe("message.inbound.linear.issue.updated");
+    expect(collected[2].topic).toBe("message.inbound.linear.issue.removed");
+  });
+
+  test("AppUserNotification → publishes message.inbound.linear.agent.{action}", async () => {
+    const collected = collectBus(bus, "message.inbound.linear.agent.#");
+    await priv(plugin)._handleWebhook(notificationEnvelope("issueCommentMention", {
+      id: "notif-1",
+      issueId: "issue-abc",
+      commentId: "comment-xyz",
+      actor: { id: "user-1", name: "Josh" },
+      issue: { id: "issue-abc", identifier: "JOSH-386", title: "Test" },
+      comment: { id: "comment-xyz", body: "@ava take a look" },
+    }), bus);
+
+    expect(collected).toHaveLength(1);
+    const msg = collected[0];
+    expect(msg.topic).toBe("message.inbound.linear.agent.issueCommentMention");
+    expect(msg.correlationId).toBe("linear-issue-abc");
+    const p = msg.payload as Record<string, unknown>;
+    expect(p.action).toBe("issueCommentMention");
+    expect(p.issueId).toBe("issue-abc");
+    expect(p.commentId).toBe("comment-xyz");
+    expect((p.notification as Record<string, unknown>).id).toBe("notif-1");
+  });
+
+  test("AppUserNotification with nested issue/comment objects (no top-level issueId)", async () => {
+    const collected = collectBus(bus, "message.inbound.linear.agent.#");
+    // Some Linear envelopes carry only nested issue.id, not a top-level issueId.
+    await priv(plugin)._handleWebhook(notificationEnvelope("issueMention", {
+      id: "notif-2",
+      issue: { id: "issue-nested", identifier: "ENG-1", title: "Nested" },
+    }), bus);
+    expect(collected).toHaveLength(1);
+    expect(collected[0].correlationId).toBe("linear-issue-nested");
+    expect((collected[0].payload as Record<string, unknown>).issueId).toBe("issue-nested");
+  });
+
+  test("AgentSessionEvent.created → publishes message.inbound.linear.agent_session.created", async () => {
+    const collected = collectBus(bus, "message.inbound.linear.agent_session.#");
+    await priv(plugin)._handleWebhook(agentSessionEnvelope("created", {
+      id: "session-1",
+      issueId: "issue-abc",
+      issue: { id: "issue-abc", title: "Onboarding" },
+    }), bus);
+
+    expect(collected).toHaveLength(1);
+    const msg = collected[0];
+    expect(msg.topic).toBe("message.inbound.linear.agent_session.created");
+    expect(msg.correlationId).toBe("session-1");
+    const p = msg.payload as Record<string, unknown>;
+    expect(p.action).toBe("created");
+    expect(p.sessionId).toBe("session-1");
+    expect(p.issueId).toBe("issue-abc");
+  });
+
+  test("AgentSessionEvent.prompted carries agentActivity through to the payload", async () => {
+    const collected = collectBus(bus, "message.inbound.linear.agent_session.#");
+    await priv(plugin)._handleWebhook(agentSessionEnvelope(
+      "prompted",
+      { id: "session-2", issueId: "issue-zzz" },
+      { type: "userMessage", content: "fix the bug pls" },
+    ), bus);
+    expect(collected).toHaveLength(1);
+    const p = collected[0].payload as Record<string, unknown>;
+    expect((p.agentActivity as Record<string, unknown>).content).toBe("fix the bug pls");
+  });
+
+  test("Issue / Comment / Project webhook missing data field → dropped, no crash", async () => {
+    const collected = collectBus(bus, "message.inbound.linear.#");
+    await priv(plugin)._handleWebhook({ action: "created", type: "Issue" } as unknown, bus);
+    await priv(plugin)._handleWebhook({ action: "created", type: "Comment" } as unknown, bus);
+    await priv(plugin)._handleWebhook({ action: "created", type: "Project" } as unknown, bus);
     expect(collected).toHaveLength(0);
   });
 

--- a/lib/plugins/linear.ts
+++ b/lib/plugins/linear.ts
@@ -7,6 +7,8 @@
  *     message.inbound.linear.issue.{created|updated|removed}
  *     message.inbound.linear.comment.{created|updated|removed}
  *     message.inbound.linear.project.{created|updated|removed}
+ *     message.inbound.linear.agent.{issueMention|issueCommentMention|...}
+ *     message.inbound.linear.agent_session.{created|prompted}
  *
  *   The HTTP 200 is returned AFTER the bus publish completes, so a publish
  *   failure surfaces as a 5xx that Linear will retry on.
@@ -97,13 +99,24 @@ const LinearProjectDataSchema = z.object({
   url: z.string().optional(),
 });
 
-/** Action verbs Linear emits across all resource types. */
-const LINEAR_ACTIONS = ["create", "update", "remove"] as const;
+// Linear sends three distinct envelope shapes:
+//   1. Standard webhooks (Issue/Comment/Project) — action is create/update/remove
+//      or past-tense created/updated/removed. Body in `data`.
+//   2. AppUserNotification (Agent app @mentions, assignments, etc.) — action is
+//      a camelCase notification verb like issueMention, issueCommentMention,
+//      issueAssignedToYou, issueNewComment. Body in `notification`.
+//   3. AgentSessionEvent (Agent Session API — newer SDK) — action is created
+//      or prompted. Body in `agentSession`.
+// We use a permissive envelope (action as string) and branch on `type` in the
+// handler. Strict per-shape validation happens after the branch.
 
 const LinearWebhookEnvelopeSchema = z.object({
-  action: z.enum(LINEAR_ACTIONS),
-  type: z.string(),
-  data: z.record(z.string(), z.unknown()),
+  action: z.string().min(1),
+  type: z.string().min(1),
+  data: z.record(z.string(), z.unknown()).optional(),
+  notification: z.record(z.string(), z.unknown()).optional(),
+  agentSession: z.record(z.string(), z.unknown()).optional(),
+  agentActivity: z.record(z.string(), z.unknown()).optional(),
   createdAt: z.string().optional(),
   organizationId: z.string().optional(),
   webhookTimestamp: z.number().optional(),
@@ -111,6 +124,16 @@ const LinearWebhookEnvelopeSchema = z.object({
 });
 
 type LinearWebhookEnvelope = z.infer<typeof LinearWebhookEnvelopeSchema>;
+
+/** Normalize action verb tense. `create` / `created` both → `created`, etc. */
+function normalizeAction(action: string): string {
+  switch (action) {
+    case "create": return "created";
+    case "update": return "updated";
+    case "remove": return "removed";
+    default: return action;
+  }
+}
 type LinearIssueData = z.infer<typeof LinearIssueDataSchema>;
 type LinearCommentData = z.infer<typeof LinearCommentDataSchema>;
 type LinearProjectData = z.infer<typeof LinearProjectDataSchema>;
@@ -266,10 +289,13 @@ export class LinearPlugin implements Plugin {
             }
           }
 
-          // Dedup key — prefer webhookId; fall back to (type, data.id, webhookTimestamp).
-          const dataId = typeof payload.data.id === "string" ? payload.data.id : "?";
+          // Dedup key — prefer webhookId; fall back to (type, body.id, webhookTimestamp).
+          // Each envelope shape (standard / AppUserNotification / AgentSessionEvent)
+          // carries its body in a different field; check all three.
+          const body = payload.data ?? payload.notification ?? payload.agentSession;
+          const dataId = typeof body?.id === "string" ? body.id : "?";
           const dedupKey = payload.webhookId
-            ?? `${payload.type}:${dataId}:${payload.webhookTimestamp ?? 0}`;
+            ?? `${payload.type}:${payload.action}:${dataId}:${payload.webhookTimestamp ?? 0}`;
           if (dedup.isDuplicate(dedupKey)) {
             return new Response("Already processed", { status: 200 });
           }
@@ -308,14 +334,13 @@ export class LinearPlugin implements Plugin {
   }
 
   private async _handleWebhook(payload: LinearWebhookEnvelope, bus: EventBus): Promise<void> {
-    const actionMap: Record<typeof LINEAR_ACTIONS[number], string> = {
-      create: "created",
-      update: "updated",
-      remove: "removed",
-    };
-    const action = actionMap[payload.action];
+    const action = normalizeAction(payload.action);
 
     if (payload.type === "Issue") {
+      if (!payload.data) {
+        console.warn(`[linear] Issue webhook missing data field — dropping`);
+        return;
+      }
       const issueParsed = LinearIssueDataSchema.safeParse(payload.data);
       if (!issueParsed.success) {
         console.warn(`[linear] Issue payload failed schema — dropping. ${issueParsed.error.issues.map(i => i.message).join("; ")}`);
@@ -325,6 +350,10 @@ export class LinearPlugin implements Plugin {
       return;
     }
     if (payload.type === "Comment") {
+      if (!payload.data) {
+        console.warn(`[linear] Comment webhook missing data field — dropping`);
+        return;
+      }
       const commentParsed = LinearCommentDataSchema.safeParse(payload.data);
       if (!commentParsed.success) {
         console.warn(`[linear] Comment payload failed schema — dropping. ${commentParsed.error.issues.map(i => i.message).join("; ")}`);
@@ -334,6 +363,10 @@ export class LinearPlugin implements Plugin {
       return;
     }
     if (payload.type === "Project") {
+      if (!payload.data) {
+        console.warn(`[linear] Project webhook missing data field — dropping`);
+        return;
+      }
       const projectParsed = LinearProjectDataSchema.safeParse(payload.data);
       if (!projectParsed.success) {
         console.warn(`[linear] Project payload failed schema — dropping. ${projectParsed.error.issues.map(i => i.message).join("; ")}`);
@@ -342,9 +375,71 @@ export class LinearPlugin implements Plugin {
       this._publishProject(projectParsed.data, action, bus);
       return;
     }
+    if (payload.type === "AppUserNotification") {
+      // Agent app events: @mentions, assignments, comments on assigned issues, etc.
+      // Body is in `notification`. Pass the raw object through — downstream
+      // routing decides what to do with each notification kind.
+      this._publishAgentNotification(payload.action, payload.notification ?? {}, bus);
+      return;
+    }
+    if (payload.type === "AgentSessionEvent") {
+      // Linear's newer Agent Session API. Body is in `agentSession` plus
+      // optionally `agentActivity` (for prompted events).
+      this._publishAgentSession(payload.action, payload.agentSession ?? {}, payload.agentActivity, bus);
+      return;
+    }
     // Unknown envelope type — log loudly + drop. Linear adds new resource
     // types over time; fail visibly so we know to extend the plugin.
-    console.warn(`[linear] Unhandled webhook type "${payload.type}" — dropping (extend LinearPlugin to support)`);
+    console.warn(`[linear] Unhandled webhook type "${payload.type}" action="${payload.action}" — dropping (extend LinearPlugin to support)`);
+  }
+
+  private _publishAgentNotification(action: string, notification: Record<string, unknown>, bus: EventBus): void {
+    const topic = `message.inbound.linear.agent.${action}`;
+    const issueId = (notification.issueId as string | undefined)
+      ?? ((notification.issue as { id?: string } | undefined)?.id);
+    const commentId = (notification.commentId as string | undefined)
+      ?? ((notification.comment as { id?: string } | undefined)?.id);
+    const correlationId = issueId ? `linear-${issueId}` : crypto.randomUUID();
+    bus.publish(topic, {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic,
+      timestamp: Date.now(),
+      payload: {
+        action,
+        notification,
+        issueId,
+        commentId,
+      },
+    });
+    console.log(`[linear] agent.${action}${issueId ? ` on issue ${issueId}` : ""}`);
+  }
+
+  private _publishAgentSession(
+    action: string,
+    agentSession: Record<string, unknown>,
+    agentActivity: Record<string, unknown> | undefined,
+    bus: EventBus,
+  ): void {
+    const topic = `message.inbound.linear.agent_session.${action}`;
+    const sessionId = agentSession.id as string | undefined;
+    const issueId = (agentSession.issueId as string | undefined)
+      ?? ((agentSession.issue as { id?: string } | undefined)?.id);
+    const correlationId = sessionId ?? (issueId ? `linear-${issueId}` : crypto.randomUUID());
+    bus.publish(topic, {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic,
+      timestamp: Date.now(),
+      payload: {
+        action,
+        sessionId,
+        issueId,
+        agentSession,
+        agentActivity,
+      },
+    });
+    console.log(`[linear] agent_session.${action}${sessionId ? ` session=${sessionId}` : ""}`);
   }
 
   private _publishIssue(issue: LinearIssueData, action: string, bus: EventBus): void {


### PR DESCRIPTION
## Summary

Linear sends **three** distinct webhook envelope shapes in 2026. Our plugin only accepted the oldest one, so real deliveries 400'd at envelope schema validation:

```
[linear] Webhook envelope failed schema validation — action: Invalid enum value.
Expected 'create' | 'update' | 'remove', received 'issueCommentMention'; data: Required
```

| Source | action verbs | body field |
|---|---|---|
| Standard webhook | `create` / `update` / `remove` **and** `created` / `updated` / `removed` | `data` |
| AppUserNotification (Agent @mentions) | `issueMention`, `issueCommentMention`, `issueAssignedToYou`, `issueNewComment`, … | `notification` |
| AgentSessionEvent (Agent Session API) | `created`, `prompted` | `agentSession` (+ optional `agentActivity`) |

Caught during the Linear smoke after switching the Ava agent's webhook URL to `hooks.proto-labs.ai/webhooks/linear` — signature/body/secret pipe was working, just the envelope schema was three years behind.

## Changes

- `LinearWebhookEnvelopeSchema`: `action` is now `z.string().min(1)`; `data`/`notification`/`agentSession`/`agentActivity` all optional. Branch-on-`type` in the handler still gates which body field gets used.
- `normalizeAction()`: folds `create → created` (etc.) so topic suffixes stay consistent regardless of tense.
- New handler paths publish:
  - `message.inbound.linear.agent.{action}` — body in `payload.notification`
  - `message.inbound.linear.agent_session.{action}` — body in `payload.agentSession`
- Dedup key falls back across `data | notification | agentSession` when no `webhookId` present.
- Plugin docstring updated to list the new topics.

## Out of scope

Routing the new topics to agents (`channels.yaml` mapping or skill-hint) is the next PR — this one just stops rejecting valid Linear deliveries.

## Test plan

- [x] `bun test lib/plugins/__tests__/linear.test.ts` — 28 pass (22 existing + 6 new)
- [x] Full suite: 662 pass, 0 fail (was 656)
- [x] `bun run typecheck` clean
- [ ] After deploy: Linear @-mention triggers `[linear] agent.issueCommentMention on issue ...` log instead of envelope-validation 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Linear integration with support for additional webhook notification types
  * Added agent session event publishing and handling

* **Improvements**
  * Enhanced webhook event deduplication and error handling
  * Improved resilience when processing malformed webhook payloads

* **Tests**
  * Expanded webhook processing test coverage with additional action variations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/545?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->