### PR TITLE
feat(github-auth): QUINN_USER_TOKEN review identity (Stage 1 of #585)

### DIFF
--- a/lib/github-auth.ts
+++ b/lib/github-auth.ts
@@ -72,15 +72,49 @@ export class GitHubAppAuth {
 /**
  * Returns a token getter for the Quinn GitHub App, or falls back to GITHUB_TOKEN PAT.
  * Returns null if no auth is configured.
+ *
+ * **Fail-loud on partial App config.** If exactly one of `QUINN_APP_ID` and
+ * `QUINN_APP_PRIVATE_KEY` is set (the other empty / unset), refuse to
+ * silently fall back to the PAT path — that's how Quinn's PR reviews
+ * started showing up as the operator (mabry1985) instead of
+ * @protoquinn[bot] when infisical hiccuped and only injected half the
+ * secret pair on a container restart. PAT fallback only fires when *both*
+ * App vars are absent, which is the legitimate "this deployment doesn't
+ * have a GitHub App, just a PAT" mode.
  */
-export function makeGitHubAuth(): ((owner: string, repo: string) => Promise<string>) | null {
-  const appId = process.env.QUINN_APP_ID;
-  const privateKey = process.env.QUINN_APP_PRIVATE_KEY;
+/**
+ * `env` defaults to `process.env`; tests pass a literal so they don't have
+ * to mutate the live env (which `bun test` runs test files in parallel
+ * over, causing race conditions on shared `process.env`).
+ */
+export function makeGitHubAuth(
+  env: { QUINN_APP_ID?: string; QUINN_APP_PRIVATE_KEY?: string; GITHUB_TOKEN?: string } = process.env,
+): ((owner: string, repo: string) => Promise<string>) | null {
+  const appId = (env.QUINN_APP_ID ?? "").trim();
+  const privateKey = (env.QUINN_APP_PRIVATE_KEY ?? "").trim();
+
   if (appId && privateKey) {
     const app = new GitHubAppAuth(appId, privateKey);
     return (owner, repo) => app.getToken(owner, repo);
   }
-  const pat = process.env.GITHUB_TOKEN;
+
+  // Partial App config — one set, the other empty. This is misconfiguration,
+  // not a legitimate fallback. Refusing to mint a token means the next code
+  // path that needs auth throws loudly instead of silently writing as the
+  // operator's PAT identity.
+  if (appId || privateKey) {
+    const present  = appId ? "QUINN_APP_ID"          : "QUINN_APP_PRIVATE_KEY";
+    const missing  = appId ? "QUINN_APP_PRIVATE_KEY" : "QUINN_APP_ID";
+    throw new Error(
+      `[github-auth] partial GitHub App config: ${present} set but ${missing} empty/unset. ` +
+        `Refusing to fall back to GITHUB_TOKEN PAT — that would silently author commits / ` +
+        `PR reviews as the operator instead of the bot. Fix the env (likely an infisical injection ` +
+        `gap) before restarting.`,
+    );
+  }
+
+  // No App config at all — legitimate PAT-only mode.
+  const pat = env.GITHUB_TOKEN;
   if (pat) return () => Promise.resolve(pat);
   return null;
 }

--- a/lib/github-auth.ts
+++ b/lib/github-auth.ts
@@ -6,9 +6,18 @@
  * plugins stay self-contained.
  *
  * Env vars:
- *   QUINN_APP_ID          GitHub App ID
+ *   QUINN_APP_ID          GitHub App ID (quinn[bot])
  *   QUINN_APP_PRIVATE_KEY PEM private key (newlines as \n in env)
- *   GITHUB_TOKEN          PAT fallback when App credentials are absent
+ *   QUINN_USER_TOKEN      Optional. PAT of a dedicated machine-user
+ *                         account (e.g. `protoquinn`). When set, formal
+ *                         PR reviews submit under this identity instead
+ *                         of the App's quinn[bot] — required because
+ *                         GitHub App approvals don't count toward
+ *                         required-review gates (same constraint as
+ *                         Copilot reviews). See #585 for the rationale.
+ *                         Stage 1 of the Quinn-in-the-loop rollout.
+ *   GITHUB_TOKEN          Legacy PAT fallback when App credentials are
+ *                         absent. Operator's own token in dev.
  */
 
 import { createSign } from "node:crypto";
@@ -88,7 +97,7 @@ export class GitHubAppAuth {
  * over, causing race conditions on shared `process.env`).
  */
 export function makeGitHubAuth(
-  env: { QUINN_APP_ID?: string; QUINN_APP_PRIVATE_KEY?: string; GITHUB_TOKEN?: string } = process.env,
+  env: Record<string, string | undefined> = process.env,
 ): ((owner: string, repo: string) => Promise<string>) | null {
   const appId = (env.QUINN_APP_ID ?? "").trim();
   const privateKey = (env.QUINN_APP_PRIVATE_KEY ?? "").trim();
@@ -117,4 +126,44 @@ export function makeGitHubAuth(
   const pat = env.GITHUB_TOKEN;
   if (pat) return () => Promise.resolve(pat);
   return null;
+}
+
+/**
+ * Token getter specifically for **formal PR reviews** (APPROVE /
+ * REQUEST_CHANGES). Resolution order:
+ *
+ *   1. `QUINN_USER_TOKEN` — PAT belonging to a dedicated machine-user
+ *      account (e.g. `protoquinn`). GitHub does NOT count GitHub App
+ *      approvals toward required-review gates — only real user accounts
+ *      with write access do. So once you stand up that account + PAT
+ *      and set this env var, Quinn's APPROVE actually starts being
+ *      gate-satisfying. Without it, the App path (#2) still works for
+ *      advisory reviews but can't satisfy a required-reviewer rule.
+ *   2. Whatever `makeGitHubAuth()` returns — App, then PAT fallback.
+ *      Lets the rollout be incremental: deploy this code today, the
+ *      review path keeps working as quinn[bot] (advisory) until the
+ *      protoquinn account + token are created and `QUINN_USER_TOKEN`
+ *      is set in infisical.
+ *
+ * The returned getter logs once on construction so it's visible in
+ * startup output which identity reviews are landing under.
+ */
+export function makeQuinnReviewAuth(
+  env: Record<string, string | undefined> = process.env,
+): ((owner: string, repo: string) => Promise<string>) | null {
+  const userToken = (env.QUINN_USER_TOKEN ?? "").trim();
+  if (userToken) {
+    console.log("[review-auth] Quinn reviews → machine user (QUINN_USER_TOKEN). Gate-satisfying when the user has write access on the target repo.");
+    return () => Promise.resolve(userToken);
+  }
+
+  const fallback = makeGitHubAuth(env);
+  if (!fallback) return null;
+
+  const fallbackKind =
+    env.QUINN_APP_ID && env.QUINN_APP_PRIVATE_KEY ? "GitHub App (quinn[bot]) — advisory only, not gate-satisfying"
+    : env.GITHUB_TOKEN                            ? "GITHUB_TOKEN PAT (operator identity — self-review block possible)"
+    :                                               "unknown";
+  console.log(`[review-auth] Quinn reviews → ${fallbackKind}. Set QUINN_USER_TOKEN with a protoquinn PAT to upgrade.`);
+  return fallback;
 }

--- a/src/api/pr-inspector.ts
+++ b/src/api/pr-inspector.ts
@@ -26,9 +26,15 @@
  */
 
 import type { Route, ApiContext } from "./types.ts";
-import { makeGitHubAuth } from "../../lib/github-auth.ts";
+import { makeGitHubAuth, makeQuinnReviewAuth } from "../../lib/github-auth.ts";
 
 const getGithubToken = makeGitHubAuth();
+// Separate identity specifically for formal review submission (APPROVE /
+// REQUEST_CHANGES / COMMENT). When QUINN_USER_TOKEN is set, reviews ship
+// under the machine-user identity that can actually satisfy required-
+// reviewer gates — see makeQuinnReviewAuth + issue #585. Falls back to the
+// App / PAT chain otherwise.
+const getReviewToken = makeQuinnReviewAuth();
 
 type Action =
   | "list_open"
@@ -81,6 +87,34 @@ async function ghFetch(
       Accept: "application/vnd.github+json",
       "X-GitHub-Api-Version": "2022-11-28",
       "User-Agent": "protoquinn",
+    },
+  });
+}
+
+/**
+ * Like ghFetch but uses the review-specific identity (QUINN_USER_TOKEN
+ * machine-user PAT when present, else falls back to App / PAT auth).
+ * Used only for POSTing formal reviews — every other GitHub call routes
+ * through ghFetch with the App identity, which is correct for reads /
+ * webhook ops and intentionally distinct from the reviewer identity.
+ */
+async function reviewFetch(
+  owner: string,
+  name: string,
+  url: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  if (!getReviewToken) throw new Error("no GitHub review credentials (QUINN_USER_TOKEN or QUINN_APP_* or GITHUB_TOKEN)");
+  const token = await getReviewToken(owner, name);
+  return fetch(url, {
+    ...init,
+    signal: init.signal ?? AbortSignal.timeout(GH_FETCH_TIMEOUT_MS),
+    headers: {
+      ...(init.headers ?? {}),
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "protoquinn-review",
     },
   });
 }
@@ -215,7 +249,9 @@ async function submitReview(
   event: "COMMENT" | "APPROVE" | "REQUEST_CHANGES",
   body: string,
 ): Promise<string> {
-  const resp = await ghFetch(
+  // Uses reviewFetch (review-specific identity, QUINN_USER_TOKEN-first)
+  // rather than the App-auth ghFetch — see makeQuinnReviewAuth.
+  const resp = await reviewFetch(
     owner,
     name,
     `https://api.github.com/repos/${owner}/${name}/pulls/${pr}/reviews`,

--- a/src/skills/prReview.ts
+++ b/src/skills/prReview.ts
@@ -15,7 +15,7 @@
 import { review } from "../llm/reviewOrchestrator.ts";
 import { GitHubReviewSubmitter } from "../github/reviewSubmitter.ts";
 import { PullRequestTracker } from "../state/prTracker.ts";
-import { makeGitHubAuth } from "../../lib/github-auth.ts";
+import { makeGitHubAuth, makeQuinnReviewAuth } from "../../lib/github-auth.ts";
 
 export interface PRReviewInput {
   owner: string;
@@ -70,12 +70,19 @@ export async function runPRReview(
     throw new Error("[prReview] No GitHub auth configured (QUINN_APP_ID or GITHUB_TOKEN required)");
   }
 
-  // Run review pipeline
+  // Run review pipeline using App / PAT identity — reads only, no
+  // identity-sensitive writes.
   const result = await review(owner, repo, prNumber, getToken);
 
-  // Get fresh head SHA from result (it was fetched inside review())
-  // Submit the review
-  const submitter = new GitHubReviewSubmitter(getToken);
+  // Submit the review using the review-specific identity. When
+  // QUINN_USER_TOKEN is set, the formal review lands as the protoquinn
+  // machine user — required for the review to satisfy a required-
+  // reviewer gate. Falls back to the App / PAT path otherwise.
+  const getReviewToken = makeQuinnReviewAuth();
+  if (!getReviewToken) {
+    throw new Error("[prReview] No GitHub review auth configured (QUINN_USER_TOKEN or QUINN_APP_* or GITHUB_TOKEN required)");
+  }
+  const submitter = new GitHubReviewSubmitter(getReviewToken);
   const submitResult = await submitter.submitReview(
     owner,
     repo,


### PR DESCRIPTION
## Summary

Stage 1 of #585. Code-side prep so Quinn's formal reviews can ship under a dedicated machine-user identity (e.g. \`protoquinn\`) the moment a \`QUINN_USER_TOKEN\` env var lands. **Inert until you set the env var** — current App-auth behavior preserved unchanged.

The mechanics constraint: GitHub App approvals don't count toward required-review gates (same as Copilot reviews). So for Quinn's APPROVE to actually satisfy a required-reviewer rule later, the review needs to ship under a real user account with write access — not the App. This PR wires the code so that token switch happens automatically when you provide it.

Stacks on **#586** (fail-loud on partial App config).

## Changes

- **\`lib/github-auth.ts\`** — new \`makeQuinnReviewAuth()\`:
  1. Returns the \`QUINN_USER_TOKEN\` machine-user PAT when present.
  2. Falls back to the existing \`makeGitHubAuth()\` chain (App → PAT) otherwise.
  
  Logs once which identity reviews land under and whether it's gate-satisfying.

- **\`src/api/pr-inspector.ts\`** — adds a parallel \`reviewFetch()\` that uses the review identity. Only the three formal-review POST actions (\`review_comment\` / \`review_approve\` / \`review_request_changes\`) route through it. Every other GitHub op stays on \`ghFetch\` with the App identity (correct for reads + webhook ops).

- **\`src/skills/prReview.ts\`** — \`GitHubReviewSubmitter\` constructed with the review token getter. The review pipeline (CI/diff/threads reads) still uses App auth.

## Operator-side checklist (you, then me)

1. Create a \`protoquinn\` GitHub user account.
2. Invite it to the protoLabsAI org with \`write\` access on the repos Quinn should review.
3. Generate a **fine-grained PAT** scoped to those repos with: \`contents: read\`, \`pull-requests: read+write\`, \`checks: read\`. (Or classic PAT with \`repo\` + \`read:org\` if simpler.)
4. Add \`QUINN_USER_TOKEN\` to infisical (the same secret-management project Quinn's other keys live in).
5. Merge this PR + restart workstacean.

After step 5, banner reads:

\`[review-auth] Quinn reviews → machine user (QUINN_USER_TOKEN). Gate-satisfying when the user has write access on the target repo.\`

Then Stage 2 (per #585): pick a pilot repo, add \`protoquinn\` to a \`qa-reviewers\` team in CODEOWNERS or the required-reviewer ruleset, observe precision before fleet rollout.

## Test plan

- [x] \`bun test\` — 728/0 (no new tests; unable to add — \`tests/onboarding.test.ts\` \`mock.module\`s the same file process-wide, same constraint as #586's PR description)
- [x] \`bun tsc --noEmit\` — clean
- [ ] After QUINN_USER_TOKEN env set + restart: banner line confirms machine-user identity; next Quinn review on a feature branch authors as \`protoquinn\`, not \`mabry1985\` / \`quinn[bot]\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PR reviews can now be submitted using a dedicated review authentication identity when configured.

* **Bug Fixes**
  * GitHub App configuration now properly validates settings and prevents silent fallbacks on incomplete configurations.

* **Improvements**
  * Added logging to identify which authentication identity is used for PR reviews.
  * Enhanced environment variable documentation for GitHub authentication configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->