### PR TITLE
Revert "QUINN_USER_TOKEN review identity" (Stage 1 dropped — no machine-user seat)

### DIFF
--- a/lib/github-auth.ts
+++ b/lib/github-auth.ts
@@ -6,18 +6,9 @@
  * plugins stay self-contained.
  *
  * Env vars:
- *   QUINN_APP_ID          GitHub App ID (quinn[bot])
+ *   QUINN_APP_ID          GitHub App ID
  *   QUINN_APP_PRIVATE_KEY PEM private key (newlines as \n in env)
- *   QUINN_USER_TOKEN      Optional. PAT of a dedicated machine-user
- *                         account (e.g. `protoquinn`). When set, formal
- *                         PR reviews submit under this identity instead
- *                         of the App's quinn[bot] — required because
- *                         GitHub App approvals don't count toward
- *                         required-review gates (same constraint as
- *                         Copilot reviews). See #585 for the rationale.
- *                         Stage 1 of the Quinn-in-the-loop rollout.
- *   GITHUB_TOKEN          Legacy PAT fallback when App credentials are
- *                         absent. Operator's own token in dev.
+ *   GITHUB_TOKEN          PAT fallback when App credentials are absent
  */
 
 import { createSign } from "node:crypto";
@@ -90,8 +81,7 @@ export class GitHubAppAuth {
  * secret pair on a container restart. PAT fallback only fires when *both*
  * App vars are absent, which is the legitimate "this deployment doesn't
  * have a GitHub App, just a PAT" mode.
- */
-/**
+ *
  * `env` defaults to `process.env`; tests pass a literal so they don't have
  * to mutate the live env (which `bun test` runs test files in parallel
  * over, causing race conditions on shared `process.env`).
@@ -126,44 +116,4 @@ export function makeGitHubAuth(
   const pat = env.GITHUB_TOKEN;
   if (pat) return () => Promise.resolve(pat);
   return null;
-}
-
-/**
- * Token getter specifically for **formal PR reviews** (APPROVE /
- * REQUEST_CHANGES). Resolution order:
- *
- *   1. `QUINN_USER_TOKEN` — PAT belonging to a dedicated machine-user
- *      account (e.g. `protoquinn`). GitHub does NOT count GitHub App
- *      approvals toward required-review gates — only real user accounts
- *      with write access do. So once you stand up that account + PAT
- *      and set this env var, Quinn's APPROVE actually starts being
- *      gate-satisfying. Without it, the App path (#2) still works for
- *      advisory reviews but can't satisfy a required-reviewer rule.
- *   2. Whatever `makeGitHubAuth()` returns — App, then PAT fallback.
- *      Lets the rollout be incremental: deploy this code today, the
- *      review path keeps working as quinn[bot] (advisory) until the
- *      protoquinn account + token are created and `QUINN_USER_TOKEN`
- *      is set in infisical.
- *
- * The returned getter logs once on construction so it's visible in
- * startup output which identity reviews are landing under.
- */
-export function makeQuinnReviewAuth(
-  env: Record<string, string | undefined> = process.env,
-): ((owner: string, repo: string) => Promise<string>) | null {
-  const userToken = (env.QUINN_USER_TOKEN ?? "").trim();
-  if (userToken) {
-    console.log("[review-auth] Quinn reviews → machine user (QUINN_USER_TOKEN). Gate-satisfying when the user has write access on the target repo.");
-    return () => Promise.resolve(userToken);
-  }
-
-  const fallback = makeGitHubAuth(env);
-  if (!fallback) return null;
-
-  const fallbackKind =
-    env.QUINN_APP_ID && env.QUINN_APP_PRIVATE_KEY ? "GitHub App (quinn[bot]) — advisory only, not gate-satisfying"
-    : env.GITHUB_TOKEN                            ? "GITHUB_TOKEN PAT (operator identity — self-review block possible)"
-    :                                               "unknown";
-  console.log(`[review-auth] Quinn reviews → ${fallbackKind}. Set QUINN_USER_TOKEN with a protoquinn PAT to upgrade.`);
-  return fallback;
 }

--- a/src/api/pr-inspector.ts
+++ b/src/api/pr-inspector.ts
@@ -26,15 +26,9 @@
  */
 
 import type { Route, ApiContext } from "./types.ts";
-import { makeGitHubAuth, makeQuinnReviewAuth } from "../../lib/github-auth.ts";
+import { makeGitHubAuth } from "../../lib/github-auth.ts";
 
 const getGithubToken = makeGitHubAuth();
-// Separate identity specifically for formal review submission (APPROVE /
-// REQUEST_CHANGES / COMMENT). When QUINN_USER_TOKEN is set, reviews ship
-// under the machine-user identity that can actually satisfy required-
-// reviewer gates — see makeQuinnReviewAuth + issue #585. Falls back to the
-// App / PAT chain otherwise.
-const getReviewToken = makeQuinnReviewAuth();
 
 type Action =
   | "list_open"
@@ -87,34 +81,6 @@ async function ghFetch(
       Accept: "application/vnd.github+json",
       "X-GitHub-Api-Version": "2022-11-28",
       "User-Agent": "protoquinn",
-    },
-  });
-}
-
-/**
- * Like ghFetch but uses the review-specific identity (QUINN_USER_TOKEN
- * machine-user PAT when present, else falls back to App / PAT auth).
- * Used only for POSTing formal reviews — every other GitHub call routes
- * through ghFetch with the App identity, which is correct for reads /
- * webhook ops and intentionally distinct from the reviewer identity.
- */
-async function reviewFetch(
-  owner: string,
-  name: string,
-  url: string,
-  init: RequestInit = {},
-): Promise<Response> {
-  if (!getReviewToken) throw new Error("no GitHub review credentials (QUINN_USER_TOKEN or QUINN_APP_* or GITHUB_TOKEN)");
-  const token = await getReviewToken(owner, name);
-  return fetch(url, {
-    ...init,
-    signal: init.signal ?? AbortSignal.timeout(GH_FETCH_TIMEOUT_MS),
-    headers: {
-      ...(init.headers ?? {}),
-      Authorization: `Bearer ${token}`,
-      Accept: "application/vnd.github+json",
-      "X-GitHub-Api-Version": "2022-11-28",
-      "User-Agent": "protoquinn-review",
     },
   });
 }
