### PR TITLE
fix(agent-runtime): propagate skill tools/maxTurns through the yaml loader

### DIFF
--- a/src/agent-runtime/__tests__/agent-definition-loader.test.ts
+++ b/src/agent-runtime/__tests__/agent-definition-loader.test.ts
@@ -89,6 +89,56 @@ describe("parseAgentYaml", () => {
     expect(def.skills[0].name).toBe("plan");
   });
 
+  test("skill tools[] propagates from yaml to AgentSkillDefinition", () => {
+    const def = parseAgentYaml(
+      { ...validRaw, skills: [{ name: "pr_review", tools: ["pr_inspector", "react", "send_update"] }] },
+      "x.yaml",
+    );
+    expect(def.skills[0].tools).toEqual(["pr_inspector", "react", "send_update"]);
+  });
+
+  test("skill tools filters out non-strings", () => {
+    const def = parseAgentYaml(
+      { ...validRaw, skills: [{ name: "pr_review", tools: ["pr_inspector", 42, null, "react"] }] },
+      "x.yaml",
+    );
+    expect(def.skills[0].tools).toEqual(["pr_inspector", "react"]);
+  });
+
+  test("skill tools is undefined when yaml omits the field (inherits agent tools)", () => {
+    const def = parseAgentYaml(
+      { ...validRaw, skills: [{ name: "pr_review" }] },
+      "x.yaml",
+    );
+    expect(def.skills[0].tools).toBeUndefined();
+  });
+
+  test("skill maxTurns propagates positive integers", () => {
+    const def = parseAgentYaml(
+      { ...validRaw, skills: [{ name: "pr_review", maxTurns: 18 }] },
+      "x.yaml",
+    );
+    expect(def.skills[0].maxTurns).toBe(18);
+  });
+
+  test("skill maxTurns accepts -1 sentinel for unlimited", () => {
+    const def = parseAgentYaml(
+      { ...validRaw, skills: [{ name: "deep_audit", maxTurns: -1 }] },
+      "x.yaml",
+    );
+    expect(def.skills[0].maxTurns).toBe(-1);
+  });
+
+  test("skill maxTurns rejects zero / negative-non-sentinel / non-numeric (inherits)", () => {
+    for (const bad of [0, -5, "twelve", null, true]) {
+      const def = parseAgentYaml(
+        { ...validRaw, skills: [{ name: "pr_review", maxTurns: bad as unknown }] },
+        "x.yaml",
+      );
+      expect(def.skills[0].maxTurns).toBeUndefined();
+    }
+  });
+
   test("canDelegate is undefined when not provided", () => {
     const def = parseAgentYaml({ ...validRaw, canDelegate: undefined }, "x.yaml");
     expect(def.canDelegate).toBeUndefined();

--- a/src/agent-runtime/agent-definition-loader.ts
+++ b/src/agent-runtime/agent-definition-loader.ts
@@ -85,13 +85,24 @@ export function parseAgentYaml(raw: RawAgentYaml, fileName: string): AgentDefini
           const keywords = Array.isArray(s.keywords)
             ? s.keywords.filter((k): k is string => typeof k === "string")
             : undefined;
-        return {
+          const skillTools = Array.isArray(s.tools)
+            ? s.tools.filter((t): t is string => typeof t === "string")
+            : undefined;
+          // -1 means unlimited; any other non-positive value falls through to
+          // the agent-level default (handled in the executor).
+          const skillMaxTurns =
+            typeof s.maxTurns === "number" && (s.maxTurns === -1 || s.maxTurns > 0)
+              ? s.maxTurns
+              : undefined;
+          return {
             name,
             ...(typeof s.description === "string" ? { description: s.description } : {}),
             ...(keywords?.length ? { keywords } : {}),
             ...(typeof s.systemPromptOverride === "string"
               ? { systemPromptOverride: s.systemPromptOverride }
               : {}),
+            ...(skillTools ? { tools: skillTools } : {}),
+            ...(skillMaxTurns !== undefined ? { maxTurns: skillMaxTurns } : {}),
           };
         })
         .filter((s): s is AgentSkillDefinition => s !== null)


### PR DESCRIPTION
## Summary

The skill-scoped tools + maxTurns refactor (#546) added optional fields to `AgentSkillDefinition` and updated `DeepAgentExecutor` to honor them — but the yaml loader silently dropped both fields when parsing. Result: Quinn's `pr_review` yaml had `tools: [pr_inspector, clawpatch_review, react, send_update]` and `maxTurns: 18`, but at runtime she ran with the full agent toolbelt and `maxTurns: 12`.

Caught during the clawpatch end-to-end smoke when logs showed `invoke skill="pr_review" tools=14/15 maxTurns=12` instead of the expected `tools=4/15 maxTurns=18`.

## Fix

Loader picks up both fields with the same defensive parsing as the agent-level versions:

- `tools`: filtered to string-only entries (silently drops non-strings)
- `maxTurns`: positive integer or `-1` sentinel for unlimited; anything else falls through to the agent default

## Test plan

- [x] 6 new unit tests on `parseAgentYaml` covering: happy path, non-string filtering, omitted field (inherits), `-1` sentinel, rejection of `0` / negative-non-sentinel / non-numeric
- [x] Full suite: 677 pass (was 671)
- [x] `bun run typecheck` clean
- [ ] After deploy: Quinn `pr_review` log line shows `tools=4/15 maxTurns=18` instead of `14/15 maxTurns=12`
- [ ] Clawpatch smoke (task #26) — Quinn calls `clawpatch_review` and folds findings into the verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills now support configurable `tools` assignment and `maxTurns` limits per skill.
  * Special handling for unlimited turns via `-1` sentinel value.

* **Tests**
  * Added comprehensive test coverage for skill-level configuration options, including validation of tools filtering and maxTurns boundary conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->