### PR TITLE
feat(dashboard): live agent telemetry on /system (phase 2)

### DIFF
--- a/dashboard/src/components/AgentNode.tsx
+++ b/dashboard/src/components/AgentNode.tsx
@@ -1,0 +1,164 @@
+/**
+ * AgentNode — custom React Flow node for in-process / A2A / function agents.
+ *
+ * Renders a card with: agent name, type badge, status pill, current skill
+ * (when running), and the last 3 tool calls with timestamps. State is owned
+ * by SystemGraph.tsx and passed via `data.activity`.
+ */
+
+import { Handle, Position } from "@xyflow/react";
+
+type AgentStatus = "idle" | "running" | "completed" | "error";
+
+export interface AgentActivityState {
+  status: AgentStatus;
+  currentSkill?: string;
+  /** ms since epoch — used to compute the "Ns ago" labels in the activity log */
+  startedAt?: number;
+  finishedAt?: number;
+  /** Most-recent first, capped to ~5 entries by the parent */
+  toolCalls: Array<{ tools: string[]; timestamp: number }>;
+  resultPreview?: string;
+  errorMessage?: string;
+}
+
+export interface AgentNodeData {
+  label: string;
+  type: string; // "deep-agent" | "a2a" | "function"
+  activity?: AgentActivityState;
+}
+
+const STATUS_COLOR: Record<AgentStatus, string> = {
+  idle: "#30363d",
+  running: "#3fb950",     // GitHub green
+  completed: "#58a6ff",   // GitHub blue
+  error: "#f85149",       // GitHub red
+};
+
+const TYPE_LABEL: Record<string, string> = {
+  "deep-agent": "DeepAgent",
+  a2a: "A2A",
+  function: "function",
+};
+
+function relativeTime(ms: number): string {
+  const delta = Date.now() - ms;
+  if (delta < 1000) return "just now";
+  if (delta < 60_000) return `${Math.floor(delta / 1000)}s ago`;
+  if (delta < 3_600_000) return `${Math.floor(delta / 60_000)}m ago`;
+  return `${Math.floor(delta / 3_600_000)}h ago`;
+}
+
+export default function AgentNode({ data }: { data: AgentNodeData }) {
+  const activity = data.activity;
+  const status: AgentStatus = activity?.status ?? "idle";
+  const statusColor = STATUS_COLOR[status];
+
+  return (
+    <div
+      style={{
+        background: "#0d1117",
+        color: "#e6edf3",
+        border: `1px solid ${statusColor}`,
+        borderRadius: 8,
+        padding: 10,
+        minWidth: 220,
+        maxWidth: 280,
+        fontFamily: "ui-monospace, SFMono-Regular, monospace",
+        fontSize: 11,
+        boxShadow: status === "running" ? `0 0 12px ${statusColor}40` : "none",
+      }}
+    >
+      <Handle type="target" position={Position.Left} style={{ background: "#30363d" }} />
+      <Handle type="source" position={Position.Right} style={{ background: "#30363d" }} />
+
+      {/* Header: name + type badge + status pill */}
+      <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
+        <strong style={{ fontSize: 13, color: "#e6edf3" }}>{data.label}</strong>
+        <span
+          style={{
+            fontSize: 9,
+            padding: "1px 5px",
+            border: "1px solid #30363d",
+            borderRadius: 3,
+            color: "#8b949e",
+          }}
+        >
+          {TYPE_LABEL[data.type] ?? data.type}
+        </span>
+        <span style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 4 }}>
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: 4,
+              background: statusColor,
+              boxShadow: status === "running" ? `0 0 4px ${statusColor}` : "none",
+            }}
+          />
+          <span style={{ fontSize: 10, color: statusColor }}>{status}</span>
+        </span>
+      </div>
+
+      {/* Current skill */}
+      {activity?.currentSkill && (
+        <div style={{ fontSize: 10, color: "#8b949e", marginBottom: 4 }}>
+          skill: <span style={{ color: "#e6edf3" }}>{activity.currentSkill}</span>
+          {activity.startedAt && status === "running" && (
+            <span style={{ marginLeft: 6, color: "#6e7681" }}>· {relativeTime(activity.startedAt)}</span>
+          )}
+        </div>
+      )}
+
+      {/* Tool call history */}
+      {activity && activity.toolCalls.length > 0 && (
+        <div style={{ borderTop: "1px solid #21262d", paddingTop: 4, marginTop: 4 }}>
+          {activity.toolCalls.slice(0, 4).map((call, idx) => (
+            <div key={idx} style={{ fontSize: 10, color: "#8b949e", lineHeight: 1.4 }}>
+              <span style={{ color: "#7ee787" }}>↳</span>{" "}
+              <span style={{ color: "#e6edf3" }}>{call.tools.join(", ")}</span>
+              <span style={{ marginLeft: 6, color: "#6e7681" }}>{relativeTime(call.timestamp)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Result preview / error */}
+      {status === "completed" && activity?.resultPreview && (
+        <div
+          style={{
+            borderTop: "1px solid #21262d",
+            paddingTop: 4,
+            marginTop: 4,
+            fontSize: 10,
+            color: "#8b949e",
+            fontStyle: "italic",
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+          title={activity.resultPreview}
+        >
+          {activity.resultPreview}
+        </div>
+      )}
+      {status === "error" && activity?.errorMessage && (
+        <div
+          style={{
+            borderTop: `1px solid ${STATUS_COLOR.error}40`,
+            paddingTop: 4,
+            marginTop: 4,
+            fontSize: 10,
+            color: STATUS_COLOR.error,
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+          title={activity.errorMessage}
+        >
+          ⚠ {activity.errorMessage}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/ServiceNode.tsx
+++ b/dashboard/src/components/ServiceNode.tsx
@@ -1,0 +1,39 @@
+/**
+ * ServiceNode — external service that the workstacean fleet talks to.
+ * Lives on the perimeter of the graph: Discord / GitHub / Linear / LiteLLM
+ * gateway / npm. Mostly decorative — the agents are the action — but having
+ * them on the graph closes the visual loop on "what's touching what".
+ */
+
+import { Handle, Position } from "@xyflow/react";
+
+export interface ServiceNodeData {
+  label: string;
+  icon?: string; // single emoji or glyph; rendered before the label
+  description?: string;
+}
+
+export default function ServiceNode({ data }: { data: ServiceNodeData }) {
+  return (
+    <div
+      style={{
+        background: "#161b22",
+        color: "#e6edf3",
+        border: "1px dashed #58a6ff",
+        borderRadius: 999,
+        padding: "6px 14px",
+        fontFamily: "ui-monospace, SFMono-Regular, monospace",
+        fontSize: 11,
+        opacity: 0.85,
+        minWidth: 100,
+        textAlign: "center",
+      }}
+      title={data.description}
+    >
+      <Handle type="target" position={Position.Left} style={{ background: "#58a6ff", opacity: 0.4 }} />
+      <Handle type="source" position={Position.Right} style={{ background: "#58a6ff", opacity: 0.4 }} />
+      {data.icon ? <span style={{ marginRight: 4 }}>{data.icon}</span> : null}
+      <span>{data.label}</span>
+    </div>
+  );
+}

--- a/dashboard/src/components/SystemGraph.tsx
+++ b/dashboard/src/components/SystemGraph.tsx
@@ -1,26 +1,29 @@
 /**
- * SystemGraph — live plugin↔topic graph for the workstacean bus.
+ * SystemGraph — live observability surface for the workstacean fleet.
  *
- * v1 (this file): fetches /api/bus/topology on mount, renders one node per
- * plugin, one edge per publish→subscribe topic pair. Layout is a simple
- * deterministic ring so the graph stays readable without a heavy layout
- * engine; React Flow's `<Background />` + `<Controls />` give pan/zoom.
+ * Phase 1: plugin↔topic graph from /api/bus/topology (shipped #555).
+ * Phase 2 (this file): adds
+ *   - Agent nodes from /api/agents/runtime, each showing current skill +
+ *     last few tool calls inside the node (custom AgentNode component)
+ *   - External service nodes (Discord, GitHub, Linear, LiteLLM gateway, npm)
+ *     on the perimeter
+ *   - Live edge animation on bus traffic via WS /api/bus/subscribe?topic=#
+ *   - Agent state subscription on agent.runtime.activity.# so each agent's
+ *     node pulses + shows real-time skill + tool-call history
  *
- * Phase 2 (next PR): subscribe to WS /api/bus/subscribe?topic=# and animate
- * edges as messages flow. Custom AgentNode components for in-process agents
- * showing current skill + recent tool calls — driven by an
- * `agent.runtime.activity` bus topic the SkillDispatcher will publish.
+ * Layout: three concentric zones.
+ *   center  — agents (the action)
+ *   middle  — plugins (the routing layer)
+ *   outer   — external services (where work eventually lands)
  */
 
 import { useEffect, useMemo, useState } from "preact/compat";
-import {
-  ReactFlow,
-  Background,
-  Controls,
-  type Edge,
-  type Node,
-} from "@xyflow/react";
+import { ReactFlow, Background, Controls, type Edge, type Node } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import AgentNode, { type AgentActivityState } from "./AgentNode.tsx";
+import ServiceNode from "./ServiceNode.tsx";
+
+// ── Types ────────────────────────────────────────────────────────────────────
 
 interface PluginTopologyEntry {
   name: string;
@@ -30,76 +33,52 @@ interface PluginTopologyEntry {
   subscribes?: string[];
 }
 
-interface TopologyResponse {
-  success: boolean;
-  data?: { plugins: PluginTopologyEntry[] };
-  error?: string;
+interface AgentRuntimeEntry {
+  name: string;
+  type: string;
+  skills: string[];
 }
 
-/** Deterministic ring layout — index → (x, y). */
-function ringPosition(idx: number, count: number, radius = 320, cx = 400, cy = 320): { x: number; y: number } {
-  const angle = (idx / Math.max(count, 1)) * Math.PI * 2;
-  return {
-    x: cx + Math.cos(angle) * radius,
-    y: cy + Math.sin(angle) * radius,
-  };
+interface AgentActivityEvent {
+  type: "skill.start" | "tool.call" | "skill.complete" | "skill.error";
+  agentName: string;
+  correlationId: string;
+  timestamp: number;
+  skill?: string;
+  toolNames?: string[];
+  resultPreview?: string;
+  errorMessage?: string;
+  durationMs?: number;
 }
 
-/**
- * Build React Flow nodes + edges from a topology document. Each plugin is a
- * node; each (publisher, subscriber) pair sharing a topic is an edge labeled
- * with the topic name. Pattern-based subscriptions ("#", "topic.#") match
- * any publisher's topic that fits the pattern.
- */
-function buildGraph(plugins: PluginTopologyEntry[]): { nodes: Node[]; edges: Edge[] } {
-  const nodes: Node[] = plugins.map((p, idx) => ({
-    id: p.name,
-    position: ringPosition(idx, plugins.length),
-    data: {
-      label: p.name,
-    },
-    style: {
-      background: "#161b22",
-      color: "#e6edf3",
-      border: "1px solid #30363d",
-      borderRadius: 6,
-      padding: "8px 12px",
-      fontSize: 13,
-      fontFamily: "ui-monospace, SFMono-Regular, monospace",
-    },
-  }));
+// ── External services ────────────────────────────────────────────────────────
+// Hardcoded for now — the set of "things workstacean talks to but doesn't
+// own". Could be derived from config later (each service is implicit in
+// the plugin set today).
+const SERVICES: Array<{ id: string; label: string; icon: string; description: string }> = [
+  { id: "svc-discord", label: "Discord", icon: "💬", description: "Discord guild + DM transport" },
+  { id: "svc-github", label: "GitHub", icon: "⌨", description: "Webhooks + REST/GraphQL API" },
+  { id: "svc-linear", label: "Linear", icon: "📋", description: "Issue tracker + agent webhook" },
+  { id: "svc-litellm", label: "LiteLLM", icon: "🧠", description: "Gateway for all agent LLM calls" },
+  { id: "svc-npm", label: "npm", icon: "📦", description: "Published packages (protopatch, proto)" },
+];
 
-  const edges: Edge[] = [];
-  const seen = new Set<string>();
-  for (const publisher of plugins) {
-    for (const topic of publisher.publishes ?? []) {
-      for (const subscriber of plugins) {
-        if (subscriber.name === publisher.name) continue;
-        const matches = (subscriber.subscribes ?? []).some((pattern) => topicMatches(pattern, topic));
-        if (!matches) continue;
-        const key = `${publisher.name}->${subscriber.name}:${topic}`;
-        if (seen.has(key)) continue;
-        seen.add(key);
-        edges.push({
-          id: key,
-          source: publisher.name,
-          target: subscriber.name,
-          label: topic,
-          style: { stroke: "#30363d" },
-          labelStyle: { fill: "#8b949e", fontSize: 10, fontFamily: "ui-monospace, monospace" },
-        });
-      }
-    }
-  }
+// Plugin → service edges. Static map describing which plugin owns which
+// external integration. Used to draw the agent → plugin → service hops.
+const PLUGIN_TO_SERVICES: Record<string, string[]> = {
+  discord: ["svc-discord"],
+  github: ["svc-github"],
+  linear: ["svc-linear"],
+  "linear-protomaker-bridge": ["svc-linear"],
+  "pr-remediator": ["svc-github"],
+  google: [],
+  "agent-runtime": ["svc-litellm"],
+  "skill-broker": ["svc-litellm"],
+  "agent-fleet-health": [],
+};
 
-  return { nodes, edges };
-}
+// ── Topic matching (AMQP-style, same as in-memory bus) ────────────────────────
 
-/**
- * AMQP-style topic matching: `#` matches anything; `*.foo` matches one
- * segment; `foo.#` matches `foo` and `foo.anything`. Mirrors the matcher
- * the in-memory bus uses so the graph reflects actual delivery.
- */
 function topicMatches(pattern: string, topic: string): boolean {
   if (pattern === "#" || pattern === topic) return true;
   const re = new RegExp(
@@ -113,42 +92,265 @@ function topicMatches(pattern: string, topic: string): boolean {
   return re.test(topic);
 }
 
+// ── Layout ───────────────────────────────────────────────────────────────────
+// Three concentric rings. Agents at center (smallest radius — they're the
+// focal point); plugins in the middle; services on the outside.
+
+function ringPos(idx: number, count: number, radius: number, cx = 500, cy = 380) {
+  const angle = (idx / Math.max(count, 1)) * Math.PI * 2 - Math.PI / 2; // start at top
+  return { x: cx + Math.cos(angle) * radius, y: cy + Math.sin(angle) * radius };
+}
+
+interface BuildArgs {
+  plugins: PluginTopologyEntry[];
+  agents: AgentRuntimeEntry[];
+  agentActivity: Map<string, AgentActivityState>;
+  activeEdges: Set<string>;
+}
+
+function buildGraph({ plugins, agents, agentActivity, activeEdges }: BuildArgs): { nodes: Node[]; edges: Edge[] } {
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+
+  // 1. Agent nodes (inner ring)
+  agents.forEach((a, idx) => {
+    nodes.push({
+      id: `agent-${a.name}`,
+      type: "agent",
+      position: ringPos(idx, agents.length, 180),
+      data: { label: a.name, type: a.type, activity: agentActivity.get(a.name) },
+    });
+  });
+
+  // 2. Plugin nodes (middle ring)
+  plugins.forEach((p, idx) => {
+    nodes.push({
+      id: `plugin-${p.name}`,
+      position: ringPos(idx, plugins.length, 380),
+      data: { label: p.name },
+      style: {
+        background: "#161b22",
+        color: "#e6edf3",
+        border: "1px solid #30363d",
+        borderRadius: 6,
+        padding: "6px 10px",
+        fontSize: 11,
+        fontFamily: "ui-monospace, SFMono-Regular, monospace",
+      },
+    });
+  });
+
+  // 3. Service nodes (outer perimeter)
+  SERVICES.forEach((s, idx) => {
+    nodes.push({
+      id: s.id,
+      type: "service",
+      position: ringPos(idx, SERVICES.length, 580),
+      data: { label: s.label, icon: s.icon, description: s.description },
+    });
+  });
+
+  // 4. Plugin → plugin edges (publisher → subscriber per topic)
+  const seenEdges = new Set<string>();
+  for (const publisher of plugins) {
+    for (const topic of publisher.publishes ?? []) {
+      for (const subscriber of plugins) {
+        if (subscriber.name === publisher.name) continue;
+        const matches = (subscriber.subscribes ?? []).some((p) => topicMatches(p, topic));
+        if (!matches) continue;
+        const key = `${publisher.name}->${subscriber.name}:${topic}`;
+        if (seenEdges.has(key)) continue;
+        seenEdges.add(key);
+        const active = activeEdges.has(topic);
+        edges.push({
+          id: key,
+          source: `plugin-${publisher.name}`,
+          target: `plugin-${subscriber.name}`,
+          label: topic,
+          animated: active,
+          style: { stroke: active ? "#3fb950" : "#21262d", strokeWidth: active ? 1.5 : 1 },
+          labelStyle: { fill: "#6e7681", fontSize: 9, fontFamily: "ui-monospace, monospace" },
+        });
+      }
+    }
+  }
+
+  // 5. Plugin → service edges (static, from the map)
+  for (const [pluginName, serviceIds] of Object.entries(PLUGIN_TO_SERVICES)) {
+    if (!plugins.find((p) => p.name === pluginName)) continue;
+    for (const svcId of serviceIds) {
+      edges.push({
+        id: `${pluginName}->${svcId}`,
+        source: `plugin-${pluginName}`,
+        target: svcId,
+        style: { stroke: "#58a6ff", strokeDasharray: "4 4", opacity: 0.5 },
+      });
+    }
+  }
+
+  // 6. Agent → agent-runtime / skill-broker plugin edges. Each agent's
+  // dispatch flows through one of those plugins; render an edge so the
+  // animation reaches the agent node when activity is live.
+  for (const a of agents) {
+    const hostPlugin = a.type === "a2a" ? "skill-broker" : "agent-runtime";
+    if (!plugins.find((p) => p.name === hostPlugin)) continue;
+    const live = agentActivity.get(a.name)?.status === "running";
+    edges.push({
+      id: `agent-${a.name}->${hostPlugin}`,
+      source: `plugin-${hostPlugin}`,
+      target: `agent-${a.name}`,
+      animated: live,
+      style: { stroke: live ? "#3fb950" : "#30363d", strokeWidth: live ? 2 : 1 },
+    });
+  }
+
+  return { nodes, edges };
+}
+
+// ── Activity event → agent state machine ─────────────────────────────────────
+
+function applyActivity(state: Map<string, AgentActivityState>, ev: AgentActivityEvent): Map<string, AgentActivityState> {
+  const next = new Map(state);
+  const prev = next.get(ev.agentName) ?? { status: "idle" as const, toolCalls: [] };
+
+  switch (ev.type) {
+    case "skill.start":
+      next.set(ev.agentName, {
+        status: "running",
+        currentSkill: ev.skill,
+        startedAt: ev.timestamp,
+        toolCalls: [],
+      });
+      break;
+    case "tool.call":
+      next.set(ev.agentName, {
+        ...prev,
+        status: "running",
+        toolCalls: [{ tools: ev.toolNames ?? [], timestamp: ev.timestamp }, ...prev.toolCalls].slice(0, 8),
+      });
+      break;
+    case "skill.complete":
+      next.set(ev.agentName, {
+        ...prev,
+        status: "completed",
+        finishedAt: ev.timestamp,
+        resultPreview: ev.resultPreview,
+      });
+      break;
+    case "skill.error":
+      next.set(ev.agentName, {
+        ...prev,
+        status: "error",
+        finishedAt: ev.timestamp,
+        errorMessage: ev.errorMessage,
+      });
+      break;
+  }
+  return next;
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+const NODE_TYPES = { agent: AgentNode, service: ServiceNode };
+
 export default function SystemGraph() {
   const [topology, setTopology] = useState<PluginTopologyEntry[] | null>(null);
+  const [agents, setAgents] = useState<AgentRuntimeEntry[]>([]);
+  const [agentActivity, setAgentActivity] = useState<Map<string, AgentActivityState>>(new Map());
+  const [activeEdges, setActiveEdges] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
 
+  // Initial fetch — topology + agents
   useEffect(() => {
     let cancelled = false;
-    const load = async () => {
+    (async () => {
       try {
-        const resp = await fetch("/api/bus/topology");
-        const body = (await resp.json()) as TopologyResponse;
+        const [topoR, agentsR] = await Promise.all([
+          fetch("/api/bus/topology").then((r) => r.json()),
+          fetch("/api/agents/runtime").then((r) => r.json()),
+        ]);
         if (cancelled) return;
-        if (!body.success || !body.data) {
-          setError(body.error ?? "topology fetch failed");
+        if (!topoR.success) {
+          setError(topoR.error ?? "topology fetch failed");
           return;
         }
-        setTopology(body.data.plugins);
-        setError(null);
+        setTopology(topoR.data.plugins);
+        setAgents(agentsR.success ? agentsR.data.agents : []);
       } catch (err) {
         if (!cancelled) setError(err instanceof Error ? err.message : String(err));
       }
-    };
-    load();
+    })();
     return () => { cancelled = true; };
   }, []);
 
+  // WS subscription for live bus traffic
+  // Subscribes to `#` (wildcard for everything). Bus traffic with a topic
+  // we recognize as a topology edge pulses that edge for 1.5s.
+  // agent.runtime.activity.* events also drive the agent node state.
+  useEffect(() => {
+    const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const url = `${proto}//${window.location.host}/api/bus/subscribe?topic=%23`;
+    let ws: WebSocket | null = null;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let stopped = false;
+
+    const edgeTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+    const connect = () => {
+      ws = new WebSocket(url);
+      ws.onmessage = (e) => {
+        try {
+          const msg = JSON.parse(e.data) as { topic?: string; payload?: unknown };
+          if (!msg.topic) return;
+          // Agent activity → state machine
+          if (msg.topic.startsWith("agent.runtime.activity.")) {
+            const ev = msg.payload as AgentActivityEvent;
+            setAgentActivity((cur) => applyActivity(cur, ev));
+          }
+          // Pulse the edge for any topic — phase 1 just animated each match for 1.5s
+          setActiveEdges((cur) => new Set(cur).add(msg.topic!));
+          if (edgeTimers.has(msg.topic)) clearTimeout(edgeTimers.get(msg.topic)!);
+          edgeTimers.set(msg.topic, setTimeout(() => {
+            setActiveEdges((cur) => {
+              const next = new Set(cur);
+              next.delete(msg.topic!);
+              return next;
+            });
+            edgeTimers.delete(msg.topic!);
+          }, 1500));
+        } catch {
+          // ignore malformed messages — the WS may emit framing data
+        }
+      };
+      ws.onclose = () => {
+        if (stopped) return;
+        // Backoff: reconnect after 2s
+        retryTimer = setTimeout(connect, 2000);
+      };
+      ws.onerror = () => {
+        // Closing here triggers onclose → reconnect
+        ws?.close();
+      };
+    };
+    connect();
+
+    return () => {
+      stopped = true;
+      if (retryTimer) clearTimeout(retryTimer);
+      for (const t of edgeTimers.values()) clearTimeout(t);
+      ws?.close();
+    };
+  }, []);
+
   const { nodes, edges } = useMemo(
-    () => topology ? buildGraph(topology) : { nodes: [], edges: [] },
-    [topology],
+    () => topology
+      ? buildGraph({ plugins: topology, agents, agentActivity, activeEdges })
+      : { nodes: [], edges: [] },
+    [topology, agents, agentActivity, activeEdges],
   );
 
   if (error) {
-    return (
-      <div style={{ padding: 24, color: "#f85149", fontFamily: "monospace" }}>
-        topology error: {error}
-      </div>
-    );
+    return <div style={{ padding: 24, color: "#f85149", fontFamily: "monospace" }}>topology error: {error}</div>;
   }
   if (!topology) {
     return <div style={{ padding: 24, color: "#8b949e" }}>loading topology…</div>;
@@ -156,7 +358,7 @@ export default function SystemGraph() {
 
   return (
     <div style={{ width: "100%", height: "calc(100vh - 64px)", background: "#0d1117" }}>
-      <ReactFlow nodes={nodes} edges={edges} fitView>
+      <ReactFlow nodes={nodes} edges={edges} nodeTypes={NODE_TYPES} fitView minZoom={0.2}>
         <Background color="#21262d" gap={16} />
         <Controls position="bottom-right" />
       </ReactFlow>

--- a/src/agent-runtime/agent-runtime-plugin.ts
+++ b/src/agent-runtime/agent-runtime-plugin.ts
@@ -50,6 +50,31 @@ export class AgentRuntimePlugin implements Plugin {
         gatewayApiKey: this.config.gatewayApiKey,
         apiBaseUrl: this.config.apiBaseUrl ?? "http://localhost:3000",
         apiKey: this.config.apiKey ?? process.env.WORKSTACEAN_API_KEY,
+        // Live tool-call telemetry → bus → /system dashboard. Best-effort:
+        // any publish failure is swallowed inside the executor so a flaky
+        // bus never breaks Quinn mid-review.
+        onToolCall: (event) => {
+          if (!this.bus) return;
+          const topic = "agent.runtime.activity.tool.call";
+          try {
+            this.bus.publish(topic, {
+              id: crypto.randomUUID(),
+              correlationId: event.correlationId,
+              topic,
+              timestamp: Date.now(),
+              payload: {
+                type: "tool.call",
+                agentName: event.agentName,
+                correlationId: event.correlationId,
+                skill: event.skill,
+                toolNames: event.toolNames,
+                timestamp: Date.now(),
+              },
+            });
+          } catch (err) {
+            console.warn(`[agent-runtime] tool.call publish failed for ${event.agentName}:`, err);
+          }
+        },
       });
 
       for (const skill of def.skills) {

--- a/src/api/agents-runtime.ts
+++ b/src/api/agents-runtime.ts
@@ -1,0 +1,69 @@
+/**
+ * GET /api/agents/runtime — list every registered executor, grouped by agent.
+ *
+ * The existing GET /api/agents only returns the A2A registry from
+ * workspace/agents.yaml. The /system dashboard also needs in-process
+ * agents (DeepAgents like Quinn / Ava / protobot) and function-skill
+ * executors (alert.* / ceremony.* / pr.*) for the topology graph.
+ *
+ * Pulls live data from ExecutorRegistry so the response reflects what's
+ * actually wired in this process — not what a yaml says should be wired.
+ *
+ * Response:
+ *   {
+ *     success: true,
+ *     data: {
+ *       agents: [
+ *         { name: "quinn", type: "deep-agent", skills: ["pr_review","bug_triage", ...] },
+ *         { name: "protomaker", type: "a2a", skills: [...] },
+ *         { name: "alert-skill-executor", type: "function", skills: ["alert.ci_main_red", ...] },
+ *         ...
+ *       ]
+ *     }
+ *   }
+ */
+
+import type { Route, ApiContext } from "./types.ts";
+
+interface AgentSummary {
+  name: string;
+  type: string;
+  skills: string[];
+}
+
+export function createRoutes(ctx: ApiContext): Route[] {
+  return [
+    {
+      method: "GET",
+      path: "/api/agents/runtime",
+      handler: () => {
+        const registrations = ctx.executorRegistry.list();
+
+        // Group by (agentName ?? executor.type). Each unique grouping becomes
+        // one node on the dashboard. agentName takes precedence so quinn / ava
+        // / protobot show up as individuals; nameless function executors
+        // collapse under their executor type ("function").
+        const byKey = new Map<string, { type: string; skills: Set<string> }>();
+        for (const reg of registrations) {
+          const key = reg.agentName ?? reg.executor.type;
+          let entry = byKey.get(key);
+          if (!entry) {
+            entry = { type: reg.executor.type, skills: new Set() };
+            byKey.set(key, entry);
+          }
+          if (reg.skill) entry.skills.add(reg.skill);
+        }
+
+        const agents: AgentSummary[] = [...byKey.entries()]
+          .map(([name, { type, skills }]) => ({
+            name,
+            type,
+            skills: [...skills].sort(),
+          }))
+          .sort((a, b) => a.name.localeCompare(b.name));
+
+        return Response.json({ success: true, data: { agents } });
+      },
+    },
+  ];
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -26,6 +26,7 @@ import { createRoutes as linearRoutes } from "./linear.ts";
 import { createRoutes as busTopologyRoutes } from "./bus-topology.ts";
 import { createRoutes as prInspectorRoutes } from "./pr-inspector.ts";
 import { createRoutes as clawpatchRoutes } from "./clawpatch.ts";
+import { createRoutes as agentsRuntimeRoutes } from "./agents-runtime.ts";
 
 export { matchPath } from "./types.ts";
 export type { Route, ApiContext } from "./types.ts";
@@ -51,5 +52,6 @@ export function createAllRoutes(ctx: ApiContext): Route[] {
     ...busTopologyRoutes(ctx),
     ...prInspectorRoutes(ctx),
     ...clawpatchRoutes(ctx),
+    ...agentsRuntimeRoutes(ctx),
   ];
 }

--- a/src/event-bus/payloads.ts
+++ b/src/event-bus/payloads.ts
@@ -319,3 +319,45 @@ export interface WorldStateDeltaV1Payload {
   sourceAgent: string;
 }
 
+
+// ── agent.runtime.activity ────────────────────────────────────────────────────
+
+/**
+ * Live agent telemetry events. Published at meaningful points in a skill
+ * invocation by the SkillDispatcher (lifecycle) and by DeepAgentExecutor
+ * (per-tool detail). Drives the /system dashboard's agent activity panels
+ * and any future observability surface that needs "what is Quinn doing
+ * RIGHT NOW".
+ *
+ * Topic pattern:
+ *   agent.runtime.activity.skill.{start|complete|error}
+ *   agent.runtime.activity.tool.call
+ *
+ * Designed for spectator consumption — does NOT replace
+ * `agent.skill.response` (which carries the actual reply for callers).
+ * Best-effort: publish failures are swallowed inside the producer.
+ */
+export type AgentActivityType =
+  | "skill.start"
+  | "tool.call"
+  | "skill.complete"
+  | "skill.error";
+
+export interface AgentActivityPayload {
+  type: AgentActivityType;
+  /** Agent name as registered in workspace/agents/*.yaml. */
+  agentName: string;
+  /** Correlation id of the underlying skill request — pairs start/complete/error and the tool.call events between them. */
+  correlationId: string;
+  /** ms timestamp at publish time. */
+  timestamp: number;
+  skill?: string;
+  /** For tool.call events: tool names invoked in this turn. */
+  toolNames?: string[];
+  /** For skill.complete: first ~120 chars of the assistant's final text, for UI preview. */
+  resultPreview?: string;
+  /** For skill.error: message from the thrown error. */
+  errorMessage?: string;
+  /** For skill.complete / skill.error: ms between start and terminal event. */
+  durationMs?: number;
+}

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -65,6 +65,17 @@ export interface DeepAgentConfig {
   gatewayApiKey?: string;
   apiBaseUrl?: string;
   apiKey?: string;
+  /**
+   * Best-effort telemetry hook fired for each tool-call turn made during
+   * a skill invocation. Wired by `AgentRuntimePlugin` to publish on
+   * `agent.runtime.activity.tool.call` so the /system dashboard can show
+   * live per-tool-call detail inside each agent's node. Errors thrown
+   * inside the callback are swallowed — telemetry never breaks a skill.
+   *
+   * Skill-level lifecycle (start / complete / error) is emitted by the
+   * SkillDispatcher across ALL executor types and does not need this hook.
+   */
+  onToolCall?: (event: { agentName: string; correlationId: string; skill?: string; toolNames: string[] }) => void;
 }
 
 // Each tool() call infers a unique DynamicStructuredTool<ZodObject<{specific fields}>, ...>.
@@ -588,9 +599,11 @@ export class DeepAgentExecutor implements IExecutor {
   private readonly agentDef: AgentDefinition;
   private readonly model: ChatOpenAI;
   private readonly http: HttpClient;
+  private readonly onToolCall: DeepAgentConfig["onToolCall"];
 
   constructor(agentDef: AgentDefinition, config: DeepAgentConfig = {}) {
     this.agentDef = agentDef;
+    this.onToolCall = config.onToolCall;
     const gatewayUrl = config.gatewayUrl ?? process.env.LLM_GATEWAY_URL ?? process.env.OPENAI_BASE_URL;
     const apiKey = config.gatewayApiKey ?? process.env.OPENAI_API_KEY ?? "unused";
 
@@ -656,13 +669,27 @@ export class DeepAgentExecutor implements IExecutor {
       const messages = result.messages ?? [];
       console.log(`[deep-agent:${this.agentDef.name}] ${messages.length} messages returned`);
 
-      // Log tool calls made
+      // Log tool calls made + emit telemetry for the /system dashboard.
       for (const msg of messages) {
         const type = msg._getType?.() ?? msg.constructor?.name ?? "";
         if (type === "ai" || type === "AIMessage") {
           const tc = (msg as unknown as Record<string, unknown>).tool_calls;
           if (Array.isArray(tc) && tc.length > 0) {
-            console.log(`[deep-agent:${this.agentDef.name}] tool calls: ${tc.map((t: { name?: string }) => t.name).join(", ")}`);
+            const toolNames = tc.map((t: { name?: string }) => t.name).filter((n): n is string => !!n);
+            console.log(`[deep-agent:${this.agentDef.name}] tool calls: ${toolNames.join(", ")}`);
+            if (this.onToolCall && toolNames.length > 0) {
+              try {
+                this.onToolCall({
+                  agentName: this.agentDef.name,
+                  correlationId: req.correlationId,
+                  skill: req.skill,
+                  toolNames,
+                });
+              } catch (cbErr) {
+                // Telemetry must never break a running skill.
+                console.warn(`[deep-agent:${this.agentDef.name}] onToolCall callback threw:`, cbErr);
+              }
+            }
           }
         }
       }

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -16,7 +16,13 @@
 import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
 import type { ExecutorRegistry } from "./executor-registry.ts";
 import type { SkillRequest } from "./types.ts";
-import type { AgentSkillRequestPayload, AutonomousOutcomePayload, FlowItemPayload } from "../event-bus/payloads.ts";
+import type {
+  AgentSkillRequestPayload,
+  AutonomousOutcomePayload,
+  FlowItemPayload,
+  AgentActivityPayload,
+  AgentActivityType,
+} from "../event-bus/payloads.ts";
 import { IdentityRegistry } from "../../lib/identity/identity-registry.ts";
 import { ContextMailbox } from "../../lib/dm/context-mailbox.ts";
 import type { TaskTracker } from "./task-tracker.ts";
@@ -99,6 +105,9 @@ export class SkillDispatcherPlugin implements Plugin {
     "flow.item.created",
     "flow.item.updated",
     "flow.item.completed",
+    "agent.runtime.activity.skill.start",
+    "agent.runtime.activity.skill.complete",
+    "agent.runtime.activity.skill.error",
   ];
 
   private bus?: EventBus;
@@ -282,6 +291,17 @@ export class SkillDispatcherPlugin implements Plugin {
       meta: { skill, executorType: executor.type },
     });
 
+    // Live agent telemetry — the /system dashboard subscribes to
+    // agent.runtime.activity.# to render live agent state. Covers ALL
+    // executor types uniformly because we emit at the dispatcher (the
+    // chokepoint), not inside each executor.
+    const targetAgent = targets[0] ?? "(no-target)";
+    this._publishActivity("skill.start", {
+      agentName: targetAgent,
+      correlationId,
+      skill,
+    });
+
     try {
       const result = await executor.execute(req);
 
@@ -382,6 +402,13 @@ export class SkillDispatcherPlugin implements Plugin {
         console.error(
           `[skill-dispatcher] Executor "${executor.type}" error for skill "${skill}": ${(result.text ?? "").slice(0, 500)}`,
         );
+        this._publishActivity("skill.error", {
+          agentName: targetAgent,
+          correlationId,
+          skill,
+          errorMessage: (result.text ?? "").slice(0, 500),
+          durationMs: Date.now() - dispatchedAt,
+        });
         this._publishFlowEvent("flow.item.updated", {
           id: flowItemId,
           status: "blocked",
@@ -409,6 +436,13 @@ export class SkillDispatcherPlugin implements Plugin {
         console.log(
           `[skill-dispatcher] Skill "${skill}" completed via ${executor.type} — ${(result.text ?? "").length} chars: ${preview}${(result.text ?? "").length > 300 ? "…" : ""}`,
         );
+        this._publishActivity("skill.complete", {
+          agentName: targetAgent,
+          correlationId,
+          skill,
+          resultPreview: preview.slice(0, 120),
+          durationMs: Date.now() - dispatchedAt,
+        });
         if (result.data?.stopReason === "max_turns") {
           console.warn("[skill-dispatcher] Agent hit maxTurns limit");
         }
@@ -454,6 +488,13 @@ export class SkillDispatcherPlugin implements Plugin {
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
       console.error(`[skill-dispatcher] Unhandled error dispatching "${skill}": ${errorMsg}`);
+      this._publishActivity("skill.error", {
+        agentName: targetAgent,
+        correlationId,
+        skill,
+        errorMessage: errorMsg,
+        durationMs: Date.now() - dispatchedAt,
+      });
       this._publishFlowEvent("flow.item.updated", {
         id: flowItemId,
         status: "blocked",
@@ -632,6 +673,33 @@ export class SkillDispatcherPlugin implements Plugin {
       timestamp: Date.now(),
       payload: item,
     });
+  }
+
+  /**
+   * Publish a live agent activity event. Best-effort: any failure to publish
+   * is swallowed — telemetry must never break a running skill. The /system
+   * dashboard subscribes to `agent.runtime.activity.#` to render live agent
+   * state, but any other consumer is welcome.
+   */
+  private _publishActivity(type: AgentActivityType, fields: Omit<AgentActivityPayload, "type" | "timestamp">): void {
+    if (!this.bus) return;
+    const topic = `agent.runtime.activity.${type}`;
+    const payload: AgentActivityPayload = {
+      type,
+      timestamp: Date.now(),
+      ...fields,
+    };
+    try {
+      this.bus.publish(topic, {
+        id: crypto.randomUUID(),
+        correlationId: fields.correlationId,
+        topic,
+        timestamp: payload.timestamp,
+        payload,
+      });
+    } catch (err) {
+      console.warn(`[skill-dispatcher] activity-publish failed (${type}):`, err);
+    }
   }
 
   private _publishResponse(


### PR DESCRIPTION
## Summary

Plugs the React Flow graph from #555 into a live view of **what each agent is actually doing**. Watching `docker logs` for tool calls is now obsolete — the graph shows it.

## What's new

### Agent nodes (custom React Flow node)

| | |
|---|---|
| **identity** | name + type badge (DeepAgent / A2A / function) |
| **status pill** | idle / running / completed / error — colored, with a pulse for running |
| **current skill** | shown while a dispatch is in flight |
| **tool-call history** | last ~4 calls with relative timestamps (`pr_inspector` 3s ago, `clawpatch_review` 2s ago) |
| **preview** | result preview on completion; error message on failure |

### Service nodes on the perimeter

Discord, GitHub, Linear, LiteLLM gateway, npm — dashed edges from the owning plugins (github plugin → GitHub service, linear plugin → Linear service, etc.). Closes the visual loop on "what's touching what."

### Live edge animation

WS subscribes to `/api/bus/subscribe?topic=#`; any edge whose topic just saw traffic pulses green for 1.5s. Agent edges stay solid green while their agent is mid-skill, then fade.

## Backend changes

| Topic | Producer | When |
|---|---|---|
| `agent.runtime.activity.skill.start` | SkillDispatcher | Before `executor.execute()` |
| `agent.runtime.activity.skill.complete` | SkillDispatcher | After successful execution |
| `agent.runtime.activity.skill.error` | SkillDispatcher | On error result OR thrown exception |
| `agent.runtime.activity.tool.call` | DeepAgentExecutor | Per tool-call turn (via new `onToolCall` callback wired by AgentRuntimePlugin) |

Skill-level events cover **all** executor types (deep-agent, a2a, function) because they fire at the dispatcher chokepoint, not inside each executor. Tool-level events are deep-agent-only since A2A can't introspect the remote agent's internals. All producers swallow publish failures — telemetry never breaks a running skill.

## New endpoint

`GET /api/agents/runtime` — every `ExecutorRegistry` registration grouped by `(agentName ?? executor.type)`. Returns:

```json
{
  "agents": [
    { "name": "quinn",   "type": "deep-agent", "skills": ["pr_review","bug_triage","security_triage"] },
    { "name": "protomaker", "type": "a2a", "skills": [...] },
    { "name": "alert-skill-executor", "type": "function", "skills": ["alert.ci_main_red", ...] }
  ]
}
```

Strict superset of what `/api/agents` returns (which is just the A2A yaml).

## Compat

Build stack stayed Astro + Preact via the `preact/compat` alias shim from #555. `@xyflow/react` keeps working unmodified.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 703 pass / 0 fail
- [x] `dashboard/ bun run build` clean
- [ ] After deploy: visit `/system` while Quinn is reviewing a PR; observe live tool-call entries appearing in her node, status pill flipping to running → completed, edge animation matching the dispatch flow

## Out of scope

- Smarter layout (force-directed instead of concentric rings) — current layout starts to crowd at >30 nodes; will revisit
- Per-message inspection drawer (click a pulsing edge to see the bus message) — useful but adds a panel + state
- Tests for the activity-event shape — relies on smoke once it deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live agent activity visualization in the system graph dashboard with real-time status updates via WebSocket
  * Agent runtime status API showing registered agents and their available skills
  * Service node display in the system topology graph
  * Dynamic agent node indicators showing current skill execution, tool calls, and results

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->