### PR TITLE
fix(dispatcher): per-skill-per-repo cooldown at the chokepoint

### DIFF
--- a/src/executor/__tests__/skill-cooldown.test.ts
+++ b/src/executor/__tests__/skill-cooldown.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cooldownKeyFor, cooldownMsFor } from "../skill-dispatcher-plugin.ts";
+
+describe("cooldownMsFor", () => {
+  const ENV_KEYS = [
+    "WORKSTACEAN_COOLDOWN_MS_BUG_TRIAGE",
+    "WORKSTACEAN_COOLDOWN_MS_PR_REVIEW",
+    "WORKSTACEAN_COOLDOWN_MS_SECURITY_TRIAGE",
+    "WORKSTACEAN_COOLDOWN_MS_MY_NEW_SKILL",
+  ];
+  const snapshot: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) snapshot[k] = process.env[k];
+    for (const k of ENV_KEYS) delete process.env[k];
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (snapshot[k] === undefined) delete process.env[k];
+      else process.env[k] = snapshot[k];
+    }
+  });
+
+  test("returns defaults for built-in skills", () => {
+    expect(cooldownMsFor("bug_triage")).toBe(30_000);
+    expect(cooldownMsFor("pr_review")).toBe(30_000);
+    expect(cooldownMsFor("security_triage")).toBe(60_000);
+  });
+
+  test("returns 0 for unknown skills (no cooldown)", () => {
+    expect(cooldownMsFor("nonexistent_skill")).toBe(0);
+    expect(cooldownMsFor("")).toBe(0);
+  });
+
+  test("env override wins over default", () => {
+    process.env["WORKSTACEAN_COOLDOWN_MS_BUG_TRIAGE"] = "5000";
+    expect(cooldownMsFor("bug_triage")).toBe(5000);
+  });
+
+  test("env override can set cooldown for skill that has no default", () => {
+    process.env["WORKSTACEAN_COOLDOWN_MS_MY_NEW_SKILL"] = "12345";
+    expect(cooldownMsFor("my_new_skill")).toBe(12345);
+  });
+
+  test("env override of 0 disables cooldown", () => {
+    process.env["WORKSTACEAN_COOLDOWN_MS_BUG_TRIAGE"] = "0";
+    expect(cooldownMsFor("bug_triage")).toBe(0);
+  });
+
+  test("garbage env value falls back to default", () => {
+    process.env["WORKSTACEAN_COOLDOWN_MS_PR_REVIEW"] = "not-a-number";
+    expect(cooldownMsFor("pr_review")).toBe(30_000);
+    process.env["WORKSTACEAN_COOLDOWN_MS_PR_REVIEW"] = "-1";
+    expect(cooldownMsFor("pr_review")).toBe(30_000);
+  });
+});
+
+describe("cooldownKeyFor", () => {
+  test("bucketed by (skill, owner/repo) when github context present", () => {
+    const payload = { github: { owner: "protoLabsAI", repo: "protoMaker", number: 100 } };
+    expect(cooldownKeyFor("bug_triage", payload)).toBe("bug_triage:protoLabsAI/protoMaker");
+  });
+
+  test("different repos get separate buckets (the #556 fix point)", () => {
+    const a = cooldownKeyFor("bug_triage", { github: { owner: "protoLabsAI", repo: "protoMaker" } });
+    const b = cooldownKeyFor("bug_triage", { github: { owner: "protoLabsAI", repo: "protoWorkstacean" } });
+    expect(a).not.toBe(b);
+  });
+
+  test("different skills on the same repo get separate buckets", () => {
+    const ctx = { github: { owner: "x", repo: "y" } };
+    expect(cooldownKeyFor("bug_triage", ctx)).not.toBe(cooldownKeyFor("pr_review", ctx));
+  });
+
+  test("falls back to <skill>:_ when no github context", () => {
+    expect(cooldownKeyFor("bug_triage", undefined)).toBe("bug_triage:_");
+    expect(cooldownKeyFor("bug_triage", {})).toBe("bug_triage:_");
+    expect(cooldownKeyFor("bug_triage", { github: {} })).toBe("bug_triage:_");
+    expect(cooldownKeyFor("bug_triage", { github: { owner: "x" /* no repo */ } })).toBe("bug_triage:_");
+  });
+
+  test("ignores non-string owner/repo (defensive against bad payloads)", () => {
+    expect(cooldownKeyFor("x", { github: { owner: 42, repo: ["y"] } })).toBe("x:_");
+  });
+});

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -38,6 +38,55 @@ function classifyFlowType(skill: string): "feature" | "defect" | "risk" | "debt"
   return "feature";
 }
 
