### PR TITLE
fix(github): break bug_triage cascade — consume sweep label + strip needs-triage on created issues

### DIFF
--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -49,6 +49,13 @@ interface AutoTriageConfig {
   sweepLabel?: string;
   /** Run a sweep 30s after plugin install. Default true. */
   sweepOnStartup?: boolean;
+  /**
+   * Remove the sweep label from an issue once it has been dispatched for triage,
+   * so a later sweep (especially on restart) can't re-dispatch it forever.
+   * Default true. See #3503 — without this, every startup re-triages every open
+   * needs-triage issue and Quinn's own triage children cascade.
+   */
+  consumeSweepLabel?: boolean;
 }
 
 interface GitHubConfig {
@@ -970,6 +977,33 @@ export class GitHubPlugin implements Plugin {
             reply: { topic: replyTopic },
           });
           dispatched += 1;
+
+          // #3503: claim the issue by removing the sweep label now that it has
+          // been dispatched for triage. The label is the only persistent
+          // "already dispatched" marker — without removing it the next sweep
+          // (every startup, plus the bus topic) re-dispatches the same issue
+          // forever, and Quinn's own needs-triage children feed the cascade.
+          // Best-effort: a removal failure must not poison the rest of the sweep.
+          if (config.autoTriage.consumeSweepLabel !== false) {
+            try {
+              const del = await withCircuitBreaker("github-api", () =>
+                fetch(`https://api.github.com/repos/${repoSlug}/issues/${number}/labels/${encodeURIComponent(sweepLabel)}`, {
+                  method: "DELETE",
+                  headers: {
+                    Authorization: `Bearer ${token}`,
+                    Accept: "application/vnd.github+json",
+                    "User-Agent": "protoWorkstacean/1.0",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                  },
+                }),
+              );
+              if (!del.ok && del.status !== 404) {
+                console.warn(`[github] triage sweep: failed to remove "${sweepLabel}" from ${repoSlug}#${number}: ${del.status}`);
+              }
+            } catch (err) {
+              console.warn(`[github] triage sweep: label removal error for ${repoSlug}#${number}:`, err instanceof Error ? err.message : err);
+            }
+          }
         }
       } catch (err) {
         console.warn(`[github] triage sweep ${repoSlug} error:`, err instanceof Error ? err.message : err);

--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -439,6 +439,16 @@ export function createRoutes(ctx: ApiContext): Route[] {
     const issueBody = body.body as string | undefined;
     const labels = body.labels as string[] | undefined;
 
+    // #3503: an agent-created issue must never carry the triage-sweep label.
+    // bug_triage files follow-up issues; if they are born "status: needs-triage"
+    // the sweep re-triages them, spawning more follow-ups — an unbounded cascade.
+    // Anything Quinn files has already been reasoned about, so strip any
+    // needs-triage label at the boundary regardless of what the caller passed.
+    const triageSafeLabels = (labels ?? []).filter(l => !/needs-triage/i.test(l));
+    if (labels && triageSafeLabels.length !== labels.length) {
+      console.log(`[github] create_github_issue: stripped needs-triage label from new "${title}" (#3503 cascade guard)`);
+    }
+
     if (!repo || !title) {
       return Response.json({ success: false, error: "repo and title are required" }, { status: 400 });
     }
@@ -517,7 +527,7 @@ export function createRoutes(ctx: ApiContext): Route[] {
         body: JSON.stringify({
           title,
           body: issueBody ?? "",
-          labels: labels ?? [],
+          labels: triageSafeLabels,
         }),
       });
 


### PR DESCRIPTION
## Problem

Quinn's `bug_triage` cascades: the triage sweep re-dispatches every open `status: needs-triage` issue on each startup and never clears the label, and `bug_triage` files follow-up issues that are themselves born `needs-triage` — so they re-enter the sweep and spawn more.

Observed **2026-05-25** on protoMaker: `#3773 → #3776 → #3778 → #3779 → #3780 → #3781`. This recurred *after* the prior fixes (#558 self-cascade webhook guard, #559 same-title dedup) shipped, because:
- #559 dedups by *same title* — the chain has 6 distinct titles.
- #558 drops *webhook events authored by our bots* — this chain is driven by the **sweep + create_github_issue**, not webhooks.

Root-caused in protoLabsAI/protoMaker#3503.

## Fix

Two boundary guards:

1. **Sweep consumes the label** (`lib/plugins/github.ts`): after dispatching an issue for triage, remove the sweep label so a later sweep (especially on restart) can't re-dispatch it. The label is the only persistent "already dispatched" marker. New `autoTriage.consumeSweepLabel` config, default `true`. Best-effort — a removal failure (incl. 404 already-gone) doesn't poison the rest of the sweep.

2. **create_github_issue strips needs-triage** (`src/api/github.ts`): agent-created issues never carry the triage-sweep label, so Quinn's follow-ups can't re-enter the queue. Anything Quinn files has already been reasoned about.

Either alone leaves a feed path open; together they break the loop.

## Verification

- `tsc --noEmit` clean.
- Minimal diff (45 insertions, 1 deletion); no new imports; `withCircuitBreaker`, `fetch`, `encodeURIComponent` already in scope.
- CI runs `biome lint` + tests (local env can't resolve the `yaml` dep / biome binary; CI has them).

## Notes

- Removing the label at *dispatch* (not triage-completion) is intentional: dispatch is fire-and-forget on the bus, and the goal is "don't re-dispatch forever." A human re-adds `needs-triage` to re-trigger.
- Tracking issue protoLabsAI/protoMaker#3503 has the full evidence; this PR is its fix (cross-repo: issue in protoMaker, fix in protoWorkstacean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable option to control whether automated triage operations clean up related labels after processing issues.

* **Bug Fixes**
  * Improved issue creation workflow to prevent newly created issues from being unnecessarily reprocessed by automated triage operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/589?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->