### PR TITLE
fix(github-auth): fail loud on partial App config (Quinn-as-Josh regression)

### DIFF
--- a/lib/github-auth.ts
+++ b/lib/github-auth.ts
@@ -72,15 +72,49 @@ export class GitHubAppAuth {
 /**
  * Returns a token getter for the Quinn GitHub App, or falls back to GITHUB_TOKEN PAT.
  * Returns null if no auth is configured.
+ *
+ * **Fail-loud on partial App config.** If exactly one of `QUINN_APP_ID` and
+ * `QUINN_APP_PRIVATE_KEY` is set (the other empty / unset), refuse to
+ * silently fall back to the PAT path — that's how Quinn's PR reviews
+ * started showing up as the operator (mabry1985) instead of
+ * @protoquinn[bot] when infisical hiccuped and only injected half the
+ * secret pair on a container restart. PAT fallback only fires when *both*
+ * App vars are absent, which is the legitimate "this deployment doesn't
+ * have a GitHub App, just a PAT" mode.
  */
-export function makeGitHubAuth(): ((owner: string, repo: string) => Promise<string>) | null {
-  const appId = process.env.QUINN_APP_ID;
-  const privateKey = process.env.QUINN_APP_PRIVATE_KEY;
+/**
+ * `env` defaults to `process.env`; tests pass a literal so they don't have
+ * to mutate the live env (which `bun test` runs test files in parallel
+ * over, causing race conditions on shared `process.env`).
+ */
+export function makeGitHubAuth(
+  env: { QUINN_APP_ID?: string; QUINN_APP_PRIVATE_KEY?: string; GITHUB_TOKEN?: string } = process.env,
+): ((owner: string, repo: string) => Promise<string>) | null {
+  const appId = (env.QUINN_APP_ID ?? "").trim();
+  const privateKey = (env.QUINN_APP_PRIVATE_KEY ?? "").trim();
+
   if (appId && privateKey) {
     const app = new GitHubAppAuth(appId, privateKey);
     return (owner, repo) => app.getToken(owner, repo);
   }
-  const pat = process.env.GITHUB_TOKEN;
+
+  // Partial App config — one set, the other empty. This is misconfiguration,
+  // not a legitimate fallback. Refusing to mint a token means the next code
+  // path that needs auth throws loudly instead of silently writing as the
+  // operator's PAT identity.
+  if (appId || privateKey) {
+    const present  = appId ? "QUINN_APP_ID"          : "QUINN_APP_PRIVATE_KEY";
+    const missing  = appId ? "QUINN_APP_PRIVATE_KEY" : "QUINN_APP_ID";
+    throw new Error(
+      `[github-auth] partial GitHub App config: ${present} set but ${missing} empty/unset. ` +
+        `Refusing to fall back to GITHUB_TOKEN PAT — that would silently author commits / ` +
+        `PR reviews as the operator instead of the bot. Fix the env (likely an infisical injection ` +
+        `gap) before restarting.`,
+    );
+  }
+
+  // No App config at all — legitimate PAT-only mode.
+  const pat = env.GITHUB_TOKEN;
   if (pat) return () => Promise.resolve(pat);
   return null;
 }


### PR DESCRIPTION
## Summary

Quinn's PR reviews started coming through authored as the operator (\`mabry1985\`) instead of \`@protoquinn[bot]\` some time today. **Root cause**: \`makeGitHubAuth()\` silently fell back to \`GITHUB_TOKEN\` PAT whenever either of the App env vars was empty or missing — whenever infisical hiccuped and only injected one half of the pair on a container restart, the bot identity quietly disappeared.

Plugin logs printed \`[github] Auth: PAT\` honestly but nothing alerted, so the regression sat unnoticed.

## Changes

1. **Partial App config → throw, not fallback.** If \`QUINN_APP_ID\` is set but \`QUINN_APP_PRIVATE_KEY\` is empty (or vice versa), refuse to build a getter at all. The next code path that needs auth fails loudly. PAT fallback fires only when both App vars are fully absent.
2. **Trim whitespace** before the emptiness check so an infisical-injected secret padded with newlines / spaces trips the guard too.
3. **Optional \`env\` parameter** for clean test injection — bun runs test files in parallel and \`tests/onboarding.test.ts\` already \`mock.module\`s this file process-wide, so the env-arg path is needed for deterministic testing.

Per existing memory: fail-fast-and-loud — Tool/API/bus failures surface to the caller, not silent fallbacks.

## Why no dedicated tests

\`tests/onboarding.test.ts\` does \`mock.module("../lib/github-auth.ts", …)\` at the top level. Bun's \`mock.module\` is process-wide across test files. My fresh tests passed in isolation, all 6 failed when run with onboarding because every \`makeGitHubAuth\` import got routed through onboarding's mock proxy. Restructuring onboarding's mock to scope properly is bigger than this fix.

## Test plan

- [x] Full suite: 728/0
- [x] tsc clean
- [ ] After merge + image republish + watchtower pull: next Quinn PR review authors as \`protoquinn[bot]\` (App-auth verified end-to-end in the live container, this PR ensures we never silently lose it again)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub App authentication now validates that all required configuration fields are present; partial configurations will result in an error instead of falling back silently.

* **Documentation**
  * Expanded documentation describing authentication configuration requirements and validation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/586?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->