### PR TITLE
feat(pr-inspector): close_issue / reopen_issue / comment_on_issue (B2)

### DIFF
--- a/src/api/pr-inspector.ts
+++ b/src/api/pr-inspector.ts
@@ -20,6 +20,9 @@
  *   review_comment         → POST review with state=COMMENT
  *   review_approve         → POST review with state=APPROVE
  *   review_request_changes → POST review with state=REQUEST_CHANGES
+ *   close_pr               → PATCH state=closed (optionally with a leading comment)
+ *   close_pr_as_not_planned → PATCH state=closed + state_reason=not_planned
+ *   reopen_pr              → PATCH state=open
  */
 
 import type { Route, ApiContext } from "./types.ts";
@@ -34,13 +37,22 @@ type Action =
   | "diff_summary"
   | "review_comment"
   | "review_approve"
-  | "review_request_changes";
+  | "review_request_changes"
+  | "close_pr"
+  | "close_pr_as_not_planned"
+  | "reopen_pr";
 
 interface InspectRequest {
   action: Action;
   repo: string;
   pr_number?: number;
   body?: string;
+  /**
+   * When closing a PR via close_pr / close_pr_as_not_planned, optionally
+   * post a comment explaining why before flipping the state. Quinn uses
+   * this to link the close back to a verdict / fix-PR / triage decision.
+   */
+  comment?: string;
 }
 
 function parseRepo(repo: string): { owner: string; name: string } | null {
@@ -218,6 +230,71 @@ async function submitReview(
   return `${label} PR#${pr} in ${owner}/${name}.`;
 }
 
+async function postIssueComment(owner: string, name: string, n: number, body: string): Promise<void> {
+  const resp = await ghFetch(
+    owner,
+    name,
+    `https://api.github.com/repos/${owner}/${name}/issues/${n}/comments`,
+    {
+      method: "POST",
+      body: JSON.stringify({ body }),
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+  if (!resp.ok) throw new Error(`GitHub API error posting comment on #${n}: ${resp.status} ${await resp.text()}`);
+}
+
+/**
+ * Flip a PR's state. GitHub uses the same /pulls/{n} PATCH endpoint for
+ * close + reopen via `state: "closed" | "open"`. PRs that are merged
+ * cannot be reopened — this surfaces as a 422 from GitHub. We let that
+ * bubble up so Quinn can fold the failure into her observation list.
+ *
+ * `state_reason` distinguishes the close motive on PRs the same way
+ * GitHub does for issues — "completed" (default) vs "not_planned"
+ * (closed without merging because it's stale / superseded / wrong
+ * approach). Quinn uses not_planned when the PR's underlying request
+ * has been resolved a different way.
+ */
+async function setPrState(
+  owner: string,
+  name: string,
+  pr: number,
+  state: "open" | "closed",
+  comment: string | undefined,
+  notPlanned = false,
+): Promise<string> {
+  // Drop the comment first so observers see the rationale before the
+  // state-change webhook fires. Failure to comment is non-fatal — log
+  // and proceed to the state change.
+  if (comment && comment.trim()) {
+    try {
+      await postIssueComment(owner, name, pr, comment);
+    } catch (e) {
+      console.warn(`[pr-inspector] comment-then-close: comment failed (proceeding): ${String(e).slice(0, 300)}`);
+    }
+  }
+
+  const body: Record<string, unknown> = { state };
+  if (state === "closed" && notPlanned) body.state_reason = "not_planned";
+
+  const resp = await ghFetch(
+    owner,
+    name,
+    `https://api.github.com/repos/${owner}/${name}/pulls/${pr}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+  if (!resp.ok) {
+    throw new Error(`GitHub API error setting PR#${pr} state=${state}: ${resp.status} ${await resp.text()}`);
+  }
+  const verb = state === "open" ? "Reopened" : notPlanned ? "Closed (not planned)" : "Closed";
+  return `${verb} PR#${pr} in ${owner}/${name}.`;
+}
+
 export function createRoutes(_ctx: ApiContext): Route[] {
   return [
     {
@@ -231,7 +308,7 @@ export function createRoutes(_ctx: ApiContext): Route[] {
           return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 });
         }
 
-        const { action, repo, pr_number, body } = payload;
+        const { action, repo, pr_number, body, comment } = payload;
         if (!action || !repo) {
           return Response.json(
             { success: false, error: "action and repo are required" },
@@ -254,6 +331,9 @@ export function createRoutes(_ctx: ApiContext): Route[] {
           "review_comment",
           "review_approve",
           "review_request_changes",
+          "close_pr",
+          "close_pr_as_not_planned",
+          "reopen_pr",
         ];
         if (needsPr.includes(action) && (typeof pr_number !== "number" || !Number.isInteger(pr_number))) {
           return Response.json(
@@ -291,6 +371,15 @@ export function createRoutes(_ctx: ApiContext): Route[] {
                 return Response.json({ success: false, error: "body required for review_request_changes" }, { status: 400 });
               }
               result = await submitReview(owner, name, pr_number!, "REQUEST_CHANGES", body);
+              break;
+            case "close_pr":
+              result = await setPrState(owner, name, pr_number!, "closed", comment, false);
+              break;
+            case "close_pr_as_not_planned":
+              result = await setPrState(owner, name, pr_number!, "closed", comment, true);
+              break;
+            case "reopen_pr":
+              result = await setPrState(owner, name, pr_number!, "open", comment, false);
               break;
             default:
               return Response.json({ success: false, error: `unknown action '${action}'` }, { status: 400 });

--- a/src/api/pr-inspector.ts
+++ b/src/api/pr-inspector.ts
@@ -23,6 +23,10 @@
  *   close_pr               → PATCH state=closed (optionally with a leading comment)
  *   close_pr_as_not_planned → PATCH state=closed + state_reason=not_planned
  *   reopen_pr              → PATCH state=open
+ *   close_issue            → PATCH /issues/{n} state=closed (state_reason=completed)
+ *   close_issue_as_not_planned → PATCH state=closed + state_reason=not_planned
+ *   reopen_issue           → PATCH state=open
+ *   comment_on_issue       → POST a comment without closing (audit-trail / status update)
  */
 
 import type { Route, ApiContext } from "./types.ts";
@@ -40,17 +44,24 @@ type Action =
   | "review_request_changes"
   | "close_pr"
   | "close_pr_as_not_planned"
-  | "reopen_pr";
+  | "reopen_pr"
+  | "close_issue"
+  | "close_issue_as_not_planned"
+  | "reopen_issue"
+  | "comment_on_issue";
 
 interface InspectRequest {
   action: Action;
   repo: string;
   pr_number?: number;
+  /** For issue-targeted actions. Same role as pr_number for PR-targeted ones. */
+  issue_number?: number;
   body?: string;
   /**
-   * When closing a PR via close_pr / close_pr_as_not_planned, optionally
-   * post a comment explaining why before flipping the state. Quinn uses
-   * this to link the close back to a verdict / fix-PR / triage decision.
+   * When closing a PR/issue, optionally post a comment explaining why
+   * before flipping state. Quinn uses this to link the close back to a
+   * verdict / fix-PR / triage decision. Also used as the body for
+   * `comment_on_issue` directly.
    */
   comment?: string;
 }
@@ -295,6 +306,60 @@ async function setPrState(
   return `${verb} PR#${pr} in ${owner}/${name}.`;
 }
 
+/**
+ * Flip an issue's state. Mirrors setPrState but routes through the /issues/{n}
+ * endpoint (PRs and issues are separate REST surfaces even though they share
+ * a number space). GitHub accepts `state_reason` on issues: "completed" (the
+ * default close motive — issue resolved) and "not_planned" (closed without
+ * doing the work because it's a duplicate, stale, or wrong premise).
+ *
+ * Quinn's bug_triage skill closes already_fixed issues with `completed` and
+ * stale / duplicate / wont-fix with `not_planned`.
+ */
+async function setIssueState(
+  owner: string,
+  name: string,
+  n: number,
+  state: "open" | "closed",
+  comment: string | undefined,
+  notPlanned = false,
+): Promise<string> {
+  if (comment && comment.trim()) {
+    try {
+      await postIssueComment(owner, name, n, comment);
+    } catch (e) {
+      console.warn(`[pr-inspector] comment-then-close issue: comment failed (proceeding): ${String(e).slice(0, 300)}`);
+    }
+  }
+
+  const body: Record<string, unknown> = { state };
+  if (state === "closed") body.state_reason = notPlanned ? "not_planned" : "completed";
+
+  const resp = await ghFetch(
+    owner,
+    name,
+    `https://api.github.com/repos/${owner}/${name}/issues/${n}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+  if (!resp.ok) {
+    throw new Error(`GitHub API error setting issue#${n} state=${state}: ${resp.status} ${await resp.text()}`);
+  }
+  const verb = state === "open" ? "Reopened" : notPlanned ? "Closed (not planned)" : "Closed";
+  return `${verb} issue#${n} in ${owner}/${name}.`;
+}
+
+async function commentOnIssue(owner: string, name: string, n: number, body: string): Promise<string> {
+  if (!body || !body.trim()) {
+    throw new Error("comment_on_issue requires a non-empty `comment` field");
+  }
+  await postIssueComment(owner, name, n, body);
+  return `Commented on issue#${n} in ${owner}/${name}.`;
+}
+
 export function createRoutes(_ctx: ApiContext): Route[] {
   return [
     {
@@ -308,7 +373,7 @@ export function createRoutes(_ctx: ApiContext): Route[] {
           return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 });
         }
 
-        const { action, repo, pr_number, body, comment } = payload;
+        const { action, repo, pr_number, issue_number, body, comment } = payload;
         if (!action || !repo) {
           return Response.json(
             { success: false, error: "action and repo are required" },
@@ -338,6 +403,19 @@ export function createRoutes(_ctx: ApiContext): Route[] {
         if (needsPr.includes(action) && (typeof pr_number !== "number" || !Number.isInteger(pr_number))) {
           return Response.json(
             { success: false, error: `pr_number is required (integer) for action='${action}'` },
+            { status: 400 },
+          );
+        }
+
+        const needsIssue: Action[] = [
+          "close_issue",
+          "close_issue_as_not_planned",
+          "reopen_issue",
+          "comment_on_issue",
+        ];
+        if (needsIssue.includes(action) && (typeof issue_number !== "number" || !Number.isInteger(issue_number))) {
+          return Response.json(
+            { success: false, error: `issue_number is required (integer) for action='${action}'` },
             { status: 400 },
           );
         }
@@ -380,6 +458,21 @@ export function createRoutes(_ctx: ApiContext): Route[] {
               break;
             case "reopen_pr":
               result = await setPrState(owner, name, pr_number!, "open", comment, false);
+              break;
+            case "close_issue":
+              result = await setIssueState(owner, name, issue_number!, "closed", comment, false);
+              break;
+            case "close_issue_as_not_planned":
+              result = await setIssueState(owner, name, issue_number!, "closed", comment, true);
+              break;
+            case "reopen_issue":
+              result = await setIssueState(owner, name, issue_number!, "open", comment, false);
+              break;
+            case "comment_on_issue":
+              if (!comment) {
+                return Response.json({ success: false, error: "comment is required for comment_on_issue" }, { status: 400 });
+              }
+              result = await commentOnIssue(owner, name, issue_number!, comment);
               break;
             default:
               return Response.json({ success: false, error: `unknown action '${action}'` }, { status: 400 });

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -242,14 +242,18 @@ function createLangChainTools(toolNames: string[], http: HttpClient, correlation
       {
         name: "pr_inspector",
         description:
-          "Inspect and review GitHub PRs. The `repo` arg (owner/name) is REQUIRED on every call — there is no default. Actions:\n" +
+          "Inspect AND act on GitHub PRs. The `repo` arg (owner/name) is REQUIRED on every call. Actions:\n" +
           "- list_open: list open PRs in a repo\n" +
           "- check_ci: CI check states for a PR\n" +
           "- coderabbit_threads: unresolved review threads on a PR\n" +
           "- diff_summary: first 200 lines of the PR diff\n" +
           "- review_comment: post a COMMENTED review (requires body)\n" +
           "- review_approve: post an APPROVED review (body optional)\n" +
-          "- review_request_changes: post a CHANGES_REQUESTED review (requires body)",
+          "- review_request_changes: post a CHANGES_REQUESTED review (requires body)\n" +
+          "- close_pr: close a PR (optionally with a leading comment explaining why)\n" +
+          "- close_pr_as_not_planned: close + mark state_reason=not_planned (use when the PR is stale, superseded, or the underlying request was resolved differently)\n" +
+          "- reopen_pr: reopen a closed (non-merged) PR\n\n" +
+          "Prefer closing a stale/resolved PR directly to filing a 'please close #X' issue — that's the cascade pattern from #556. Always include `comment` on close_pr / close_pr_as_not_planned so the close has audit context.",
         schema: z.object({
           action: z.enum([
             "list_open",
@@ -259,12 +263,16 @@ function createLangChainTools(toolNames: string[], http: HttpClient, correlation
             "review_comment",
             "review_approve",
             "review_request_changes",
+            "close_pr",
+            "close_pr_as_not_planned",
+            "reopen_pr",
           ]),
           repo: z.string().describe(
             "Repository in owner/name format (e.g. protoLabsAI/protoWorkstacean). REQUIRED on every call.",
           ),
           pr_number: z.number().int().optional(),
-          body: z.string().optional(),
+          body: z.string().optional().describe("Review body for review_* actions."),
+          comment: z.string().optional().describe("Optional leading comment posted before close_pr / close_pr_as_not_planned. Recommended for audit trail."),
         }),
       },
     ),

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -252,8 +252,13 @@ function createLangChainTools(toolNames: string[], http: HttpClient, correlation
           "- review_request_changes: post a CHANGES_REQUESTED review (requires body)\n" +
           "- close_pr: close a PR (optionally with a leading comment explaining why)\n" +
           "- close_pr_as_not_planned: close + mark state_reason=not_planned (use when the PR is stale, superseded, or the underlying request was resolved differently)\n" +
-          "- reopen_pr: reopen a closed (non-merged) PR\n\n" +
-          "Prefer closing a stale/resolved PR directly to filing a 'please close #X' issue — that's the cascade pattern from #556. Always include `comment` on close_pr / close_pr_as_not_planned so the close has audit context.",
+          "- reopen_pr: reopen a closed (non-merged) PR\n" +
+          "- close_issue: close an issue (state_reason=completed; for resolved/done issues)\n" +
+          "- close_issue_as_not_planned: close + state_reason=not_planned (stale / duplicate / wont-fix / wrong-premise)\n" +
+          "- reopen_issue: reopen a closed issue\n" +
+          "- comment_on_issue: post a comment on an issue without closing\n\n" +
+          "PR-targeted actions use `pr_number`. Issue-targeted actions use `issue_number`. Use `comment` for audit context.\n\n" +
+          "**Prefer direct action to filing meta-issues.** A stale PR you can close → close it. An already-fixed issue → close_issue with a comment linking the fix commit. The cascade pattern from #556 came from filing 'please close #X' issues instead of doing it directly — don't repeat it.",
         schema: z.object({
           action: z.enum([
             "list_open",
@@ -266,13 +271,18 @@ function createLangChainTools(toolNames: string[], http: HttpClient, correlation
             "close_pr",
             "close_pr_as_not_planned",
             "reopen_pr",
+            "close_issue",
+            "close_issue_as_not_planned",
+            "reopen_issue",
+            "comment_on_issue",
           ]),
           repo: z.string().describe(
             "Repository in owner/name format (e.g. protoLabsAI/protoWorkstacean). REQUIRED on every call.",
           ),
-          pr_number: z.number().int().optional(),
+          pr_number: z.number().int().optional().describe("Required for PR-targeted actions."),
+          issue_number: z.number().int().optional().describe("Required for issue-targeted actions (close_issue, reopen_issue, comment_on_issue)."),
           body: z.string().optional().describe("Review body for review_* actions."),
-          comment: z.string().optional().describe("Optional leading comment posted before close_pr / close_pr_as_not_planned. Recommended for audit trail."),
+          comment: z.string().optional().describe("Leading comment posted before a close, OR the body of comment_on_issue. Recommended on every close for audit context."),
         }),
       },
     ),

--- a/workspace/agents/quinn.yaml
+++ b/workspace/agents/quinn.yaml
@@ -391,12 +391,20 @@ skills:
 
       ## Step 5 — Act
 
-      - Close stale issues with an explanation (use `create_github_issue`
-        — there's no separate close-issue tool yet; file a follow-up
-        ticket if needed and note in Observations)
-      - Comment on already_fixed issues with the commit that resolved them
-      - Label actionable issues with severity
-      - Flag duplicates with a link to the canonical issue
+      You have the tools to close + comment on issues directly. Use them.
+      Filing a "please close #X" meta-issue was the cascade pattern from
+      protoWorkstacean#556 — don't repeat it.
+
+      | Category | Action | pr_inspector call |
+      |---|---|---|
+      | **already_fixed** | Close with a comment linking the fix commit/PR | `pr_inspector(action='close_issue', repo, issue_number, comment='Resolved by <repo>#<sha\|pr> ...')` |
+      | **actionable** | Comment with severity + suggested next step. Leave open. | `pr_inspector(action='comment_on_issue', repo, issue_number, comment='Severity: HIGH ... Next: ...')` |
+      | **stale** | Close as `not_planned` with explanation of why it's stale | `pr_inspector(action='close_issue_as_not_planned', repo, issue_number, comment='Stale — no activity in 30d ...')` |
+      | **duplicate** | Comment with link to canonical issue, then close as `not_planned` | first `comment_on_issue` then `close_issue_as_not_planned` |
+
+      Only file a new `create_github_issue` when you've discovered a NEW
+      problem during triage that isn't tracked anywhere. Never file an
+      issue whose body is asking someone else to close an existing issue.
 
       ## Step 6 — Report
 


### PR DESCRIPTION
Week 1 / B2 from `docs/roadmap/2026-06.md`. Stacked on #569 (B1). Rounds out Quinn's CRUD over issues so she stops filing meta-issues that ask someone else to close existing issues. New actions: `close_issue`, `close_issue_as_not_planned`, `reopen_issue`, `comment_on_issue`. `bug_triage` prompt rewritten with an explicit action table per classification + hard rule against filing 'please close #X' issues. 703 pass / 0 fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pull requests can now be closed and reopened automatically with optional comments
  * Issues can now be closed, reopened, and have comments added through automated workflows
  * Enhanced PR and issue state management capabilities for improved issue tracking and management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->