@@ -249,9 +215,7 @@ async function submitReview(
   event: "COMMENT" | "APPROVE" | "REQUEST_CHANGES",
   body: string,
 ): Promise<string> {
-  // Uses reviewFetch (review-specific identity, QUINN_USER_TOKEN-first)
-  // rather than the App-auth ghFetch — see makeQuinnReviewAuth.
-  const resp = await reviewFetch(
+  const resp = await ghFetch(
     owner,
     name,
     `https://api.github.com/repos/${owner}/${name}/pulls/${pr}/reviews`,

--- a/src/skills/prReview.ts
+++ b/src/skills/prReview.ts
@@ -15,7 +15,7 @@
 import { review } from "../llm/reviewOrchestrator.ts";
 import { GitHubReviewSubmitter } from "../github/reviewSubmitter.ts";
 import { PullRequestTracker } from "../state/prTracker.ts";
-import { makeGitHubAuth, makeQuinnReviewAuth } from "../../lib/github-auth.ts";
+import { makeGitHubAuth } from "../../lib/github-auth.ts";
 
 export interface PRReviewInput {
   owner: string;
@@ -70,19 +70,12 @@ export async function runPRReview(
     throw new Error("[prReview] No GitHub auth configured (QUINN_APP_ID or GITHUB_TOKEN required)");
   }
 
-  // Run review pipeline using App / PAT identity — reads only, no
-  // identity-sensitive writes.
+  // Run review pipeline
   const result = await review(owner, repo, prNumber, getToken);
 
-  // Submit the review using the review-specific identity. When
-  // QUINN_USER_TOKEN is set, the formal review lands as the protoquinn
-  // machine user — required for the review to satisfy a required-
-  // reviewer gate. Falls back to the App / PAT path otherwise.
-  const getReviewToken = makeQuinnReviewAuth();
-  if (!getReviewToken) {
-    throw new Error("[prReview] No GitHub review auth configured (QUINN_USER_TOKEN or QUINN_APP_* or GITHUB_TOKEN required)");
-  }
-  const submitter = new GitHubReviewSubmitter(getReviewToken);
+  // Get fresh head SHA from result (it was fetched inside review())
+  // Submit the review
+  const submitter = new GitHubReviewSubmitter(getToken);
   const submitResult = await submitter.submitReview(
     owner,
     repo,


### PR DESCRIPTION
## Summary

Operator decided against burning a paid GitHub seat for a dedicated \`protoquinn\` machine-user account. Stage 1 of #585 is off the table; the \`QUINN_USER_TOKEN\` code path is dead weight without that account, and per the greenfield-strict rule we don't ship inert code waiting for a flag that won't flip.

Reverts the QUINN_USER_TOKEN content from #587 while **preserving #586's fail-loud-on-partial-App-config change**, which was bundled in via squash-merge ordering. Net effect: dev returns to the state it should have been at after #586 alone (fail-loud + env-arg + trim), minus the dedicated-review-identity scaffolding.

Quinn stays App-authed (\`quinn[bot]\`). Reviews remain advisory-only — they can't satisfy a required-reviewer rule because GitHub App approvals don't count toward that gate (same constraint as Copilot reviews). The path to "Quinn as a gate" requires a different approach now; tracked in updated #585.

## Test plan

- [x] \`bun test\` — 728/0
- [x] \`bun tsc --noEmit\` clean
- [x] \`makeGitHubAuth\` still has the partial-config throw (carried from #586)
- [x] No \`QUINN_USER_TOKEN\` / \`makeQuinnReviewAuth\` / \`reviewFetch\` symbols left

## Follow-ups

- #586 becomes a no-op once this lands (its content is preserved here). Will close it.
- #585 needs a fresh look — without a machine-user seat, the gate-satisfying path has to find a different mechanism (or accept Quinn stays advisory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated GitHub authentication across all operations, including PR reviews. Review submissions now use the same credentials and authentication flow as other standard GitHub interactions, eliminating the requirement for separate review-specific configuration and reducing overall setup complexity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->