+// ── Per-skill-per-repo cooldown ────────────────────────────────────────────────
+//
+// When a webhook fires bug_triage on every issue Quinn herself just filed, the
+// resulting cascade can spawn 23 near-duplicate issues in 60s (see
+// protoWorkstacean#556 + #558 for the surface fix at the github plugin). This
+// is a defense-in-depth chokepoint at the dispatcher: even if some other
+// trigger source bypasses the github filter, the same `(skill, repo)` pair
+// can only dispatch once per cooldown window.
+//
+// Defaults: bug_triage 30s, pr_review 30s, security_triage 60s. Everything
+// else: 0 (no cooldown). Override per skill with
+// WORKSTACEAN_COOLDOWN_MS_<SKILL>=<ms> (case-insensitive — env var matches
+// against UPPER_SNAKE of the skill name).
+const DEFAULT_SKILL_COOLDOWN_MS: Record<string, number> = {
+  bug_triage: 30_000,
+  pr_review: 30_000,
+  security_triage: 60_000,
+};
+
+/**
+ * Resolve cooldown window for a skill. Env override
+ * `WORKSTACEAN_COOLDOWN_MS_BUG_TRIAGE=15000` would shorten bug_triage to 15s.
+ * Returns 0 for skills with no default + no env override → no cooldown.
+ */
+export function cooldownMsFor(skill: string): number {
+  const envKey = `WORKSTACEAN_COOLDOWN_MS_${skill.toUpperCase()}`;
+  const raw = process.env[envKey];
+  if (raw !== undefined) {
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : (DEFAULT_SKILL_COOLDOWN_MS[skill] ?? 0);
+  }
+  return DEFAULT_SKILL_COOLDOWN_MS[skill] ?? 0;
+}
+
+/**
+ * Build the cooldown bucket key for a dispatch. Bucketed by (skill, repo) so
+ * `bug_triage` on protoMaker has its own cooldown bucket separate from
+ * `bug_triage` on protoWorkstacean — different repos don't share back-pressure.
+ * Falls back to `<skill>:_` (no repo) when the payload doesn't carry a github
+ * context (chat dispatches, manual /publish calls, etc.).
+ */
+export function cooldownKeyFor(skill: string, payload: Record<string, unknown> | undefined): string {
+  const github = (payload?.["github"] as Record<string, unknown> | undefined);
+  const owner = typeof github?.["owner"] === "string" ? github["owner"] : undefined;
+  const repo = typeof github?.["repo"] === "string" ? github["repo"] : undefined;
+  const repoKey = owner && repo ? `${owner}/${repo}` : "_";
+  return `${skill}:${repoKey}`;
+}
+
 export class SkillDispatcherPlugin implements Plugin {
   readonly name = "skill-dispatcher";
   readonly description = "Sole agent.skill.request subscriber — resolves executor and dispatches";
@@ -65,6 +114,14 @@ export class SkillDispatcherPlugin implements Plugin {
    * and dispatch a competing execution.
    */
   private readonly activeExecutions = new Map<string, { startedAt: number; skill: string }>();
+
+  /**
+   * Per-skill-per-repo cooldown bucket — see DEFAULT_SKILL_COOLDOWN_MS +
+   * cooldownKeyFor() at top of file. Last dispatch time per key; consulted
+   * before dispatch, updated on accept. Drops are logged loudly so they're
+   * visible in the same place as the dispatch log line.
+   */
+  private readonly lastDispatchAt = new Map<string, number>();
 
   constructor(
     private readonly registry: ExecutorRegistry,
@@ -148,6 +205,28 @@ export class SkillDispatcherPlugin implements Plugin {
       console.warn(`[skill-dispatcher] No executor found for ${searched} — dropping`);
       this._publishResponse(replyTopic, correlationId, undefined, `No executor registered for ${searched}`);
       return;
+    }
+
+    // ── Per-skill-per-repo cooldown ────────────────────────────────────────
+    // Defense-in-depth against cascades (protoWorkstacean#556). Same
+    // (skill, repo) pair can only dispatch once per cooldown window; bucketed
+    // per repo so e.g. bug_triage on protoMaker doesn't gate bug_triage on
+    // protoWorkstacean. Defaults in DEFAULT_SKILL_COOLDOWN_MS; override per
+    // skill via WORKSTACEAN_COOLDOWN_MS_<SKILL>.
+    const cooldownMs = cooldownMsFor(skill);
+    if (cooldownMs > 0) {
+      const key = cooldownKeyFor(skill, payload as Record<string, unknown>);
+      const last = this.lastDispatchAt.get(key);
+      if (last !== undefined && Date.now() - last < cooldownMs) {
+        const remaining = cooldownMs - (Date.now() - last);
+        this.activeExecutions.delete(correlationId);
+        console.warn(
+          `[skill-dispatcher] Cooldown drop: "${key}" dispatched ${Date.now() - last}ms ago (window=${cooldownMs}ms, ${remaining}ms remaining)`,
+        );
+        this._publishResponse(replyTopic, correlationId, undefined, `Cooldown: ${key} (${remaining}ms remaining)`);
+        return;
+      }
+      this.lastDispatchAt.set(key, Date.now());
     }
 
     console.log(


### PR DESCRIPTION
## Summary

Third defense-in-depth layer for #556. Even if the github-side self-cascade filter (#558) and the `create_github_issue` dedup (#559) both miss something, the dispatcher itself now refuses to dispatch the same `(skill, repo)` pair within a cooldown window.

Putting the cooldown at `SkillDispatcher` matches the existing chokepoint-invariant pattern there — covers ALL trigger sources (webhooks, ceremonies, agent-to-agent delegation, manual `/publish`), not just the github webhook path.

## Bucketing

`cooldownKeyFor(skill, payload)`:
- With github context → `<skill>:<owner>/<repo>` (Quinn dispatches from webhooks)
- Without → `<skill>:_` (chat / cron / manual)

Different repos → separate buckets (bug_triage on protoMaker doesn't gate bug_triage on protoWorkstacean).
Different skills on same repo → separate buckets (pr_review + bug_triage on the same repo don't share back-pressure).

## Defaults

| Skill | Cooldown |
|---|---|
| `bug_triage` | 30s (the #556 cascade) |
| `pr_review` | 30s (auto-dispatch via webhook synchronize bursts) |
| `security_triage` | 60s (incident dedup matters more) |
| anything else | 0 (no cooldown) |

Override per skill:
```
WORKSTACEAN_COOLDOWN_MS_BUG_TRIAGE=5000
```

Set to 0 to disable. Garbage values fall back to the default.

## Drops

Logged via `[skill-dispatcher] Cooldown drop: "<key>" dispatched Nms ago (window=Xms, Yms remaining)` so they're visible in the same place as the dispatch log line. Caller's reply topic gets:

```json
{ "success": false, "error": "Cooldown: bug_triage:protoLabsAI/protoMaker (12345ms remaining)" }
```

…so a retrying agent gets back-pressure signal instead of silence.

## Test plan

- [x] 11 unit tests on `cooldownMsFor` + `cooldownKeyFor` — defaults, env overrides, 0-disable, garbage-value fallback, per-repo bucketing
- [x] Full suite: 694 pass / 0 fail
- [x] `bun run typecheck` clean
- [ ] After deploy: rapid double-fire of `bug_triage` on same repo → second logs `Cooldown drop` and `success: false` response. Different repos → both dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added skill dispatch cooldown system to prevent rapid duplicate executions
  * Cooldowns are configurable per skill using environment variable overrides
  * Each skill maintains separate cooldown periods per repository
  * When a skill is in cooldown, requests receive an error response indicating remaining wait time

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->