### PR TITLE
feat(quinn): wire clawpatch (protoPatch) into bug_triage + map fleet repos

### DIFF
--- a/src/api/clawpatch.ts
+++ b/src/api/clawpatch.ts
@@ -35,8 +35,8 @@ import type { Route, ApiContext } from "./types.ts";
  * Override with CLAWPATCH_STATE_ROOT for testing or when DATA_DIR isn't set.
  */
 const CLAWPATCH_STATE_ROOT =
-  process.env["CLAWPATCH_STATE_ROOT"]
-  ?? join(process.env["DATA_DIR"] ?? "/data", "clawpatch");
+  process.env["CLAWPATCH_STATE_ROOT"] ??
+  join(process.env["DATA_DIR"] ?? "/data", "clawpatch");
 
 function stateDirFor(repo: string): string {
   // owner/repo → owner-repo so the path stays one level deep.
@@ -66,11 +66,21 @@ interface ReviewRequest {
 }
 
 const BUILT_IN_REPO_PATHS: Record<string, string> = {
-  // Repos mounted read-only into the workstacean container today (see
-  // homelab-iac/stacks/ai/docker-compose.yml workstacean.volumes).
+  // Repos clawpatch can review. Paths follow the deploy-host convention
+  // (~/dev/labs/{repo}, protoWorkstacean at ~/dev/protoWorkstacean). Each
+  // must ALSO be mounted read-only into the container for the path to exist —
+  // see homelab-iac/stacks/ai/docker-compose.yml workstacean.volumes. An entry
+  // here without a mount resolves to a missing path and clawpatch reports it.
+  // Keep in sync with the active repos in workspace/projects.yaml.
   "protoLabsAI/protoWorkstacean": "/home/josh/dev/protoWorkstacean",
+  "protoLabsAI/protoMaker": "/home/josh/dev/labs/protoMaker",
   "protoLabsAI/protoCLI": "/home/josh/dev/labs/protoCLI",
   "protoLabsAI/mythxengine": "/home/josh/dev/labs/mythxengine",
+  "protoLabsAI/escape-from-qud": "/home/josh/dev/labs/escape-from-qud",
+  "protoLabsAI/release-tools": "/home/josh/dev/labs/release-tools",
+  "protoLabsAI/protoPatch": "/home/josh/dev/labs/protoPatch",
+  "protoLabsAI/pwnDeck": "/home/josh/dev/labs/pwnDeck",
+  "protoLabsAI/contentMachine": "/home/josh/dev/labs/contentMachine",
 };
 
 function resolveRepoPath(repo: string): string | null {
@@ -98,7 +108,11 @@ interface ClawpatchExecResult {
 
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
 
-function runClawpatch(args: string[], cwd: string, timeoutMs: number): Promise<ClawpatchExecResult> {
+function runClawpatch(
+  args: string[],
+  cwd: string,
+  timeoutMs: number,
+): Promise<ClawpatchExecResult> {
   return new Promise((resolve) => {
     const child = spawn("clawpatch", args, {
       cwd,
@@ -112,8 +126,12 @@ function runClawpatch(args: string[], cwd: string, timeoutMs: number): Promise<C
       timedOut = true;
       child.kill("SIGKILL");
     }, timeoutMs);
-    child.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString("utf-8"); });
-    child.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString("utf-8"); });
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf-8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf-8");
+    });
     child.on("close", (code) => {
       clearTimeout(timer);
       resolve({ stdout, stderr, exitCode: code ?? -1, timedOut });
@@ -145,18 +163,25 @@ export function createRoutes(_ctx: ApiContext): Route[] {
         try {
           payload = (await req.json()) as ReviewRequest;
         } catch {
-          return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 });
+          return Response.json(
+            { success: false, error: "Invalid JSON" },
+            { status: 400 },
+          );
         }
         const { repo, since, limit, model, provider } = payload;
         if (!repo) {
-          return Response.json({ success: false, error: "repo is required" }, { status: 400 });
+          return Response.json(
+            { success: false, error: "repo is required" },
+            { status: 400 },
+          );
         }
         const repoPath = resolveRepoPath(repo);
         if (!repoPath) {
+          const known = Object.keys(BUILT_IN_REPO_PATHS).join(", ");
           return Response.json(
             {
               success: false,
-              error: `repo '${repo}' is not mounted in this container — only repos in CLAWPATCH_REPO_PATH_MAP / the built-in mounts (protoWorkstacean, protoCLI, mythxengine) work today. On-demand PR checkouts are not implemented.`,
+              error: `repo '${repo}' is not mounted in this container — only mapped+mounted repos work today (${known}, plus any CLAWPATCH_REPO_PATH_MAP overrides). On-demand PR checkouts are not implemented.`,
             },
             { status: 400 },
           );
@@ -167,15 +192,26 @@ export function createRoutes(_ctx: ApiContext): Route[] {
         // re-map features for every PR review.
         const stateDir = stateDirFor(repo);
         const effectiveProvider = provider ?? "gateway";
-        const args = ["ci", "--provider", effectiveProvider, "--json", "--state-dir", stateDir];
+        const args = [
+          "ci",
+          "--provider",
+          effectiveProvider,
+          "--json",
+          "--state-dir",
+          stateDir,
+        ];
         if (since) args.push("--since", since);
-        if (typeof limit === "number" && limit > 0) args.push("--limit", String(limit));
+        if (typeof limit === "number" && limit > 0)
+          args.push("--limit", String(limit));
         if (model) args.push("--model", model);
 
         const result = await runClawpatch(args, repoPath, DEFAULT_TIMEOUT_MS);
         if (result.timedOut) {
           return Response.json(
-            { success: false, error: `clawpatch timed out after ${DEFAULT_TIMEOUT_MS}ms` },
+            {
+              success: false,
+              error: `clawpatch timed out after ${DEFAULT_TIMEOUT_MS}ms`,
+            },
             { status: 504 },
           );
         }
@@ -205,7 +241,10 @@ export function createRoutes(_ctx: ApiContext): Route[] {
           );
         }
 
-        return Response.json({ success: true, data: { repo, repoPath, ...parsed } });
+        return Response.json({
+          success: true,
+          data: { repo, repoPath, ...parsed },
+        });
       },
     },
   ];

