### PR TITLE
chore(docker): install protopatch from npm (^0.6.1) instead of github main

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,15 @@ RUN pnpm config set global-bin-dir /opt/clawpatch/bin && \
 # pnpm refuses to install globally unless its bin dir is in PATH at the
 # time of install. Add it ahead of the global add.
 ENV PATH="/opt/clawpatch/bin:${PATH}"
-# pnpm 11 refuses to run prepack on git deps unless the package is
-# allowlisted. protoPatch needs to compile TS via its prepack, so allow it.
-RUN pnpm add -g --allow-build=@protolabsai/protopatch github:protoLabsAI/protoPatch && \
+# protoPatch is now published on npm. Version-pinning (^0.6.1) gets us:
+# 1. Reproducible builds — the same image build resolves the same minor/patch
+#    pair, no surprise upstream main shift between builds.
+# 2. Automatic cache-bust on version bump — bumping this line (or letting
+#    Renovate do it) invalidates the layer cleanly; with `github:`
+#    the Docker layer cached forever even after a protoPatch update
+#    because the install command stayed byte-identical.
+# 3. No --allow-build needed — published tarballs don't run prepack.
+RUN pnpm add -g @protolabsai/protopatch@^0.6.1 && \
     ls /opt/clawpatch/bin
 # protoCLI (@protolabsai/proto) speaks the Agent Client Protocol via
 # `proto --acp`, and acpx is the generic ACP-agent driver. Together they give


### PR DESCRIPTION
## Summary

`@protolabsai/protopatch@0.6.1` is now on npm with SLSA provenance attestation. Switch the workstacean image from the `github:` install (always-resolves-to-main, Docker layer caches indefinitely) to a proper version-pinned npm install.

## Why this matters

Today the running container was on `clawpatch 0.5.0` even though several protoPatch versions had landed since — the `pnpm add -g github:protoLabsAI/protoPatch` line in the Dockerfile was byte-identical between builds so Docker reused the stale layer forever. Version-pinning makes the install command change every time you bump, so the layer naturally invalidates.

## Net change

```diff
-RUN pnpm add -g --allow-build=@protolabsai/protopatch github:protoLabsAI/protoPatch && \
+RUN pnpm add -g @protolabsai/protopatch@^0.6.1 && \
     ls /opt/clawpatch/bin
```

Also drops `--allow-build` since published tarballs don't run prepack hooks.

## After this lands

- Next dev publish-image run rebuilds with `clawpatch 0.6.1` baked in
- Quinn's `clawpatch_review` calls land on a build that includes the `proto` provider (Phase 2)
- Future protoPatch upgrades: just bump `^0.6.1` to the new version constraint here, no need to think about cache busting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Docker build process to use a published npm package instead of a git dependency, improving build reliability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->