### PR TITLE
feat(clawpatch): provider arg on clawpatch_review (gateway vs proto)

### DIFF
--- a/src/api/clawpatch.ts
+++ b/src/api/clawpatch.ts
@@ -50,8 +50,19 @@ interface ReviewRequest {
   repo: string;
   since?: string;
   limit?: number;
-  /** Override the model for this invocation. Defaults to the gateway provider's default. */
+  /** Override the model for this invocation. Defaults to the provider's default. */
   model?: string;
+  /**
+   * Which protoPatch provider to use. `gateway` (default) sends an
+   * already-assembled prompt to the LiteLLM endpoint — fast/cheap/stateless,
+   * good for nearly every PR. `proto` spawns protoCLI as a live ACP agent
+   * so it can read additional files, run LSP queries, and shell out during
+   * review — slower + more tokens but deeper structural read on non-trivial
+   * changes. Other valid values: claude, codex, acpx — these need the
+   * respective CLI installed and OAuth'd inside the container, which we
+   * don't bootstrap today.
+   */
+  provider?: "gateway" | "proto" | "claude" | "codex" | "acpx";
 }
 
 const BUILT_IN_REPO_PATHS: Record<string, string> = {
@@ -136,7 +147,7 @@ export function createRoutes(_ctx: ApiContext): Route[] {
         } catch {
           return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 });
         }
-        const { repo, since, limit, model } = payload;
+        const { repo, since, limit, model, provider } = payload;
         if (!repo) {
           return Response.json({ success: false, error: "repo is required" }, { status: 400 });
         }