--- a/workspace/agents/quinn.yaml
+++ b/workspace/agents/quinn.yaml
@@ -346,6 +346,13 @@ skills:
     # actions. Excludes the narrow PR-review surface (pr_inspector is
     # there for CI verification on specific PRs referenced by an issue,
     # but the heavy lifting is board + repo scan).
+    #
+    # clawpatch_review is available here too (not just in pr_review): when an
+    # issue points at a repo region, a structural scan confirms whether the
+    # bug is real and where it lives — grounding the actionable/stale call in
+    # findings instead of guesswork. Same gateway-backed tool, same
+    # already-mounted-repo limitation (v1). protoPatch (the clawpatch fork) is
+    # installed in the runtime at /opt/clawpatch/bin.
     tools:
       - get_projects
       - get_pr_pipeline
@@ -353,6 +360,7 @@ skills:
       - get_branch_drift
       - chat_with_agent
       - pr_inspector
+      - clawpatch_review
       - create_github_issue
       - searxng_search
       - react
@@ -377,6 +385,25 @@ skills:
       For each open bug or blocked feature, check whether the root cause
       has already been fixed in recent commits. Search relevant keywords
       in the last 2 weeks of commit history.
+
+      ## Step 3b — Structural scan for actionable candidates (clawpatch)
+
+      For a bug that survives Step 3 (not already fixed) and names a repo
+      protoLabs manages, run `clawpatch_review(repo='owner/name')` to scan
+      that repo's code for structural findings. Use it to:
+
+      - **Confirm actionable** — a matching CLAWPATCH finding in the affected
+        area corroborates the bug is real and shows where it lives; cite it
+        ("CLAWPATCH/HIGH: ...") in the classification.
+      - **Inform severity** — finding severity feeds the label in Step 5.
+      - **Demote to stale** — if the affected code no longer exists or
+        clawpatch returns nothing relevant, that supports a stale/duplicate
+        call.
+
+      clawpatch only handles repos already mounted in the runtime (v1); if it
+      returns "repo not mounted" or errors (timeout, gateway 5xx), note it as
+      a LOW observation and classify from the board + commit evidence alone.
+      Do not block triage on clawpatch.
 
       ## Step 4 — Classify
 


### PR DESCRIPTION
protoPatch (`@protolabsai/protopatch`, the clawpatch fork) was only wired into Quinn's `pr_review`. This sets it up for **triage** too — so when Quinn triages a bug she can run a structural scan to confirm it's real and locate it, instead of classifying from board/commit guesswork.

## Changes

**`quinn.yaml` `bug_triage`:**
- Add `clawpatch_review` to the toolbelt
- New prompt **Step 3b — Structural scan for actionable candidates**: run `clawpatch_review(repo)` on surviving bugs, cite `CLAWPATCH/<sev>` findings in the classification, inform severity, or demote to stale when nothing relevant turns up. Degrades gracefully (LOW observation) when a repo isn't mounted or clawpatch errors — never blocks triage.

**`clawpatch.ts`:**
- Extend the built-in repo→path map to the full active fleet from `projects.yaml` (protoMaker, escape-from-qud, release-tools, protoPatch, pwnDeck, contentMachine), `~/dev/labs/{repo}` convention
- "not mounted" error now lists the map keys dynamically (was a stale hardcoded 3-repo list)

## Infra follow-up (homelab-iac)

The new repos must also be **mounted read-only** into the workstacean container (`docker-compose workstacean.volumes`) for the mapped paths to exist. Until then `clawpatch_review` reports "not mounted" for them and triage falls back to board+commit evidence (handled by the prompt). That mount config lives in homelab-iac, not this repo.

Typecheck clean; no clawpatch tests affected.