### PR TITLE
fix(clawpatch): write state into /data, not into the read-only repo mount

### DIFF
--- a/src/api/clawpatch.ts
+++ b/src/api/clawpatch.ts
@@ -23,8 +23,28 @@
  */
 
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
 import type { Route, ApiContext } from "./types.ts";
+
+/**
+ * Where clawpatch persists `.clawpatch/` (features, findings, runs, reports,
+ * etc.). Repo mounts in the workstacean container are read-only, so we put
+ * state in the workstacean-data volume — one subdirectory per owner/repo.
+ *
+ * Override with CLAWPATCH_STATE_ROOT for testing or when DATA_DIR isn't set.
+ */
+const CLAWPATCH_STATE_ROOT =
+  process.env["CLAWPATCH_STATE_ROOT"]
+  ?? join(process.env["DATA_DIR"] ?? "/data", "clawpatch");
+
+function stateDirFor(repo: string): string {
+  // owner/repo → owner-repo so the path stays one level deep.
+  const slug = repo.replace("/", "-");
+  const dir = join(CLAWPATCH_STATE_ROOT, slug);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
 
 interface ReviewRequest {
   repo: string;
@@ -131,7 +151,11 @@ export function createRoutes(_ctx: ApiContext): Route[] {
           );
         }
 
-        const args = ["ci", "--provider", "gateway", "--json"];
+        // Workstacean mounts repo source read-only, so push clawpatch state
+        // into the writable data volume — one dir per owner/repo so we don't
+        // re-map features for every PR review.
+        const stateDir = stateDirFor(repo);
+        const args = ["ci", "--provider", "gateway", "--json", "--state-dir", stateDir];
         if (since) args.push("--since", since);
         if (typeof limit === "number" && limit > 0) args.push("--limit", String(limit));
         if (model) args.push("--model", model);


### PR DESCRIPTION
Closes the last gap in the clawpatch-Quinn integration: `/api/clawpatch/review` now passes `--state-dir /data/clawpatch/<owner>-<repo>` so clawpatch's mappings + findings persist in the writable data volume instead of trying to create `.clawpatch/` inside the read-only host-repo mount.

Verified Quinn invokes the tool + folds findings via PR #553's verdict body:

> **LOW / CLAWPATCH**: clawpatch_review returned `ENOENT: no such file or directory, mkdir '/home/josh/dev/protoWorkstacean/.clawpatch'`. Infrastructure gap unrelated to PR quality — clawpatch is not yet bootstrapped for this repo mount.

After this lands and deploys, the same Quinn dispatch should yield real `CLAWPATCH/<SEVERITY>` findings instead of the bootstrap error.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 677 pass
- [ ] After deploy: re-fire Quinn on a small protoWorkstacean PR, observe `CLAWPATCH/...` finding(s) folded into the verdict body

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clawpatch state persistence by directing analysis outputs to a dedicated writable directory, now organized per repository for better data management and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/554?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->