### PR TITLE
feat(quinn): clawpatch_review tool + pr_review prompt update

### DIFF
--- a/src/api/clawpatch.ts
+++ b/src/api/clawpatch.ts
@@ -1,0 +1,176 @@
+/**
+ * POST /api/clawpatch/review — structural code review via clawpatch.
+ *
+ * Wraps the `clawpatch ci --provider gateway --json` invocation behind an
+ * HTTP endpoint so the LLM tool wrapper stays a thin caller and shell exec
+ * is bounded to this route.
+ *
+ * Repo resolution
+ * ---------------
+ * The tool accepts `repo` in owner/name format. We map it to a local
+ * filesystem path via `CLAWPATCH_REPO_PATH_MAP` (JSON env override) or a
+ * built-in default that knows about repos mounted into the workstacean
+ * container today. v1 only supports already-mounted repos; on-demand PR
+ * checkouts are phase 2.
+ *
+ * Env
+ * ---
+ *   CLAWPATCH_REPO_PATH_MAP    JSON string mapping owner/name → absolute
+ *                              path inside the container. Overrides built-in.
+ *   CLAWPATCH_GATEWAY_MODEL    Forwarded to clawpatch (default protolabs/smart)
+ *   OPENAI_API_KEY / OPENAI_BASE_URL  Already set in the container env;
+ *                              clawpatch's gateway provider picks them up.
+ */
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import type { Route, ApiContext } from "./types.ts";
+
+interface ReviewRequest {
+  repo: string;
+  since?: string;
+  limit?: number;
+  /** Override the model for this invocation. Defaults to the gateway provider's default. */
+  model?: string;
+}
+
+const BUILT_IN_REPO_PATHS: Record<string, string> = {
+  // Repos mounted read-only into the workstacean container today (see
+  // homelab-iac/stacks/ai/docker-compose.yml workstacean.volumes).
+  "protoLabsAI/protoWorkstacean": "/home/josh/dev/protoWorkstacean",
+  "protoLabsAI/protoCLI": "/home/josh/dev/labs/protoCLI",
+  "protoLabsAI/mythxengine": "/home/josh/dev/labs/mythxengine",
+};
+
+function resolveRepoPath(repo: string): string | null {
+  let overrides: Record<string, string> = {};
+  const raw = process.env["CLAWPATCH_REPO_PATH_MAP"];
+  if (raw) {
+    try {
+      overrides = JSON.parse(raw) as Record<string, string>;
+    } catch {
+      // Fall through with empty overrides — bad JSON shouldn't break the route.
+    }
+  }
+  const path = overrides[repo] ?? BUILT_IN_REPO_PATHS[repo];
+  if (!path) return null;
+  if (!existsSync(path)) return null;
+  return path;
+}
+
+interface ClawpatchExecResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  timedOut: boolean;
+}
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+
+function runClawpatch(args: string[], cwd: string, timeoutMs: number): Promise<ClawpatchExecResult> {
+  return new Promise((resolve) => {
+    const child = spawn("clawpatch", args, {
+      cwd,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
+    child.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString("utf-8"); });
+    child.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString("utf-8"); });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ stdout, stderr, exitCode: code ?? -1, timedOut });
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      resolve({ stdout, stderr: stderr + String(err), exitCode: -1, timedOut });
+    });
+  });
+}
+
+interface CiJsonOutput {
+  run?: string;
+  reviewed?: number;
+  findings?: number;
+  jobs?: number;
+  errors?: Array<{ feature?: string; message?: string; layer?: string }>;
+  report?: string;
+  items?: unknown[];
+}
+
+export function createRoutes(_ctx: ApiContext): Route[] {
+  return [
+    {
+      method: "POST",
+      path: "/api/clawpatch/review",
+      handler: async (req) => {
+        let payload: ReviewRequest;
+        try {
+          payload = (await req.json()) as ReviewRequest;
+        } catch {
+          return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 });
+        }
+        const { repo, since, limit, model } = payload;
+        if (!repo) {
+          return Response.json({ success: false, error: "repo is required" }, { status: 400 });
+        }
+        const repoPath = resolveRepoPath(repo);
+        if (!repoPath) {
+          return Response.json(
+            {
+              success: false,
+              error: `repo '${repo}' is not mounted in this container — only repos in CLAWPATCH_REPO_PATH_MAP / the built-in mounts (protoWorkstacean, protoCLI, mythxengine) work today. On-demand PR checkouts are not implemented.`,
+            },
+            { status: 400 },
+          );
+        }
+
+        const args = ["ci", "--provider", "gateway", "--json"];
+        if (since) args.push("--since", since);
+        if (typeof limit === "number" && limit > 0) args.push("--limit", String(limit));
+        if (model) args.push("--model", model);
+
+        const result = await runClawpatch(args, repoPath, DEFAULT_TIMEOUT_MS);
+        if (result.timedOut) {
+          return Response.json(
+            { success: false, error: `clawpatch timed out after ${DEFAULT_TIMEOUT_MS}ms` },
+            { status: 504 },
+          );
+        }
+        if (result.exitCode !== 0) {
+          return Response.json(
+            {
+              success: false,
+              error: `clawpatch exited ${result.exitCode}: ${result.stderr.slice(0, 1000) || result.stdout.slice(0, 1000)}`,
+            },
+            { status: 500 },
+          );
+        }
+
+        // `clawpatch ci --json` writes a JSON object to stdout. The schema is
+        // documented in protoPatch/src/cli.ts; we treat it loosely here because
+        // schema drift would otherwise block working reviews.
+        let parsed: CiJsonOutput;
+        try {
+          parsed = JSON.parse(result.stdout) as CiJsonOutput;
+        } catch (err) {
+          return Response.json(
+            {
+              success: false,
+              error: `clawpatch returned non-JSON on stdout: ${String(err).slice(0, 300)}; preview=${result.stdout.slice(0, 300)}`,
+            },
+            { status: 500 },
+          );
+        }
+
+        return Response.json({ success: true, data: { repo, repoPath, ...parsed } });
+      },
+    },
+  ];
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -25,6 +25,7 @@ import { createRoutes as googleRoutes } from "./google.ts";
 import { createRoutes as linearRoutes } from "./linear.ts";
 import { createRoutes as busTopologyRoutes } from "./bus-topology.ts";
 import { createRoutes as prInspectorRoutes } from "./pr-inspector.ts";
