### PR TITLE
feat(clawpatch): on-demand checkout cache (C2)

### DIFF
--- a/docs/explanation/clawpatch-checkouts.md
+++ b/docs/explanation/clawpatch-checkouts.md
@@ -152,15 +152,20 @@ Note: the function gets a new `sha` parameter, so the route handler now requires
 * **C1** (this doc, 2 pts) — RFC, sign-off.
 * **C2** — `lib/checkout-cache.ts` + resolver wire-up + unit tests (LRU eviction, traversal rejection, oversize refusal, concurrency). 5 pts.
 * **C3** — `workspace/ceremonies/clawpatch-cache-cleanup.yaml` calling `checkoutCache.prune()` daily at 03:00 UTC via a function executor. 3 pts.
-* **C4** — Drop the "v1 only handles three repos" caveat from Quinn's `pr_review` prompt; drop `BUILT_IN_REPO_PATHS` (turns into a documented fast-path comment, or moves into the cache as a never-evict pinning). 3 pts.
+* **C4** — Drop the "v1 only handles three repos" caveat from Quinn's `pr_review` prompt; drop `BUILT_IN_REPO_PATHS` entirely so every repo routes through the cache. 3 pts.
 
 Total: 13 pts.
 
-After C4 the only place hard-coded repo paths live is whatever short list we pin as never-evict in the cache (likely the three currently mounted repos that already have host filesystem paths). Everything else routes through GitHub-tarball + extract on first hit.
+After C4, hard-coded repo paths are gone from production. Every repo — including the ones that used to be bind-mounted — routes through GitHub-tarball + extract. The only escape hatch is `CLAWPATCH_REPO_PATH_MAP` for local dev (pointing at a working tree on disk), never set in the deployed container.
+
+## Resolved decisions (sign-off on #578)
+
+Per "better way over fast way":
+
+1. **No bind-mount fast path. No cache pinning.** Drop `BUILT_IN_REPO_PATHS` entirely. Every repo, including `protoWorkstacean` / `protoCLI` / `mythxengine`, routes through the checkout cache. The fast path was buying us "skip extract IO for three repos" at the cost of a real correctness ambiguity — "did Quinn review the host's checkout or the PR's actual ref?" — and a dual-code-path operator model. Consistency wins.
+2. **TTL: 1h, not 24h.** SHA-keyed content-addressing means correctness is fine at any TTL — this is purely a "freshness over warm-cache hit-rate" choice. An hour amortizes the review-comment burst case (same PR head re-reviewed several times in quick succession) without holding stale source long enough to risk base-branch drift hiding review-relevant changes.
 
 ## Open questions
 
-1. **Pinning vs. eviction for the legacy mounted repos**: do `protoWorkstacean` / `protoCLI` / `mythxengine` get treated as never-evict cache entries (occupying a slot but immune to LRU), or do we keep the host bind-mount fast path and bypass the cache entirely for them? Bias toward the latter — host bind-mount is zero-latency, the cache adds extract IO. **Decision needed before C2.**
-2. **What constitutes "fresh"**? 24h TTL feels right for branch drift but is arbitrary. Worth instrumenting in C2 — log the age-on-hit so we can tune later.
-3. **GitHub tarball rate limits**: App credentials get 15k req/hr, and a tarball is 1 req. We'd need to be reviewing >4 PRs/sec to feel it. Not a real constraint at fleet size. Note but don't gate on it.
+* **GitHub tarball rate limits**: App credentials get 15k req/hr, and a tarball is 1 req. We'd need to be reviewing >4 PRs/sec to feel it. Not a real constraint at fleet size. Note but don't gate on it.
 

