### PR TITLE
docs(c1): design doc — clawpatch on-demand checkout cache

### DIFF
--- a/docs/explanation/clawpatch-checkouts.md
+++ b/docs/explanation/clawpatch-checkouts.md
@@ -1,0 +1,166 @@
+---
+title: Clawpatch checkouts — on-demand source for any repo
+---
+
+_RFC + design for the checkout cache that lets Quinn's `clawpatch_review` work against every repo in `workspace/projects.yaml`, not just the three currently mounted into the container._
+
+---
+
+## Problem
+
+`POST /api/clawpatch/review` runs `clawpatch ci --provider gateway --json` inside a path resolved by `resolveRepoPath(repo)` in [`src/api/clawpatch.ts`](../../src/api/clawpatch.ts). Today that resolver consults exactly two sources:
+
+1. The `CLAWPATCH_REPO_PATH_MAP` env (JSON override).
+2. A hard-coded `BUILT_IN_REPO_PATHS` map of ~9 repos that the homelab compose file bind-mounts read-only into the workstacean container.
+
+A repo without an entry — or with an entry whose mount the operator forgot to add to the compose file — gets a hard error: _"repo 'X' is not mounted in this container — only mapped+mounted repos work today (…). On-demand PR checkouts are not implemented."_
+
+That ceiling is everywhere Quinn touches a repo she didn't grow up with. As we keep onboarding repos (every entry in `workspace/projects.yaml` is a candidate), the gap widens: edit compose, redeploy, then she can review it. Worse, the mount is a snapshot of the operator's local checkout, not the PR's actual code — Quinn was technically reviewing whatever ref happened to be checked out on the host, not the PR head.
+
+We want a self-service checkout cache: when Quinn asks to review a PR on a repo she's never seen, the API fetches the exact ref from GitHub, extracts it locally, hands the path to clawpatch, and caches the extracted tree for the next call.
+
+---
+
+## Source of truth: GitHub tarball
+
+GitHub exposes `GET /repos/{owner}/{repo}/tarball/{ref}` which streams a `.tar.gz` of the tree at `ref`. `ref` can be a branch, tag, or commit SHA — for PR reviews we pass the head commit SHA (already in the `since` parameter shape clawpatch uses to derive the diff). The API returns a redirect to `codeload.github.com`; we follow it and stream straight to extraction.
+
+Auth uses the existing `makeGitHubAuth()` helper — same App credentials that file issues, post review comments, and read PR data. No new credential surface.
+
+We do **not** clone with git. We never need `.git` history — clawpatch reads working-tree files and a diff that we hand it via `--since`. Tarballs are smaller, faster, cacheable by SHA, and don't need git installed in the workstacean image.
+
+---
+
+## Cache layout
+
+Content-addressed by ref, one tree per (owner, repo, sha):
+
+```
+/data/checkouts/
+  protoLabsAI-escape-from-qud/
+    f3a91c8b…/           ← extracted tree
+      package.json
+      src/
+      …
+    last-access          ← ISO timestamp, updated on hit
+  protoLabsAI-protoMaker/
+    a17e..../
+      …
+```
+
+Path shape: `${DATA_DIR}/checkouts/<owner>-<repo>/<sha>/`. Same `<owner>-<repo>` slug shape that `stateDirFor()` already uses for the clawpatch state root — keeps the two volumes' layouts consistent.
+
+The cache dir is created lazily on first checkout. `DATA_DIR` defaults to `/data` (same as clawpatch state), overridable for tests via the same `CLAWPATCH_STATE_ROOT` style — propose `CLAWPATCH_CHECKOUT_ROOT`.
+
+A `last-access` file (touched on every hit) is the LRU clock. Cheaper than restating directories during eviction sweeps.
+
+---
+
+## Cache invalidation
+
+Two independent triggers — whichever fires first:
+
+* **Size cap**: 5 GB total under `/data/checkouts/`. When exceeded after a new extract, evict by `last-access` ascending until back under the limit.
+* **Entry cap**: 50 entries. Same eviction policy.
+
+Why two: a single ~100 MB monorepo checkout could blow the size budget alone; a flurry of small repos could blow the entry budget without hitting the size budget. Both are escape valves for "the disk is going to fill up tonight, and I'd rather drop old checkouts than crash."
+
+**TTL refresh**: an extracted tree is "fresh" for 24 hours. After that the resolver re-fetches even if the cache hit is for the exact SHA. That covers the case where a PR is rebased mid-review and the base branch drifts — clawpatch's diff is anchored to a base, and `--since base_sha` against a stale base would lie about what changed. 24h is a heuristic; happy to dial down to 1h if we observe drift complaints. (24h was picked over "always re-fetch" because most reviews land within an hour of opening — keeping the warm path warm is worth the small staleness risk.)
+
+Eviction lives in a daily ceremony, **not** inline on each request — see [C3](#c3-cache-cleanup-ceremony). Inline eviction adds tail latency to every review call.
+
+---
+
+## Security
+
+Three guards, all enforced before the extract:
+
+1. **Allowlist gate**: `repo` must match an entry in `workspace/projects.yaml`. Same registry that `create_github_issue` checks. No arbitrary `owner/name` from a tool call extracts code into our data volume — Quinn can only review repos we've already declared we manage.
+2. **Tarball entry sanitization**: every entry path is rejected if it
+   * starts with `/`,
+   * contains `..` segments,
+   * resolves outside the per-(repo,sha) extract directory after normalization,
+   * or has `type === "symlink"` / `"link"` (no symlinks honoured — write them as regular files or skip).
+   `tar` with `strip-components=1` (GitHub's tarballs nest under `<repo>-<sha>/`) plus a manual entry filter. The filter is sloppy-allow rather than belt-and-suspenders: GitHub's archives are not adversarial inputs, but the registry isn't a trust boundary either.
+3. **Disk-quota guard**: refuse to extract a tarball larger than 1 GB compressed. Clawpatch is for code review — anyone shipping a binary tree larger than that into Git is misusing it, and we don't want a runaway extract to fill the volume mid-stream.
+
+No symlinks, no special files, no `..`. If a real repo legitimately tracks a symlink, clawpatch loses that fidelity — we accept it. Code review reads file contents; symlinks are out of scope.
+
+---
+
+## Concurrency
+
+Per-(repo, sha) extraction mutex. If two reviews of the same PR head arrive within seconds of each other (Quinn re-checking after a comment, or two ceremonies firing on overlapping windows), the second waits for the first's extract to finish rather than racing on the same directory.
+
+Implemented as an in-memory `Map<string, Promise<string>>` in `lib/checkout-cache.ts` — the key is `${repo}@${sha}`, the value is the extract promise. Cleared from the map on settle (resolve or reject). Single-node only — when we go multi-node ([Multi-node](architecture.md) in the architecture doc), the second node would re-extract, which is wasteful but safe (content-addressed).
+
+---
+
+## Public API
+
+```ts
+// lib/checkout-cache.ts
+export interface CheckoutCache {
+  /**
+   * Resolve a local path for (repo, sha). Returns the cached path if one
+   * exists and is fresh (< 24h); otherwise fetches the tarball from GitHub,
+   * extracts it under /data/checkouts/<owner>-<repo>/<sha>/, and returns
+   * the new path. Touches last-access on hit.
+   *
+   * Throws if:
+   *   - repo is not in the projects.yaml allowlist
+   *   - the GitHub API returns non-2xx
+   *   - tarball validation fails (oversize, traversal, symlink)
+   */
+  resolve(repo: string, sha: string): Promise<string>;
+
+  /**
+   * Prune the cache by both size and entry limits. Returns counts.
+   * Called from a daily ceremony, not inline.
+   */
+  prune(): Promise<{ evicted: number; bytesFreed: number }>;
+}
+```
+
+`src/api/clawpatch.ts:resolveRepoPath()` becomes:
+
+```ts
+async function resolveRepoPath(repo: string, sha: string): Promise<string | null> {
+  const override = readOverrideMap()[repo];
+  if (override && existsSync(override)) return override;            // fast path for dev
+  const builtIn = BUILT_IN_REPO_PATHS[repo];
+  if (builtIn && existsSync(builtIn)) return builtIn;               // fast path for mounted repos
+  return await checkoutCache.resolve(repo, sha);                    // on-demand path
+}
+```
+
+Note: the function gets a new `sha` parameter, so the route handler now requires `since` (the PR head SHA) when the repo isn't mounted. That's already what clawpatch is given for diff anchoring — no new caller-side change, we just route it through the resolver. Existing built-in callers that don't pass a SHA still hit the fast path because the override / built-in check happens first.
+
+---
+
+## What this isn't
+
+* Not a Git clone. No commit history, no branches, no `git log`. If clawpatch ever needs blame or history, we'd add a parallel cache mode then.
+* Not a build cache. We don't run `npm install` / `pnpm install` / `bun install` after extraction. Clawpatch reviews source; if a future provider needs node_modules, that's a separate problem.
+* Not a writable workspace. The extracted tree is treated as read-only by clawpatch — review state still goes under `${CLAWPATCH_STATE_ROOT}/<owner>-<repo>/`, untouched by the cache evictor.
+* Not multi-tenant. One operator's workstacean serves one fleet; the cache is single-volume and not shared cross-node.
+
+---
+
+## Rollout
+
+* **C1** (this doc, 2 pts) — RFC, sign-off.
+* **C2** — `lib/checkout-cache.ts` + resolver wire-up + unit tests (LRU eviction, traversal rejection, oversize refusal, concurrency). 5 pts.
+* **C3** — `workspace/ceremonies/clawpatch-cache-cleanup.yaml` calling `checkoutCache.prune()` daily at 03:00 UTC via a function executor. 3 pts.
+* **C4** — Drop the "v1 only handles three repos" caveat from Quinn's `pr_review` prompt; drop `BUILT_IN_REPO_PATHS` (turns into a documented fast-path comment, or moves into the cache as a never-evict pinning). 3 pts.
+
+Total: 13 pts.
+
+After C4 the only place hard-coded repo paths live is whatever short list we pin as never-evict in the cache (likely the three currently mounted repos that already have host filesystem paths). Everything else routes through GitHub-tarball + extract on first hit.
+
+## Open questions
+
+1. **Pinning vs. eviction for the legacy mounted repos**: do `protoWorkstacean` / `protoCLI` / `mythxengine` get treated as never-evict cache entries (occupying a slot but immune to LRU), or do we keep the host bind-mount fast path and bypass the cache entirely for them? Bias toward the latter — host bind-mount is zero-latency, the cache adds extract IO. **Decision needed before C2.**
+2. **What constitutes "fresh"**? 24h TTL feels right for branch drift but is arbitrary. Worth instrumenting in C2 — log the age-on-hit so we can tune later.
+3. **GitHub tarball rate limits**: App credentials get 15k req/hr, and a tarball is 1 req. We'd need to be reviewing >4 PRs/sec to feel it. Not a real constraint at fleet size. Note but don't gate on it.
+


### PR DESCRIPTION
## Summary

RFC for the checkout cache that unblocks Quinn's structural review on any repo we manage. Today \`clawpatch_review\` only works against repos hard-coded in \`BUILT_IN_REPO_PATHS\` (protoWorkstacean / protoCLI / mythxengine and a handful more that need a compose-file mount). This proposes \`/data/checkouts/<owner>-<repo>/<sha>/\` as a content-addressed cache fed by GitHub tarball downloads.

Covers:
- GitHub tarball API as source of truth (no git clone — no \`.git\`, no history needed for clawpatch)
- LRU cache: 5 GB **or** 50 entries, evict by \`last-access\` mtime
- 24h TTL refresh for base-branch drift on the same SHA
- Security: \`projects.yaml\` allowlist + tarball entry sanitization (no \`..\`, no symlinks, no oversize)
- Per-(repo, sha) extraction mutex
- Pulls eviction out of the request path into a daily ceremony (C3)

Roadmap: C1 (2 pts) from \`docs/roadmap/2026-06.md\`.

## ⚠️ Open questions flagged for sign-off before C2

1. **Pinning vs eviction for legacy mounted repos** — keep the host bind-mount fast path and bypass the cache for the three currently mounted repos, OR treat them as never-evict cache entries? Doc biases toward the former (zero-latency vs extract IO).
2. **24h TTL** — arbitrary heuristic; want to log age-on-hit during C2 and tune later. Open to dialing down to 1h if drift complaints land.

## Test plan

- [ ] Read \`docs/explanation/clawpatch-checkouts.md\` end-to-end
- [ ] Resolve the two open questions above
- [ ] Approve to unblock C2

🤖 Generated with [Claude Code](https://claude.com/claude-code)