### PR TITLE
feat(router): [linear] event=… delivered to <agent> per-event log (A3.5)

### DIFF
--- a/src/router/__tests__/router-plugin.test.ts
+++ b/src/router/__tests__/router-plugin.test.ts
@@ -408,6 +408,101 @@ describe("RouterPlugin", () => {
     });
   });
 
+  describe("linear event delivery surface", () => {
+    test("emits [linear] event=… delivered to <agent> alongside [router] log", async () => {
+      const { workspaceDir, cleanup } = makeWorkspace({
+        agents: { "quinn.yaml": quinnAgent, "ava.yaml": avaAgent },
+      });
+      try {
+        const bus = new InMemoryEventBus();
+        const plugin = new RouterPlugin({ workspaceDir });
+        plugin.install(bus);
+
+        const logs: string[] = [];
+        const origLog = console.log;
+        console.log = (...args: unknown[]) => { logs.push(args.map(String).join(" ")); };
+        try {
+          const requestPromise = waitForSkillRequest(bus);
+          bus.publish(
+            "message.inbound.linear.agent.issueCommentMention",
+            makeInbound("message.inbound.linear.agent.issueCommentMention", {
+              content: "this is a bug in the auth flow",
+            }),
+          );
+          await requestPromise;
+        } finally {
+          console.log = origLog;
+        }
+
+        const linearLine = logs.find(l => l.includes("[linear] event=agent.issueCommentMention"));
+        expect(linearLine).toBeDefined();
+        expect(linearLine).toContain("delivered to quinn");
+        expect(linearLine).toContain("skill=bug_triage");
+
+        plugin.uninstall();
+      } finally { cleanup(); }
+    });
+
+    test("logs delivered to none when no skill matches a linear topic", async () => {
+      const { workspaceDir, cleanup } = makeWorkspace({ agents: { "quinn.yaml": quinnAgent } });
+      try {
+        const bus = new InMemoryEventBus();
+        const plugin = new RouterPlugin({ workspaceDir });
+        plugin.install(bus);
+
+        const logs: string[] = [];
+        const origLog = console.log;
+        console.log = (...args: unknown[]) => { logs.push(args.map(String).join(" ")); };
+        try {
+          bus.publish(
+            "message.inbound.linear.project.created",
+            makeInbound("message.inbound.linear.project.created", { content: "no keywords here" }),
+          );
+          // Synchronous publish path — give the subscriber a tick to run.
+          await new Promise(r => setTimeout(r, 20));
+        } finally {
+          console.log = origLog;
+        }
+
+        const linearLine = logs.find(l => l.includes("[linear] event=project.created"));
+        expect(linearLine).toBeDefined();
+        expect(linearLine).toContain("delivered to none");
+
+        plugin.uninstall();
+      } finally { cleanup(); }
+    });
+
+    test("does not emit [linear] line for non-linear topics", async () => {
+      const { workspaceDir, cleanup } = makeWorkspace({ agents: { "quinn.yaml": quinnAgent } });
+      try {
+        const bus = new InMemoryEventBus();
+        const plugin = new RouterPlugin({ workspaceDir });
+        plugin.install(bus);
+
+        const logs: string[] = [];
+        const origLog = console.log;
+        console.log = (...args: unknown[]) => { logs.push(args.map(String).join(" ")); };
+        try {
+          const requestPromise = waitForSkillRequest(bus);
+          bus.publish(
+            "message.inbound.discord.42",
+            makeInbound("message.inbound.discord.42", {
+              content: "bug report",
+              skillHint: "bug_triage",
+            }),
+          );
+          await requestPromise;
+        } finally {
+          console.log = origLog;
+        }
+
+        expect(logs.some(l => l.startsWith("[linear]"))).toBe(false);
+
+        plugin.uninstall();
+      } finally { cleanup(); }
+    });
+  });
+
   describe("uninstall", () => {
     test("stops routing after uninstall", async () => {
       const { workspaceDir, cleanup } = makeWorkspace({ agents: { "quinn.yaml": quinnAgent } });

--- a/src/router/router-plugin.ts
+++ b/src/router/router-plugin.ts
@@ -51,6 +51,19 @@ export interface RouterConfig {
   channelRegistry?: ChannelRegistry;
 }
 
+/**
+ * Extract the Linear event identifier from an inbound topic, returning e.g.
+ * `agent.issueCommentMention`, `issue.created`, `comment.created` — or
+ * undefined for non-Linear topics. Used to emit a `[linear] event=…` delivery
+ * log alongside the generic `[router]` line.
+ */
+function extractLinearEvent(topic: string): string | undefined {
+  const prefix = "message.inbound.linear.";
+  if (!topic.startsWith(prefix)) return undefined;
+  const rest = topic.slice(prefix.length);
+  return rest || undefined;
+}
+
 /** Build reply topic from channel + optional recipient. */
 function buildReplyTopic(channel: string, recipient?: string): string {
   if (channel === "signal") {
@@ -210,6 +223,10 @@ export class RouterPlugin implements Plugin {
         (content ? ` content="${content.slice(0, 60)}"` : "") +
         " — dropping",
       );
+      const linearEvent = extractLinearEvent(msg.topic);
+      if (linearEvent) {
+        console.log(`[linear] event=${linearEvent} delivered to none (no skill match)`);
+      }
       return;
     }
 
@@ -247,6 +264,17 @@ export class RouterPlugin implements Plugin {
       (agentName ? ` [${agentName}]` : "") +
       ` reply → ${replyTopic}`,
     );
+
+    // Per-event delivery surface for Linear so operators can debug routing
+    // without grepping for the message.inbound.linear.* topic shape. The
+    // `[linear]` prefix matches the rest of LinearPlugin's logs so a single
+    // grep covers publish + delivery.
+    const linearEvent = extractLinearEvent(msg.topic);
+    if (linearEvent) {
+      console.log(
+        `[linear] event=${linearEvent} delivered to ${agentName ?? "none"} (skill=${skill})`,
+      );
+    }
 
     const skillRequest: BusMessage = {
       id: crypto.randomUUID(),


### PR DESCRIPTION
## Summary

- Adds a per-event `[linear] event=<kind>.<action> delivered to <agent> (skill=<skill>)` log line emitted from RouterPlugin whenever an inbound `message.inbound.linear.*` topic is resolved (or dropped).
- Mirrors the `[linear]` prefix used by LinearPlugin's publish-side logs, so a single grep covers Linear traffic from webhook ingest through agent delivery — no more chasing topic shapes like `message.inbound.linear.agent.issueCommentMention`.
- Drop case logs `delivered to none (no skill match)` so operators see the silent-floor case too.

Roadmap: A3.5 (1 pt) from \`docs/roadmap/2026-06.md\`.

## Test plan

- [x] `bun test src/router/__tests__/router-plugin.test.ts` — 19 pass (+3 new)
- [x] Full suite: 706 pass / 0 fail
- [ ] Live deploy: tail container logs after merge, fire a Linear issue update, confirm `[linear] event=…` line appears next to the `[router]` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test suite for Linear event delivery routing, verifying correct skill-matched agent delivery, fallback behavior for unmatched events, and proper handling of non-Linear topics.

* **Chores**
  * Implemented enhanced logging infrastructure for Linear-specific event routing with improved delivery outcome visibility and skill matching information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->