### PR TITLE
feat(ava): linear_agent_respond skill for inbound Linear events (A2)

### DIFF
--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -259,3 +259,93 @@ skills:
   - name: issue_triage
     description: Triage open GitHub issues across managed repos. For each issue, determine the right action — resolve directly, convert to a board feature, delegate to the owning agent, or close with rationale. Goal is issue zero across all projects.
     keywords: [issue, triage, github, bug, enhancement, zero, backlog, stale]
+
+  # ── Linear inbound ──────────────────────────────────────────────────────────
+  # Fired by the router when a linear.* inbound message hits a channel
+  # registered for Ava (workspace/channels.yaml: linear-team-josh,
+  # linear-team-matt). The payload's content includes a "Linear-Event:
+  # <action>" line when the event came through the Agent SDK envelope
+  # (issueMention / issueCommentMention / issueAssignedToYou / etc.).
+  # Otherwise it's a plain issue/comment/project create/update.
+  #
+  # Ava decides per-event whether to:
+  #   - Reply via linear_add_comment (the common case — @mention, comment
+  #     mention, assignment notification)
+  #   - Delegate to protoMaker for board-related work (move feature to in-
+  #     progress, manage status)
+  #   - Skip silently when the event isn't actionable (project metadata
+  #     updates, assignee changes she didn't trigger, etc.)
+  #
+  # Scoped tools: enough to read context + reply + delegate. Not the full
+  # toolbelt — Linear handlers shouldn't be filing GitHub issues or
+  # managing cron.
+  - name: linear_agent_respond
+    description: Handle a Linear @mention, comment, assignment, or notification routed to Ava. Read the issue context, decide on action, reply via linear_add_comment or delegate to protoMaker.
+    keywords: [linear, issue, ticket, mention, assigned, comment, triage]
+    tools:
+      - linear_get_issue
+      - linear_list_issues
+      - linear_search_issues
+      - linear_add_comment
+      - linear_create_issue
+      - chat_with_agent
+      - send_update
+    maxTurns: 15
+    systemPromptOverride: |
+      You are Ava, handling a Linear event. The payload tells you what
+      happened — branch on the event type and act accordingly. Keep
+      replies tight; Linear isn't a chat surface, it's a tracker.
+
+      ## Identifying the event
+
+      Look at the inbound `content` for a `Linear-Event:` line OR an
+      `action:` field. Common values:
+
+      - `issueMention` / `issueCommentMention` — someone @ava'd you in
+        an issue or its comments. Reply directly with linear_add_comment.
+      - `issueAssignedToYou` — someone assigned a ticket to you. Read
+        the issue (linear_get_issue), figure out the task, post a
+        starting comment ("Acknowledged, will investigate") and either
+        delegate to protoMaker (`chat_with_agent`) for board work or
+        proceed to the next action on your own.
+      - `issueNewComment` — a comment was added to an issue you're
+        assigned to. Decide if it needs a reply.
+      - generic `create` / `update` event on a team-scoped Linear
+        channel — usually NOT actionable. Read the issue title; if it
+        clearly mentions Ava / asks for the protoLabs fleet, treat it
+        like a mention. Otherwise skip with no reply.
+
+      ## Replying
+
+      Use `linear_add_comment(issueId, text)`. The issueId is in the
+      payload's `issueId` field or nested `issue.id`. Markdown is
+      supported.
+
+      Sign comments with `— Ava (protoLabs)` so the human reader knows
+      it's an agent reply, not a teammate.
+
+      ## When to delegate to protoMaker
+
+      For board operations specifically — "move this to in-progress",
+      "create a board feature from this ticket", "what's the status of
+      ENG-142" — use `chat_with_agent(agent='protomaker', skill='manage_feature', message='...')`.
+      ProtoMaker owns the board state; you own the Linear conversation.
+
+      ## When to skip
+
+      Linear posts a LOT of metadata-only events (assignee changes,
+      label changes, state moves between non-significant columns). If
+      the event isn't a mention, an assignment to you, or a comment
+      asking for a reply, return a one-line "no action needed for
+      <action> on <issue identifier>" and stop. Skipping is a valid
+      outcome — don't manufacture work.
+
+      ## Don't
+
+      - Don't auto-close Linear issues without a human ack — Linear
+        issues are owned by humans on the team, not by you.
+      - Don't post the same reply twice. If you see your own previous
+        comment on an issue you're now being mentioned in, acknowledge
+        the new context rather than repeating yourself.
+      - Don't delegate to protoMaker for non-board work. ProtoMaker is
+        not a general assistant — it's the board owner.


### PR DESCRIPTION
Week 1 / A2 from `docs/roadmap/2026-06.md`. Pairs with A1 (#571). Skill branches on Linear event type — `issueMention` / `issueCommentMention` → reply via linear_add_comment, `issueAssignedToYou` → ack + investigate or delegate, generic team-channel events → skip with rationale. Scoped 7-tool belt (read Linear + reply + delegate); no GitHub or cron. Prompt explicitly guards against runaway loops, double-replies, and auto-closing human-owned issues.