### PR TITLE
Promote dev → main: clawpatch integration + Quinn skill scoping + Linear Agent SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,16 @@ ENV PATH="/opt/clawpatch/bin:${PATH}"
 # allowlisted. protoPatch needs to compile TS via its prepack, so allow it.
 RUN pnpm add -g --allow-build=@protolabsai/protopatch github:protoLabsAI/protoPatch && \
     ls /opt/clawpatch/bin
+# protoCLI (@protolabsai/proto) speaks the Agent Client Protocol via
+# `proto --acp`, and acpx is the generic ACP-agent driver. Together they give
+# us a path to drive clawpatch's `acpx` provider with protoCLI as the
+# underlying agent — phase 2 of the Quinn-clawpatch integration, when we
+# want interactive tool-use review on top of the gateway provider's
+# stateless LLM path. Installed in the same stage so they share the
+# self-contained /opt/clawpatch install root.
+RUN pnpm add -g @protolabsai/proto@latest acpx@latest && \
+    proto --version && \
+    acpx --version
 
 # build the dashboard Astro static site
 FROM oven/bun:1 AS dashboard-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,34 @@ RUN curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${
     curl -fsSL "https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-amd64" -o /usr/local/lib/docker/cli-plugins/docker-buildx && \
     chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
 
+# clawpatch (protoLabs fork) — installed in a dedicated Node stage so it
+# stays isolated from the bun-based release image. The fork ships a `gateway`
+# provider that POSTs the assembled prompt to our LiteLLM endpoint
+# (http://gateway:4000/v1 inside the docker-ai network); Quinn uses it via
+# the `clawpatch_review` tool during pr_review for structural code findings.
+# pnpm is pinned to the version protoPatch uses so the global install runs
+# its prepack build with the same toolchain.
+FROM node:22-bookworm-slim AS clawpatch-build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+RUN corepack enable && corepack prepare pnpm@11.1.2 --activate
+# Pin every pnpm path into /opt/clawpatch so the entire install (bin, global
+# manifests, AND the content-addressable store) is self-contained and can be
+# COPY'd to the release stage in one shot. Without store-dir pointing here,
+# packages land in /root/.local/share/pnpm/store and the release-stage
+# binaries break with MODULE_NOT_FOUND.
+RUN pnpm config set global-bin-dir /opt/clawpatch/bin && \
+    pnpm config set global-dir /opt/clawpatch/pnpm && \
+    pnpm config set store-dir /opt/clawpatch/store
+# pnpm refuses to install globally unless its bin dir is in PATH at the
+# time of install. Add it ahead of the global add.
+ENV PATH="/opt/clawpatch/bin:${PATH}"
+# pnpm 11 refuses to run prepack on git deps unless the package is
+# allowlisted. protoPatch needs to compile TS via its prepack, so allow it.
+RUN pnpm add -g --allow-build=@protolabsai/protopatch github:protoLabsAI/protoPatch && \
+    ls /opt/clawpatch/bin
+
 # build the dashboard Astro static site
 FROM oven/bun:1 AS dashboard-build
 WORKDIR /dashboard
@@ -47,7 +75,14 @@ FROM base AS release
 COPY --from=install /temp/prod/node_modules node_modules
 COPY . .
 COPY --from=dashboard-build /dashboard/dist dashboard/dist
+# clawpatch + a minimal Node runtime to run it (the JS CLI is shebanged
+# `#!/usr/bin/env node`). PATH puts /opt/clawpatch/bin first so the
+# `clawpatch` / `protopatch` binaries resolve.
+COPY --from=node:22-bookworm-slim /usr/local/bin/node /usr/local/bin/node
+COPY --from=clawpatch-build /opt/clawpatch /opt/clawpatch
+ENV PATH="/opt/clawpatch/bin:${PATH}"
 ENV NODE_ENV=production
 RUN bun test
+RUN clawpatch --version
 RUN mkdir -p data
 CMD ["bun", "run", "src/index.ts"]

--- a/lib/plugins/__tests__/linear.test.ts
+++ b/lib/plugins/__tests__/linear.test.ts
@@ -55,8 +55,18 @@ function collectBus(bus: InMemoryEventBus, pattern: string): BusMessage[] {
 }
 
 // Wrap a payload as a Linear webhook envelope (post-Zod-parse shape).
-function envelope(action: "create" | "update" | "remove", type: string, data: Record<string, unknown>) {
+function envelope(action: string, type: string, data: Record<string, unknown>) {
   return { action, type, data };
+}
+
+// AppUserNotification envelope — body in `notification`, action is camelCase verb.
+function notificationEnvelope(action: string, notification: Record<string, unknown>) {
+  return { action, type: "AppUserNotification", notification };
+}
+
+// AgentSessionEvent envelope — body in `agentSession`, optional `agentActivity`.
+function agentSessionEnvelope(action: string, agentSession: Record<string, unknown>, agentActivity?: Record<string, unknown>) {
+  return { action, type: "AgentSessionEvent", agentSession, agentActivity };
 }
 
 describe("LinearPlugin — inbound webhooks", () => {
@@ -171,6 +181,100 @@ describe("LinearPlugin — inbound webhooks", () => {
   test("unknown envelope type is dropped (no publish, logged as a warning)", async () => {
     const collected = collectBus(bus, "message.inbound.linear.#");
     await priv(plugin)._handleWebhook(envelope("create", "Reaction", { id: "r-1" }), bus);
+    expect(collected).toHaveLength(0);
+  });
+
+  test("past-tense action ('created') normalizes to the same topic suffix as 'create'", async () => {
+    const collected = collectBus(bus, "message.inbound.linear.issue.#");
+    await priv(plugin)._handleWebhook(envelope("created", "Issue", {
+      id: "issue-uuid-past-tense",
+      title: "Past-tense action",
+      team: { id: "team-1", key: "ENG", name: "Engineering" },
+    }), bus);
+    await priv(plugin)._handleWebhook(envelope("updated", "Issue", {
+      id: "issue-uuid-updated",
+      title: "Updated",
+      team: { id: "team-1", key: "ENG", name: "Engineering" },
+    }), bus);
+    await priv(plugin)._handleWebhook(envelope("removed", "Issue", {
+      id: "issue-uuid-removed",
+      title: "Removed",
+    }), bus);
+    expect(collected).toHaveLength(3);
+    expect(collected[0].topic).toBe("message.inbound.linear.issue.created");
+    expect(collected[1].topic).toBe("message.inbound.linear.issue.updated");
+    expect(collected[2].topic).toBe("message.inbound.linear.issue.removed");
+  });
+
+  test("AppUserNotification → publishes message.inbound.linear.agent.{action}", async () => {
+    const collected = collectBus(bus, "message.inbound.linear.agent.#");
+    await priv(plugin)._handleWebhook(notificationEnvelope("issueCommentMention", {
+      id: "notif-1",
+      issueId: "issue-abc",
+      commentId: "comment-xyz",
+      actor: { id: "user-1", name: "Josh" },
+      issue: { id: "issue-abc", identifier: "JOSH-386", title: "Test" },
+      comment: { id: "comment-xyz", body: "@ava take a look" },
+    }), bus);
+
+    expect(collected).toHaveLength(1);
+    const msg = collected[0];
+    expect(msg.topic).toBe("message.inbound.linear.agent.issueCommentMention");
+    expect(msg.correlationId).toBe("linear-issue-abc");
+    const p = msg.payload as Record<string, unknown>;
+    expect(p.action).toBe("issueCommentMention");
+    expect(p.issueId).toBe("issue-abc");
+    expect(p.commentId).toBe("comment-xyz");
+    expect((p.notification as Record<string, unknown>).id).toBe("notif-1");
+  });
+
+  test("AppUserNotification with nested issue/comment objects (no top-level issueId)", async () => {
+    const collected = collectBus(bus, "message.inbound.linear.agent.#");
+    // Some Linear envelopes carry only nested issue.id, not a top-level issueId.
+    await priv(plugin)._handleWebhook(notificationEnvelope("issueMention", {
+      id: "notif-2",
+      issue: { id: "issue-nested", identifier: "ENG-1", title: "Nested" },
+    }), bus);
+    expect(collected).toHaveLength(1);
+    expect(collected[0].correlationId).toBe("linear-issue-nested");
+    expect((collected[0].payload as Record<string, unknown>).issueId).toBe("issue-nested");
+  });
+
+  test("AgentSessionEvent.created → publishes message.inbound.linear.agent_session.created", async () => {
+    const collected = collectBus(bus, "message.inbound.linear.agent_session.#");
+    await priv(plugin)._handleWebhook(agentSessionEnvelope("created", {
+      id: "session-1",
+      issueId: "issue-abc",
+      issue: { id: "issue-abc", title: "Onboarding" },
+    }), bus);
+
+    expect(collected).toHaveLength(1);
+    const msg = collected[0];
+    expect(msg.topic).toBe("message.inbound.linear.agent_session.created");
+    expect(msg.correlationId).toBe("session-1");
+    const p = msg.payload as Record<string, unknown>;
+    expect(p.action).toBe("created");
+    expect(p.sessionId).toBe("session-1");
+    expect(p.issueId).toBe("issue-abc");
+  });
+
+  test("AgentSessionEvent.prompted carries agentActivity through to the payload", async () => {
+    const collected = collectBus(bus, "message.inbound.linear.agent_session.#");
+    await priv(plugin)._handleWebhook(agentSessionEnvelope(
+      "prompted",
+      { id: "session-2", issueId: "issue-zzz" },
+      { type: "userMessage", content: "fix the bug pls" },
+    ), bus);
+    expect(collected).toHaveLength(1);
+    const p = collected[0].payload as Record<string, unknown>;
+    expect((p.agentActivity as Record<string, unknown>).content).toBe("fix the bug pls");
+  });
+
+  test("Issue / Comment / Project webhook missing data field → dropped, no crash", async () => {
+    const collected = collectBus(bus, "message.inbound.linear.#");
+    await priv(plugin)._handleWebhook({ action: "created", type: "Issue" } as unknown, bus);
+    await priv(plugin)._handleWebhook({ action: "created", type: "Comment" } as unknown, bus);
+    await priv(plugin)._handleWebhook({ action: "created", type: "Project" } as unknown, bus);
     expect(collected).toHaveLength(0);
   });
 

--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -199,7 +199,11 @@ function extractContext(event: string, payload: Record<string, unknown>): GitHub
     };
   }
 
-  if (event === "pull_request" && (payload.action === "opened" || payload.action === "synchronize")) {
+  if (event === "pull_request" && (
+    payload.action === "opened" ||
+    payload.action === "synchronize" ||
+    payload.action === "review_requested"
+  )) {
     const pr = payload.pull_request as Record<string, unknown>;
     return {
       owner, repo: repoName,
@@ -500,7 +504,20 @@ export class GitHubPlugin implements Plugin {
     // verdict. Dedup'd via recentDispatches so a fast-updating branch doesn't
     // flood the bus.
     if (event === "pull_request" && (payload.action === "opened" || payload.action === "synchronize")) {
-      this._handleAutoReview(event, payload, ctx, bus);
+      this._handleAutoReview(event, payload, ctx, bus, { skipDedup: false });
+      return;
+    }
+
+    // ── Re-review path: pull_request review_requested for @protoquinn[bot] ────
+    // Native GitHub "Re-request review" button → Quinn re-reviews. Bypasses
+    // dedup because the human is explicitly asking. Other review_requested
+    // events (for human reviewers) are ignored.
+    if (event === "pull_request" && payload.action === "review_requested") {
+      const reviewer = payload.requested_reviewer as Record<string, unknown> | undefined;
+      const login = (reviewer?.login as string | undefined)?.toLowerCase();
+      if (login === "protoquinn" || login === "protoquinn[bot]") {
+        this._handleAutoReview(event, payload, ctx, bus, { skipDedup: true });
+      }
       return;
     }
 
@@ -583,13 +600,16 @@ export class GitHubPlugin implements Plugin {
     payload: Record<string, unknown>,
     ctx: GitHubEventContext,
     bus: EventBus,
+    opts: { skipDedup: boolean } = { skipDedup: false },
   ): void {
     const action = payload.action as string;
     const dedupKey = `pr-review:${ctx.owner}/${ctx.repo}#${ctx.number}`;
-    const lastDispatched = this.recentDispatches.get(dedupKey);
-    if (lastDispatched && Date.now() - lastDispatched < GitHubPlugin.DEDUP_WINDOW_MS) {
-      console.log(`[github] Auto-review: skipping duplicate ${dedupKey} (dispatched ${Date.now() - lastDispatched}ms ago)`);
-      return;
+    if (!opts.skipDedup) {
+      const lastDispatched = this.recentDispatches.get(dedupKey);
+      if (lastDispatched && Date.now() - lastDispatched < GitHubPlugin.DEDUP_WINDOW_MS) {
+        console.log(`[github] Auto-review: skipping duplicate ${dedupKey} (dispatched ${Date.now() - lastDispatched}ms ago)`);
+        return;
+      }
     }
     this.recentDispatches.set(dedupKey, Date.now());
 

--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -493,6 +493,17 @@ export class GitHubPlugin implements Plugin {
       }
     }
 
+    // ── Auto-review path: pull_request opened/synchronize ─────────────────────
+    // Every opened/synchronized PR triggers Quinn's pr_review skill — no
+    // @mention required. PRs are trusted by virtue of being in our repo;
+    // Quinn's pr_inspector + system prompt do the gating on what to actually
+    // verdict. Dedup'd via recentDispatches so a fast-updating branch doesn't
+    // flood the bus.
+    if (event === "pull_request" && (payload.action === "opened" || payload.action === "synchronize")) {
+      this._handleAutoReview(event, payload, ctx, bus);
+      return;
+    }
+
     // ── @mention path (existing, unchanged) ──────────────────────────────────
     if (!ctx.body.toLowerCase().includes(config.mentionHandle.toLowerCase())) return;
 
@@ -566,6 +577,72 @@ export class GitHubPlugin implements Plugin {
   /** Tracks recently-dispatched (owner/repo#number) to suppress duplicate webhook deliveries. */
   private recentDispatches = new Map<string, number>();
   private static readonly DEDUP_WINDOW_MS = 60_000;
+
+  private _handleAutoReview(
+    event: string,
+    payload: Record<string, unknown>,
+    ctx: GitHubEventContext,
+    bus: EventBus,
+  ): void {
+    const action = payload.action as string;
+    const dedupKey = `pr-review:${ctx.owner}/${ctx.repo}#${ctx.number}`;
+    const lastDispatched = this.recentDispatches.get(dedupKey);
+    if (lastDispatched && Date.now() - lastDispatched < GitHubPlugin.DEDUP_WINDOW_MS) {
+      console.log(`[github] Auto-review: skipping duplicate ${dedupKey} (dispatched ${Date.now() - lastDispatched}ms ago)`);
+      return;
+    }
+    this.recentDispatches.set(dedupKey, Date.now());
+
+    const pr = payload.pull_request as Record<string, unknown>;
+    const isDraft = pr?.draft as boolean;
+    if (isDraft) {
+      console.log(`[github] Auto-review: skipping draft PR ${ctx.owner}/${ctx.repo}#${ctx.number}`);
+      return;
+    }
+
+    const correlationId = crypto.randomUUID();
+    pendingComments.set(correlationId, { owner: ctx.owner, repo: ctx.repo, number: ctx.number });
+
+    const content = [
+      `Auto-review — pull_request.${action} on ${ctx.owner}/${ctx.repo}#${ctx.number}`,
+      `Title: ${ctx.title}`,
+      `Author: @${ctx.author}`,
+      `URL: ${ctx.url}`,
+      ``,
+      `Use pr_inspector with repo="${ctx.owner}/${ctx.repo}" and pr_number=${ctx.number} to pull CI status, the diff, and any unresolved review threads. Issue your verdict (PASS / WARN / FAIL) via review_approve / review_comment / review_request_changes.`,
+      ``,
+      ctx.body,
+    ].join("\n");
+
+    const topic = `message.inbound.github.${ctx.owner}.${ctx.repo}.${event}.${ctx.number}`;
+    const replyTopic = `message.outbound.github.${ctx.owner}.${ctx.repo}.${ctx.number}`;
+
+    bus.publish(topic, {
+      id: `${event}-${action}-${ctx.owner}-${ctx.repo}-${ctx.number}-${correlationId.slice(0, 8)}`,
+      correlationId,
+      topic,
+      timestamp: Date.now(),
+      payload: {
+        sender: ctx.author,
+        channel: `${ctx.owner}/${ctx.repo}#${ctx.number}`,
+        content,
+        skillHint: "pr_review",
+        github: {
+          event,
+          action,
+          owner: ctx.owner,
+          repo: ctx.repo,
+          number: ctx.number,
+          title: ctx.title,
+          url: ctx.url,
+        },
+      },
+      source: { interface: "github" as const },
+      reply: { topic: replyTopic },
+    });
+
+    console.log(`[github] Auto-review: ${ctx.owner}/${ctx.repo}#${ctx.number} (${action}) → pr_review`);
+  }
 
   private _handleAutoTriage(
     event: string,

--- a/lib/plugins/linear.ts
+++ b/lib/plugins/linear.ts
@@ -7,6 +7,8 @@
  *     message.inbound.linear.issue.{created|updated|removed}
  *     message.inbound.linear.comment.{created|updated|removed}
  *     message.inbound.linear.project.{created|updated|removed}
+ *     message.inbound.linear.agent.{issueMention|issueCommentMention|...}
+ *     message.inbound.linear.agent_session.{created|prompted}
  *
  *   The HTTP 200 is returned AFTER the bus publish completes, so a publish
  *   failure surfaces as a 5xx that Linear will retry on.
@@ -97,13 +99,24 @@ const LinearProjectDataSchema = z.object({
   url: z.string().optional(),
 });
 
-/** Action verbs Linear emits across all resource types. */
-const LINEAR_ACTIONS = ["create", "update", "remove"] as const;
+// Linear sends three distinct envelope shapes:
+//   1. Standard webhooks (Issue/Comment/Project) — action is create/update/remove
+//      or past-tense created/updated/removed. Body in `data`.
+//   2. AppUserNotification (Agent app @mentions, assignments, etc.) — action is
+//      a camelCase notification verb like issueMention, issueCommentMention,
+//      issueAssignedToYou, issueNewComment. Body in `notification`.
+//   3. AgentSessionEvent (Agent Session API — newer SDK) — action is created
+//      or prompted. Body in `agentSession`.
+// We use a permissive envelope (action as string) and branch on `type` in the
+// handler. Strict per-shape validation happens after the branch.
 
 const LinearWebhookEnvelopeSchema = z.object({
-  action: z.enum(LINEAR_ACTIONS),
-  type: z.string(),
-  data: z.record(z.string(), z.unknown()),
+  action: z.string().min(1),
+  type: z.string().min(1),
+  data: z.record(z.string(), z.unknown()).optional(),
+  notification: z.record(z.string(), z.unknown()).optional(),
+  agentSession: z.record(z.string(), z.unknown()).optional(),
+  agentActivity: z.record(z.string(), z.unknown()).optional(),
   createdAt: z.string().optional(),
   organizationId: z.string().optional(),
   webhookTimestamp: z.number().optional(),
@@ -111,6 +124,16 @@ const LinearWebhookEnvelopeSchema = z.object({
 });
 
 type LinearWebhookEnvelope = z.infer<typeof LinearWebhookEnvelopeSchema>;
+
+/** Normalize action verb tense. `create` / `created` both → `created`, etc. */
+function normalizeAction(action: string): string {
+  switch (action) {
+    case "create": return "created";
+    case "update": return "updated";
+    case "remove": return "removed";
+    default: return action;
+  }
+}
 type LinearIssueData = z.infer<typeof LinearIssueDataSchema>;
 type LinearCommentData = z.infer<typeof LinearCommentDataSchema>;
 type LinearProjectData = z.infer<typeof LinearProjectDataSchema>;
@@ -266,10 +289,13 @@ export class LinearPlugin implements Plugin {
             }
           }
 
-          // Dedup key — prefer webhookId; fall back to (type, data.id, webhookTimestamp).
-          const dataId = typeof payload.data.id === "string" ? payload.data.id : "?";
+          // Dedup key — prefer webhookId; fall back to (type, body.id, webhookTimestamp).
+          // Each envelope shape (standard / AppUserNotification / AgentSessionEvent)
+          // carries its body in a different field; check all three.
+          const body = payload.data ?? payload.notification ?? payload.agentSession;
+          const dataId = typeof body?.id === "string" ? body.id : "?";
           const dedupKey = payload.webhookId
-            ?? `${payload.type}:${dataId}:${payload.webhookTimestamp ?? 0}`;
+            ?? `${payload.type}:${payload.action}:${dataId}:${payload.webhookTimestamp ?? 0}`;
           if (dedup.isDuplicate(dedupKey)) {
             return new Response("Already processed", { status: 200 });
           }
@@ -308,14 +334,13 @@ export class LinearPlugin implements Plugin {
   }
 
   private async _handleWebhook(payload: LinearWebhookEnvelope, bus: EventBus): Promise<void> {
-    const actionMap: Record<typeof LINEAR_ACTIONS[number], string> = {
-      create: "created",
-      update: "updated",
-      remove: "removed",
-    };
-    const action = actionMap[payload.action];
+    const action = normalizeAction(payload.action);
 
     if (payload.type === "Issue") {
+      if (!payload.data) {
+        console.warn(`[linear] Issue webhook missing data field — dropping`);
+        return;
+      }
       const issueParsed = LinearIssueDataSchema.safeParse(payload.data);
       if (!issueParsed.success) {
         console.warn(`[linear] Issue payload failed schema — dropping. ${issueParsed.error.issues.map(i => i.message).join("; ")}`);
@@ -325,6 +350,10 @@ export class LinearPlugin implements Plugin {
       return;
     }
     if (payload.type === "Comment") {
+      if (!payload.data) {
+        console.warn(`[linear] Comment webhook missing data field — dropping`);
+        return;
+      }
       const commentParsed = LinearCommentDataSchema.safeParse(payload.data);
       if (!commentParsed.success) {
         console.warn(`[linear] Comment payload failed schema — dropping. ${commentParsed.error.issues.map(i => i.message).join("; ")}`);
@@ -334,6 +363,10 @@ export class LinearPlugin implements Plugin {
       return;
     }
     if (payload.type === "Project") {
+      if (!payload.data) {
+        console.warn(`[linear] Project webhook missing data field — dropping`);
+        return;
+      }
       const projectParsed = LinearProjectDataSchema.safeParse(payload.data);
       if (!projectParsed.success) {
         console.warn(`[linear] Project payload failed schema — dropping. ${projectParsed.error.issues.map(i => i.message).join("; ")}`);
@@ -342,9 +375,71 @@ export class LinearPlugin implements Plugin {
       this._publishProject(projectParsed.data, action, bus);
       return;
     }
+    if (payload.type === "AppUserNotification") {
+      // Agent app events: @mentions, assignments, comments on assigned issues, etc.
+      // Body is in `notification`. Pass the raw object through — downstream
+      // routing decides what to do with each notification kind.
+      this._publishAgentNotification(payload.action, payload.notification ?? {}, bus);
+      return;
+    }
+    if (payload.type === "AgentSessionEvent") {
+      // Linear's newer Agent Session API. Body is in `agentSession` plus
+      // optionally `agentActivity` (for prompted events).
+      this._publishAgentSession(payload.action, payload.agentSession ?? {}, payload.agentActivity, bus);
+      return;
+    }
     // Unknown envelope type — log loudly + drop. Linear adds new resource
     // types over time; fail visibly so we know to extend the plugin.
-    console.warn(`[linear] Unhandled webhook type "${payload.type}" — dropping (extend LinearPlugin to support)`);
+    console.warn(`[linear] Unhandled webhook type "${payload.type}" action="${payload.action}" — dropping (extend LinearPlugin to support)`);
+  }
+
+  private _publishAgentNotification(action: string, notification: Record<string, unknown>, bus: EventBus): void {
+    const topic = `message.inbound.linear.agent.${action}`;
+    const issueId = (notification.issueId as string | undefined)
+      ?? ((notification.issue as { id?: string } | undefined)?.id);
+    const commentId = (notification.commentId as string | undefined)
+      ?? ((notification.comment as { id?: string } | undefined)?.id);
+    const correlationId = issueId ? `linear-${issueId}` : crypto.randomUUID();
+    bus.publish(topic, {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic,
+      timestamp: Date.now(),
+      payload: {
+        action,
+        notification,
+        issueId,
+        commentId,
+      },
+    });
+    console.log(`[linear] agent.${action}${issueId ? ` on issue ${issueId}` : ""}`);
+  }
+
+  private _publishAgentSession(
+    action: string,
+    agentSession: Record<string, unknown>,
+    agentActivity: Record<string, unknown> | undefined,
+    bus: EventBus,
+  ): void {
+    const topic = `message.inbound.linear.agent_session.${action}`;
+    const sessionId = agentSession.id as string | undefined;
+    const issueId = (agentSession.issueId as string | undefined)
+      ?? ((agentSession.issue as { id?: string } | undefined)?.id);
+    const correlationId = sessionId ?? (issueId ? `linear-${issueId}` : crypto.randomUUID());
+    bus.publish(topic, {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic,
+      timestamp: Date.now(),
+      payload: {
+        action,
+        sessionId,
+        issueId,
+        agentSession,
+        agentActivity,
+      },
+    });
+    console.log(`[linear] agent_session.${action}${sessionId ? ` session=${sessionId}` : ""}`);
   }
 
   private _publishIssue(issue: LinearIssueData, action: string, bus: EventBus): void {

--- a/src/agent-runtime/types.ts
+++ b/src/agent-runtime/types.ts
@@ -29,6 +29,21 @@ export interface AgentSkillDefinition {
   keywords?: string[];
   /** Override the system prompt for this specific skill. */
   systemPromptOverride?: string;
+  /**
+   * Restrict tools available when this skill executes. If set, the runtime
+   * intersects with the agent's `tools[]` — a skill cannot add tools the
+   * agent doesn't already declare. If unset, all of agent.tools are
+   * available. Use this to prevent a focused skill (e.g. pr_review) from
+   * fanning out into delegation / web search territory and exhausting
+   * the recursion limit.
+   */
+  tools?: string[];
+  /**
+   * Override the agent's `maxTurns` for this skill. Recursion limit in
+   * LangGraph is `maxTurns * 2 + 1` — bump for skills that need many
+   * tool calls (e.g. board sweeps), keep tight for narrow ones.
+   */
+  maxTurns?: number;
 }
 
 /**

--- a/src/api/clawpatch.ts
+++ b/src/api/clawpatch.ts
@@ -1,0 +1,176 @@
+/**
+ * POST /api/clawpatch/review — structural code review via clawpatch.
+ *
+ * Wraps the `clawpatch ci --provider gateway --json` invocation behind an
+ * HTTP endpoint so the LLM tool wrapper stays a thin caller and shell exec
+ * is bounded to this route.
+ *
+ * Repo resolution
+ * ---------------
+ * The tool accepts `repo` in owner/name format. We map it to a local
+ * filesystem path via `CLAWPATCH_REPO_PATH_MAP` (JSON env override) or a
+ * built-in default that knows about repos mounted into the workstacean
+ * container today. v1 only supports already-mounted repos; on-demand PR
+ * checkouts are phase 2.
+ *
+ * Env
+ * ---
+ *   CLAWPATCH_REPO_PATH_MAP    JSON string mapping owner/name → absolute
+ *                              path inside the container. Overrides built-in.
+ *   CLAWPATCH_GATEWAY_MODEL    Forwarded to clawpatch (default protolabs/smart)
+ *   OPENAI_API_KEY / OPENAI_BASE_URL  Already set in the container env;
+ *                              clawpatch's gateway provider picks them up.
+ */
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import type { Route, ApiContext } from "./types.ts";
+
+interface ReviewRequest {
+  repo: string;
+  since?: string;
+  limit?: number;
+  /** Override the model for this invocation. Defaults to the gateway provider's default. */
+  model?: string;
+}
+
+const BUILT_IN_REPO_PATHS: Record<string, string> = {
+  // Repos mounted read-only into the workstacean container today (see
+  // homelab-iac/stacks/ai/docker-compose.yml workstacean.volumes).
+  "protoLabsAI/protoWorkstacean": "/home/josh/dev/protoWorkstacean",
+  "protoLabsAI/protoCLI": "/home/josh/dev/labs/protoCLI",
+  "protoLabsAI/mythxengine": "/home/josh/dev/labs/mythxengine",
+};
+
+function resolveRepoPath(repo: string): string | null {
+  let overrides: Record<string, string> = {};
+  const raw = process.env["CLAWPATCH_REPO_PATH_MAP"];
+  if (raw) {
+    try {
+      overrides = JSON.parse(raw) as Record<string, string>;
+    } catch {
+      // Fall through with empty overrides — bad JSON shouldn't break the route.
+    }
+  }
+  const path = overrides[repo] ?? BUILT_IN_REPO_PATHS[repo];
+  if (!path) return null;
+  if (!existsSync(path)) return null;
+  return path;
+}
+
+interface ClawpatchExecResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  timedOut: boolean;
+}
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+
+function runClawpatch(args: string[], cwd: string, timeoutMs: number): Promise<ClawpatchExecResult> {
+  return new Promise((resolve) => {
+    const child = spawn("clawpatch", args, {
+      cwd,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
+    child.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString("utf-8"); });
+    child.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString("utf-8"); });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ stdout, stderr, exitCode: code ?? -1, timedOut });
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      resolve({ stdout, stderr: stderr + String(err), exitCode: -1, timedOut });
+    });
+  });
+}
+
+interface CiJsonOutput {
+  run?: string;
+  reviewed?: number;
+  findings?: number;
+  jobs?: number;
+  errors?: Array<{ feature?: string; message?: string; layer?: string }>;
+  report?: string;
+  items?: unknown[];
+}
+
+export function createRoutes(_ctx: ApiContext): Route[] {
+  return [
+    {
+      method: "POST",
+      path: "/api/clawpatch/review",
+      handler: async (req) => {
+        let payload: ReviewRequest;
+        try {
+          payload = (await req.json()) as ReviewRequest;
+        } catch {
+          return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 });
+        }
+        const { repo, since, limit, model } = payload;
+        if (!repo) {
+          return Response.json({ success: false, error: "repo is required" }, { status: 400 });
+        }
+        const repoPath = resolveRepoPath(repo);
+        if (!repoPath) {
+          return Response.json(
+            {
+              success: false,
+              error: `repo '${repo}' is not mounted in this container — only repos in CLAWPATCH_REPO_PATH_MAP / the built-in mounts (protoWorkstacean, protoCLI, mythxengine) work today. On-demand PR checkouts are not implemented.`,
+            },
+            { status: 400 },
+          );
+        }
+
+        const args = ["ci", "--provider", "gateway", "--json"];
+        if (since) args.push("--since", since);
+        if (typeof limit === "number" && limit > 0) args.push("--limit", String(limit));
+        if (model) args.push("--model", model);
+
+        const result = await runClawpatch(args, repoPath, DEFAULT_TIMEOUT_MS);
+        if (result.timedOut) {
+          return Response.json(
+            { success: false, error: `clawpatch timed out after ${DEFAULT_TIMEOUT_MS}ms` },
+            { status: 504 },
+          );
+        }
+        if (result.exitCode !== 0) {
+          return Response.json(
+            {
+              success: false,
+              error: `clawpatch exited ${result.exitCode}: ${result.stderr.slice(0, 1000) || result.stdout.slice(0, 1000)}`,
+            },
+            { status: 500 },
+          );
+        }
+
+        // `clawpatch ci --json` writes a JSON object to stdout. The schema is
+        // documented in protoPatch/src/cli.ts; we treat it loosely here because
+        // schema drift would otherwise block working reviews.
+        let parsed: CiJsonOutput;
+        try {
+          parsed = JSON.parse(result.stdout) as CiJsonOutput;
+        } catch (err) {
+          return Response.json(
+            {
+              success: false,
+              error: `clawpatch returned non-JSON on stdout: ${String(err).slice(0, 300)}; preview=${result.stdout.slice(0, 300)}`,
+            },
+            { status: 500 },
+          );
+        }
+
+        return Response.json({ success: true, data: { repo, repoPath, ...parsed } });
+      },
+    },
+  ];
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -25,6 +25,7 @@ import { createRoutes as googleRoutes } from "./google.ts";
 import { createRoutes as linearRoutes } from "./linear.ts";
 import { createRoutes as busTopologyRoutes } from "./bus-topology.ts";
 import { createRoutes as prInspectorRoutes } from "./pr-inspector.ts";
+import { createRoutes as clawpatchRoutes } from "./clawpatch.ts";
 
 export { matchPath } from "./types.ts";
 export type { Route, ApiContext } from "./types.ts";
@@ -49,5 +50,6 @@ export function createAllRoutes(ctx: ApiContext): Route[] {
     ...linearRoutes(ctx),
     ...busTopologyRoutes(ctx),
     ...prInspectorRoutes(ctx),
+    ...clawpatchRoutes(ctx),
   ];
 }

--- a/src/executor/__tests__/deep-agent-extract-text.test.ts
+++ b/src/executor/__tests__/deep-agent-extract-text.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { extractAiText } from "../executors/deep-agent-executor.ts";
+
+describe("extractAiText", () => {
+  test("returns trimmed string content as-is", () => {
+    expect(extractAiText("  hello world  ")).toBe("hello world");
+  });
+
+  test("returns empty string for null, undefined, number, boolean, plain object", () => {
+    expect(extractAiText(null)).toBe("");
+    expect(extractAiText(undefined)).toBe("");
+    expect(extractAiText(42)).toBe("");
+    expect(extractAiText(true)).toBe("");
+    expect(extractAiText({})).toBe("");
+  });
+
+  test("extracts text from a single text-type block", () => {
+    expect(extractAiText([{ type: "text", text: "PR looks good." }])).toBe("PR looks good.");
+  });
+
+  test("skips thinking blocks and returns only text blocks (reasoning-model shape)", () => {
+    const content = [
+      { type: "thinking", thinking: "Let me check the CI..." },
+      { type: "text", text: "VERDICT: PASS — CI is green." },
+    ];
+    expect(extractAiText(content)).toBe("VERDICT: PASS — CI is green.");
+  });
+
+  test("concatenates multiple text blocks in order", () => {
+    const content = [
+      { type: "text", text: "Part 1. " },
+      { type: "thinking", thinking: "..." },
+      { type: "text", text: "Part 2." },
+    ];
+    expect(extractAiText(content)).toBe("Part 1. Part 2.");
+  });
+
+  test("ignores unknown block types", () => {
+    const content = [
+      { type: "image", url: "..." },
+      { type: "text", text: "only this" },
+      { type: "tool_use", id: "abc", name: "x" },
+    ];
+    expect(extractAiText(content)).toBe("only this");
+  });
+
+  test("returns empty string when no text blocks present (all thinking / tool calls)", () => {
+    const content = [
+      { type: "thinking", thinking: "..." },
+      { type: "tool_use", id: "abc", name: "pr_inspector" },
+    ];
+    expect(extractAiText(content)).toBe("");
+  });
+
+  test("accepts string entries inside an array", () => {
+    expect(extractAiText(["hello ", "world"])).toBe("hello world");
+  });
+});

--- a/src/executor/__tests__/deep-agent-skill-scope.test.ts
+++ b/src/executor/__tests__/deep-agent-skill-scope.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { effectiveToolsFor, effectiveMaxTurnsFor } from "../executors/deep-agent-executor.ts";
+
+describe("effectiveToolsFor", () => {
+  const agentTools = ["pr_inspector", "create_github_issue", "chat_with_agent", "searxng_search", "react"];
+
+  test("returns agent tools unchanged when skill omits tools", () => {
+    expect(effectiveToolsFor(undefined, agentTools)).toEqual(agentTools);
+  });
+
+  test("intersects with agent tools when skill declares its own list", () => {
+    expect(effectiveToolsFor(["pr_inspector", "react"], agentTools)).toEqual(["pr_inspector", "react"]);
+  });
+
+  test("skill cannot grant access to a tool the agent doesn't have", () => {
+    expect(effectiveToolsFor(["pr_inspector", "phantom_tool"], agentTools)).toEqual(["pr_inspector"]);
+  });
+
+  test("empty skill list yields empty effective list", () => {
+    expect(effectiveToolsFor([], agentTools)).toEqual([]);
+  });
+
+  test("preserves skill-declared ordering (independent of agent ordering)", () => {
+    expect(effectiveToolsFor(["react", "pr_inspector"], agentTools)).toEqual(["react", "pr_inspector"]);
+  });
+
+  test("agent with no tools always yields empty regardless of skill", () => {
+    expect(effectiveToolsFor(["pr_inspector"], [])).toEqual([]);
+    expect(effectiveToolsFor(undefined, [])).toEqual([]);
+  });
+});
+
+describe("effectiveMaxTurnsFor", () => {
+  test("skill override wins when set", () => {
+    expect(effectiveMaxTurnsFor(18, 12)).toBe(18);
+  });
+
+  test("agent maxTurns is the fallback when skill omits", () => {
+    expect(effectiveMaxTurnsFor(undefined, 12)).toBe(12);
+  });
+
+  test("skill override of 0 is honored (not treated as falsy)", () => {
+    expect(effectiveMaxTurnsFor(0, 12)).toBe(0);
+  });
+});

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -18,6 +18,31 @@ import type { IExecutor, SkillRequest, SkillResult } from "../types.ts";
 
 const LANGFUSE_ENABLED = !!(process.env.LANGFUSE_PUBLIC_KEY && process.env.LANGFUSE_SECRET_KEY);
 
+/**
+ * Extract the assistant's text output from a LangChain AIMessage's `content`.
+ * Reasoning-style models (e.g. protolabs/reasoning, o3, claude with extended
+ * thinking) emit `content` as an array of typed blocks rather than a string:
+ *   [{type: "thinking", thinking: "..."}, {type: "text", text: "..."}]
+ * The text we want is the concatenation of `text`-typed blocks. Returns the
+ * trimmed result, or "" if no usable text was found.
+ */
+export function extractAiText(content: unknown): string {
+  if (typeof content === "string") return content.trim();
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const block of content) {
+    if (typeof block === "string") {
+      parts.push(block);
+      continue;
+    }
+    if (block && typeof block === "object") {
+      const b = block as Record<string, unknown>;
+      if (b.type === "text" && typeof b.text === "string") parts.push(b.text);
+    }
+  }
+  return parts.join("").trim();
+}
+
 export interface DeepAgentConfig {
   gatewayUrl?: string;
   gatewayApiKey?: string;
@@ -598,13 +623,12 @@ export class DeepAgentExecutor implements IExecutor {
       let text = "";
       for (let i = messages.length - 1; i >= 0; i--) {
         const msg = messages[i];
-        const content = msg.content;
-        if (typeof content === "string" && content.trim()) {
-          const type = msg._getType?.() ?? msg.constructor?.name ?? "";
-          if (type === "ai" || type === "AIMessage") {
-            text = content.trim();
-            break;
-          }
+        const type = msg._getType?.() ?? msg.constructor?.name ?? "";
+        if (type !== "ai" && type !== "AIMessage") continue;
+        const extracted = extractAiText(msg.content);
+        if (extracted) {
+          text = extracted;
+          break;
         }
       }
 

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -207,6 +207,20 @@ function createLangChainTools(toolNames: string[], http: HttpClient, correlation
         schema: z.object({ title: z.string(), severity: z.enum(["critical", "high", "medium", "low"]), description: z.string().optional() }),
       },
     ),
+    clawpatch_review: tool(
+      async (input) => JSON.stringify(await http.post("/api/clawpatch/review", input)),
+      {
+        name: "clawpatch_review",
+        description:
+          "Run structural code review via clawpatch (protoLabs fork). Maps the repo into semantic feature slices, reviews each via the gateway LLM provider, and returns structured findings (correctness bugs, security issues, race/concurrency bugs, data-loss, resource leaks, error-handling gaps, API contract mismatches, missing tests, build hazards, maintainability risks). Use this DURING pr_review to get a structural read on the changed surface before forming a verdict — fold findings into the QA Audit body's Observations section with severity + file:line cites. Today v1 only works for repos already mounted in the container (protoWorkstacean, protoCLI, mythxengine); other repos return a clear error. The `since` arg scopes the review to features touched since that git ref (typically the PR base) — pass it whenever you have the PR base SHA or branch.",
+        schema: z.object({
+          repo: z.string().describe("Repository in owner/name format (e.g. protoLabsAI/protoWorkstacean)."),
+          since: z.string().optional().describe("Git ref (branch or SHA) to diff against. Limits the review to features touched since that ref. Use the PR base (typically 'main' or 'dev')."),
+          limit: z.number().int().optional().describe("Maximum number of features to review. Useful for spot-checks on large repos."),
+          model: z.string().optional().describe("Gateway model override (e.g. protolabs/fast for cheap, protolabs/reasoning for deeper). Default protolabs/smart."),
+        }),
+      },
+    ),
     pr_inspector: tool(
       async (input) => JSON.stringify(await http.post("/api/pr/inspect", input)),
       {

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -26,6 +26,23 @@ const LANGFUSE_ENABLED = !!(process.env.LANGFUSE_PUBLIC_KEY && process.env.LANGF
  * The text we want is the concatenation of `text`-typed blocks. Returns the
  * trimmed result, or "" if no usable text was found.
  */
+/**
+ * Resolve which tools a skill invocation gets. When a skill declares its own
+ * `tools` list we intersect with the agent's declared tools — a skill cannot
+ * grant access to tools the agent never advertised. When the skill omits
+ * tools we fall back to the agent's full list. Pure function, easy to unit-
+ * test; the runtime branch in `execute()` is a thin wrapper around this.
+ */
+export function effectiveToolsFor(skillTools: string[] | undefined, agentTools: string[]): string[] {
+  if (!skillTools) return agentTools;
+  return skillTools.filter(t => agentTools.includes(t));
+}
+
+/** Skill's maxTurns wins when set; else inherit from the agent. */
+export function effectiveMaxTurnsFor(skillMaxTurns: number | undefined, agentMaxTurns: number): number {
+  return skillMaxTurns ?? agentMaxTurns;
+}
+
 export function extractAiText(content: unknown): string {
   if (typeof content === "string") return content.trim();
   if (!Array.isArray(content)) return "";
@@ -574,7 +591,21 @@ export class DeepAgentExecutor implements IExecutor {
 
   async execute(req: SkillRequest): Promise<SkillResult> {
     const prompt = req.content ?? req.prompt ?? this._buildPrompt(req);
-    const tools = createLangChainTools(this.agentDef.tools, this.http, req.correlationId, this.agentDef.name);
+
+    const skillDef = req.skill
+      ? this.agentDef.skills.find(s => s.name === req.skill)
+      : undefined;
+
+    // Skill-level tools override: intersect with agent.tools (a skill can't
+    // grant access to tools the agent doesn't declare). When skill.tools is
+    // unset, all of agent.tools are available. This is the structural way
+    // to keep narrow skills (pr_review) from fanning out into delegation /
+    // web search and exhausting the recursion limit.
+    const agentTools = this.agentDef.tools;
+    const effectiveTools = effectiveToolsFor(skillDef?.tools, agentTools);
+    const tools = createLangChainTools(effectiveTools, this.http, req.correlationId, this.agentDef.name);
+
+    const effectiveMaxTurns = effectiveMaxTurnsFor(skillDef?.maxTurns, this.agentDef.maxTurns);
 
     const callbacks = LANGFUSE_ENABLED
       ? [new LangfuseCallbackHandler({
@@ -588,9 +619,6 @@ export class DeepAgentExecutor implements IExecutor {
       // Resolve skill-level systemPromptOverride if this skill defines one.
       // Skills like diagnose_pr_stuck have narrow, structured output requirements
       // that replace the agent's general-purpose prompt.
-      const skillDef = req.skill
-        ? this.agentDef.skills.find(s => s.name === req.skill)
-        : undefined;
       const basePrompt = skillDef?.systemPromptOverride ?? this.agentDef.systemPrompt;
 
       const agent = createReactAgent({
@@ -599,11 +627,11 @@ export class DeepAgentExecutor implements IExecutor {
         messageModifier: new SystemMessage(basePrompt),
       });
 
-      console.log(`[deep-agent:${this.agentDef.name}] invoke with ${tools.length} tools, prompt length=${prompt.length}, langfuse=${LANGFUSE_ENABLED}`);
+      console.log(`[deep-agent:${this.agentDef.name}] invoke skill="${req.skill ?? "?"}" tools=${tools.length}/${agentTools.length} maxTurns=${effectiveMaxTurns} promptLen=${prompt.length} langfuse=${LANGFUSE_ENABLED}`);
 
       const result = await agent.invoke(
         { messages: [{ role: "user", content: prompt }] },
-        { recursionLimit: this.agentDef.maxTurns * 2 + 1, callbacks },
+        { recursionLimit: effectiveMaxTurns * 2 + 1, callbacks },
       );
 
       const messages = result.messages ?? [];

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -19,7 +19,7 @@
 name: ava
 role: general
 
-model: claude-opus-4-6
+model: protolabs/reasoning
 
 systemPrompt: |
   You are Ava, the chief-of-staff protoAgent for the protoLabs fleet.

--- a/workspace/agents/protobot.yaml
+++ b/workspace/agents/protobot.yaml
@@ -12,7 +12,7 @@
 name: protobot
 role: devops
 
-model: claude-sonnet-4-6
+model: protolabs/reasoning
 
 systemPrompt: |
   You are protoBot, the Discord operations agent for protoLabs.

--- a/workspace/agents/quinn.yaml
+++ b/workspace/agents/quinn.yaml
@@ -19,7 +19,7 @@
 name: quinn
 role: qa
 
-model: claude-sonnet-4-6
+model: protolabs/reasoning
 
 systemPrompt: |
   You are Quinn, QA Engineer and Release Manager for protoLabs.

--- a/workspace/agents/quinn.yaml
+++ b/workspace/agents/quinn.yaml
@@ -137,6 +137,10 @@ systemPrompt: |
 tools:
   # GitHub PR review surface (the core)
   - pr_inspector
+  # Structural code review via clawpatch (protoLabs fork). Returns
+  # finding-shaped output (severity, category, file:line evidence,
+  # recommendation). Quinn folds findings into her pr_review verdict.
+  - clawpatch_review
   # Read-only project context
   - get_projects
   - get_ci_health
@@ -168,13 +172,15 @@ skills:
       APPROVED / COMMENTED / CHANGES_REQUESTED review via the GitHub
       Review API. Feeds the autonomous merge loop in pr-remediator.
     keywords: [pr_review, review, pull request, audit, formal review]
-    # Scoped toolbelt: pr_review is exhaustively served by pr_inspector
-    # alone (7 actions cover list / CI / diff / threads / submit). react +
-    # send_update for Discord acknowledgment. Anything else (chat_with_agent,
-    # searxng_search, board inspection) lures the loop into thrashing and
-    # has historically hit the recursion limit on simple PRs.
+    # Scoped toolbelt: pr_inspector covers all GitHub-side review IO;
+    # clawpatch_review adds a structural code-review pass via the gateway
+    # provider when the PR is non-trivial; react + send_update for
+    # Discord acknowledgment. No delegation tools (chat_with_agent /
+    # searxng_search etc.) — those historically lured the loop into
+    # thrashing and hit the recursion limit on simple PRs.
     tools:
       - pr_inspector
+      - clawpatch_review
       - react
       - send_update
     maxTurns: 18
@@ -220,6 +226,28 @@ skills:
       observation, not a blocker. If the error is a missing-repo error,
       STOP — you skipped step 1, go back and parse the repo from the
       dispatch message, then retry.
+
+      ## Step 2b — Structural review (clawpatch)
+
+      For PRs with non-trivial code changes, also call:
+
+      - `clawpatch_review(repo='owner/name', since='<pr-base>')`
+
+      Use the PR's base branch (typically `main` or `dev`) as the
+      `since` arg so clawpatch only reviews features touched by this PR.
+      Each finding has severity, category, file:line evidence, and a
+      recommendation. Fold the highest-impact findings into your
+      Observations section with the same SEVERITY tags you'd assign
+      yourself, and cite clawpatch as the source ("CLAWPATCH/HIGH: ...").
+
+      If clawpatch returns "repo not mounted" — the v1 only handles
+      repos baked into the workstacean container (protoWorkstacean,
+      protoCLI, mythxengine). Note it as a LOW observation and continue
+      with the regular diff-based review.
+
+      If clawpatch errors for any other reason (timeout, gateway 5xx),
+      note it as a LOW observation and proceed — clawpatch is a
+      finding-source, not a gate.
 
       ## Step 3 — Apply the rubric
 

--- a/workspace/agents/quinn.yaml
+++ b/workspace/agents/quinn.yaml
@@ -168,6 +168,16 @@ skills:
       APPROVED / COMMENTED / CHANGES_REQUESTED review via the GitHub
       Review API. Feeds the autonomous merge loop in pr-remediator.
     keywords: [pr_review, review, pull request, audit, formal review]
+    # Scoped toolbelt: pr_review is exhaustively served by pr_inspector
+    # alone (7 actions cover list / CI / diff / threads / submit). react +
+    # send_update for Discord acknowledgment. Anything else (chat_with_agent,
+    # searxng_search, board inspection) lures the loop into thrashing and
+    # has historically hit the recursion limit on simple PRs.
+    tools:
+      - pr_inspector
+      - react
+      - send_update
+    maxTurns: 18
     systemPromptOverride: |
       You are Quinn, performing a **formal PR review**.
 
@@ -291,6 +301,22 @@ skills:
       duplicate. Close, comment, or label as appropriate. Return a
       summary with counts per category.
     keywords: [bug, triage, issues, blocked, stale, duplicate]
+    # Scoped toolbelt: bug_triage needs board context + GitHub issue
+    # actions. Excludes the narrow PR-review surface (pr_inspector is
+    # there for CI verification on specific PRs referenced by an issue,
+    # but the heavy lifting is board + repo scan).
+    tools:
+      - get_projects
+      - get_pr_pipeline
+      - get_ci_health
+      - get_branch_drift
+      - chat_with_agent
+      - pr_inspector
+      - create_github_issue
+      - searxng_search
+      - react
+      - send_update
+    maxTurns: 25
     systemPromptOverride: |
       You are Quinn, performing **bug triage**.
 
@@ -344,6 +370,17 @@ skills:
       identify the affected project, file an incident, escalate to HITL
       on uncertainty.
     keywords: [security, vulnerability, cve, dependabot, incident]
+    # Scoped toolbelt: incident filing + research + escalation. No PR
+    # review surface — security findings on a specific PR go through
+    # pr_review with the security-severity rubric applied there.
+    tools:
+      - get_projects
+      - report_incident
+      - create_github_issue
+      - searxng_search
+      - send_update
+      - msg_operator
+    maxTurns: 15
     systemPromptOverride: |
       You are Quinn, performing **security triage**.
 


### PR DESCRIPTION
## Summary

Rolling up 11 dev commits since the last promotion. Lands the full v1 clawpatch chain (gateway provider, Dockerfile bake, Quinn tool wiring), the skill-scoped tools refactor that stops Quinn's GraphRecursionError thrashing, the Linear Agent SDK envelope support, the re-review trigger for the GitHub native flow, and the fleet-wide model swap to `protolabs/reasoning`.

This brings the **workspace YAML** files current — without this, the running container reads stale agent configs from the bind-mount and Quinn ignores her scoped toolbelt + the new `clawpatch_review` tool.

### Highlights

- **#535 / #542 / #543** — Quinn / Ava / protobot all on `protolabs/reasoning`
- **#544** — `pull_request.review_requested` → re-trigger Quinn (native GitHub button)
- **#545** — Linear plugin accepts Agent SDK envelopes + past-tense actions
- **#546** — `AgentSkillDefinition.tools / maxTurns` — skill-scoped toolbelts
- **#547 / #549** — clawpatch + proto + acpx baked into the release image
- **#548** — `clawpatch_review` tool on `DeepAgentExecutor` + wired into Quinn's `pr_review`

### What flips on after merge

Once watchtower pulls the new main-tagged image (or the local checkout `git pull`s + the container restarts), Quinn's running with:
- `pr_review` toolbelt scoped to `[pr_inspector, clawpatch_review, react, send_update]`, `maxTurns: 18`
- `bug_triage` widened to board + repo + GitHub actions, `maxTurns: 25`
- `security_triage` narrow to incident filing + research + escalation, `maxTurns: 15`
- `clawpatch_review` invokable for non-trivial PRs → folds findings into the QA Audit verdict

## Test plan

- [x] Each constituent PR shipped green individually
- [ ] After promotion: `docker logs workstacean | grep "invoke skill"` shows `tools=4/14` for a `pr_review` dispatch (was `13/14` with the stale yaml)
- [ ] E2E smoke (task #26) — Quinn folds a `CLAWPATCH/<SEVERITY>:` observation into a real PR verdict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated clawpatch structural code review tool for enhanced PR analysis
  * Added clawpatch API endpoint for CI review checks
  * Extended Linear webhook support for agent notifications and session events

* **Enhancements**
  * Automated PR review routing with intelligent reviewer detection on GitHub
  * Implemented per-skill tool and turn-limit controls for granular agent resource management
  * Updated agent models and configurations for improved reasoning capabilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/550?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->