### PR TITLE
feat(dashboard): edge inspection drawer (D3)

### DIFF
--- a/dashboard/src/components/MessageDrawer.tsx
+++ b/dashboard/src/components/MessageDrawer.tsx
@@ -1,0 +1,213 @@
+/**
+ * MessageDrawer — slide-in side panel showing the recent message history for
+ * a single bus topic, opened by clicking an edge in SystemGraph (D3).
+ *
+ * The SystemGraph keeps a per-topic ring buffer of the last N WS-observed
+ * messages — this component renders that slice as a scrollable list of
+ * timestamp / correlationId / payload-preview rows. Clicking a row's
+ * correlationId opens the trace waterfall at /trace?correlationId=... (D1),
+ * stitching the two debugging surfaces together.
+ *
+ * Drawer behavior: fixed right-side overlay, closes on backdrop click or
+ * Esc. No portal — Astro client:load renders the component in-place under
+ * the SystemGraph container, and `position: fixed` lifts it visually.
+ */
+
+import { useEffect } from "preact/hooks";
+
+export interface DrawerMessage {
+  /** Stable id (random or msg.id from the WS frame) — used as React key. */
+  id: string;
+  topic: string;
+  correlationId?: string;
+  timestamp: number;
+  payload?: unknown;
+}
+
+interface Props {
+  topic: string;
+  messages: DrawerMessage[];
+  onClose: () => void;
+}
+
+export default function MessageDrawer({ topic, messages, onClose }: Props) {
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <>
+      <div class="md-backdrop" onClick={onClose} />
+      <aside class="md-drawer" role="dialog" aria-label={`Messages on topic ${topic}`}>
+        <header class="md-header">
+          <div>
+            <h3 class="md-title">{topic}</h3>
+            <p class="md-meta">
+              {messages.length} message{messages.length === 1 ? "" : "s"} in WS buffer
+              {messages.length > 0 && ` · newest ${relativeTime(messages[messages.length - 1].timestamp)}`}
+            </p>
+          </div>
+          <button class="md-close" onClick={onClose} aria-label="Close">×</button>
+        </header>
+
+        {messages.length === 0 ? (
+          <div class="md-empty">
+            No traffic observed on this topic since this dashboard opened.
+            History resets on each page load — the WS subscription only
+            captures messages that fire while you're watching.
+          </div>
+        ) : (
+          <ol class="md-list">
+            {[...messages].reverse().map((m) => (
+              <li class="md-row" key={m.id}>
+                <div class="md-row-head">
+                  <span class="md-ts">{new Date(m.timestamp).toLocaleTimeString()}</span>
+                  {m.correlationId ? (
+                    <a class="md-trace-link" href={`/trace?correlationId=${encodeURIComponent(m.correlationId)}`}>
+                      trace →
+                    </a>
+                  ) : (
+                    <span class="md-no-trace">no correlationId</span>
+                  )}
+                </div>
+                {m.correlationId && (
+                  <code class="md-corr">{m.correlationId}</code>
+                )}
+                <pre class="md-payload">{previewPayload(m.payload)}</pre>
+              </li>
+            ))}
+          </ol>
+        )}
+      </aside>
+
+      <style>{DRAWER_STYLES}</style>
+    </>
+  );
+}
+
+function relativeTime(ts: number): string {
+  const dt = Date.now() - ts;
+  if (dt < 1000) return "just now";
+  if (dt < 60_000) return `${Math.floor(dt / 1000)}s ago`;
+  return `${Math.floor(dt / 60_000)}m ago`;
+}
+
+function previewPayload(payload: unknown): string {
+  if (payload == null) return "(empty)";
+  try {
+    const s = JSON.stringify(payload, null, 2);
+    if (s.length > 1200) return s.slice(0, 1200) + "\n… (truncated)";
+    return s;
+  } catch {
+    return String(payload);
+  }
+}
+
+const DRAWER_STYLES = `
+  .md-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.35);
+    z-index: 100;
+  }
+  .md-drawer {
+    position: fixed;
+    top: 0;
+    right: 0;
+    height: 100vh;
+    width: 480px;
+    max-width: 90vw;
+    background: #0d1117;
+    border-left: 1px solid #30363d;
+    color: #c9d1d9;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    z-index: 101;
+    display: flex;
+    flex-direction: column;
+    box-shadow: -8px 0 24px rgba(0, 0, 0, 0.5);
+  }
+  .md-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    padding: 1rem 1.25rem 0.75rem;
+    border-bottom: 1px solid #21262d;
+  }
+  .md-title {
+    margin: 0;
+    font-size: 0.95rem;
+    color: #58a6ff;
+    word-break: break-all;
+  }
+  .md-meta {
+    margin: 0.25rem 0 0;
+    color: #8b949e;
+    font-size: 0.8rem;
+  }
+  .md-close {
+    background: transparent;
+    border: none;
+    color: #8b949e;
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 0.25rem;
+  }
+  .md-close:hover { color: #f85149; }
+  .md-empty {
+    padding: 2rem 1.25rem;
+    color: #8b949e;
+    font-size: 0.85rem;
+    line-height: 1.5;
+  }
+  .md-list {
+    list-style: none;
+    padding: 0.75rem 1.25rem;
+    margin: 0;
+    overflow-y: auto;
+    flex: 1;
+  }
+  .md-row {
+    margin-bottom: 1rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px dashed #21262d;
+  }
+  .md-row:last-child { border-bottom: none; }
+  .md-row-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.35rem;
+  }
+  .md-ts { color: #8b949e; font-size: 0.8rem; }
+  .md-trace-link {
+    color: #58a6ff;
+    text-decoration: none;
+    font-size: 0.8rem;
+  }
+  .md-trace-link:hover { text-decoration: underline; }
+  .md-no-trace { color: #6e7681; font-size: 0.75rem; font-style: italic; }
+  .md-corr {
+    display: block;
+    color: #c9d1d9;
+    font-size: 0.75rem;
+    margin-bottom: 0.35rem;
+    opacity: 0.7;
+    word-break: break-all;
+  }
+  .md-payload {
+    background: #161b22;
+    padding: 0.6rem;
+    margin: 0;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    overflow-x: auto;
+    max-height: 240px;
+    overflow-y: auto;
+    color: #c9d1d9;
+  }
+`;

