### PR TITLE
feat(docker): bake @protolabsai/proto + acpx into release image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,16 @@ ENV PATH="/opt/clawpatch/bin:${PATH}"
 # allowlisted. protoPatch needs to compile TS via its prepack, so allow it.
 RUN pnpm add -g --allow-build=@protolabsai/protopatch github:protoLabsAI/protoPatch && \
     ls /opt/clawpatch/bin
+# protoCLI (@protolabsai/proto) speaks the Agent Client Protocol via
+# `proto --acp`, and acpx is the generic ACP-agent driver. Together they give
+# us a path to drive clawpatch's `acpx` provider with protoCLI as the
+# underlying agent — phase 2 of the Quinn-clawpatch integration, when we
+# want interactive tool-use review on top of the gateway provider's
+# stateless LLM path. Installed in the same stage so they share the
+# self-contained /opt/clawpatch install root.
+RUN pnpm add -g @protolabsai/proto@latest acpx@latest && \
+    proto --version && \
+    acpx --version
 
 # build the dashboard Astro static site
 FROM oven/bun:1 AS dashboard-build


### PR DESCRIPTION
## Summary

Adds `@protolabsai/proto` (protoCLI) and `acpx` to the release image alongside the existing `clawpatch` install. Both come from npm — no git deps, no `--allow-build`, no compose changes. ~10-second additional build time.

protoCLI speaks the Agent Client Protocol (`proto --acp`); acpx is the generic ACP-agent driver. Together they're the runtime half of phase 2 — driving clawpatch's `acpx` provider with protoCLI as the underlying agent. That gives Quinn an interactive tool-use review mode (read files, run typecheck, etc.) complementary to the gateway provider's stateless LLM mode.

This PR is **runtime-only**. Wiring clawpatch to route `acpx` through `proto --acp` needs a small patch on the protoPatch side — separate PR once we've smoke-tested the v1 (gateway) path and decided protoCLI-backed acpx is worth shipping. Doing the runtime install first means that follow-up is a one-line provider tweak.

## Verified

```
$ docker run --rm <release-image> sh -c 'clawpatch --version && protopatch --version && proto --version && acpx --version'
0.5.0     # clawpatch
0.5.0     # protopatch
0.41.0    # @protolabsai/proto
0.10.0    # acpx
```

## Out of scope (separate PRs when needed)

- Patching clawpatch's `acpx` provider to support `proto` as the underlying agent (currently routes by hard-coded subcommand name)
- Deciding per-skill which provider Quinn uses (`gateway` for fast/cheap, `acpx` for deep)
- protoCLI auth bootstrap inside the container (acpx will need it for any agent that requires login)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker build environment with additional tooling to support the build process.
  * Added verification checks to ensure all build dependencies are properly installed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->