+import { createRoutes as clawpatchRoutes } from "./clawpatch.ts";
 
 export { matchPath } from "./types.ts";
 export type { Route, ApiContext } from "./types.ts";
@@ -49,5 +50,6 @@ export function createAllRoutes(ctx: ApiContext): Route[] {
     ...linearRoutes(ctx),
     ...busTopologyRoutes(ctx),
     ...prInspectorRoutes(ctx),
+    ...clawpatchRoutes(ctx),
   ];
 }

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -207,6 +207,20 @@ function createLangChainTools(toolNames: string[], http: HttpClient, correlation
         schema: z.object({ title: z.string(), severity: z.enum(["critical", "high", "medium", "low"]), description: z.string().optional() }),
       },
     ),
+    clawpatch_review: tool(
+      async (input) => JSON.stringify(await http.post("/api/clawpatch/review", input)),
+      {
+        name: "clawpatch_review",
+        description:
+          "Run structural code review via clawpatch (protoLabs fork). Maps the repo into semantic feature slices, reviews each via the gateway LLM provider, and returns structured findings (correctness bugs, security issues, race/concurrency bugs, data-loss, resource leaks, error-handling gaps, API contract mismatches, missing tests, build hazards, maintainability risks). Use this DURING pr_review to get a structural read on the changed surface before forming a verdict — fold findings into the QA Audit body's Observations section with severity + file:line cites. Today v1 only works for repos already mounted in the container (protoWorkstacean, protoCLI, mythxengine); other repos return a clear error. The `since` arg scopes the review to features touched since that git ref (typically the PR base) — pass it whenever you have the PR base SHA or branch.",
+        schema: z.object({
+          repo: z.string().describe("Repository in owner/name format (e.g. protoLabsAI/protoWorkstacean)."),
+          since: z.string().optional().describe("Git ref (branch or SHA) to diff against. Limits the review to features touched since that ref. Use the PR base (typically 'main' or 'dev')."),
+          limit: z.number().int().optional().describe("Maximum number of features to review. Useful for spot-checks on large repos."),
+          model: z.string().optional().describe("Gateway model override (e.g. protolabs/fast for cheap, protolabs/reasoning for deeper). Default protolabs/smart."),
+        }),
+      },
+    ),
     pr_inspector: tool(
       async (input) => JSON.stringify(await http.post("/api/pr/inspect", input)),
       {

--- a/workspace/agents/quinn.yaml
+++ b/workspace/agents/quinn.yaml
@@ -137,6 +137,10 @@ systemPrompt: |
 tools:
   # GitHub PR review surface (the core)
   - pr_inspector
+  # Structural code review via clawpatch (protoLabs fork). Returns
+  # finding-shaped output (severity, category, file:line evidence,
+  # recommendation). Quinn folds findings into her pr_review verdict.
+  - clawpatch_review
   # Read-only project context
   - get_projects
   - get_ci_health
@@ -168,13 +172,15 @@ skills:
       APPROVED / COMMENTED / CHANGES_REQUESTED review via the GitHub
       Review API. Feeds the autonomous merge loop in pr-remediator.
     keywords: [pr_review, review, pull request, audit, formal review]
-    # Scoped toolbelt: pr_review is exhaustively served by pr_inspector
-    # alone (7 actions cover list / CI / diff / threads / submit). react +
-    # send_update for Discord acknowledgment. Anything else (chat_with_agent,
-    # searxng_search, board inspection) lures the loop into thrashing and
-    # has historically hit the recursion limit on simple PRs.
+    # Scoped toolbelt: pr_inspector covers all GitHub-side review IO;
+    # clawpatch_review adds a structural code-review pass via the gateway
+    # provider when the PR is non-trivial; react + send_update for
+    # Discord acknowledgment. No delegation tools (chat_with_agent /
+    # searxng_search etc.) — those historically lured the loop into
+    # thrashing and hit the recursion limit on simple PRs.
     tools:
       - pr_inspector
+      - clawpatch_review
       - react
       - send_update
     maxTurns: 18
@@ -220,6 +226,28 @@ skills:
       observation, not a blocker. If the error is a missing-repo error,
       STOP — you skipped step 1, go back and parse the repo from the
       dispatch message, then retry.
+
+      ## Step 2b — Structural review (clawpatch)
+
+      For PRs with non-trivial code changes, also call:
+
+      - `clawpatch_review(repo='owner/name', since='<pr-base>')`
+
+      Use the PR's base branch (typically `main` or `dev`) as the
+      `since` arg so clawpatch only reviews features touched by this PR.
+      Each finding has severity, category, file:line evidence, and a
+      recommendation. Fold the highest-impact findings into your
+      Observations section with the same SEVERITY tags you'd assign
+      yourself, and cite clawpatch as the source ("CLAWPATCH/HIGH: ...").
+
+      If clawpatch returns "repo not mounted" — the v1 only handles
+      repos baked into the workstacean container (protoWorkstacean,
+      protoCLI, mythxengine). Note it as a LOW observation and continue
+      with the regular diff-based review.
+
+      If clawpatch errors for any other reason (timeout, gateway 5xx),
+      note it as a LOW observation and proceed — clawpatch is a
+      finding-source, not a gate.
 
       ## Step 3 — Apply the rubric
 


### PR DESCRIPTION
## Summary

Wires the in-container clawpatch CLI (baked in by #547) into Quinn's `pr_review` skill. Quinn now calls `clawpatch_review` during PR review to get structural findings (severity / category / file:line evidence / recommendation) from the same diff she's already auditing, and folds the highest-impact ones into her Observations section.

This is the third leg of the goal: _"Quinn folds clawpatch structural findings into her verdict on protoWorkstacean PRs."_

## Three pieces

1. **`POST /api/clawpatch/review`** — wraps `clawpatch ci --provider gateway --json` behind an HTTP endpoint so the LLM tool stays a thin caller and shell exec is bounded to one place. Repo path resolution via a built-in map (the repos already mounted into the container: `protoWorkstacean`, `protoCLI`, `mythxengine`) plus a `CLAWPATCH_REPO_PATH_MAP` env override so adding more doesn't need a redeploy. v1 explicitly errors on unmounted repos — on-demand clones are phase 2.

2. **`clawpatch_review` tool** — added to `DeepAgentExecutor`. Args: `repo` (required), `since` (PR base for diff-scoped review), `limit`, `model`. Description teaches the model when to invoke and how to fold findings into the verdict.

3. **Quinn's `pr_review`** — `clawpatch_review` added to her scoped toolbelt. New "Step 2b — Structural review (clawpatch)" section in the prompt tells her to call it on non-trivial PRs, scope via `since=<pr-base>`, and attribute findings as `CLAWPATCH/<SEVERITY>: ...`. Errors degrade to a LOW observation rather than blocking — clawpatch is a finding-source, not a gate.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 671 pass, 0 fail
- [ ] After deploy (depends on #547 baking the binary in): open a test PR in protoWorkstacean, observe Quinn's verdict include a `CLAWPATCH/...` observation
- [ ] If gateway timeout or other clawpatch error: confirm Quinn degrades gracefully (LOW observation, verdict still produced)

## Out of scope

- On-demand PR clones for arbitrary repos (phase 2)
- protoCLI/acpx provider wiring (task #25)
- Auto-fix loop (task #20 follow-on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structural code review capability enabling automated analysis of pull requests for code quality assessment.
  * New code review tool integrates with PR review workflows, providing agents with enhanced evaluation capabilities for comprehensive pull request assessment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->