### PR TITLE
feat(dashboard): /system page with React Flow plugin↔topic graph (v1)

### DIFF
--- a/dashboard/astro.config.mjs
+++ b/dashboard/astro.config.mjs
@@ -1,8 +1,22 @@
 import { defineConfig } from "astro/config";
 import preact from "@astrojs/preact";
 
+// @xyflow/react ships React-only. Aliasing react / react-dom to preact/compat
+// (the standard Preact shim) lets us pull in @xyflow/react without dragging
+// in 130 KB of full React. The @astrojs/preact `compat: true` flag turns on
+// preact/compat at the Astro layer; the Vite alias block does the same at
+// the bundler layer for direct imports from .tsx components.
 export default defineConfig({
   output: "static",
   outDir: "./dist",
-  integrations: [preact()],
+  integrations: [preact({ compat: true })],
+  vite: {
+    resolve: {
+      alias: {
+        react: "preact/compat",
+        "react-dom": "preact/compat",
+        "react/jsx-runtime": "preact/jsx-runtime",
+      },
+    },
+  },
 });

--- a/dashboard/bun.lock
+++ b/dashboard/bun.lock
@@ -6,6 +6,7 @@
       "name": "workstacean-dashboard",
       "dependencies": {
         "@astrojs/preact": "^4.0.0",
+        "@xyflow/react": "^12.10.2",
         "astro": "^6.0.1",
         "preact": "^10.25.0",
       },