--- a/lib/__tests__/checkout-cache.test.ts
+++ b/lib/__tests__/checkout-cache.test.ts
@@ -1,0 +1,234 @@
+/**
+ * CheckoutCache unit tests — exercise extraction, the LRU pruner, the TTL
+ * refresh path, the concurrency mutex, and tarball-entry security guards
+ * against an in-memory tar fixture. Hits real `tar` on disk (the lib shells
+ * out to it) but never touches GitHub — `fetchTarball` is stubbed.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CheckoutCache } from "../checkout-cache.ts";
+
+const SHA_A = "1234567890abcdef1234567890abcdef12345678";
+const SHA_B = "abcdef0123456789abcdef0123456789abcdef01";
+
+/**
+ * Build a minimal GitHub-shaped tarball in a temp dir and return its bytes.
+ * Top-level directory is `${repo}-${sha}/` to match what `tar
+ * --strip-components=1` expects.
+ */
+function makeTarball(
+  repo: string,
+  sha: string,
+  files: Record<string, string>,
+  opts?: { withSymlink?: boolean; withTraversal?: boolean },
+): Buffer {
+  const slug = repo.replace("/", "-");
+  const stage = mkdtempSync(join(tmpdir(), "tarball-fixture-"));
+  const root = join(stage, `${slug}-${sha}`);
+  mkdirSync(root, { recursive: true });
+  for (const [path, content] of Object.entries(files)) {
+    const full = join(root, path);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, content);
+  }
+  if (opts?.withSymlink) {
+    const linkSrc = join(root, "link.txt");
+    spawnSync("ln", ["-s", "/etc/passwd", linkSrc]);
+  }
+  if (opts?.withTraversal) {
+    // Hand-craft a tarball with a `../escaped.txt` entry. Easiest path:
+    // build it via `tar` with --transform.
+    writeFileSync(join(root, "evil.txt"), "should-not-extract");
+  }
+  const out = join(stage, "out.tgz");
+  const tarArgs = ["-czf", out, "-C", stage, `${slug}-${sha}`];
+  if (opts?.withTraversal) {
+    tarArgs.push("--transform=s|evil.txt|../escaped.txt|");
+  }
+  const tar = spawnSync("tar", tarArgs);
+  if (tar.status !== 0) {
+    throw new Error(`fixture tar failed: ${tar.stderr.toString()}`);
+  }
+  const bytes = readFileSync(out);
+  rmSync(stage, { recursive: true, force: true });
+  return bytes;
+}
+
+function makeCache(opts?: ConstructorParameters<typeof CheckoutCache>[0]) {
+  const root = mkdtempSync(join(tmpdir(), "checkout-cache-test-"));
+  const cache = new CheckoutCache({
+    root,
+    getToken: async () => "fake-token",
+    fetchTarball: async () => Buffer.alloc(0), // overridden per-test
+    ...opts,
+  });
+  return {
+    root,
+    cache,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+describe("CheckoutCache", () => {
+  describe("resolve()", () => {
+    test("first call fetches + extracts, second call hits cache", async () => {
+      let fetches = 0;
+      const tarball = makeTarball("acme/widgets", SHA_A, {
+        "README.md": "# widgets",
+        "src/index.ts": "export const x = 1;",
+      });
+      const { cache, root, cleanup } = makeCache({
+        fetchTarball: async () => { fetches++; return tarball; },
+      });
+      try {
+        const path1 = await cache.resolve("acme/widgets", SHA_A);
+        expect(path1).toBe(join(root, "acme-widgets", SHA_A));
+        expect(existsSync(join(path1, "README.md"))).toBe(true);
+        expect(existsSync(join(path1, "src", "index.ts"))).toBe(true);
+        expect(fetches).toBe(1);
+
+        const path2 = await cache.resolve("acme/widgets", SHA_A);
+        expect(path2).toBe(path1);
+        expect(fetches).toBe(1); // cache hit
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("rejects bad repo + bad sha shapes", async () => {
+      const { cache, cleanup } = makeCache();
+      try {
+        await expect(cache.resolve("bare-name", SHA_A)).rejects.toThrow(/invalid repo/);
+        await expect(cache.resolve("acme/widgets", "not-hex")).rejects.toThrow(/invalid sha/);
+      } finally { cleanup(); }
+    });
+
+    test("stale entry past TTL is refetched", async () => {
+      let fetches = 0;
+      const tarball = makeTarball("acme/widgets", SHA_A, { "a.txt": "1" });
+      const { cache, root, cleanup } = makeCache({
+        ttlMs: 1000, // 1s for test
+        fetchTarball: async () => { fetches++; return tarball; },
+      });
+      try {
+        await cache.resolve("acme/widgets", SHA_A);
+        // Backdate the entry's mtime past the TTL.
+        const dir = join(root, "acme-widgets", SHA_A);
+        const old = new Date(Date.now() - 5_000);
+        utimesSync(dir, old, old);
+
+        await cache.resolve("acme/widgets", SHA_A);
+        expect(fetches).toBe(2);
+      } finally { cleanup(); }
+    });
+
+    test("concurrent calls for same (repo, sha) share one extraction", async () => {
+      let fetches = 0;
+      const tarball = makeTarball("acme/widgets", SHA_A, { "a.txt": "1" });
+      const { cache, cleanup } = makeCache({
+        fetchTarball: async () => {
+          fetches++;
+          await new Promise(r => setTimeout(r, 50));
+          return tarball;
+        },
+      });
+      try {
+        const [p1, p2, p3] = await Promise.all([
+          cache.resolve("acme/widgets", SHA_A),
+          cache.resolve("acme/widgets", SHA_A),
+          cache.resolve("acme/widgets", SHA_A),
+        ]);
+        expect(p1).toBe(p2);
+        expect(p2).toBe(p3);
+        expect(fetches).toBe(1);
+      } finally { cleanup(); }
+    });
+  });
+
+  describe("security guards", () => {
+    test("refuses tarballs containing symlinks", async () => {
+      const tarball = makeTarball("acme/widgets", SHA_A, { "a.txt": "1" }, { withSymlink: true });
+      const { cache, root, cleanup } = makeCache({ fetchTarball: async () => tarball });
+      try {
+        await expect(cache.resolve("acme/widgets", SHA_A)).rejects.toThrow(/symlink/);
+        // half-extracted tree must be cleaned up
+        expect(existsSync(join(root, "acme-widgets", SHA_A))).toBe(false);
+      } finally { cleanup(); }
+    });
+
+    test("refuses tarballs with .. traversal", async () => {
+      const tarball = makeTarball("acme/widgets", SHA_A, { "a.txt": "1" }, { withTraversal: true });
+      const { cache, root, cleanup } = makeCache({ fetchTarball: async () => tarball });
+      try {
+        await expect(cache.resolve("acme/widgets", SHA_A)).rejects.toThrow(/\.\./);
+        expect(existsSync(join(root, "acme-widgets", SHA_A))).toBe(false);
+      } finally { cleanup(); }
+    });
+  });
+
+  describe("prune()", () => {
+    test("evicts LRU entries when over entry cap", async () => {
+      const { cache, root, cleanup } = makeCache({
+        entryLimit: 2,
+        // 10 GB headroom so size cap never trips.
+        sizeLimitBytes: 10 * 1024 * 1024 * 1024,
+        fetchTarball: async (_o, _r, sha) =>
+          makeTarball("acme/widgets", sha, { "a.txt": `${sha}` }),
+      });
+      try {
+        await cache.resolve("acme/widgets", SHA_A);
+        // Force ordering by backdating SHA_A so it's clearly the oldest.
+        const aDir = join(root, "acme-widgets", SHA_A);
+        const old = new Date(Date.now() - 60_000);
+        utimesSync(aDir, old, old);
+
+        await cache.resolve("acme/widgets", SHA_B);
+        const cSha = "fedcba9876543210fedcba9876543210fedcba98";
+        await cache.resolve("acme/widgets", cSha);
+
+        const res = await cache.prune();
+        expect(res.evicted).toBeGreaterThanOrEqual(1);
+        expect(existsSync(aDir)).toBe(false);                              // LRU victim
+        expect(existsSync(join(root, "acme-widgets", cSha))).toBe(true);    // freshest stays
+      } finally { cleanup(); }
+    });
+
+    test("evicts entries past TTL outright (no LRU survivor)", async () => {
+      const { cache, root, cleanup } = makeCache({
+        ttlMs: 1000,
+        fetchTarball: async (_o, _r, sha) =>
+          makeTarball("acme/widgets", sha, { "a.txt": "1" }),
+      });
+      try {
+        await cache.resolve("acme/widgets", SHA_A);
+        const dir = join(root, "acme-widgets", SHA_A);
+        const old = new Date(Date.now() - 5_000);
+        utimesSync(dir, old, old);
+
+        const res = await cache.prune();
+        expect(res.evicted).toBe(1);
+        expect(existsSync(dir)).toBe(false);
+      } finally { cleanup(); }
+    });
+
+    test("no-op on missing root", async () => {
+      const root = join(tmpdir(), `does-not-exist-${crypto.randomUUID()}`);
+      const cache = new CheckoutCache({ root });
+      const res = await cache.prune();
+      expect(res.evicted).toBe(0);
+      expect(res.bytesFreed).toBe(0);
+    });
+  });
+});

--- a/lib/checkout-cache.ts
+++ b/lib/checkout-cache.ts
@@ -1,18 +1,18 @@
 /**
  * CheckoutCache — content-addressed source-tree cache for clawpatch.
  *
- * Backs `src/api/clawpatch.ts` so structural review works against any repo
- * in workspace/projects.yaml, not just the three currently bind-mounted into
- * the workstacean container. Source of truth is GitHub's tarball endpoint
- * (`GET /repos/{owner}/{repo}/tarball/{ref}`); a successful fetch lands at
- * `${CHECKOUT_ROOT}/<owner>-<repo>/<sha>/`.
+ * Backs `src/api/clawpatch.ts` so structural review works against every
+ * repo in workspace/projects.yaml — including the ones that used to be
+ * bind-mounted into the container. Source of truth is GitHub's tarball
+ * endpoint (`GET /repos/{owner}/{repo}/tarball/{ref}`); a successful fetch
+ * lands at `${CHECKOUT_ROOT}/<owner>-<repo>/<sha>/`.
  *
  * Design notes live in docs/explanation/clawpatch-checkouts.md (C1) — the
  * short version:
  *
  *   - LRU eviction at 5 GB OR 50 entries, whichever first.
- *   - 24h TTL refresh: a cached SHA older than this gets re-fetched so the
- *     diff base doesn't lie about what changed after a rebase.
+ *   - 1h TTL refresh: per the C1 sign-off — "better way over fast way" —
+ *     over the 24h heuristic the doc originally biased toward.
  *   - Per-(repo, sha) extraction mutex: simultaneous reviews on the same PR
  *     head queue rather than racing.
  *   - Security: projects.yaml allowlist (enforced by the caller) plus
@@ -43,7 +43,12 @@ const DEFAULT_CHECKOUT_ROOT =
 
 const DEFAULT_SIZE_LIMIT_BYTES = 5 * 1024 * 1024 * 1024; // 5 GB
 const DEFAULT_ENTRY_LIMIT = 50;
-const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+// 1h TTL. SHA-keyed content-addressing makes correctness fine at any TTL;
+// this picks "fresh" over "warm-cache hit-rate". An hour amortizes the
+// review-comment burst case (same PR head re-reviewed several times in
+// quick succession) without holding stale source long enough to risk
+// base-branch drift hiding review-relevant changes. Per C1 sign-off (#578).
+const DEFAULT_TTL_MS = 60 * 60 * 1000;
 const MAX_COMPRESSED_BYTES = 1 * 1024 * 1024 * 1024; // 1 GB
 
 export interface CheckoutCacheConfig {

--- a/lib/checkout-cache.ts
+++ b/lib/checkout-cache.ts
@@ -1,0 +1,338 @@
+/**
+ * CheckoutCache — content-addressed source-tree cache for clawpatch.
+ *
+ * Backs `src/api/clawpatch.ts` so structural review works against any repo
+ * in workspace/projects.yaml, not just the three currently bind-mounted into
+ * the workstacean container. Source of truth is GitHub's tarball endpoint
+ * (`GET /repos/{owner}/{repo}/tarball/{ref}`); a successful fetch lands at
+ * `${CHECKOUT_ROOT}/<owner>-<repo>/<sha>/`.
+ *
+ * Design notes live in docs/explanation/clawpatch-checkouts.md (C1) — the
+ * short version:
+ *
+ *   - LRU eviction at 5 GB OR 50 entries, whichever first.
+ *   - 24h TTL refresh: a cached SHA older than this gets re-fetched so the
+ *     diff base doesn't lie about what changed after a rebase.
+ *   - Per-(repo, sha) extraction mutex: simultaneous reviews on the same PR
+ *     head queue rather than racing.
+ *   - Security: projects.yaml allowlist (enforced by the caller) plus
+ *     tarball entry filter — reject `..`, absolute paths, and symlinks.
+ *
+ * Eviction lives in `prune()`, invoked from a daily ceremony (C3). The hot
+ * path never sweeps — inline eviction would add unpredictable tail latency
+ * to every review call.
+ */
+
+import { spawn } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const DEFAULT_CHECKOUT_ROOT =
+  process.env["CLAWPATCH_CHECKOUT_ROOT"] ??
+  join(process.env["DATA_DIR"] ?? "/data", "checkouts");
+
+const DEFAULT_SIZE_LIMIT_BYTES = 5 * 1024 * 1024 * 1024; // 5 GB
+const DEFAULT_ENTRY_LIMIT = 50;
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+const MAX_COMPRESSED_BYTES = 1 * 1024 * 1024 * 1024; // 1 GB
+
+export interface CheckoutCacheConfig {
+  root?: string;
+  sizeLimitBytes?: number;
+  entryLimit?: number;
+  ttlMs?: number;
+  /**
+   * Override for the GitHub auth-token getter. Defaults to a thunk that
+   * returns the `GITHUB_TOKEN` env var so the cache can be exercised in
+   * tests without the App-auth stack.
+   */
+  getToken?: (owner: string, repo: string) => Promise<string>;
+  /**
+   * Override the actual tarball fetch — tests inject a stub that copies a
+   * fixture rather than hitting codeload.github.com.
+   */
+  fetchTarball?: (
+    owner: string,
+    repo: string,
+    sha: string,
+    token: string,
+  ) => Promise<Buffer>;
+}
+
+interface ResolvedConfig {
+  root: string;
+  sizeLimitBytes: number;
+  entryLimit: number;
+  ttlMs: number;
+  getToken: (owner: string, repo: string) => Promise<string>;
+  fetchTarball: (
+    owner: string,
+    repo: string,
+    sha: string,
+    token: string,
+  ) => Promise<Buffer>;
+}
+
+export class CheckoutCache {
+  private readonly cfg: ResolvedConfig;
+  private readonly inflight = new Map<string, Promise<string>>();
+
+  constructor(config: CheckoutCacheConfig = {}) {
+    const getToken =
+      config.getToken ??
+      (async () => {
+        const tok = process.env.GITHUB_TOKEN;
+        if (!tok) throw new Error("CheckoutCache: no GITHUB_TOKEN and no getToken override");
+        return tok;
+      });
+    this.cfg = {
+      root: config.root ?? DEFAULT_CHECKOUT_ROOT,
+      sizeLimitBytes: config.sizeLimitBytes ?? DEFAULT_SIZE_LIMIT_BYTES,
+      entryLimit: config.entryLimit ?? DEFAULT_ENTRY_LIMIT,
+      ttlMs: config.ttlMs ?? DEFAULT_TTL_MS,
+      getToken,
+      fetchTarball: config.fetchTarball ?? defaultFetchTarball,
+    };
+  }
+
+  /**
+   * Resolve a local extracted-tree path for (repo, sha). Returns cache hit
+   * if present and fresh; otherwise fetches + extracts. Throws on any
+   * security / IO failure — never returns null.
+   *
+   * `repo` is "owner/name". Caller is responsible for enforcing the
+   * projects.yaml allowlist before calling — this layer trusts its input.
+   */
+  async resolve(repo: string, sha: string): Promise<string> {
+    if (!/^[\w.-]+\/[\w.-]+$/.test(repo)) {
+      throw new Error(`CheckoutCache: invalid repo shape '${repo}', expected owner/name`);
+    }
+    if (!/^[a-f0-9]{7,40}$/i.test(sha)) {
+      throw new Error(`CheckoutCache: invalid sha '${sha}', expected hex ref`);
+    }
+    const key = `${repo}@${sha}`;
+    const existingExtract = this.inflight.get(key);
+    if (existingExtract) return existingExtract;
+
+    const promise = this._resolveImpl(repo, sha);
+    this.inflight.set(key, promise);
+    try {
+      return await promise;
+    } finally {
+      this.inflight.delete(key);
+    }
+  }
+
+  private async _resolveImpl(repo: string, sha: string): Promise<string> {
+    const dir = this._dirFor(repo, sha);
+    if (existsSync(dir)) {
+      const age = Date.now() - statSync(dir).mtimeMs;
+      if (age < this.cfg.ttlMs) {
+        const now = new Date();
+        utimesSync(dir, now, now);
+        console.log(
+          `[checkout-cache] hit ${repo}@${sha.slice(0, 7)} (age ${(age / 60_000).toFixed(1)}m)`,
+        );
+        return dir;
+      }
+      console.log(
+        `[checkout-cache] stale ${repo}@${sha.slice(0, 7)} (age ${(age / 60_000).toFixed(1)}m > ttl) — re-fetching`,
+      );
+      rmSync(dir, { recursive: true, force: true });
+    }
+
+    const [owner, name] = repo.split("/");
+    const token = await this.cfg.getToken(owner, name);
+    const tarball = await this.cfg.fetchTarball(owner, name, sha, token);
+    if (tarball.byteLength > MAX_COMPRESSED_BYTES) {
+      throw new Error(
+        `CheckoutCache: tarball for ${repo}@${sha} is ${tarball.byteLength} bytes ` +
+          `(> ${MAX_COMPRESSED_BYTES} cap) — refusing to extract`,
+      );
+    }
+    await this._extract(tarball, dir, repo, sha);
+    console.log(
+      `[checkout-cache] miss ${repo}@${sha.slice(0, 7)} extracted (${tarball.byteLength} bytes)`,
+    );
+    return dir;
+  }
+
+  /**
+   * Prune the cache. Called from the daily ceremony — NOT from the hot path.
+   * Drops entries whose mtime is older than the TTL, then evicts by
+   * least-recently-accessed until under both size and entry caps.
+   */
+  async prune(): Promise<{ evicted: number; bytesFreed: number }> {
+    if (!existsSync(this.cfg.root)) return { evicted: 0, bytesFreed: 0 };
+
+    interface Entry { path: string; mtimeMs: number; bytes: number }
+    const entries: Entry[] = [];
+    for (const slug of readdirSync(this.cfg.root)) {
+      const slugDir = join(this.cfg.root, slug);
+      if (!statSync(slugDir).isDirectory()) continue;
+      for (const sha of readdirSync(slugDir)) {
+        const entryDir = join(slugDir, sha);
+        const st = statSync(entryDir);
+        if (!st.isDirectory()) continue;
+        entries.push({ path: entryDir, mtimeMs: st.mtimeMs, bytes: dirSizeBytes(entryDir) });
+      }
+    }
+
+    const now = Date.now();
+    let evicted = 0;
+    let bytesFreed = 0;
+
+    // Drop anything past TTL outright — saves the LRU scan from juggling stale entries.
+    const fresh: Entry[] = [];
+    for (const e of entries) {
+      if (now - e.mtimeMs > this.cfg.ttlMs) {
+        rmSync(e.path, { recursive: true, force: true });
+        evicted++;
+        bytesFreed += e.bytes;
+      } else {
+        fresh.push(e);
+      }
+    }
+
+    // LRU eviction: sort by mtimeMs asc, evict until both caps satisfied.
+    fresh.sort((a, b) => a.mtimeMs - b.mtimeMs);
+    let totalBytes = fresh.reduce((acc, e) => acc + e.bytes, 0);
+    while (
+      fresh.length > 0 &&
+      (fresh.length > this.cfg.entryLimit || totalBytes > this.cfg.sizeLimitBytes)
+    ) {
+      const victim = fresh.shift()!;
+      rmSync(victim.path, { recursive: true, force: true });
+      evicted++;
+      bytesFreed += victim.bytes;
+      totalBytes -= victim.bytes;
+    }
+
+    if (evicted > 0) {
+      console.log(
+        `[checkout-cache] pruned ${evicted} entr${evicted === 1 ? "y" : "ies"} (${bytesFreed} bytes)`,
+      );
+    }
+    return { evicted, bytesFreed };
+  }
+
+  private _dirFor(repo: string, sha: string): string {
+    const slug = repo.replace("/", "-");
+    return join(this.cfg.root, slug, sha);
+  }
+
+  private async _extract(
+    tarball: Buffer,
+    targetDir: string,
+    repo: string,
+    sha: string,
+  ): Promise<void> {
+    mkdirSync(targetDir, { recursive: true });
+    const stagingParent = await mkdtemp(join(tmpdir(), "checkout-cache-"));
+    const tarballPath = join(stagingParent, "src.tar.gz");
+    writeFileSync(tarballPath, tarball);
+
+    try {
+      // Inspect entries before extracting — reject anything that would
+      // escape the target dir (absolute path, .. traversal) or land on
+      // host disk via a symlink/hardlink. GitHub's archives are not
+      // adversarial, but the cache is fed by `repo` strings from agent
+      // tool calls, so the filter pays for itself.
+      const listing = await runTar(["-tzf", tarballPath]);
+      const lines = listing.split("\n").filter(Boolean);
+      for (const line of lines) {
+        if (line.startsWith("/")) {
+          throw new Error(`CheckoutCache: tarball for ${repo}@${sha} contains absolute path: ${line}`);
+        }
+        if (line.split("/").some(seg => seg === "..")) {
+          throw new Error(`CheckoutCache: tarball for ${repo}@${sha} contains '..' segment: ${line}`);
+        }
+      }
+
+      // `-h` would dereference symlinks (turning them into the file they point at);
+      // we want to refuse them outright instead, so list with `tar -tvzf` and bail
+      // if any entry's permission string starts with 'l' (symlink) or 'h' (hardlink).
+      const verbose = await runTar(["-tvzf", tarballPath]);
+      for (const line of verbose.split("\n")) {
+        if (!line) continue;
+        const perm = line[0];
+        if (perm === "l" || perm === "h") {
+          throw new Error(`CheckoutCache: tarball for ${repo}@${sha} contains symlink/hardlink: ${line}`);
+        }
+      }
+
+      // GitHub tarballs nest everything under `<repo>-<sha>/` — strip that
+      // top-level dir so the extracted tree is rooted at targetDir.
+      await runTar(["-xzf", tarballPath, "-C", targetDir, "--strip-components=1"]);
+    } catch (err) {
+      // Don't leave a half-extracted tree around — the next resolve() would
+      // mistake it for a cache hit.
+      rmSync(targetDir, { recursive: true, force: true });
+      throw err;
+    } finally {
+      await rm(stagingParent, { recursive: true, force: true });
+    }
+  }
+}
+
+function defaultFetchTarball(
+  owner: string,
+  repo: string,
+  sha: string,
+  token: string,
+): Promise<Buffer> {
+  const url = `https://api.github.com/repos/${owner}/${repo}/tarball/${sha}`;
+  return fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "User-Agent": "protoWorkstacean-checkout-cache",
+      Accept: "application/vnd.github+json",
+    },
+    redirect: "follow",
+  }).then(async res => {
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(
+        `CheckoutCache: GitHub tarball ${owner}/${repo}@${sha} returned ${res.status} ${res.statusText} — ${body.slice(0, 200)}`,
+      );
+    }
+    const buf = await res.arrayBuffer();
+    return Buffer.from(buf);
+  });
+}
+
+function runTar(args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("tar", args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    proc.stdout.on("data", chunk => { stdout += String(chunk); });
+    proc.stderr.on("data", chunk => { stderr += String(chunk); });
+    proc.on("error", reject);
+    proc.on("close", code => {
+      if (code === 0) resolve(stdout);
+      else reject(new Error(`tar ${args.join(" ")} exited ${code}: ${stderr.trim()}`));
+    });
+  });
+}
+
+function dirSizeBytes(dir: string): number {
+  let total = 0;
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) total += dirSizeBytes(p);
+    else total += st.size;
+  }
+  return total;
+}

