### PR TITLE
feat(observability): webhook→done latency log for Quinn PR reviews (PR-1)

### DIFF
--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -690,6 +690,12 @@ export class GitHubPlugin implements Plugin {
     const correlationId = crypto.randomUUID();
     pendingComments.set(correlationId, { owner: ctx.owner, repo: ctx.repo, number: ctx.number });
 
+    // Stamp the webhook-arrival time so skill-dispatcher can compute
+    // webhook→done latency at completion. The /system trace view (D1)
+    // already has per-message timestamps via BusHistoryRecorder; this
+    // gives us a clean one-line summary in workstacean's stdout too.
+    const webhookArrivedAt = Date.now();
+
     const content = [
       `Auto-review — pull_request.${action} on ${ctx.owner}/${ctx.repo}#${ctx.number}`,
       `Title: ${ctx.title}`,
@@ -708,7 +714,7 @@ export class GitHubPlugin implements Plugin {
       id: `${event}-${action}-${ctx.owner}-${ctx.repo}-${ctx.number}-${correlationId.slice(0, 8)}`,
       correlationId,
       topic,
-      timestamp: Date.now(),
+      timestamp: webhookArrivedAt,
       payload: {
         sender: ctx.author,
         channel: `${ctx.owner}/${ctx.repo}#${ctx.number}`,
@@ -723,6 +729,7 @@ export class GitHubPlugin implements Plugin {
           title: ctx.title,
           url: ctx.url,
         },
+        meta: { webhookArrivedAt },
       },
       source: { interface: "github" as const },
       reply: { topic: replyTopic },

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -436,6 +436,30 @@ export class SkillDispatcherPlugin implements Plugin {
         console.log(
           `[skill-dispatcher] Skill "${skill}" completed via ${executor.type} — ${(result.text ?? "").length} chars: ${preview}${(result.text ?? "").length > 300 ? "…" : ""}`,
         );
+
+        // Trigger-to-done latency. When a surface plugin (today: github
+        // _handleAutoReview) stamps payload.meta.webhookArrivedAt, surface
+        // the full webhook→done duration split into queue time vs execute
+        // time. A separate single-line summary so it's grep-friendly and
+        // independent of the completion-text-preview log above.
+        const webhookArrivedAt = typeof payload.meta?.webhookArrivedAt === "number"
+          ? payload.meta.webhookArrivedAt
+          : undefined;
+        if (webhookArrivedAt) {
+          const now = Date.now();
+          const totalMs = now - webhookArrivedAt;
+          const queueMs = dispatchedAt - webhookArrivedAt;
+          const executeMs = now - dispatchedAt;
+          const gh = payload.github as { owner?: string; repo?: string; number?: number } | undefined;
+          const repoRef = gh?.owner && gh?.repo && gh?.number
+            ? ` [${gh.owner}/${gh.repo}#${gh.number}]`
+            : "";
+          console.log(
+            `[skill-latency] ${skill} webhook→done ${(totalMs / 1000).toFixed(2)}s ` +
+              `(queue ${queueMs}ms, execute ${(executeMs / 1000).toFixed(2)}s)${repoRef}`,
+          );
+        }
+
         this._publishActivity("skill.complete", {
           agentName: targetAgent,
           correlationId,


### PR DESCRIPTION
## Summary

First piece of the observability sprint that grew out of #585. Adds a single grep-friendly log line at the end of every webhook-triggered skill completion surfacing the **webhook→done** latency, split into queue time vs execute time:

\`\`\`
[skill-latency] pr_review webhook→done 14.7s (queue 28ms, execute 14.7s) [protoLabsAI/protoWorkstacean#580]
\`\`\`

Measurement is the prerequisite for "can we make Quinn's reviews faster?" — without it we don't know where the latency lives (LLM, tool calls, bus hops, or just the GitHub round-trip).

## Changes

- **\`lib/plugins/github.ts\` (\`_handleAutoReview\`)** — stamps \`payload.meta.webhookArrivedAt\` at bus-publish time, plus passes that same timestamp as the \`BusMessage.timestamp\` so the BusHistoryRecorder ring buffer (D1) preserves it for /system/trace.
- **\`src/executor/skill-dispatcher-plugin.ts\`** — reads \`meta.webhookArrivedAt\` in the success path and emits the \`[skill-latency]\` log. Guarded on \"only when the field is set\" so cron / direct-API / agent-to-agent dispatches keep their existing log shape.

## Why "skill-latency" not "pr-review"

The mechanism is generic. Any surface plugin that stamps \`webhookArrivedAt\` on inbound dispatch gets the latency line for free. \`github.*\` is the only one wired today; same shape will fit linear / discord / scheduled-trigger when wanted.

## Test plan

- [x] \`bun test\` — 728/0
- [x] \`bun tsc --noEmit\` clean
- [ ] Open a test PR after deploy → confirm \`[skill-latency] pr_review webhook→done …\` appears once per review in workstacean stdout
- [ ] Check that non-pr_review skills (cron-triggered ceremonies, agent-issued dispatches) don't emit the latency line spuriously

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Added webhook processing latency metrics with breakdown of queue time versus execution time for performance monitoring
- Improved webhook event timestamp accuracy by using consistent arrival time across processing stages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/595?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->