### PR TITLE
fix(github): self-cascade guard — drop webhook events authored by our own bots

### DIFF
--- a/lib/plugins/__tests__/github-agent-bot-filter.test.ts
+++ b/lib/plugins/__tests__/github-agent-bot-filter.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { isAgentBotActor } from "../github.ts";
+
+describe("isAgentBotActor", () => {
+  const ENV_KEY = "WORKSTACEAN_AGENT_BOT_LOGINS";
+  let snapshot: string | undefined;
+
+  beforeEach(() => {
+    snapshot = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (snapshot === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = snapshot;
+  });
+
+  test("matches the default protoLabs agent bots (both bare + [bot]-suffixed)", () => {
+    expect(isAgentBotActor("protoquinn")).toBe(true);
+    expect(isAgentBotActor("protoquinn[bot]")).toBe(true);
+    expect(isAgentBotActor("ava")).toBe(true);
+    expect(isAgentBotActor("ava[bot]")).toBe(true);
+    expect(isAgentBotActor("protobot")).toBe(true);
+    expect(isAgentBotActor("protobot[bot]")).toBe(true);
+  });
+
+  test("does NOT match human authors or unrelated bots", () => {
+    expect(isAgentBotActor("mabry1985")).toBe(false);
+    expect(isAgentBotActor("dependabot[bot]")).toBe(false);
+    expect(isAgentBotActor("coderabbitai[bot]")).toBe(false);
+    expect(isAgentBotActor("github-actions[bot]")).toBe(false);
+  });
+
+  test("treats undefined / null / empty as not-a-bot (defensive)", () => {
+    expect(isAgentBotActor(undefined)).toBe(false);
+    expect(isAgentBotActor(null)).toBe(false);
+    expect(isAgentBotActor("")).toBe(false);
+  });
+
+  test("comparison is case-insensitive (GitHub login casing is inconsistent across payload paths)", () => {
+    expect(isAgentBotActor("ProToQuiNN[Bot]")).toBe(true);
+    expect(isAgentBotActor("AVA")).toBe(true);
+  });
+
+  test("WORKSTACEAN_AGENT_BOT_LOGINS env override replaces the default set entirely", () => {
+    process.env[ENV_KEY] = "custom-bot,another-bot[bot]";
+    expect(isAgentBotActor("custom-bot")).toBe(true);
+    expect(isAgentBotActor("another-bot[bot]")).toBe(true);
+    // Defaults are NOT merged in — protoquinn is no longer in the set
+    expect(isAgentBotActor("protoquinn")).toBe(false);
+    expect(isAgentBotActor("ava[bot]")).toBe(false);
+  });
+
+  test("env override strips whitespace and ignores empty entries", () => {
+    process.env[ENV_KEY] = "  foo  ,, bar[bot]  ,";
+    expect(isAgentBotActor("foo")).toBe(true);
+    expect(isAgentBotActor("bar[bot]")).toBe(true);
+    expect(isAgentBotActor("")).toBe(false);
+  });
+});

--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -59,6 +59,46 @@ interface GitHubConfig {
 }
 
 /**
+ * Logins we treat as "our own agent bots" — events authored by these
+ * accounts are dropped from auto-triage and @mention paths to prevent
+ * self-cascades (Quinn files an issue → webhook → triage → Quinn files
+ * another issue → ...). See protoWorkstacean#556 for the original 23-
+ * issue cascade that surfaced this.
+ *
+ * The default set covers the App identities + their bare-handle aliases
+ * (GitHub sometimes returns `quinn` vs `quinn[bot]` depending on the
+ * payload path). Override the full set via env:
+ *
+ *   WORKSTACEAN_AGENT_BOT_LOGINS=protoquinn[bot],protoquinn,ava[bot],ava,foo[bot]
+ *
+ * Auto-review (pull_request opened/synchronize → Quinn) is intentionally
+ * NOT filtered — pr-remediator opens PRs as @protoquinn[bot] and those
+ * should still be reviewed; self-approval is already guarded by GitHub
+ * itself.
+ */
+const DEFAULT_AGENT_BOT_LOGINS = [
+  "protoquinn",
+  "protoquinn[bot]",
+  "ava",
+  "ava[bot]",
+  "protobot",
+  "protobot[bot]",
+];
+
+function agentBotLogins(): Set<string> {
+  const raw = process.env["WORKSTACEAN_AGENT_BOT_LOGINS"];
+  const list = raw
+    ? raw.split(",").map((s) => s.trim()).filter(Boolean)
+    : DEFAULT_AGENT_BOT_LOGINS;
+  return new Set(list.map((s) => s.toLowerCase()));
+}
+
+export function isAgentBotActor(login: string | undefined | null): boolean {
+  if (!login) return false;
+  return agentBotLogins().has(login.toLowerCase());
+}
+
+/**
  * Derive monitoredRepos from projects.yaml (all active projects with a github field).
  * Called each time config is loaded so hot-reloads of projects.yaml are reflected.
  */
@@ -480,6 +520,26 @@ export class GitHubPlugin implements Plugin {
 
     const ctx = extractContext(event, payload);
     if (!ctx) return;
+
+    // ── Self-cascade guard ─────────────────────────────────────────────────────
+    // Drop issue + issue_comment + pull_request_review_comment events authored
+    // by our own agent bots before they reach auto-triage or the @mention path.
+    // Without this, Quinn files an issue → GitHub webhook → bug_triage →
+    // Quinn files another issue → infinite cascade (protoWorkstacean#556 ate
+    // protoMaker with 23 duplicate triage issues in 60s). pull_request events
+    // are intentionally NOT filtered here — pr-remediator opens legitimate
+    // bot-authored PRs that should still be reviewed; GitHub's self-approval
+    // check already prevents same-account approvals.
+    if (
+      (event === "issues" || event === "issue_comment" || event === "pull_request_review_comment") &&
+      isAgentBotActor(ctx.author)
+    ) {
+      console.log(
+        `[github] Dropping ${event}.${payload.action} on ${ctx.owner}/${ctx.repo}#${ctx.number} — ` +
+        `authored by agent bot ${ctx.author} (self-cascade guard, see #556)`,
+      );
+      return;
+    }
 
     // ── Auto-triage path: issues.opened/reopened in monitored repos ───────────
     // Fires when autoTriage is enabled and the issue body does NOT contain an


### PR DESCRIPTION
## Summary

Fixes the cascade documented in #556. Quinn filed 23 near-duplicate triage issues on protoMaker in ~60 seconds because **every issue she filed came back to her as an inbound webhook** which auto-triage gladly dispatched. The loop only ran because Quinn's own filings re-entered her own input queue.

This PR cuts the loop at the source: when an `issues` / `issue_comment` / `pull_request_review_comment` event's author matches a known agent-bot login, drop it before either the auto-triage or @mention path can fire.

## Why filter here, not at the dispatcher

Matches the chokepoint-invariant pattern we've been building (#437 cooldown, #444 target-registry guard, #459 fleet-health actor filter, #465 destructive-verdict guard). The github plugin is the natural chokepoint for "did this event come from one of our agents" — that's where the webhook is parsed and the author field is naturally available.

## Agent-bot set

Default (case-insensitive, covers both bare + `[bot]` suffix forms):

```
protoquinn, protoquinn[bot]
ava, ava[bot]
protobot, protobot[bot]
```

Override via `WORKSTACEAN_AGENT_BOT_LOGINS=foo,bar[bot]` (full replace).

## Scope

- ✅ `issues` events
- ✅ `issue_comment` events
- ✅ `pull_request_review_comment` events
- ❌ `pull_request` events — pr-remediator legitimately opens bot-authored PRs that should still be reviewed; GitHub already prevents same-account approvals

## Test plan

- [x] 6 new unit tests on `isAgentBotActor`: default hits, human misses, unrelated-bot misses (dependabot/coderabbit/github-actions), nil/empty defensive, case-insensitivity, env override
- [x] Full suite: 683 pass / 0 fail
- [x] `bun run typecheck` clean
- [ ] After deploy + protoMaker webhook re-enable: filing a test issue as `@protoquinn[bot]` should produce `[github] Dropping ... — authored by agent bot ... (self-cascade guard, see #556)` log line and NOT dispatch `bug_triage`

## Companion PRs (queued)

- **B**: `/api/github/issues` dedup on (repo, title, body[:200], 6h window)
- **C**: extend `meta.cooldownMs` to key by `(skill, repo)` so `bug_triage` on different repos doesn't share a bucket
- **D**: bulk-close protoMaker#3747-3769 + re-enable webhook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented bot detection to identify agent-authored GitHub issues and comments, preventing them from triggering auto-triage and mention-based dispatches that could create cascade loops. Supports configuration via environment variable.

* **Tests**
  * Added test coverage for bot identification and configuration override behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->