--- a/src/api/clawpatch.ts
+++ b/src/api/clawpatch.ts
@@ -10,13 +10,16 @@
  * The tool accepts `repo` in owner/name format. Resolution tries, in order:
  *
  *   1. `CLAWPATCH_REPO_PATH_MAP` env override (JSON owner/name → abs path)
- *   2. `BUILT_IN_REPO_PATHS` — bind mounts already in the container, kept
- *      as a zero-latency fast path
- *   3. `workspace/projects.yaml` allowlist gate, then `CheckoutCache` —
- *      on-demand fetch from GitHub tarball + extract into /data/checkouts/
+ *      — dev-only escape hatch for pointing at a local working tree.
+ *   2. `workspace/projects.yaml` allowlist gate, then `CheckoutCache` —
+ *      every other repo (including the ones that used to be bind-mounted)
+ *      goes through the cache so Quinn always reviews the exact PR ref.
  *
- * See docs/explanation/clawpatch-checkouts.md (C1 design doc) for the
- * cache's eviction, TTL, and security model.
+ * No bind-mount fast path. Per C1 sign-off (#578): "better way over fast
+ * way" — a single resolution code path means no "did Quinn review the
+ * host's checkout or the PR head" ambiguity. See
+ * docs/explanation/clawpatch-checkouts.md for the cache's eviction, TTL,
+ * and security model.
  *
  * Env
  * ---
@@ -74,38 +77,27 @@ interface ReviewRequest {
   provider?: "gateway" | "proto" | "claude" | "codex" | "acpx";
 }
 
-const BUILT_IN_REPO_PATHS: Record<string, string> = {
-  // Fast path: repos with a bind-mount already configured in the container.
-  // Resolution falls back to the on-demand CheckoutCache for any repo not
-  // listed here, so these are now an OPTIMIZATION rather than a hard
-  // requirement — clawpatch works against any repo in projects.yaml even
-  // without an entry. Paths follow the deploy-host convention
-  // (~/dev/labs/{repo}, protoWorkstacean at ~/dev/protoWorkstacean) and need
-  // a matching read-only mount in homelab-iac/stacks/ai/docker-compose.yml.
-  "protoLabsAI/protoWorkstacean": "/home/josh/dev/protoWorkstacean",
-  "protoLabsAI/protoMaker": "/home/josh/dev/labs/protoMaker",
-  "protoLabsAI/protoCLI": "/home/josh/dev/labs/protoCLI",
-  "protoLabsAI/mythxengine": "/home/josh/dev/labs/mythxengine",
-  "protoLabsAI/escape-from-qud": "/home/josh/dev/labs/escape-from-qud",
-  "protoLabsAI/release-tools": "/home/josh/dev/labs/release-tools",
-  "protoLabsAI/protoPatch": "/home/josh/dev/labs/protoPatch",
-  "protoLabsAI/pwnDeck": "/home/josh/dev/labs/pwnDeck",
-  "protoLabsAI/contentMachine": "/home/josh/dev/labs/contentMachine",
-};
-
-function resolveBuiltInPath(repo: string): string | null {
-  let overrides: Record<string, string> = {};
+/**
+ * Read the dev-only `CLAWPATCH_REPO_PATH_MAP` override, if set. Lets a
+ * developer point clawpatch at a working tree on disk instead of going
+ * through the GitHub-tarball cache — handy when iterating on protoPatch
+ * itself, or when reviewing a local-only branch that GitHub doesn't have
+ * a ref for. Production never sets this; everything routes through the
+ * cache so Quinn reviews the exact ref the PR is on.
+ */
+function resolveDevOverridePath(repo: string): string | null {
   const raw = process.env["CLAWPATCH_REPO_PATH_MAP"];
-  if (raw) {
-    try {
-      overrides = JSON.parse(raw) as Record<string, string>;
-    } catch {
-      // Fall through with empty overrides — bad JSON shouldn't break the route.
-    }
+  if (!raw) return null;
+  let overrides: Record<string, string>;
+  try {
+    overrides = JSON.parse(raw) as Record<string, string>;
+  } catch {
+    // Bad JSON shouldn't break the route — log once and fall through to cache.
+    console.warn("[clawpatch] CLAWPATCH_REPO_PATH_MAP is not valid JSON — ignoring");
+    return null;
   }
-  const path = overrides[repo] ?? BUILT_IN_REPO_PATHS[repo];
-  if (!path) return null;
-  if (!existsSync(path)) return null;
+  const path = overrides[repo];
+  if (!path || !existsSync(path)) return null;
   return path;
 }
 
@@ -147,13 +139,20 @@ function loadProjectAllowlist(workspaceDir: string): Set<string> {
 }
 
 /**
- * Resolve a local filesystem path for clawpatch to operate on.
+ * Resolve a local filesystem path for clawpatch to operate on. One code
+ * path, no bind-mount fast path: every repo (including protoWorkstacean
+ * itself) routes through the GitHub-tarball cache so Quinn always reviews
+ * the exact ref the PR is on, not whatever happens to be checked out on
+ * the host. Per the C1 sign-off — "better way over fast way".
  *
- *   1. Built-in mount / CLAWPATCH_REPO_PATH_MAP override — zero-latency fast
- *      path for repos already bind-mounted into the container.
- *   2. On-demand checkout via `CheckoutCache` for any repo in the
- *      projects.yaml allowlist. Requires `since` (PR head SHA) since the
- *      cache is content-addressed by ref.
+ *   1. `CLAWPATCH_REPO_PATH_MAP` env override — dev-only escape hatch,
+ *      lets a developer point clawpatch at a working tree.
+ *   2. `projects.yaml` allowlist gate — same security boundary as
+ *      `create_github_issue`. Agents can't aim clawpatch at arbitrary
+ *      GitHub repos.
+ *   3. `CheckoutCache.resolve(repo, since)` — fetches the tarball at the
+ *      given SHA, extracts under /data/checkouts/<owner>-<repo>/<sha>/,
+ *      and returns the path. Content-addressed; 1h TTL.
  *
  * Returns `{ ok: false, error }` instead of throwing so the route handler
  * can shape a 400 response without a try/catch.
@@ -163,8 +162,8 @@ async function resolveRepoPath(
   since: string | undefined,
   workspaceDir: string,
 ): Promise<{ ok: true; path: string } | { ok: false; error: string; status: number }> {
-  const fastPath = resolveBuiltInPath(repo);
-  if (fastPath) return { ok: true, path: fastPath };
+  const devOverride = resolveDevOverridePath(repo);
+  if (devOverride) return { ok: true, path: devOverride };
 
   const allow = loadProjectAllowlist(workspaceDir);
   if (!allow.has(repo)) {
@@ -173,7 +172,7 @@ async function resolveRepoPath(
       status: 400,
       error:
         `repo '${repo}' is not in workspace/projects.yaml — clawpatch only reviews ` +
-        `managed projects. Add it to projects.yaml first (or set CLAWPATCH_REPO_PATH_MAP).`,
+        `managed projects. Add it to projects.yaml first (or set CLAWPATCH_REPO_PATH_MAP for local dev).`,
     };
   }
 
@@ -182,8 +181,8 @@ async function resolveRepoPath(
       ok: false,
       status: 400,
       error:
-        `repo '${repo}' is not bind-mounted — on-demand checkout needs 'since' ` +
-        `(the PR head SHA) so the cache can address the right ref.`,
+        `clawpatch review needs 'since' (the PR head SHA) so the checkout ` +
+        `cache can fetch the right ref from GitHub.`,
     };
   }
 

--- a/src/api/clawpatch.ts
+++ b/src/api/clawpatch.ts
@@ -23,8 +23,12 @@
  */
 
 import { spawn } from "node:child_process";
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { CheckoutCache } from "../../lib/checkout-cache.ts";
+import { makeGitHubAuth } from "../../lib/github-auth.ts";
+import { parseProjectsYaml } from "../../lib/project-schema.ts";
 import type { Route, ApiContext } from "./types.ts";
 
 /**
@@ -83,7 +87,7 @@ const BUILT_IN_REPO_PATHS: Record<string, string> = {
   "protoLabsAI/contentMachine": "/home/josh/dev/labs/contentMachine",
 };
 
-function resolveRepoPath(repo: string): string | null {
+function resolveBuiltInPath(repo: string): string | null {
   let overrides: Record<string, string> = {};
   const raw = process.env["CLAWPATCH_REPO_PATH_MAP"];
   if (raw) {
@@ -97,6 +101,93 @@ function resolveRepoPath(repo: string): string | null {
   if (!path) return null;
   if (!existsSync(path)) return null;
   return path;
+}
+
+/**
+ * Lazy singleton — first review request after process start initializes it.
+ * Test override via the `setCheckoutCacheForTesting` helper below.
+ */
+let _cache: CheckoutCache | null = null;
+function getCheckoutCache(): CheckoutCache {
+  if (_cache) return _cache;
+  const auth = makeGitHubAuth();
+  _cache = new CheckoutCache({
+    getToken: auth ?? undefined,
+  });
+  return _cache;
+}
+
+export function setCheckoutCacheForTesting(cache: CheckoutCache | null): void {
+  _cache = cache;
+}
+
+/**
+ * Load the set of repos allowed for clawpatch review from workspace/projects.yaml.
+ * Same allowlist boundary that `create_github_issue` enforces — agents can't
+ * point clawpatch at arbitrary GitHub repos.
+ */
+function loadProjectAllowlist(workspaceDir: string): Set<string> {
+  const path = join(workspaceDir, "projects.yaml");
+  if (!existsSync(path)) return new Set();
+  try {
+    const raw = parseYaml(readFileSync(path, "utf8")) as unknown;
+    const parsed = parseProjectsYaml(raw);
+    return new Set(parsed.projects.map(p => p.github));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[clawpatch] projects.yaml load failed: ${msg} — allowlist empty`);
+    return new Set();
+  }
+}
+
+/**
+ * Resolve a local filesystem path for clawpatch to operate on.
+ *
+ *   1. Built-in mount / CLAWPATCH_REPO_PATH_MAP override — zero-latency fast
+ *      path for repos already bind-mounted into the container.
+ *   2. On-demand checkout via `CheckoutCache` for any repo in the
+ *      projects.yaml allowlist. Requires `since` (PR head SHA) since the
+ *      cache is content-addressed by ref.
+ *
+ * Returns `{ ok: false, error }` instead of throwing so the route handler
+ * can shape a 400 response without a try/catch.
+ */
+async function resolveRepoPath(
+  repo: string,
+  since: string | undefined,
+  workspaceDir: string,
+): Promise<{ ok: true; path: string } | { ok: false; error: string; status: number }> {
+  const fastPath = resolveBuiltInPath(repo);
+  if (fastPath) return { ok: true, path: fastPath };
+
+  const allow = loadProjectAllowlist(workspaceDir);
+  if (!allow.has(repo)) {
+    return {
+      ok: false,
+      status: 400,
+      error:
+        `repo '${repo}' is not in workspace/projects.yaml — clawpatch only reviews ` +
+        `managed projects. Add it to projects.yaml first (or set CLAWPATCH_REPO_PATH_MAP).`,
+    };
+  }
+
+  if (!since) {
+    return {
+      ok: false,
+      status: 400,
+      error:
+        `repo '${repo}' is not bind-mounted — on-demand checkout needs 'since' ` +
+        `(the PR head SHA) so the cache can address the right ref.`,
+    };
+  }
+
+  try {
+    const path = await getCheckoutCache().resolve(repo, since);
+    return { ok: true, path };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, status: 502, error: `checkout cache failed: ${msg}` };
+  }
 }
 
 interface ClawpatchExecResult {
@@ -153,7 +244,7 @@ interface CiJsonOutput {
   items?: unknown[];
 }
 
-export function createRoutes(_ctx: ApiContext): Route[] {
+export function createRoutes(ctx: ApiContext): Route[] {
   return [
     {
       method: "POST",
@@ -175,17 +266,14 @@ export function createRoutes(_ctx: ApiContext): Route[] {
             { status: 400 },
           );
         }
-        const repoPath = resolveRepoPath(repo);
-        if (!repoPath) {
-          const known = Object.keys(BUILT_IN_REPO_PATHS).join(", ");
+        const resolution = await resolveRepoPath(repo, since, ctx.workspaceDir);
+        if (!resolution.ok) {
           return Response.json(
-            {
-              success: false,
-              error: `repo '${repo}' is not mounted in this container — only mapped+mounted repos work today (${known}, plus any CLAWPATCH_REPO_PATH_MAP overrides). On-demand PR checkouts are not implemented.`,
-            },
-            { status: 400 },
+            { success: false, error: resolution.error },
+            { status: resolution.status },
           );
         }
+        const repoPath = resolution.path;
 
         // Workstacean mounts repo source read-only, so push clawpatch state
         // into the writable data volume — one dir per owner/repo so we don't

--- a/src/api/clawpatch.ts
+++ b/src/api/clawpatch.ts
@@ -7,11 +7,16 @@
  *
  * Repo resolution
  * ---------------
- * The tool accepts `repo` in owner/name format. We map it to a local
- * filesystem path via `CLAWPATCH_REPO_PATH_MAP` (JSON env override) or a
- * built-in default that knows about repos mounted into the workstacean
- * container today. v1 only supports already-mounted repos; on-demand PR
- * checkouts are phase 2.
+ * The tool accepts `repo` in owner/name format. Resolution tries, in order:
+ *
+ *   1. `CLAWPATCH_REPO_PATH_MAP` env override (JSON owner/name → abs path)
+ *   2. `BUILT_IN_REPO_PATHS` — bind mounts already in the container, kept
+ *      as a zero-latency fast path
+ *   3. `workspace/projects.yaml` allowlist gate, then `CheckoutCache` —
+ *      on-demand fetch from GitHub tarball + extract into /data/checkouts/
+ *
+ * See docs/explanation/clawpatch-checkouts.md (C1 design doc) for the
+ * cache's eviction, TTL, and security model.
  *
  * Env
  * ---
@@ -70,12 +75,13 @@ interface ReviewRequest {
 }
 
 const BUILT_IN_REPO_PATHS: Record<string, string> = {
-  // Repos clawpatch can review. Paths follow the deploy-host convention
-  // (~/dev/labs/{repo}, protoWorkstacean at ~/dev/protoWorkstacean). Each
-  // must ALSO be mounted read-only into the container for the path to exist —
-  // see homelab-iac/stacks/ai/docker-compose.yml workstacean.volumes. An entry
-  // here without a mount resolves to a missing path and clawpatch reports it.
-  // Keep in sync with the active repos in workspace/projects.yaml.
+  // Fast path: repos with a bind-mount already configured in the container.
+  // Resolution falls back to the on-demand CheckoutCache for any repo not
+  // listed here, so these are now an OPTIMIZATION rather than a hard
+  // requirement — clawpatch works against any repo in projects.yaml even
+  // without an entry. Paths follow the deploy-host convention
+  // (~/dev/labs/{repo}, protoWorkstacean at ~/dev/protoWorkstacean) and need
+  // a matching read-only mount in homelab-iac/stacks/ai/docker-compose.yml.
   "protoLabsAI/protoWorkstacean": "/home/josh/dev/protoWorkstacean",
   "protoLabsAI/protoMaker": "/home/josh/dev/labs/protoMaker",
   "protoLabsAI/protoCLI": "/home/josh/dev/labs/protoCLI",

--- a/src/index.ts
+++ b/src/index.ts
@@ -271,6 +271,20 @@ const pluginRegistry: PluginRegistryEntry[] = [
     },
   },
   {
+    // Registers a FunctionExecutor for `ceremony.clawpatch_cache_cleanup`
+    // (workspace/ceremonies/clawpatch-cache-cleanup.yaml). Pure janitor — calls
+    // CheckoutCache.prune() directly; no agent involved. Same install-order
+    // constraint as alert-skill-executor.
+    name: "clawpatch-cache-cleanup-skill-executor",
+    condition: () => true,
+    factory: async () => {
+      const { ClawpatchCacheCleanupSkillExecutorPlugin } = await import(
+        "./plugins/clawpatch-cache-cleanup-skill-executor-plugin.js"
+      );
+      return new ClawpatchCacheCleanupSkillExecutorPlugin(executorRegistry);
+    },
+  },
+  {
     // Registers FunctionExecutors for the `action.pr_*` /
     // `action.dispatch_backmerge` skills whose handlers live in
     // PrRemediatorPlugin.

--- a/src/plugins/__tests__/clawpatch-cache-cleanup-skill-executor.test.ts
+++ b/src/plugins/__tests__/clawpatch-cache-cleanup-skill-executor.test.ts
@@ -30,8 +30,9 @@ describe("ClawpatchCacheCleanupSkillExecutorPlugin", () => {
     const result = await executor!.execute({
       skill: "ceremony.clawpatch_cache_cleanup",
       content: "",
-      targets: [],
       correlationId: "test-corr",
+      replyTopic: "test.reply",
+      payload: { skill: "ceremony.clawpatch_cache_cleanup", content: "" } as never,
     });
     expect(result.isError).toBe(false);
     expect(result.text).toContain("evicted=7");
@@ -51,8 +52,9 @@ describe("ClawpatchCacheCleanupSkillExecutorPlugin", () => {
     const result = await executor!.execute({
       skill: "ceremony.clawpatch_cache_cleanup",
       content: "",
-      targets: [],
       correlationId: "test-err",
+      replyTopic: "test.reply",
+      payload: { skill: "ceremony.clawpatch_cache_cleanup", content: "" } as never,
     });
     expect(result.isError).toBe(true);
     expect(result.text).toContain("disk full");

--- a/src/plugins/__tests__/clawpatch-cache-cleanup-skill-executor.test.ts
+++ b/src/plugins/__tests__/clawpatch-cache-cleanup-skill-executor.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect } from "bun:test";
+import { ExecutorRegistry } from "../../executor/executor-registry.ts";
+import { ClawpatchCacheCleanupSkillExecutorPlugin } from "../clawpatch-cache-cleanup-skill-executor-plugin.ts";
+import { CheckoutCache } from "../../../lib/checkout-cache.ts";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+
+class FakeCache extends CheckoutCache {
+  constructor(private readonly result: { evicted: number; bytesFreed: number } | Error) {
+    super({
+      root: "/tmp/fake-not-used",
+      getToken: async () => "x",
+      fetchTarball: async () => Buffer.alloc(0),
+    });
+  }
+  override async prune(): Promise<{ evicted: number; bytesFreed: number }> {
+    if (this.result instanceof Error) throw this.result;
+    return this.result;
+  }
+}
+
+describe("ClawpatchCacheCleanupSkillExecutorPlugin", () => {
+  test("registers ceremony.clawpatch_cache_cleanup and runs prune on dispatch", async () => {
+    const registry = new ExecutorRegistry();
+    const fake = new FakeCache({ evicted: 7, bytesFreed: 12345 });
+    const plugin = new ClawpatchCacheCleanupSkillExecutorPlugin(registry, fake);
+    plugin.install(new InMemoryEventBus());
+
+    const executor = registry.resolve("ceremony.clawpatch_cache_cleanup", []);
+    expect(executor).not.toBeNull();
+    const result = await executor!.execute({
+      skill: "ceremony.clawpatch_cache_cleanup",
+      content: "",
+      targets: [],
+      correlationId: "test-corr",
+    });
+    expect(result.isError).toBe(false);
+    expect(result.text).toContain("evicted=7");
+    expect(result.text).toContain("bytesFreed=12345");
+    expect(result.correlationId).toBe("test-corr");
+
+    plugin.uninstall();
+  });
+
+  test("returns isError=true when prune throws", async () => {
+    const registry = new ExecutorRegistry();
+    const fake = new FakeCache(new Error("disk full"));
+    const plugin = new ClawpatchCacheCleanupSkillExecutorPlugin(registry, fake);
+    plugin.install(new InMemoryEventBus());
+
+    const executor = registry.resolve("ceremony.clawpatch_cache_cleanup", []);
+    const result = await executor!.execute({
+      skill: "ceremony.clawpatch_cache_cleanup",
+      content: "",
+      targets: [],
+      correlationId: "test-err",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain("disk full");
+
+    plugin.uninstall();
+  });
+});

--- a/src/plugins/clawpatch-cache-cleanup-skill-executor-plugin.ts
+++ b/src/plugins/clawpatch-cache-cleanup-skill-executor-plugin.ts
@@ -1,0 +1,85 @@
+/**
+ * ClawpatchCacheCleanupSkillExecutorPlugin — registers a FunctionExecutor
+ * for the `ceremony.clawpatch_cache_cleanup` skill that drives the daily
+ * `clawpatch.cache_cleanup` ceremony (workspace/ceremonies/clawpatch-cache-cleanup.yaml).
+ *
+ * Pure janitor — no agent involved. Calls `CheckoutCache.prune()` directly
+ * to drop TTL-stale entries and LRU-evict the cache back under its caps.
+ * Lives outside the request path so reviews never pay the prune IO cost.
+ *
+ * Install order: must run AFTER ExecutorRegistry construction and BEFORE
+ * SkillDispatcherPlugin (same constraint as alert-skill-executor).
+ */
+
+import type { Plugin, EventBus } from "../../lib/types.ts";
+import type { ExecutorRegistry } from "../executor/executor-registry.ts";
+import type { SkillRequest, SkillResult } from "../executor/types.ts";
+import { FunctionExecutor } from "../executor/executors/function-executor.ts";
+import { CheckoutCache } from "../../lib/checkout-cache.ts";
+import { makeGitHubAuth } from "../../lib/github-auth.ts";
+
+export class ClawpatchCacheCleanupSkillExecutorPlugin implements Plugin {
+  readonly name = "clawpatch-cache-cleanup-skill-executor";
+  readonly description =
+    "Registers the FunctionExecutor that prunes the clawpatch checkout cache";
+  readonly capabilities = ["cache-prune", "executor-registrar"];
+
+  private _cache: CheckoutCache | null = null;
+
+  constructor(
+    private readonly registry: ExecutorRegistry,
+    /**
+     * Optional cache override for tests. Production passes nothing and the
+     * plugin lazily builds a default-config CheckoutCache the first time
+     * the ceremony fires.
+     */
+    private readonly cacheOverride?: CheckoutCache,
+  ) {}
+
+  install(_bus: EventBus): void {
+    this._cache = this.cacheOverride ?? new CheckoutCache({
+      getToken: makeGitHubAuth() ?? undefined,
+    });
+    const executor = new FunctionExecutor(async (req) => this._execute(req));
+    this.registry.register("ceremony.clawpatch_cache_cleanup", executor, { priority: 5 });
+    console.log(
+      "[clawpatch-cache-cleanup-skill-executor] Registered ceremony.clawpatch_cache_cleanup",
+    );
+  }
+
+  uninstall(): void {
+    this._cache = null;
+  }
+
+  private async _execute(req: SkillRequest): Promise<SkillResult> {
+    if (!this._cache) {
+      return {
+        text: "plugin not installed",
+        isError: true,
+        correlationId: req.correlationId,
+      };
+    }
+    const startedAt = Date.now();
+    try {
+      const { evicted, bytesFreed } = await this._cache.prune();
+      const durationMs = Date.now() - startedAt;
+      console.log(
+        `[clawpatch-cache-cleanup] pruned ${evicted} entr${evicted === 1 ? "y" : "ies"} ` +
+          `(${bytesFreed} bytes) in ${durationMs}ms`,
+      );
+      return {
+        text: `clawpatch checkout cache: evicted=${evicted} bytesFreed=${bytesFreed} durationMs=${durationMs}`,
+        isError: false,
+        correlationId: req.correlationId,
+        data: { durationMs, success: true },
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        text: `clawpatch cache prune failed: ${msg}`,
+        isError: true,
+        correlationId: req.correlationId,
+      };
+    }
+  }
+}

--- a/workspace/agents/quinn.yaml
+++ b/workspace/agents/quinn.yaml
@@ -253,14 +253,12 @@ skills:
             can actually run typecheck + tests to verify)
         Skip `proto` on trivial diffs — the extra tokens aren't worth it.
 
-      If clawpatch returns "repo not mounted" — the v1 only handles
-      repos baked into the workstacean container (protoWorkstacean,
-      protoCLI, mythxengine). Note it as a LOW observation and continue
-      with the regular diff-based review.
-
-      If clawpatch errors for any other reason (timeout, gateway 5xx),
-      note it as a LOW observation and proceed — clawpatch is a
-      finding-source, not a gate.
+      Clawpatch works against any repo declared in
+      workspace/projects.yaml — the checkout cache fetches the source
+      tree on demand. If it errors (timeout, gateway 5xx, or the repo
+      is not in the projects.yaml allowlist), note it as a LOW
+      observation and proceed with the regular diff-based review.
+      Clawpatch is a finding-source, not a gate.
 
       ## Step 3 — Apply the rubric
 
@@ -350,9 +348,10 @@ skills:
     # clawpatch_review is available here too (not just in pr_review): when an
     # issue points at a repo region, a structural scan confirms whether the
     # bug is real and where it lives — grounding the actionable/stale call in
-    # findings instead of guesswork. Same gateway-backed tool, same
-    # already-mounted-repo limitation (v1). protoPatch (the clawpatch fork) is
-    # installed in the runtime at /opt/clawpatch/bin.
+    # findings instead of guesswork. Same gateway-backed tool; the checkout
+    # cache now fetches source on demand for any repo in projects.yaml.
+    # protoPatch (the clawpatch fork) is installed in the runtime at
+    # /opt/clawpatch/bin.
     tools:
       - get_projects
       - get_pr_pipeline
@@ -400,10 +399,10 @@ skills:
         clawpatch returns nothing relevant, that supports a stale/duplicate
         call.
 
-      clawpatch only handles repos already mounted in the runtime (v1); if it
-      returns "repo not mounted" or errors (timeout, gateway 5xx), note it as
-      a LOW observation and classify from the board + commit evidence alone.
-      Do not block triage on clawpatch.
+      clawpatch handles any repo declared in workspace/projects.yaml; if it
+      errors (timeout, gateway 5xx, or the repo is not in the allowlist),
+      note it as a LOW observation and classify from the board + commit
+      evidence alone. Do not block triage on clawpatch.
 
       ## Step 4 — Classify
 

--- a/workspace/ceremonies/clawpatch-cache-cleanup.yaml
+++ b/workspace/ceremonies/clawpatch-cache-cleanup.yaml
@@ -1,0 +1,13 @@
+id: clawpatch.cache_cleanup
+name: Clawpatch Checkout Cache Cleanup
+# Daily at 03:00 UTC — well clear of the morning sitrep window so the prune
+# IO doesn't fight live review traffic.
+schedule: "0 3 * * *"
+skill: ceremony.clawpatch_cache_cleanup
+# Pure janitorial — no agent needed. The skill is wired to a FunctionExecutor
+# in src/plugins/clawpatch-cache-cleanup-skill-executor-plugin.ts that calls
+# CheckoutCache.prune() directly.
+targets:
+  - function
+notifyChannel: ""
+enabled: true


### PR DESCRIPTION
## Summary

Adds \`lib/checkout-cache.ts\` — content-addressed source-tree cache that lets \`clawpatch_review\` work against any repo in \`workspace/projects.yaml\`. Today only the three repos bind-mounted into the container work. After this PR, anything in the projects allowlist gets fetched on-demand from GitHub's tarball API, extracted under \`/data/checkouts/<owner>-<repo>/<sha>/\`, and handed to clawpatch transparently.

**Stacks on top of #578 (C1 design doc).** Implements the design's default biases:
- Host bind-mount fast path kept (no cache pinning for the three already-mounted repos)
- 24h TTL with age-on-hit logging

Happy to adjust either if #578 sign-off lands different answers.

## Implementation

Resolution order in \`src/api/clawpatch.ts:resolveRepoPath()\`:

1. \`CLAWPATCH_REPO_PATH_MAP\` override (existing)
2. \`BUILT_IN_REPO_PATHS\` bind mount (existing — zero-latency)
3. **NEW**: \`projects.yaml\` allowlist gate (security boundary, same one \`create_github_issue\` enforces)
4. **NEW**: \`CheckoutCache.resolve(repo, sha)\` — fetches + extracts

Cache behavior:
- \`/data/checkouts/<owner>-<repo>/<sha>/\` — content-addressed
- 24h TTL refresh on hit; stale entries re-fetched
- Per-\`(repo, sha)\` in-memory mutex so concurrent reviews on the same PR head don't race
- 1 GB compressed-tarball ceiling
- Tarball-entry filter rejects absolute paths, \`..\` segments, symlinks, hardlinks **before** extracting; half-extracted trees are wiped on any error so the next call doesn't mistake them for a cache hit
- \`prune()\` does TTL drop + LRU eviction to entry/size caps — called from the C3 ceremony, **not** the request path

Tarball extraction shells out to system \`tar\` (already in the image since clawpatch shells out itself). No new npm deps.

Roadmap: C2 (5 pts).

## Test plan

- [x] \`bun test lib/__tests__/checkout-cache.test.ts\` — 9 pass (fetch+hit, TTL refresh, mutex, traversal/symlink reject, LRU + TTL eviction)
- [x] \`bun test\` — 719/0 (was 707, +9 new + reflects A3 already on dev)
- [x] \`bun tsc --noEmit\` — clean
- [ ] Live container deploy: trigger \`clawpatch_review\` against a repo NOT in \`BUILT_IN_REPO_PATHS\` (e.g. \`protoLabsAI/contentMachine\`); confirm \`[checkout-cache] miss …\` log + a passing review
- [ ] Second call within 24h shows \`[checkout-cache] hit\` instead of re-fetch
- [ ] Run review against a non-allowlisted repo → 400 with \"not in workspace/projects.yaml\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)