### PR TITLE
feat(deep-agent): skill-scoped tools + per-skill maxTurns override

### DIFF
--- a/src/agent-runtime/types.ts
+++ b/src/agent-runtime/types.ts
@@ -29,6 +29,21 @@ export interface AgentSkillDefinition {
   keywords?: string[];
   /** Override the system prompt for this specific skill. */
   systemPromptOverride?: string;
+  /**
+   * Restrict tools available when this skill executes. If set, the runtime
+   * intersects with the agent's `tools[]` — a skill cannot add tools the
+   * agent doesn't already declare. If unset, all of agent.tools are
+   * available. Use this to prevent a focused skill (e.g. pr_review) from
+   * fanning out into delegation / web search territory and exhausting
+   * the recursion limit.
+   */
+  tools?: string[];
+  /**
+   * Override the agent's `maxTurns` for this skill. Recursion limit in
+   * LangGraph is `maxTurns * 2 + 1` — bump for skills that need many
+   * tool calls (e.g. board sweeps), keep tight for narrow ones.
+   */
+  maxTurns?: number;
 }
 
 /**

--- a/src/executor/__tests__/deep-agent-skill-scope.test.ts
+++ b/src/executor/__tests__/deep-agent-skill-scope.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { effectiveToolsFor, effectiveMaxTurnsFor } from "../executors/deep-agent-executor.ts";
+
+describe("effectiveToolsFor", () => {
+  const agentTools = ["pr_inspector", "create_github_issue", "chat_with_agent", "searxng_search", "react"];
+
+  test("returns agent tools unchanged when skill omits tools", () => {
+    expect(effectiveToolsFor(undefined, agentTools)).toEqual(agentTools);
+  });
+
+  test("intersects with agent tools when skill declares its own list", () => {
+    expect(effectiveToolsFor(["pr_inspector", "react"], agentTools)).toEqual(["pr_inspector", "react"]);
+  });
+
+  test("skill cannot grant access to a tool the agent doesn't have", () => {
+    expect(effectiveToolsFor(["pr_inspector", "phantom_tool"], agentTools)).toEqual(["pr_inspector"]);
+  });
+
+  test("empty skill list yields empty effective list", () => {
+    expect(effectiveToolsFor([], agentTools)).toEqual([]);
+  });
+
+  test("preserves skill-declared ordering (independent of agent ordering)", () => {
+    expect(effectiveToolsFor(["react", "pr_inspector"], agentTools)).toEqual(["react", "pr_inspector"]);
+  });
+
+  test("agent with no tools always yields empty regardless of skill", () => {
+    expect(effectiveToolsFor(["pr_inspector"], [])).toEqual([]);
+    expect(effectiveToolsFor(undefined, [])).toEqual([]);
+  });
+});
+
+describe("effectiveMaxTurnsFor", () => {
+  test("skill override wins when set", () => {
+    expect(effectiveMaxTurnsFor(18, 12)).toBe(18);
+  });
+
+  test("agent maxTurns is the fallback when skill omits", () => {
+    expect(effectiveMaxTurnsFor(undefined, 12)).toBe(12);
+  });
+
+  test("skill override of 0 is honored (not treated as falsy)", () => {
+    expect(effectiveMaxTurnsFor(0, 12)).toBe(0);
+  });
+});

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -26,6 +26,23 @@ const LANGFUSE_ENABLED = !!(process.env.LANGFUSE_PUBLIC_KEY && process.env.LANGF
  * The text we want is the concatenation of `text`-typed blocks. Returns the
  * trimmed result, or "" if no usable text was found.
  */
