### PR TITLE
chore(fleet): archive rabbit-hole.io, add 5 repos to Quinn review scope

### DIFF
--- a/workspace/projects.yaml
+++ b/workspace/projects.yaml
@@ -1,5 +1,4 @@
 projects:
-
   - slug: protoworkstacean
     title: protoWorkstacean
     team: dev
@@ -75,7 +74,10 @@ projects:
     repoUrl: "https://github.com/protoLabsAI/rabbit-hole.io"
     projectPath: /home/josh/dev/labs/rabbit-hole-io
     defaultBranch: main
-    status: active
+    # Archived 2026-05-25 — project is dead. Archived (not deleted) so the
+    # A2APlugin index drops it from active scope while history/routing
+    # remains resolvable. Quinn no longer reviews or triages this repo.
+    status: archived
     agents: [quinn]
     discord:
       dev:
@@ -94,6 +96,96 @@ projects:
     defaultBranch: main
     status: active
     onboardedAt: "2026-04-17T20:15:40.845Z"
+    agents: [quinn]
+    discord:
+      dev:
+        channelId: ""
+        webhook: ""
+      release:
+        channelId: ""
+        webhook: ""
+
+  - slug: escape-from-qud
+    title: escape-from-qud
+    team: dev
+    github: protoLabsAI/escape-from-qud
+    repoUrl: "https://github.com/protoLabsAI/escape-from-qud"
+    projectPath: /home/josh/dev/labs/escape-from-qud
+    defaultBranch: main
+    status: active
+    onboardedAt: "2026-05-25T06:05:23.000Z"
+    agents: [quinn]
+    discord:
+      dev:
+        channelId: ""
+        webhook: ""
+      release:
+        channelId: ""
+        webhook: ""
+
+  - slug: release-tools
+    title: release-tools
+    team: dev
+    github: protoLabsAI/release-tools
+    repoUrl: "https://github.com/protoLabsAI/release-tools"
+    projectPath: /home/josh/dev/labs/release-tools
+    defaultBranch: main
+    status: active
+    onboardedAt: "2026-05-25T06:05:23.000Z"
+    agents: [quinn]
+    discord:
+      dev:
+        channelId: ""
+        webhook: ""
+      release:
+        channelId: ""
+        webhook: ""
+
+  - slug: protopatch
+    title: protoPatch
+    team: dev
+    github: protoLabsAI/protoPatch
+    repoUrl: "https://github.com/protoLabsAI/protoPatch"
+    projectPath: /home/josh/dev/labs/protoPatch
+    defaultBranch: main
+    status: active
+    onboardedAt: "2026-05-25T06:05:23.000Z"
+    agents: [quinn]
+    discord:
+      dev:
+        channelId: ""
+        webhook: ""
+      release:
+        channelId: ""
+        webhook: ""
+
+  - slug: pwndeck
+    title: pwnDeck
+    team: dev
+    github: protoLabsAI/pwnDeck
+    repoUrl: "https://github.com/protoLabsAI/pwnDeck"
+    projectPath: /home/josh/dev/labs/pwnDeck
+    defaultBranch: main
+    status: active
+    onboardedAt: "2026-05-25T06:05:23.000Z"
+    agents: [quinn]
+    discord:
+      dev:
+        channelId: ""
+        webhook: ""
+      release:
+        channelId: ""
+        webhook: ""
+
+  - slug: contentmachine
+    title: contentMachine
+    team: dev
+    github: protoLabsAI/contentMachine
+    repoUrl: "https://github.com/protoLabsAI/contentMachine"
+    projectPath: /home/josh/dev/labs/contentMachine
+    defaultBranch: main
+    status: active
+    onboardedAt: "2026-05-25T06:05:23.000Z"
     agents: [quinn]
     discord:
       dev:


### PR DESCRIPTION
## Summary

Updates the fleet project registry (`workspace/projects.yaml`):

- **Archived** `rabbit-hole.io` (dead). `status: archived` so `A2APlugin` drops it from active scope — Quinn stops reviewing/triaging — while history/routing stay resolvable.
- **Added 5 active repos**, all `agents: [quinn]`:

| Repo | Webhook | Note |
| --- | --- | --- |
| escape-from-qud | 630122469 | registered earlier today |
| release-tools | 630396222 | new |
| protoPatch | 630396231 | CLI *for* Quinn — its own source still gets reviewed |
| pwnDeck | 630396233 | new |
| contentMachine | 630396236 | new |

All 5 webhooks are live on the repos (`hooks.proto-labs.ai/webhook/github`, subscribed to issues / issue_comment / pull_request / pull_request_review_comment).

## Notes

- **Discord** blocks left empty (matching `protoagent`). Quinn PR review works without them; feature-lifecycle notifications won't route to a channel until provisioned. Follow-up: `provision_discord` per repo.
- **projectPath** follows the deploy-host convention. PR review is webhook/API-driven (no local checkout needed); native-tool skills like `board_health` that use `cwd` would need the repo checked out on the Quinn host.

YAML validated (11 projects: 10 active, 1 archived).

Companion work coming: a `.beads/` + `.automaker/` workspace-config **standard** so we can flag drift across these watched repos in CI/fleet (separate issue/PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Archived one existing project while maintaining resolution in historical records and routing.
  * Added five new projects with active status, onboarding timestamps, and team configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->