--- a/dashboard/src/components/SystemGraph.tsx
+++ b/dashboard/src/components/SystemGraph.tsx
@@ -10,6 +10,9 @@
  *   - Live edge animation on bus traffic via WS /api/bus/subscribe?topic=#
  *   - Agent state subscription on agent.runtime.activity.# so each agent's
  *     node pulses + shows real-time skill + tool-call history
+ * Phase 3 (D3): clicking an edge opens MessageDrawer with the last
+ *   TOPIC_HISTORY_CAP messages observed on that topic + jump-to-trace
+ *   links into /trace?correlationId=… (D1).
  *
  * Layout: three concentric zones.
  *   center  — agents (the action)
@@ -17,11 +20,15 @@
  *   outer   — external services (where work eventually lands)
  */
 
-import { useEffect, useMemo, useState } from "preact/compat";
+import { useEffect, useMemo, useRef, useState } from "preact/compat";
 import { ReactFlow, Background, Controls, type Edge, type Node } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import AgentNode, { type AgentActivityState } from "./AgentNode.tsx";
 import ServiceNode from "./ServiceNode.tsx";
+import MessageDrawer, { type DrawerMessage } from "./MessageDrawer.tsx";
+
+/** Ring-buffer cap for per-topic history shown in the edge drawer. */
+const TOPIC_HISTORY_CAP = 20;
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -259,6 +266,23 @@ export default function SystemGraph() {
   const [agentActivity, setAgentActivity] = useState<Map<string, AgentActivityState>>(new Map());
   const [activeEdges, setActiveEdges] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
+  // Per-topic ring buffer of recent WS-observed messages. Lives in a ref
+  // (not state) because every WS frame would otherwise re-trigger the
+  // whole graph rebuild — we only need to re-render when the operator
+  // actually opens the drawer for a specific topic.
+  const topicHistoryRef = useRef<Map<string, DrawerMessage[]>>(new Map());
+  const openTopicRef = useRef<string | null>(null);
+  const [openTopic, _setOpenTopic] = useState<string | null>(null);
+  // Wrapper keeps the ref + state in sync so the WS handler — which closes
+  // over its initial state via the once-mount useEffect — can see the
+  // latest open-drawer topic without re-subscribing on every change.
+  const setOpenTopic = (t: string | null) => {
+    openTopicRef.current = t;
+    _setOpenTopic(t);
+  };
+  // Bumps when the open drawer's topic gets a new message — keeps the
+  // drawer's view in sync without re-rendering the whole graph.
+  const [drawerTick, setDrawerTick] = useState(0);
 
   // Initial fetch — topology + agents
   useEffect(() => {
@@ -300,12 +324,32 @@ export default function SystemGraph() {
       ws = new WebSocket(url);
       ws.onmessage = (e) => {
         try {
-          const msg = JSON.parse(e.data) as { topic?: string; payload?: unknown };
+          const msg = JSON.parse(e.data) as {
+            topic?: string;
+            payload?: unknown;
+            correlationId?: string;
+            timestamp?: number;
+          };
           if (!msg.topic) return;
           // Agent activity → state machine
           if (msg.topic.startsWith("agent.runtime.activity.")) {
             const ev = msg.payload as AgentActivityEvent;
             setAgentActivity((cur) => applyActivity(cur, ev));
+          }
+          // Per-topic ring buffer for D3's edge drawer. Cap at TOPIC_HISTORY_CAP.
+          const buf = topicHistoryRef.current.get(msg.topic) ?? [];
+          buf.push({
+            id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+            topic: msg.topic,
+            correlationId: msg.correlationId,
+            timestamp: msg.timestamp ?? Date.now(),
+            payload: msg.payload,
+          });
+          if (buf.length > TOPIC_HISTORY_CAP) buf.splice(0, buf.length - TOPIC_HISTORY_CAP);
+          topicHistoryRef.current.set(msg.topic, buf);
+          // If the drawer is open on this topic, force a re-render.
+          if (msg.topic === openTopicRef.current) {
+            setDrawerTick((t) => t + 1);
           }
           // Pulse the edge for any topic — phase 1 just animated each match for 1.5s
           setActiveEdges((cur) => new Set(cur).add(msg.topic!));
@@ -356,12 +400,39 @@ export default function SystemGraph() {
     return <div style={{ padding: 24, color: "#8b949e" }}>loading topology…</div>;
   }
 
+  const drawerMessages = useMemo(
+    () => (openTopic ? topicHistoryRef.current.get(openTopic) ?? [] : []),
+    // drawerTick is the WS-driven invalidation signal; openTopic re-runs when
+    // the drawer switches topics.
+    [openTopic, drawerTick],
+  );
+
   return (
     <div style={{ width: "100%", height: "calc(100vh - 64px)", background: "#0d1117" }}>
-      <ReactFlow nodes={nodes} edges={edges} nodeTypes={NODE_TYPES} fitView minZoom={0.2}>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={NODE_TYPES}
+        fitView
+        minZoom={0.2}
+        onEdgeClick={(_evt: unknown, edge: Edge) => {
+          // Edges built from publisher → subscriber carry their topic as the
+          // edge label. Static plugin → service edges have no topic — those
+          // skip the drawer.
+          const topic = typeof edge.label === "string" ? edge.label : null;
+          if (topic) setOpenTopic(topic);
+        }}
+      >
         <Background color="#21262d" gap={16} />
         <Controls position="bottom-right" />
       </ReactFlow>
+      {openTopic && (
+        <MessageDrawer
+          topic={openTopic}
+          messages={drawerMessages}
+          onClose={() => setOpenTopic(null)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Clicking an edge in SystemGraph opens **MessageDrawer** — a slide-in side panel showing the last 20 WS-observed messages on that topic. Each row has a timestamp, correlationId, payload preview, and a "trace →" link that jumps to \`/trace?correlationId=…\` (D1's waterfall).

This closes the debugging loop the roadmap calls out: **/system becomes the primary debugging surface, \`docker logs\` the fallback, not the front line**. See an interesting pulsing edge → click → see the recent payloads → pick one → walk the full causal chain in the trace view.

Roadmap: D3 (5 pts). **Completes Week 4 and the full 44-point monthly plan.**

## Pieces

- \`dashboard/src/components/MessageDrawer.tsx\` — fixed right-side drawer (480px / 90vw), backdrop click + Esc to close, expandable payload \`<pre>\` capped at 1200 chars, jump-to-trace anchor
- \`dashboard/src/components/SystemGraph.tsx\`:
  - Adds \`topicHistoryRef = Map<topic, DrawerMessage[]>\` (cap 20 per topic) fed by the existing WS \`#\` subscription
  - \`onEdgeClick\` reads the edge's \`label\` (the topic name encoded in \`buildGraph\`); static plugin → service edges have no label and don't open the drawer
  - \`drawerTick\` state bumps when the open drawer's topic receives a new message, forcing a re-render without rebuilding the whole graph
  - History is in a \`useRef\` — every WS frame would otherwise re-trigger the entire \`buildGraph\` chain and animate-jitter the layout

## Notable design choices

- **History resets on reload.** The drawer is a "watch live" buffer, not an archive. For archival lookups, the trace link goes to \`/api/bus/history\` — a separate 10k-event / 30-min ring on the server side. Two surfaces, two scopes.
- **\`useRef\` for history, \`useState\` only for the tick.** Avoids the whole-graph rebuild loop on every WS frame. The \`openTopic\` ref pattern keeps the once-mount WS handler in sync with the latest open-drawer topic without re-subscribing.

## Test plan

- [x] \`bun tsc --noEmit\` in dashboard — no new errors (pre-existing DiscoveryView errors unrelated)
- [x] Server-side \`bun test\` — 710 / 0 (this is dashboard-only)
- [ ] Live deploy: open /system, click a pulsing animated edge, confirm drawer opens with recent payloads
- [ ] Click "trace →" on a row, confirm /trace?correlationId=… loads the waterfall for that id
- [ ] Click backdrop / press Esc, confirm drawer closes; click a different edge, confirm topic switches cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)