@@ -273,6 +274,18 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -288,6 +301,10 @@
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+
+    "@xyflow/react": ["@xyflow/react@12.10.2", "", { "dependencies": { "@xyflow/system": "0.0.76", "classcat": "^5.0.3", "zustand": "^4.4.0" }, "peerDependencies": { "react": ">=17", "react-dom": ">=17" } }, "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ=="],
+
+    "@xyflow/system": ["@xyflow/system@0.0.76", "", { "dependencies": { "@types/d3-drag": "^3.0.7", "@types/d3-interpolate": "^3.0.4", "@types/d3-selection": "^3.0.10", "@types/d3-transition": "^3.0.8", "@types/d3-zoom": "^3.0.8", "d3-drag": "^3.0.0", "d3-interpolate": "^3.0.1", "d3-selection": "^3.0.0", "d3-zoom": "^3.0.0" } }, "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
@@ -325,6 +342,8 @@
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
+    "classcat": ["classcat@5.0.5", "", {}, "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="],
+
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
@@ -348,6 +367,24 @@
     "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
 
     "csso": ["csso@5.0.5", "", { "dependencies": { "css-tree": "~2.2.0" } }, "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -623,6 +660,10 @@
 
     "radix3": ["radix3@1.1.2", "", {}, "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="],
 
+    "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
+
+    "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
+
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
@@ -660,6 +701,8 @@
     "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
 
     "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -735,6 +778,8 @@
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-location": ["vfile-location@5.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg=="],
@@ -762,6 +807,8 @@
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -10,8 +10,9 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^6.0.1",
     "@astrojs/preact": "^4.0.0",
+    "@xyflow/react": "^12.10.2",
+    "astro": "^6.0.1",
     "preact": "^10.25.0"
   },
   "devDependencies": {

--- a/dashboard/src/components/SystemGraph.tsx
+++ b/dashboard/src/components/SystemGraph.tsx
@@ -1,0 +1,165 @@
+/**
+ * SystemGraph — live plugin↔topic graph for the workstacean bus.
+ *
+ * v1 (this file): fetches /api/bus/topology on mount, renders one node per
+ * plugin, one edge per publish→subscribe topic pair. Layout is a simple
+ * deterministic ring so the graph stays readable without a heavy layout
+ * engine; React Flow's `<Background />` + `<Controls />` give pan/zoom.
+ *
+ * Phase 2 (next PR): subscribe to WS /api/bus/subscribe?topic=# and animate
+ * edges as messages flow. Custom AgentNode components for in-process agents
+ * showing current skill + recent tool calls — driven by an
+ * `agent.runtime.activity` bus topic the SkillDispatcher will publish.
+ */
+
+import { useEffect, useMemo, useState } from "preact/compat";
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  type Edge,
+  type Node,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+
+interface PluginTopologyEntry {
+  name: string;
+  description?: string;
+  capabilities?: string[];
+  publishes?: string[];
+  subscribes?: string[];
+}
+
+interface TopologyResponse {
+  success: boolean;
+  data?: { plugins: PluginTopologyEntry[] };
+  error?: string;
+}
+
+/** Deterministic ring layout — index → (x, y). */
+function ringPosition(idx: number, count: number, radius = 320, cx = 400, cy = 320): { x: number; y: number } {
+  const angle = (idx / Math.max(count, 1)) * Math.PI * 2;
+  return {
+    x: cx + Math.cos(angle) * radius,
+    y: cy + Math.sin(angle) * radius,
+  };
+}
+
+/**
+ * Build React Flow nodes + edges from a topology document. Each plugin is a
+ * node; each (publisher, subscriber) pair sharing a topic is an edge labeled
+ * with the topic name. Pattern-based subscriptions ("#", "topic.#") match
+ * any publisher's topic that fits the pattern.
+ */
+function buildGraph(plugins: PluginTopologyEntry[]): { nodes: Node[]; edges: Edge[] } {
+  const nodes: Node[] = plugins.map((p, idx) => ({
+    id: p.name,
+    position: ringPosition(idx, plugins.length),
+    data: {
+      label: p.name,
+    },
+    style: {
+      background: "#161b22",
+      color: "#e6edf3",
+      border: "1px solid #30363d",
+      borderRadius: 6,
+      padding: "8px 12px",
+      fontSize: 13,
+      fontFamily: "ui-monospace, SFMono-Regular, monospace",
+    },
+  }));
+
+  const edges: Edge[] = [];
+  const seen = new Set<string>();
+  for (const publisher of plugins) {
+    for (const topic of publisher.publishes ?? []) {
+      for (const subscriber of plugins) {
+        if (subscriber.name === publisher.name) continue;
+        const matches = (subscriber.subscribes ?? []).some((pattern) => topicMatches(pattern, topic));
+        if (!matches) continue;
+        const key = `${publisher.name}->${subscriber.name}:${topic}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        edges.push({
+          id: key,
+          source: publisher.name,
+          target: subscriber.name,
+          label: topic,
+          style: { stroke: "#30363d" },
+          labelStyle: { fill: "#8b949e", fontSize: 10, fontFamily: "ui-monospace, monospace" },
+        });
+      }
+    }
+  }
+
+  return { nodes, edges };
+}
+
+/**
+ * AMQP-style topic matching: `#` matches anything; `*.foo` matches one
+ * segment; `foo.#` matches `foo` and `foo.anything`. Mirrors the matcher
+ * the in-memory bus uses so the graph reflects actual delivery.
+ */
+function topicMatches(pattern: string, topic: string): boolean {
+  if (pattern === "#" || pattern === topic) return true;
+  const re = new RegExp(
+    "^"
+    + pattern
+        .split(".")
+        .map((seg) => seg === "#" ? ".*" : seg === "*" ? "[^.]+" : seg.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+        .join("\\.")
+    + "$",
+  );
+  return re.test(topic);
+}
+
+export default function SystemGraph() {
+  const [topology, setTopology] = useState<PluginTopologyEntry[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const resp = await fetch("/api/bus/topology");
+        const body = (await resp.json()) as TopologyResponse;
+        if (cancelled) return;
+        if (!body.success || !body.data) {
+          setError(body.error ?? "topology fetch failed");
+          return;
+        }
+        setTopology(body.data.plugins);
+        setError(null);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      }
+    };
+    load();
+    return () => { cancelled = true; };
+  }, []);
+
+  const { nodes, edges } = useMemo(
+    () => topology ? buildGraph(topology) : { nodes: [], edges: [] },
+    [topology],
+  );
+
+  if (error) {
+    return (
+      <div style={{ padding: 24, color: "#f85149", fontFamily: "monospace" }}>
+        topology error: {error}
+      </div>
+    );
+  }
+  if (!topology) {
+    return <div style={{ padding: 24, color: "#8b949e" }}>loading topology…</div>;
+  }
+
+  return (
+    <div style={{ width: "100%", height: "calc(100vh - 64px)", background: "#0d1117" }}>
+      <ReactFlow nodes={nodes} edges={edges} fitView>
+        <Background color="#21262d" gap={16} />
+        <Controls position="bottom-right" />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/dashboard/src/layouts/DashboardLayout.astro
+++ b/dashboard/src/layouts/DashboardLayout.astro
@@ -10,6 +10,7 @@ const { title, activePage } = Astro.props;
 
 const navItems = [
   { href: "/", label: "Overview", id: "overview" },
+  { href: "/system", label: "System", id: "system" },
   { href: "/events", label: "Events", id: "events" },
   { href: "/agents", label: "Agents", id: "agents" },
   { href: "/outcomes", label: "Outcomes", id: "outcomes" },

--- a/dashboard/src/pages/system.astro
+++ b/dashboard/src/pages/system.astro
@@ -1,0 +1,18 @@
+---
+import DashboardLayout from "../layouts/DashboardLayout.astro";
+import SystemGraph from "../components/SystemGraph.tsx";
+---
+
+<DashboardLayout title="System" activePage="system">
+  <SystemGraph client:only="preact" />
+</DashboardLayout>
+
+<style>
+  /* React Flow needs an explicit height — let the graph fill the content area. */
+  :global(.content) {
+    display: flex;
+    flex-direction: column;
+    padding: 0 !important;
+    overflow: hidden;
+  }
+</style>


### PR DESCRIPTION
## Summary

First slice of the live observability surface you asked for. New **/system** dashboard page renders the bus topology from `/api/bus/topology` as a React Flow graph — one node per plugin, one edge per publish→subscribe topic pair (AMQP-style topic matching mirrors the in-memory bus's pattern logic).

Deterministic ring layout so it stays readable without a heavy layout engine; React Flow's `<Controls />` + `<Background />` give pan/zoom for free.

## Phase 2 (next PR)

- Subscribe to `WS /api/bus/subscribe?topic=#` and animate edges as messages flow
- Custom `AgentNode` components for in-process agents (Quinn / Ava / protobot) showing **current skill + recent tool calls** in-node — driven by an `agent.runtime.activity` bus topic the `SkillDispatcher` will publish
- External-service nodes (Discord / GitHub / Linear / LiteLLM) on the edges

## Wiring details

- `dashboard/astro.config.mjs`: `@astrojs/preact({ compat: true })` + Vite `resolve.alias` for `react` / `react-dom` / `react/jsx-runtime` → `preact/compat`. `@xyflow/react` is React-only but works fine via the standard Preact shim — saves dragging in 130 KB of React.
- `dashboard/src/components/SystemGraph.tsx`: fetches topology, builds Nodes + Edges, owns the ReactFlow viewport. `topicMatches()` is the same AMQP-style matcher the bus uses, so the rendered graph reflects actual delivery semantics, not just string equality.
- `dashboard/src/pages/system.astro`: thin Astro shell + sidebar nav entry. `client:only="preact"` so React Flow only renders client-side (no SSR for the graph).

## Test plan

- [x] `bun run build` in `dashboard/` succeeds; `/system/index.html` written
- [ ] After deploy: navigate to `/system`, see the bus topology rendered as nodes + edges
- [ ] Quinn auto-review on this PR exercises clawpatch_review against protoWorkstacean (verifying #554's writable-state-dir works for real findings — task #26 follow-on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added System page to dashboard navigation displaying an interactive visualization of system topology
  * Graph shows all plugins and their message topic connections in real-time, with edge labels identifying matched topics between plugins

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/555?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->