### PR TITLE
feat(dashboard): skill-trace waterfall (D1)

### DIFF
--- a/dashboard/src/components/SkillTrace.tsx
+++ b/dashboard/src/components/SkillTrace.tsx
@@ -1,0 +1,301 @@
+/**
+ * SkillTrace — vertical waterfall view of a single correlationId's full
+ * causal chain across the bus. Fetches from /api/bus/history and renders
+ * the message sequence with relative timestamps so an operator can see
+ * an entire skill dispatch (inbound → router → dispatcher → executor →
+ * activity → response) at a glance, then click through to Langfuse for
+ * the LLM-call detail when needed.
+ *
+ * URL form: /system/trace/<correlationId>
+ *
+ * Backend contract: GET /api/bus/history?correlationId=... → {
+ *   success: true,
+ *   data: { correlationId, count, messages: BusMessage[], stats }
+ * }
+ */
+
+import { useEffect, useMemo, useState } from "preact/hooks";
+
+interface BusMessage {
+  id: string;
+  correlationId: string;
+  topic: string;
+  timestamp: number;
+  payload?: Record<string, unknown>;
+  source?: { interface?: string };
+}
+
+interface HistoryResponse {
+  success: boolean;
+  data?: {
+    correlationId: string;
+    count: number;
+    messages: BusMessage[];
+    stats: { size: number; capacity: number; ttlMs: number };
+  };
+  error?: string;
+}
+
+export default function SkillTrace() {
+  const [correlationId, setCorrelationId] = useState<string>(() => {
+    if (typeof window === "undefined") return "";
+    return new URLSearchParams(window.location.search).get("correlationId") ?? "";
+  });
+  const [data, setData] = useState<HistoryResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [inputValue, setInputValue] = useState(correlationId);
+
+  useEffect(() => {
+    if (!correlationId) {
+      setData(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(`/api/bus/history?correlationId=${encodeURIComponent(correlationId)}`)
+      .then(r => r.json())
+      .then((j: HistoryResponse) => {
+        if (cancelled) return;
+        if (!j.success) {
+          setError(j.error ?? "unknown error");
+        } else {
+          setData(j);
+        }
+      })
+      .catch(err => {
+        if (!cancelled) setError(String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [correlationId]);
+
+  const messages = data?.data?.messages ?? [];
+  const t0 = messages[0]?.timestamp ?? 0;
+
+  const langfuseUrl = useMemo(() => {
+    const base = (import.meta.env.PUBLIC_LANGFUSE_URL ?? "https://cloud.langfuse.com").replace(/\/$/, "");
+    return `${base}/traces?search=${encodeURIComponent(correlationId)}`;
+  }, [correlationId]);
+
+  const search = (
+    <form
+      class="trace-search"
+      onSubmit={(e) => {
+        e.preventDefault();
+        const next = inputValue.trim();
+        if (!next || next === correlationId) return;
+        // Push state so back-button works.
+        const url = new URL(window.location.href);
+        url.searchParams.set("correlationId", next);
+        window.history.pushState({}, "", url.toString());
+        setCorrelationId(next);
+      }}
+    >
+      <input
+        type="text"
+        placeholder="correlationId"
+        value={inputValue}
+        onInput={(e) => setInputValue((e.target as HTMLInputElement).value)}
+      />
+      <button type="submit">Trace</button>
+    </form>
+  );
+
+  if (!correlationId) {
+    return (
+      <div class="skill-trace">
+        <header class="trace-header">
+          <h2>Skill trace</h2>
+          {search}
+        </header>
+        <p class="trace-empty">
+          Paste a correlationId to load every bus message under it. Trace
+          history lives in memory for 30 minutes after the messages fire.
+        </p>
+        <style>{TRACE_STYLES}</style>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return <div class="trace-empty">Loading trace for {correlationId}…</div>;
+  }
+  if (error) {
+    return (
+      <div class="trace-empty trace-error">
+        <h3>Trace lookup failed</h3>
+        <p>{error}</p>
+        <p>
+          The bus history buffer is in-memory and capped at the recorder's TTL
+          (30 minutes by default). If this correlation is older than that
+          window, it's been pruned.
+        </p>
+      </div>
+    );
+  }
+  if (messages.length === 0) {
+    return (
+      <div class="trace-empty">
+        <h3>No bus messages for {correlationId}</h3>
+        <p>Either the id is wrong, no traffic ran under it, or the entry
+          aged out of the 30-min ring.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div class="skill-trace">
+      <header class="trace-header">
+        <div>
+          <h2>Trace · <code>{correlationId}</code></h2>
+          <p class="trace-meta">
+            {messages.length} message{messages.length === 1 ? "" : "s"} ·
+            spans {((messages[messages.length - 1].timestamp - t0) / 1000).toFixed(2)}s
+          </p>
+        </div>
+        {search}
+        <a class="langfuse-link" href={langfuseUrl} target="_blank" rel="noreferrer">
+          Open in Langfuse →
+        </a>
+      </header>
+
+      <ol class="trace-list">
+        {messages.map((m) => {
+          const isOpen = expanded === m.id;
+          return (
+            <li class="trace-row" key={m.id}>
+              <button
+                class="trace-row-toggle"
+                onClick={() => setExpanded(isOpen ? null : m.id)}
+                aria-expanded={isOpen}
+              >
+                <span class="trace-ts">+{((m.timestamp - t0) / 1000).toFixed(3)}s</span>
+                <span class="trace-topic">{m.topic}</span>
+                <span class="trace-source">{m.source?.interface ?? "-"}</span>
+              </button>
+              {isOpen && (
+                <pre class="trace-payload">{JSON.stringify(m.payload ?? {}, null, 2)}</pre>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+
+      <style>{TRACE_STYLES}</style>
+    </div>
+  );
+}
+
+const TRACE_STYLES = `
+        .skill-trace {
+          padding: 1.5rem;
+          font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+          color: #c9d1d9;
+          background: #0d1117;
+          min-height: 100%;
+        }
+        .trace-header {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          margin-bottom: 1rem;
+          padding-bottom: 0.75rem;
+          border-bottom: 1px solid #21262d;
+        }
+        .trace-header h2 {
+          margin: 0;
+          font-size: 1.1rem;
+        }
+        .trace-meta {
+          margin: 0.25rem 0 0;
+          color: #8b949e;
+          font-size: 0.85rem;
+        }
+        .langfuse-link {
+          padding: 0.4rem 0.75rem;
+          background: #21262d;
+          color: #58a6ff;
+          text-decoration: none;
+          border-radius: 4px;
+          font-size: 0.85rem;
+        }
+        .langfuse-link:hover {
+          background: #30363d;
+        }
+        .trace-empty {
+          padding: 2rem;
+          color: #8b949e;
+          font-family: ui-monospace, monospace;
+        }
+        .trace-error h3 { color: #f85149; }
+        .trace-list {
+          list-style: none;
+          padding: 0;
+          margin: 0;
+        }
+        .trace-row {
+          border-left: 2px solid #30363d;
+          padding-left: 0.75rem;
+          margin-bottom: 0.5rem;
+        }
+        .trace-row-toggle {
+          display: grid;
+          grid-template-columns: 5rem 1fr 6rem;
+          gap: 0.75rem;
+          width: 100%;
+          background: transparent;
+          color: inherit;
+          border: none;
+          padding: 0.4rem 0;
+          font-family: inherit;
+          font-size: 0.85rem;
+          text-align: left;
+          cursor: pointer;
+        }
+        .trace-row-toggle:hover {
+          background: #161b22;
+        }
+        .trace-ts { color: #8b949e; }
+        .trace-topic { color: #58a6ff; }
+        .trace-source { color: #7ee787; text-align: right; }
+        .trace-payload {
+          background: #161b22;
+          color: #c9d1d9;
+          padding: 0.75rem;
+          margin: 0.25rem 0 0;
+          border-radius: 4px;
+          font-size: 0.8rem;
+          overflow-x: auto;
+          max-height: 400px;
+          overflow-y: auto;
+        }
+        .trace-search {
+          display: flex;
+          gap: 0.5rem;
+        }
+        .trace-search input {
+          background: #0d1117;
+          color: #c9d1d9;
+          border: 1px solid #30363d;
+          padding: 0.4rem 0.6rem;
+          border-radius: 4px;
+          font-family: inherit;
+          font-size: 0.85rem;
+          min-width: 18rem;
+        }
+        .trace-search button {
+          background: #238636;
+          color: white;
+          border: none;
+          padding: 0.4rem 0.9rem;
+          border-radius: 4px;
+          font-size: 0.85rem;
+          cursor: pointer;
+        }
+        .trace-search button:hover { background: #2ea043; }
+`;

--- a/dashboard/src/layouts/DashboardLayout.astro
+++ b/dashboard/src/layouts/DashboardLayout.astro
@@ -11,6 +11,7 @@ const { title, activePage } = Astro.props;
 const navItems = [
   { href: "/", label: "Overview", id: "overview" },
   { href: "/system", label: "System", id: "system" },
+  { href: "/trace", label: "Trace", id: "trace" },
   { href: "/events", label: "Events", id: "events" },
   { href: "/agents", label: "Agents", id: "agents" },
   { href: "/outcomes", label: "Outcomes", id: "outcomes" },

--- a/dashboard/src/pages/trace.astro
+++ b/dashboard/src/pages/trace.astro
@@ -1,0 +1,24 @@
+---
+// /trace?correlationId=<id> — vertical waterfall view of every bus message
+// under a single correlationId. Backed by /api/bus/history; see
+// SkillTrace.tsx for the rendering layer and history-recorder.ts for the
+// in-memory ring buffer.
+//
+// Using a query param rather than /trace/<id> keeps Astro's static output
+// happy — no per-id prerendering, no server runtime required. SkillTrace
+// reads the param from window.location on mount.
+
+import DashboardLayout from "../layouts/DashboardLayout.astro";
+import SkillTrace from "../components/SkillTrace.tsx";
+---
+
+<DashboardLayout title="Skill Trace" activePage="system">
+  <SkillTrace client:load />
+</DashboardLayout>
+
+<style>
+  :global(.content) {
+    padding: 0 !important;
+    overflow: auto;
+  }
+</style>

--- a/src/api/bus-history.ts
+++ b/src/api/bus-history.ts
@@ -1,0 +1,73 @@
+/**
+ * GET /api/bus/history — replay slice of the in-memory bus history buffer.
+ *
+ * Query params:
+ *   correlationId  — return every message whose correlationId === this value,
+ *                    oldest first. Used by the dashboard's
+ *                    /system/trace/:correlationId waterfall (D1).
+ *   limit          — when no correlationId is given, return the N most-recent
+ *                    messages across all correlations. Defaults to 200,
+ *                    capped at 1000 so a curl dump can't OOM the dashboard.
+ *
+ * The buffer is a 10k-event ring with 30-min TTL (see history-recorder.ts).
+ * Returns 503 if no recorder is wired — never falls back to "empty array
+ * looks like success" because callers (dashboard waterfall) need to
+ * distinguish "no history" from "feature disabled".
+ */
+
+import type { Route, ApiContext } from "./types.ts";
+
+const DEFAULT_LIMIT = 200;
+const MAX_LIMIT = 1000;
+
+export function createRoutes(ctx: ApiContext): Route[] {
+  return [
+    {
+      method: "GET",
+      path: "/api/bus/history",
+      handler: (req) => {
+        if (!ctx.busHistory) {
+          return Response.json(
+            { success: false, error: "bus-history-recorder not installed" },
+            { status: 503 },
+          );
+        }
+
+        const url = new URL(req.url);
+        const correlationId = url.searchParams.get("correlationId");
+
+        if (correlationId) {
+          const messages = ctx.busHistory.byCorrelationId(correlationId);
+          return Response.json({
+            success: true,
+            data: {
+              correlationId,
+              count: messages.length,
+              messages,
+              stats: ctx.busHistory.stats(),
+            },
+          });
+        }
+
+        const rawLimit = url.searchParams.get("limit");
+        const limit = clampLimit(rawLimit);
+        const messages = ctx.busHistory.recent(limit);
+        return Response.json({
+          success: true,
+          data: {
+            count: messages.length,
+            messages,
+            stats: ctx.busHistory.stats(),
+          },
+        });
+      },
+    },
+  ];
+}
+
+function clampLimit(raw: string | null): number {
+  if (!raw) return DEFAULT_LIMIT;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_LIMIT;
+  return Math.min(n, MAX_LIMIT);
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -27,6 +27,7 @@ import { createRoutes as busTopologyRoutes } from "./bus-topology.ts";
 import { createRoutes as prInspectorRoutes } from "./pr-inspector.ts";
 import { createRoutes as clawpatchRoutes } from "./clawpatch.ts";
 import { createRoutes as agentsRuntimeRoutes } from "./agents-runtime.ts";
+import { createRoutes as busHistoryRoutes } from "./bus-history.ts";
 
 export { matchPath } from "./types.ts";
 export type { Route, ApiContext } from "./types.ts";
@@ -53,5 +54,6 @@ export function createAllRoutes(ctx: ApiContext): Route[] {
     ...prInspectorRoutes(ctx),
     ...clawpatchRoutes(ctx),
     ...agentsRuntimeRoutes(ctx),
+    ...busHistoryRoutes(ctx),
   ];
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -14,6 +14,7 @@ import type { TelemetryService } from "../telemetry/telemetry-service.ts";
 import type { ContextMailbox } from "../../lib/dm/context-mailbox.ts";
 import type { TaskTracker } from "../executor/task-tracker.ts";
 import type { AgentKeyRegistry } from "../../lib/auth/agent-keys.ts";
+import type { BusHistoryRecorder } from "../event-bus/history-recorder.ts";
 
 export type Params = Record<string, string>;
 export type RouteHandler = (req: Request, params: Params) => Response | Promise<Response>;
@@ -45,6 +46,12 @@ export interface ApiContext {
   agentKeys?: AgentKeyRegistry;
   mailbox?: ContextMailbox;
   taskTracker?: TaskTracker;
+  /**
+   * Optional in-memory ring buffer of recent bus messages. Backs
+   * /api/bus/history (D1 skill-trace view). Wired in src/index.ts only
+   * when the bus-history-recorder plugin is installed.
+   */
+  busHistory?: BusHistoryRecorder;
 }
 
 /** Match a path against a pattern like "/api/foo/:id/run". Returns params or null. */

--- a/src/event-bus/__tests__/history-recorder.test.ts
+++ b/src/event-bus/__tests__/history-recorder.test.ts
@@ -1,0 +1,106 @@
+import { describe, test, expect } from "bun:test";
+import { BusHistoryRecorder, BusHistoryRecorderPlugin } from "../history-recorder.ts";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import type { BusMessage } from "../../../lib/types.ts";
+
+function makeMsg(topic: string, correlationId: string, timestamp = Date.now()): BusMessage {
+  return {
+    id: crypto.randomUUID(),
+    correlationId,
+    topic,
+    timestamp,
+    payload: { topic },
+  };
+}
+
+describe("BusHistoryRecorder", () => {
+  describe("ring buffer", () => {
+    test("records up to capacity in publish order", () => {
+      const r = new BusHistoryRecorder({ maxEvents: 3 });
+      r.record(makeMsg("t1", "c1"));
+      r.record(makeMsg("t2", "c1"));
+      r.record(makeMsg("t3", "c2"));
+
+      expect(r.stats().size).toBe(3);
+      const recent = r.recent(10);
+      expect(recent.map(m => m.topic)).toEqual(["t1", "t2", "t3"]);
+    });
+
+    test("wraps when full — oldest dropped", () => {
+      const r = new BusHistoryRecorder({ maxEvents: 3 });
+      r.record(makeMsg("t1", "c1"));
+      r.record(makeMsg("t2", "c1"));
+      r.record(makeMsg("t3", "c1"));
+      r.record(makeMsg("t4", "c1"));
+      r.record(makeMsg("t5", "c1"));
+
+      expect(r.stats().size).toBe(3);
+      const recent = r.recent(10);
+      expect(recent.map(m => m.topic)).toEqual(["t3", "t4", "t5"]);
+    });
+  });
+
+  describe("byCorrelationId", () => {
+    test("filters by correlationId, oldest first", () => {
+      const r = new BusHistoryRecorder({ maxEvents: 10 });
+      r.record(makeMsg("a", "X"));
+      r.record(makeMsg("b", "Y"));
+      r.record(makeMsg("c", "X"));
+      r.record(makeMsg("d", "Z"));
+      r.record(makeMsg("e", "X"));
+
+      const trace = r.byCorrelationId("X");
+      expect(trace.map(m => m.topic)).toEqual(["a", "c", "e"]);
+    });
+
+    test("returns empty when no matches", () => {
+      const r = new BusHistoryRecorder({ maxEvents: 10 });
+      r.record(makeMsg("a", "X"));
+      expect(r.byCorrelationId("missing")).toEqual([]);
+    });
+  });
+
+  describe("TTL", () => {
+    test("skips entries past ttl on read", () => {
+      const r = new BusHistoryRecorder({ maxEvents: 10, ttlMs: 1000 });
+      const oldTs = Date.now() - 5_000;
+      r.record(makeMsg("old", "X", oldTs));
+      r.record(makeMsg("new", "X"));
+
+      const trace = r.byCorrelationId("X");
+      expect(trace.map(m => m.topic)).toEqual(["new"]);
+    });
+
+    test("prune() drops stale slots so payloads can be GC'd", () => {
+      const r = new BusHistoryRecorder({ maxEvents: 10, ttlMs: 1000 });
+      const oldTs = Date.now() - 5_000;
+      r.record(makeMsg("old1", "X", oldTs));
+      r.record(makeMsg("old2", "Y", oldTs));
+      r.record(makeMsg("new", "X"));
+      r.prune();
+
+      // Stats remain at high-water size; reads still skip the now-empty slots.
+      expect(r.byCorrelationId("X").map(m => m.topic)).toEqual(["new"]);
+      expect(r.byCorrelationId("Y")).toEqual([]);
+    });
+  });
+
+  describe("BusHistoryRecorderPlugin", () => {
+    test("auto-records every published message", () => {
+      const bus = new InMemoryEventBus();
+      const recorder = new BusHistoryRecorder();
+      const plugin = new BusHistoryRecorderPlugin(recorder);
+      plugin.install(bus);
+
+      bus.publish("foo.bar", makeMsg("foo.bar", "trace-1"));
+      bus.publish("foo.baz", makeMsg("foo.baz", "trace-1"));
+      bus.publish("qux", makeMsg("qux", "trace-2"));
+
+      const trace = recorder.byCorrelationId("trace-1");
+      expect(trace.map(m => m.topic)).toEqual(["foo.bar", "foo.baz"]);
+      expect(recorder.byCorrelationId("trace-2").map(m => m.topic)).toEqual(["qux"]);
+
+      plugin.uninstall();
+    });
+  });
+});

--- a/src/event-bus/history-recorder.ts
+++ b/src/event-bus/history-recorder.ts
@@ -1,0 +1,157 @@
+/**
+ * BusHistoryRecorder — in-memory ring buffer that captures every bus message
+ * for later replay/inspection. Backs the dashboard's /system/trace/:correlationId
+ * waterfall (D1) so an operator can step through a skill's full causal chain
+ * without leaving the UI for Langfuse.
+ *
+ * Design:
+ *   - Subscribe to "#" once via the recorder plugin → every published message
+ *     lands in the buffer in publish order.
+ *   - Ring buffer capped at MAX_EVENTS (10k by default) — overwrites oldest
+ *     on the (MAX_EVENTS + 1)th event. Memory ceiling is ~10k * (small BusMessage)
+ *     = single-digit MBs; bounded by message-payload size, not entry count.
+ *   - 30-min TTL: entries older than this are skipped on read AND swept by a
+ *     periodic pruner so old payloads can be GC'd between bursts.
+ *
+ * Read API:
+ *   - byCorrelationId(id) — every message whose `correlationId === id`,
+ *     oldest first. Used by /api/bus/history?correlationId=...
+ *   - recent(limit) — most recent N messages across all correlations, used
+ *     by /api/bus/history (no filter) for debug dumps.
+ *
+ * Not durable. Process restart wipes history. That's fine for the live-debug
+ * use case — anyone wanting persistent traces uses Langfuse.
+ */
+
+import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
+
+const DEFAULT_MAX_EVENTS = 10_000;
+const DEFAULT_TTL_MS = 30 * 60 * 1000;
+const PRUNE_INTERVAL_MS = 60_000;
+
+export interface HistoryRecorderConfig {
+  maxEvents?: number;
+  ttlMs?: number;
+}
+
+export class BusHistoryRecorder {
+  private readonly ring: BusMessage[];
+  private readonly maxEvents: number;
+  private readonly ttlMs: number;
+  private head = 0;
+  private size = 0;
+
+  constructor(config: HistoryRecorderConfig = {}) {
+    this.maxEvents = config.maxEvents ?? DEFAULT_MAX_EVENTS;
+    this.ttlMs = config.ttlMs ?? DEFAULT_TTL_MS;
+    this.ring = new Array(this.maxEvents);
+  }
+
+  record(msg: BusMessage): void {
+    this.ring[this.head] = msg;
+    this.head = (this.head + 1) % this.maxEvents;
+    if (this.size < this.maxEvents) this.size++;
+  }
+
+  /**
+   * Every message whose correlationId matches, oldest first. Honours TTL —
+   * older entries are skipped even if still in the ring.
+   */
+  byCorrelationId(correlationId: string): BusMessage[] {
+    const cutoff = Date.now() - this.ttlMs;
+    const out: BusMessage[] = [];
+    for (const msg of this._iterOldestFirst()) {
+      if (!msg) continue;
+      if (msg.timestamp < cutoff) continue;
+      if (msg.correlationId === correlationId) out.push(msg);
+    }
+    return out;
+  }
+
+  /**
+   * The N most-recent messages across all correlations, freshest last (i.e.
+   * the same order as they were published). Honours TTL.
+   */
+  recent(limit: number): BusMessage[] {
+    const cutoff = Date.now() - this.ttlMs;
+    const all: BusMessage[] = [];
+    for (const msg of this._iterOldestFirst()) {
+      if (!msg) continue;
+      if (msg.timestamp < cutoff) continue;
+      all.push(msg);
+    }
+    return all.slice(-limit);
+  }
+
+  stats(): { size: number; capacity: number; ttlMs: number } {
+    return { size: this.size, capacity: this.maxEvents, ttlMs: this.ttlMs };
+  }
+
+  /**
+   * Drop entries past the TTL by overwriting with `undefined`. Called from
+   * a 1-min timer so old payloads become GC-eligible without waiting for
+   * the ring to overwrite them.
+   */
+  prune(): void {
+    const cutoff = Date.now() - this.ttlMs;
+    let purged = 0;
+    for (let i = 0; i < this.maxEvents; i++) {
+      const msg = this.ring[i];
+      if (msg && msg.timestamp < cutoff) {
+        this.ring[i] = undefined as unknown as BusMessage;
+        purged++;
+      }
+    }
+    if (purged > 0 && this.size > 0) {
+      // size tracks high-water; we don't decrement on prune so future
+      // record() calls keep using ring slots in order. byCorrelationId /
+      // recent already skip undefined entries.
+    }
+  }
+
+  private *_iterOldestFirst(): IterableIterator<BusMessage | undefined> {
+    if (this.size < this.maxEvents) {
+      // Ring hasn't wrapped yet — entries 0..size-1 are in order.
+      for (let i = 0; i < this.size; i++) yield this.ring[i];
+      return;
+    }
+    // Wrapped — head points at the oldest slot.
+    for (let i = 0; i < this.maxEvents; i++) {
+      yield this.ring[(this.head + i) % this.maxEvents];
+    }
+  }
+}
+
+/**
+ * Plugin that subscribes to `#` and writes every message to a shared
+ * BusHistoryRecorder. The recorder is the contract surface — the plugin is
+ * just the wiring.
+ */
+export class BusHistoryRecorderPlugin implements Plugin {
+  readonly name = "bus-history-recorder";
+  readonly description =
+    "Records every bus message into an in-memory ring buffer for /api/bus/history";
+  readonly capabilities = ["bus-history"];
+
+  private subscriptionId: string | null = null;
+  private pruneTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(public readonly recorder: BusHistoryRecorder) {}
+
+  install(bus: EventBus): void {
+    this.subscriptionId = bus.subscribe("#", this.name, msg => this.recorder.record(msg));
+    this.pruneTimer = setInterval(() => this.recorder.prune(), PRUNE_INTERVAL_MS);
+    if (typeof this.pruneTimer.unref === "function") this.pruneTimer.unref();
+    console.log(
+      `[bus-history-recorder] installed (cap=${this.recorder.stats().capacity}, ttlMs=${this.recorder.stats().ttlMs})`,
+    );
+  }
+
+  uninstall(): void {
+    if (this.pruneTimer) {
+      clearInterval(this.pruneTimer);
+      this.pruneTimer = null;
+    }
+    this.subscriptionId = null;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,15 @@ if (!existsSync(dataDir)) {
 
 const bus = new InMemoryEventBus();
 
+// --- Bus history recorder — in-memory ring buffer that captures every bus
+//     message for /api/bus/history. Installed BEFORE any other plugin so we
+//     don't miss early startup traffic. See src/event-bus/history-recorder.ts
+//     for ring + TTL semantics.
+import { BusHistoryRecorder, BusHistoryRecorderPlugin } from "./event-bus/history-recorder.ts";
+const busHistoryRecorder = new BusHistoryRecorder();
+const busHistoryRecorderPlugin = new BusHistoryRecorderPlugin(busHistoryRecorder);
+busHistoryRecorderPlugin.install(bus);
+
 // --- Context mailbox — mid-execution DM queue for debounced message injection ---
 import { ContextMailbox } from "../lib/dm/context-mailbox.ts";
 const contextMailbox = new ContextMailbox();
@@ -460,6 +469,7 @@ const apiContext: ApiContext = {
   agentKeys,
   mailbox: contextMailbox,
   taskTracker,
+  busHistory: busHistoryRecorder,
 };
 
 const routes = createAllRoutes(apiContext);


### PR DESCRIPTION
## Summary

Adds **\`/trace?correlationId=<id>\`** — a vertical waterfall of every bus message tied to a single \`correlationId\`. Pull up the full causal chain of any skill dispatch (inbound → router → dispatcher → executor → activity → response) without leaving the dashboard. Click through to Langfuse for LLM-call detail when you need it.

Roadmap: D1 (5 pts) from \`docs/roadmap/2026-06.md\`.

## Pieces

- \`src/event-bus/history-recorder.ts\` — \`BusHistoryRecorder\` ring buffer (10k events, 30-min TTL, auto-prune every 60s) + \`BusHistoryRecorderPlugin\` that subscribes to \`#\` and feeds the recorder
- \`src/api/bus-history.ts\` — \`GET /api/bus/history?correlationId=...\` (returns \`messages: BusMessage[]\` oldest-first) and a recent-N fallback capped at 1000 entries
- \`src/index.ts\` wires the recorder before any other plugin starts publishing so we don't miss early startup traffic; passes it through \`ApiContext.busHistory\`
- \`dashboard/src/components/SkillTrace.tsx\` — Preact component with relative timestamps, expandable payloads, search input, and a Langfuse deep-link
- \`dashboard/src/pages/trace.astro\` — static page (query param, not dynamic route, so \`output: "static"\` keeps working)
- \`DashboardLayout.astro\` — adds "Trace" sidebar entry

## Notable design choices

- **Query param, not dynamic route.** \`/trace?correlationId=...\` instead of \`/trace/:correlationId\` so Astro doesn't need server-rendering. SkillTrace pulls the id off \`window.location\` on mount.
- **503, not empty success, when the recorder isn't wired.** Lets the dashboard distinguish "feature disabled" from "no traffic with that id" — both would otherwise render as an empty list.
- **Not durable.** Process restart wipes history. Anyone wanting persistent traces uses Langfuse — the deep-link is right there.

## Test plan

- [x] \`bun test src/event-bus/__tests__/history-recorder.test.ts\` — 7 pass (ring wrap, correlation filter, TTL skip + prune, plugin auto-record)
- [x] Full \`bun test\` — 717 / 0
- [x] \`bun tsc --noEmit\` (server) — clean; dashboard typecheck has pre-existing DiscoveryView errors unrelated to this change
- [ ] Live deploy: fire any skill (e.g. a Discord DM), grab its \`correlationId\` from logs, open \`/trace?correlationId=...\`, confirm waterfall renders
- [ ] Wait 30+ min, refresh same trace, confirm 503/empty-list (TTL prune works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)