@@ -155,7 +166,8 @@ export function createRoutes(_ctx: ApiContext): Route[] {
         // into the writable data volume — one dir per owner/repo so we don't
         // re-map features for every PR review.
         const stateDir = stateDirFor(repo);
-        const args = ["ci", "--provider", "gateway", "--json", "--state-dir", stateDir];
+        const effectiveProvider = provider ?? "gateway";
+        const args = ["ci", "--provider", effectiveProvider, "--json", "--state-dir", stateDir];
         if (since) args.push("--since", since);
         if (typeof limit === "number" && limit > 0) args.push("--limit", String(limit));
         if (model) args.push("--model", model);

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -212,12 +212,17 @@ function createLangChainTools(toolNames: string[], http: HttpClient, correlation
       {
         name: "clawpatch_review",
         description:
-          "Run structural code review via clawpatch (protoLabs fork). Maps the repo into semantic feature slices, reviews each via the gateway LLM provider, and returns structured findings (correctness bugs, security issues, race/concurrency bugs, data-loss, resource leaks, error-handling gaps, API contract mismatches, missing tests, build hazards, maintainability risks). Use this DURING pr_review to get a structural read on the changed surface before forming a verdict — fold findings into the QA Audit body's Observations section with severity + file:line cites. Today v1 only works for repos already mounted in the container (protoWorkstacean, protoCLI, mythxengine); other repos return a clear error. The `since` arg scopes the review to features touched since that git ref (typically the PR base) — pass it whenever you have the PR base SHA or branch.",
+          "Run structural code review via clawpatch. Maps the repo into semantic feature slices, reviews each, and returns structured findings (correctness bugs, security issues, race/concurrency, data-loss, resource leaks, bad error handling, API contract mismatches, missing tests, build hazards, maintainability risks). Use DURING pr_review to fold findings into the QA Audit body's Observations section with severity + file:line cites.\n\n" +
+          "**Provider choice:**\n" +
+          "- `gateway` (default) — stateless LLM call to the LiteLLM endpoint. Prompt has file contents pre-inlined. Fast, cheap, good for nearly every PR.\n" +
+          "- `proto` — spawns protoCLI as a live ACP agent during review. Agent has tool access: read additional files, run LSP queries, run typecheck/lint. Slower + more tokens but deeper structural read. Use on non-trivial PRs that warrant active investigation (large diffs, suspicious test coverage, novel patterns).\n\n" +
+          "Today v1 only works for repos already mounted in the container (protoWorkstacean, protoCLI, mythxengine); other repos return a clear error. The `since` arg scopes the review to features touched since that git ref — pass the PR base.",
         schema: z.object({
           repo: z.string().describe("Repository in owner/name format (e.g. protoLabsAI/protoWorkstacean)."),
           since: z.string().optional().describe("Git ref (branch or SHA) to diff against. Limits the review to features touched since that ref. Use the PR base (typically 'main' or 'dev')."),
           limit: z.number().int().optional().describe("Maximum number of features to review. Useful for spot-checks on large repos."),
-          model: z.string().optional().describe("Gateway model override (e.g. protolabs/fast for cheap, protolabs/reasoning for deeper). Default protolabs/smart."),
+          model: z.string().optional().describe("Model override. Defaults vary per provider (gateway: protolabs/smart; proto: protolabs/reasoning)."),
+          provider: z.enum(["gateway", "proto"]).optional().describe("Review path. 'gateway' (default) for fast stateless LLM review; 'proto' for live tool-using ACP agent review on non-trivial changes."),
         }),
       },
     ),

--- a/workspace/agents/quinn.yaml
+++ b/workspace/agents/quinn.yaml
@@ -240,6 +240,19 @@ skills:
       Observations section with the same SEVERITY tags you'd assign
       yourself, and cite clawpatch as the source ("CLAWPATCH/HIGH: ...").
 
+      **Provider choice:**
+
+      - Default to `provider: gateway` — fast, cheap, good for ~every PR.
+      - Use `provider: proto` for PRs where structural depth matters
+        more than turnaround:
+          - Large diffs (>10 files)
+          - Code paths involving auth, payments, data-loss-risk
+          - Novel patterns the gateway provider keeps producing
+            low-confidence findings on
+          - Refactor PRs claiming behavior-preserving changes (proto
+            can actually run typecheck + tests to verify)
+        Skip `proto` on trivial diffs — the extra tokens aren't worth it.
+
       If clawpatch returns "repo not mounted" — the v1 only handles
       repos baked into the workstacean container (protoWorkstacean,
       protoCLI, mythxengine). Note it as a LOW observation and continue


### PR DESCRIPTION
## Summary

Pairs with **protoPatch v0.6.0** (just merged) which added the `proto` provider — drives protoCLI as a live ACP agent so it can read files / run LSP / shell out during review. Complements the existing `gateway` provider's stateless prompt-with-inlined-files mode.

This PR teaches workstacean to expose the choice to Quinn.

## Wiring

| Layer | Change |
|---|---|
| `/api/clawpatch/review` | New optional `provider` field. Default `gateway` (unchanged behavior). Forwarded to `clawpatch ci --provider <p>`. |
| `clawpatch_review` tool schema | New `provider: enum("gateway", "proto")` arg + description teaching the model when each pays off. |
| Quinn's `pr_review` prompt | New "Provider choice" rubric in Step 2b — default gateway, escalate to proto on big diffs / auth-payment-data-loss code / refactor PRs. Skip proto on trivial diffs. |

Re-baking the Docker image (this PR triggers publish-image) picks up protoPatch v0.6.0 automatically since the Dockerfile installs from `github:protoLabsAI/protoPatch` main.

## When `proto` over `gateway`

Quinn's rubric, codified in her yaml:

- Large diffs (>10 files)
- Auth / payments / data-loss-risk code
- Novel patterns gateway keeps low-confidence on
- Refactor PRs claiming behavior-preserving — proto can run typecheck + tests to verify

Trivial PRs stay on gateway. The extra proto tokens aren't worth it.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 703 pass / 0 fail
- [ ] After deploy: dispatch `pr_review` on a non-trivial PR; observe Quinn invoking `clawpatch_review(provider: "proto")` on its own judgment (or via explicit override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional provider selection for code reviews, allowing users to choose between multiple review providers (`gateway`, `proto`, `claude`, `codex`, `acpx`).

* **Documentation**
  * Updated review tool descriptions and guidance to clarify provider options and usage recommendations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/561?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->