+/**
+ * Resolve which tools a skill invocation gets. When a skill declares its own
+ * `tools` list we intersect with the agent's declared tools — a skill cannot
+ * grant access to tools the agent never advertised. When the skill omits
+ * tools we fall back to the agent's full list. Pure function, easy to unit-
+ * test; the runtime branch in `execute()` is a thin wrapper around this.
+ */
+export function effectiveToolsFor(skillTools: string[] | undefined, agentTools: string[]): string[] {
+  if (!skillTools) return agentTools;
+  return skillTools.filter(t => agentTools.includes(t));
+}
+
+/** Skill's maxTurns wins when set; else inherit from the agent. */
+export function effectiveMaxTurnsFor(skillMaxTurns: number | undefined, agentMaxTurns: number): number {
+  return skillMaxTurns ?? agentMaxTurns;
+}
+
 export function extractAiText(content: unknown): string {
   if (typeof content === "string") return content.trim();
   if (!Array.isArray(content)) return "";
@@ -574,7 +591,21 @@ export class DeepAgentExecutor implements IExecutor {
 
   async execute(req: SkillRequest): Promise<SkillResult> {
     const prompt = req.content ?? req.prompt ?? this._buildPrompt(req);
-    const tools = createLangChainTools(this.agentDef.tools, this.http, req.correlationId, this.agentDef.name);
+
+    const skillDef = req.skill
+      ? this.agentDef.skills.find(s => s.name === req.skill)
+      : undefined;
+
+    // Skill-level tools override: intersect with agent.tools (a skill can't
+    // grant access to tools the agent doesn't declare). When skill.tools is
+    // unset, all of agent.tools are available. This is the structural way
+    // to keep narrow skills (pr_review) from fanning out into delegation /
+    // web search and exhausting the recursion limit.
+    const agentTools = this.agentDef.tools;
+    const effectiveTools = effectiveToolsFor(skillDef?.tools, agentTools);
+    const tools = createLangChainTools(effectiveTools, this.http, req.correlationId, this.agentDef.name);
+
+    const effectiveMaxTurns = effectiveMaxTurnsFor(skillDef?.maxTurns, this.agentDef.maxTurns);
 
     const callbacks = LANGFUSE_ENABLED
       ? [new LangfuseCallbackHandler({
@@ -588,9 +619,6 @@ export class DeepAgentExecutor implements IExecutor {
       // Resolve skill-level systemPromptOverride if this skill defines one.
       // Skills like diagnose_pr_stuck have narrow, structured output requirements
       // that replace the agent's general-purpose prompt.
-      const skillDef = req.skill
-        ? this.agentDef.skills.find(s => s.name === req.skill)
-        : undefined;
       const basePrompt = skillDef?.systemPromptOverride ?? this.agentDef.systemPrompt;
 
       const agent = createReactAgent({
@@ -599,11 +627,11 @@ export class DeepAgentExecutor implements IExecutor {
         messageModifier: new SystemMessage(basePrompt),
       });
 
-      console.log(`[deep-agent:${this.agentDef.name}] invoke with ${tools.length} tools, prompt length=${prompt.length}, langfuse=${LANGFUSE_ENABLED}`);
+      console.log(`[deep-agent:${this.agentDef.name}] invoke skill="${req.skill ?? "?"}" tools=${tools.length}/${agentTools.length} maxTurns=${effectiveMaxTurns} promptLen=${prompt.length} langfuse=${LANGFUSE_ENABLED}`);
 
       const result = await agent.invoke(
         { messages: [{ role: "user", content: prompt }] },
-        { recursionLimit: this.agentDef.maxTurns * 2 + 1, callbacks },
+        { recursionLimit: effectiveMaxTurns * 2 + 1, callbacks },
       );
 
       const messages = result.messages ?? [];

--- a/workspace/agents/quinn.yaml
+++ b/workspace/agents/quinn.yaml
@@ -168,6 +168,16 @@ skills:
       APPROVED / COMMENTED / CHANGES_REQUESTED review via the GitHub
       Review API. Feeds the autonomous merge loop in pr-remediator.
     keywords: [pr_review, review, pull request, audit, formal review]
+    # Scoped toolbelt: pr_review is exhaustively served by pr_inspector
+    # alone (7 actions cover list / CI / diff / threads / submit). react +
+    # send_update for Discord acknowledgment. Anything else (chat_with_agent,
+    # searxng_search, board inspection) lures the loop into thrashing and
+    # has historically hit the recursion limit on simple PRs.
+    tools:
+      - pr_inspector
+      - react
+      - send_update
+    maxTurns: 18
     systemPromptOverride: |
       You are Quinn, performing a **formal PR review**.
 
@@ -291,6 +301,22 @@ skills:
       duplicate. Close, comment, or label as appropriate. Return a
       summary with counts per category.
     keywords: [bug, triage, issues, blocked, stale, duplicate]
+    # Scoped toolbelt: bug_triage needs board context + GitHub issue
+    # actions. Excludes the narrow PR-review surface (pr_inspector is
+    # there for CI verification on specific PRs referenced by an issue,
+    # but the heavy lifting is board + repo scan).
+    tools:
+      - get_projects
+      - get_pr_pipeline
+      - get_ci_health
+      - get_branch_drift
+      - chat_with_agent
+      - pr_inspector
+      - create_github_issue
+      - searxng_search
+      - react
+      - send_update
+    maxTurns: 25
     systemPromptOverride: |
       You are Quinn, performing **bug triage**.
 
@@ -344,6 +370,17 @@ skills:
       identify the affected project, file an incident, escalate to HITL
       on uncertainty.
     keywords: [security, vulnerability, cve, dependabot, incident]
+    # Scoped toolbelt: incident filing + research + escalation. No PR
+    # review surface — security findings on a specific PR go through
+    # pr_review with the security-severity rubric applied there.
+    tools:
+      - get_projects
+      - report_incident
+      - create_github_issue
+      - searxng_search
+      - send_update
+      - msg_operator
+    maxTurns: 15
     systemPromptOverride: |
       You are Quinn, performing **security triage**.
 


### PR DESCRIPTION
## Summary

Quinn was hitting `GraphRecursionError` on simple PR reviews because every skill saw her full 14-tool belt and the model would fan out into `chat_with_agent`, `searxng_search`, etc. instead of staying inside `pr_inspector`. Structural fix: let a skill narrow its own tool surface so the model literally cannot see what isn't exposed.

### Runtime

- `AgentSkillDefinition` gets two new optional fields:
  - `tools?: string[]` — intersected with `agent.tools` at invoke time; a skill cannot grant access to tools the agent doesn't declare.
  - `maxTurns?: number` — overrides `agent.maxTurns` for this skill.
- `DeepAgentExecutor` wires both. Pure-function helpers (`effectiveToolsFor`, `effectiveMaxTurnsFor`) extracted so the resolution is unit-testable without spinning up an LLM.

### Quinn

| Skill | Tools | maxTurns | Why |
|---|---|---|---|
| `pr_review` | `pr_inspector, react, send_update` | 18 | pr_inspector has 7 actions covering list/CI/threads/diff/submit — exhaustive for a single PR. |
| `bug_triage` | board + repo + GitHub issue actions | 25 | Needs wider context for cross-repo classification. |
| `security_triage` | incident filing + research + escalation | 15 | Narrow, escalation-first by design. |

### Logging

The per-invoke log line now reports skill, effective vs. total tools, and effective maxTurns — easier to confirm scoping at a glance:

```
[deep-agent:quinn] invoke skill="pr_review" tools=3/14 maxTurns=18 promptLen=153 langfuse=true
```

## Test plan

- [x] `bun test src/executor/__tests__/deep-agent-skill-scope.test.ts` — 9 pass (inheritance, intersection, ordering, empty-agent edge, zero-not-falsy)
- [x] Full suite: 671 pass, 0 fail (was 662)
- [x] `bun run typecheck` clean
- [ ] After deploy: a fresh Quinn `pr_review` dispatch logs `tools=3/14` and does NOT call `chat_with_agent` / `searxng_search` / `get_pr_pipeline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills can now restrict their available toolset independently of the agent's overall tools
  * Skills can now override the agent's maximum turn limit with skill-specific values
  * Updated agent configuration to leverage new per-skill tool and turn limit controls

* **Tests**
  * Added comprehensive test coverage for per-skill tool scoping and turn limit computation logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/546?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->