### PR TITLE
feat(pr-inspector): close_pr / close_pr_as_not_planned / reopen_pr (B1)

### DIFF
--- a/src/api/pr-inspector.ts
+++ b/src/api/pr-inspector.ts
@@ -20,6 +20,9 @@
  *   review_comment         → POST review with state=COMMENT
  *   review_approve         → POST review with state=APPROVE
  *   review_request_changes → POST review with state=REQUEST_CHANGES
+ *   close_pr               → PATCH state=closed (optionally with a leading comment)
+ *   close_pr_as_not_planned → PATCH state=closed + state_reason=not_planned
+ *   reopen_pr              → PATCH state=open
  */
 
 import type { Route, ApiContext } from "./types.ts";
@@ -34,13 +37,22 @@ type Action =
   | "diff_summary"
   | "review_comment"
   | "review_approve"
-  | "review_request_changes";
+  | "review_request_changes"
+  | "close_pr"
+  | "close_pr_as_not_planned"
+  | "reopen_pr";
 
 interface InspectRequest {
   action: Action;
   repo: string;
   pr_number?: number;
   body?: string;
+  /**
+   * When closing a PR via close_pr / close_pr_as_not_planned, optionally
+   * post a comment explaining why before flipping the state. Quinn uses
+   * this to link the close back to a verdict / fix-PR / triage decision.
+   */
+  comment?: string;
 }
 
 function parseRepo(repo: string): { owner: string; name: string } | null {
@@ -218,6 +230,71 @@ async function submitReview(
   return `${label} PR#${pr} in ${owner}/${name}.`;
 }
 
+async function postIssueComment(owner: string, name: string, n: number, body: string): Promise<void> {
+  const resp = await ghFetch(
+    owner,
+    name,
+    `https://api.github.com/repos/${owner}/${name}/issues/${n}/comments`,
+    {
+      method: "POST",
+      body: JSON.stringify({ body }),
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+  if (!resp.ok) throw new Error(`GitHub API error posting comment on #${n}: ${resp.status} ${await resp.text()}`);
+}
+
+/**
+ * Flip a PR's state. GitHub uses the same /pulls/{n} PATCH endpoint for
+ * close + reopen via `state: "closed" | "open"`. PRs that are merged
+ * cannot be reopened — this surfaces as a 422 from GitHub. We let that
+ * bubble up so Quinn can fold the failure into her observation list.
+ *
+ * `state_reason` distinguishes the close motive on PRs the same way
+ * GitHub does for issues — "completed" (default) vs "not_planned"
+ * (closed without merging because it's stale / superseded / wrong
+ * approach). Quinn uses not_planned when the PR's underlying request
+ * has been resolved a different way.
+ */
+async function setPrState(
+  owner: string,
+  name: string,
+  pr: number,
+  state: "open" | "closed",
+  comment: string | undefined,
+  notPlanned = false,
+): Promise<string> {
+  // Drop the comment first so observers see the rationale before the
+  // state-change webhook fires. Failure to comment is non-fatal — log
+  // and proceed to the state change.
+  if (comment && comment.trim()) {
+    try {
+      await postIssueComment(owner, name, pr, comment);
+    } catch (e) {
+      console.warn(`[pr-inspector] comment-then-close: comment failed (proceeding): ${String(e).slice(0, 300)}`);
+    }
+  }
+
+  const body: Record<string, unknown> = { state };
+  if (state === "closed" && notPlanned) body.state_reason = "not_planned";
+
+  const resp = await ghFetch(
+    owner,
+    name,
+    `https://api.github.com/repos/${owner}/${name}/pulls/${pr}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+  if (!resp.ok) {
+    throw new Error(`GitHub API error setting PR#${pr} state=${state}: ${resp.status} ${await resp.text()}`);
+  }
+  const verb = state === "open" ? "Reopened" : notPlanned ? "Closed (not planned)" : "Closed";
+  return `${verb} PR#${pr} in ${owner}/${name}.`;
+}
+
 export function createRoutes(_ctx: ApiContext): Route[] {
   return [
     {
@@ -231,7 +308,7 @@ export function createRoutes(_ctx: ApiContext): Route[] {
           return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 });
         }
 
-        const { action, repo, pr_number, body } = payload;
+        const { action, repo, pr_number, body, comment } = payload;
         if (!action || !repo) {
           return Response.json(
             { success: false, error: "action and repo are required" },
@@ -254,6 +331,9 @@ export function createRoutes(_ctx: ApiContext): Route[] {
           "review_comment",
           "review_approve",
           "review_request_changes",
+          "close_pr",
+          "close_pr_as_not_planned",
+          "reopen_pr",
         ];
         if (needsPr.includes(action) && (typeof pr_number !== "number" || !Number.isInteger(pr_number))) {
           return Response.json(
@@ -291,6 +371,15 @@ export function createRoutes(_ctx: ApiContext): Route[] {
                 return Response.json({ success: false, error: "body required for review_request_changes" }, { status: 400 });
               }
               result = await submitReview(owner, name, pr_number!, "REQUEST_CHANGES", body);
+              break;
+            case "close_pr":
+              result = await setPrState(owner, name, pr_number!, "closed", comment, false);
+              break;
+            case "close_pr_as_not_planned":
+              result = await setPrState(owner, name, pr_number!, "closed", comment, true);
+              break;
+            case "reopen_pr":
+              result = await setPrState(owner, name, pr_number!, "open", comment, false);
               break;
             default:
               return Response.json({ success: false, error: `unknown action '${action}'` }, { status: 400 });

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -242,14 +242,18 @@ function createLangChainTools(toolNames: string[], http: HttpClient, correlation
       {
         name: "pr_inspector",
         description:
-          "Inspect and review GitHub PRs. The `repo` arg (owner/name) is REQUIRED on every call — there is no default. Actions:\n" +
+          "Inspect AND act on GitHub PRs. The `repo` arg (owner/name) is REQUIRED on every call. Actions:\n" +
           "- list_open: list open PRs in a repo\n" +
           "- check_ci: CI check states for a PR\n" +
           "- coderabbit_threads: unresolved review threads on a PR\n" +
           "- diff_summary: first 200 lines of the PR diff\n" +
           "- review_comment: post a COMMENTED review (requires body)\n" +
           "- review_approve: post an APPROVED review (body optional)\n" +
-          "- review_request_changes: post a CHANGES_REQUESTED review (requires body)",
+          "- review_request_changes: post a CHANGES_REQUESTED review (requires body)\n" +
+          "- close_pr: close a PR (optionally with a leading comment explaining why)\n" +
+          "- close_pr_as_not_planned: close + mark state_reason=not_planned (use when the PR is stale, superseded, or the underlying request was resolved differently)\n" +
+          "- reopen_pr: reopen a closed (non-merged) PR\n\n" +
+          "Prefer closing a stale/resolved PR directly to filing a 'please close #X' issue — that's the cascade pattern from #556. Always include `comment` on close_pr / close_pr_as_not_planned so the close has audit context.",
         schema: z.object({
           action: z.enum([
             "list_open",
@@ -259,12 +263,16 @@ function createLangChainTools(toolNames: string[], http: HttpClient, correlation
             "review_comment",
             "review_approve",
             "review_request_changes",
+            "close_pr",
+            "close_pr_as_not_planned",
+            "reopen_pr",
           ]),
           repo: z.string().describe(
             "Repository in owner/name format (e.g. protoLabsAI/protoWorkstacean). REQUIRED on every call.",
           ),
           pr_number: z.number().int().optional(),
-          body: z.string().optional(),
+          body: z.string().optional().describe("Review body for review_* actions."),
+          comment: z.string().optional().describe("Optional leading comment posted before close_pr / close_pr_as_not_planned. Recommended for audit trail."),
         }),
       },
     ),


### PR DESCRIPTION
Week 1 / B1 from `docs/roadmap/2026-06.md`. Gives Quinn the capability she was missing behind the #556 cascade — closing a stale/superseded PR directly instead of filing a 'please close #X' meta-issue. Adds `close_pr`, `close_pr_as_not_planned`, `reopen_pr` actions to `/api/pr/inspect` and the matching enum entries to the `pr_inspector` tool schema. Optional `comment` field posts a leading audit comment before flipping state. `bun test` 703 pass / 0 fail; `bun run typecheck` clean.