### PR TITLE
fix(api): surface A2A agents in /api/agents/runtime even pre-discovery (E3)

### DIFF
--- a/src/api/agents-runtime.ts
+++ b/src/api/agents-runtime.ts
@@ -1,34 +1,65 @@
 /**
  * GET /api/agents/runtime — list every registered executor, grouped by agent.
  *
- * The existing GET /api/agents only returns the A2A registry from
- * workspace/agents.yaml. The /system dashboard also needs in-process
- * agents (DeepAgents like Quinn / Ava / protobot) and function-skill
- * executors (alert.* / ceremony.* / pr.*) for the topology graph.
+ * Combines two sources so the /system dashboard sees the complete fleet:
  *
- * Pulls live data from ExecutorRegistry so the response reflects what's
- * actually wired in this process — not what a yaml says should be wired.
+ *   1. ExecutorRegistry — every live registration grouped by
+ *      (agentName ?? executor.type). Catches in-process DeepAgents
+ *      (quinn / ava / protobot) plus the function-executor cluster for
+ *      alert.* / ceremony.* / pr.* skills.
  *
- * Response:
+ *   2. workspace/agents.yaml — A2A agents (protomaker, protopen). These
+ *      don't appear in the registry until SkillBrokerPlugin's async card
+ *      discovery completes, but they're known statically from yaml. We
+ *      surface them eagerly with a `pendingDiscovery: true` marker
+ *      so the dashboard renders the node even before discovery returns.
+ *      Once discovery lands, the executor registration takes over and
+ *      the pending flag clears.
+ *
+ * Response shape:
  *   {
  *     success: true,
  *     data: {
  *       agents: [
- *         { name: "quinn", type: "deep-agent", skills: ["pr_review","bug_triage", ...] },
- *         { name: "protomaker", type: "a2a", skills: [...] },
- *         { name: "alert-skill-executor", type: "function", skills: ["alert.ci_main_red", ...] },
+ *         { name: "quinn", type: "deep-agent", skills: ["pr_review", ...] },
+ *         { name: "protomaker", type: "a2a", skills: [...], pendingDiscovery: false },
+ *         { name: "function", type: "function", skills: ["alert.*", ...] },
  *         ...
  *       ]
  *     }
  *   }
  */
 
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
 import type { Route, ApiContext } from "./types.ts";
 
 interface AgentSummary {
   name: string;
   type: string;
   skills: string[];
+  /** True iff this agent is known from yaml but hasn't registered any skill yet (A2A card discovery in flight). */
+  pendingDiscovery?: boolean;
+}
+
+interface YamlAgent {
+  name?: string;
+  url?: string;
+  external?: boolean;
+}
+
+function loadYamlAgents(workspaceDir: string): YamlAgent[] {
+  const path = join(workspaceDir, "agents.yaml");
+  if (!existsSync(path)) return [];
+  try {
+    const parsed = parseYaml(readFileSync(path, "utf8")) as { agents?: YamlAgent[] };
+    return Array.isArray(parsed?.agents) ? parsed.agents : [];
+  } catch {
+    // Tolerate yaml parse errors — the live registry view is still useful
+    // and an over-noisy 500 on /api/agents/runtime breaks the dashboard.
+    return [];
+  }
 }
 
 export function createRoutes(ctx: ApiContext): Route[] {
@@ -39,10 +70,7 @@ export function createRoutes(ctx: ApiContext): Route[] {
       handler: () => {
         const registrations = ctx.executorRegistry.list();
 
-        // Group by (agentName ?? executor.type). Each unique grouping becomes
-        // one node on the dashboard. agentName takes precedence so quinn / ava
-        // / protobot show up as individuals; nameless function executors
-        // collapse under their executor type ("function").
+        // 1. Group registry entries by (agentName ?? executor.type).
         const byKey = new Map<string, { type: string; skills: Set<string> }>();
         for (const reg of registrations) {
           const key = reg.agentName ?? reg.executor.type;
@@ -54,12 +82,28 @@ export function createRoutes(ctx: ApiContext): Route[] {
           if (reg.skill) entry.skills.add(reg.skill);
         }
 
+        // 2. Merge in yaml-declared A2A agents. If they already have a
+        // registry entry (skills discovered, in-process loaded), the
+        // registry data wins. Otherwise we mark them pendingDiscovery
+        // so the dashboard renders a node with no skills yet.
+        for (const ya of loadYamlAgents(ctx.workspaceDir)) {
+          if (!ya.name) continue;
+          if (byKey.has(ya.name)) continue;
+          byKey.set(ya.name, { type: "a2a", skills: new Set() });
+        }
+
         const agents: AgentSummary[] = [...byKey.entries()]
-          .map(([name, { type, skills }]) => ({
-            name,
-            type,
-            skills: [...skills].sort(),
-          }))
+          .map(([name, { type, skills }]) => {
+            const skillList = [...skills].sort();
+            const summary: AgentSummary = { name, type, skills: skillList };
+            // Only A2A agents can be in "discovery pending" — others
+            // either declare their skills via yaml (deep-agents) or are
+            // synthetic plugin-level (function).
+            if (type === "a2a" && skillList.length === 0) {
+              summary.pendingDiscovery = true;
+            }
+            return summary;
+          })
           .sort((a, b) => a.name.localeCompare(b.name));
 
         return Response.json({ success: true, data: { agents } });


### PR DESCRIPTION
Week 1 / E3 from `docs/roadmap/2026-06.md`. protomaker + protopen were invisible on /system because they don't declare skills in agents.yaml and rely on async card discovery. Route now reads agents.yaml directly + merges in yaml-only entries with `pendingDiscovery: true`. Once card discovery lands, the registry entry wins. 703 pass / 0 fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent runtime now aggregates agents from both the executor registry and workspace configuration files, eliminating duplicates and improving discovery coverage.
  * Agents undergoing discovery are now flagged with a pending discovery indicator, providing better visibility into agent availability status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->