### PR TITLE
feat(observability): Discord alert on Quinn REQUEST_CHANGES (PR-2)

### DIFF
--- a/src/api/pr-inspector.ts
+++ b/src/api/pr-inspector.ts
@@ -27,6 +27,7 @@
 
 import type { Route, ApiContext } from "./types.ts";
 import { makeGitHubAuth } from "../../lib/github-auth.ts";
+import { REVIEW_TOPICS } from "../event-bus/topics.ts";
 
 const getGithubToken = makeGitHubAuth();
 
@@ -208,6 +209,44 @@ async function diffSummary(owner: string, name: string, pr: number): Promise<str
   return `**Diff for PR#${pr}:**\n\n\`\`\`diff\n${preview}\n\`\`\`${suffix}`;
 }
 
+/**
+ * Fire-and-forget bus notification that Quinn just submitted a formal
+ * review. Subscribers (today: quinn-review-notifier-plugin for Discord
+ * embeds) react to specific verdicts. Failure to publish must never
+ * cascade into the route handler — caller already returned a successful
+ * GitHub API result by the time this runs.
+ */
+function publishReviewSubmitted(
+  ctx: ApiContext,
+  owner: string,
+  name: string,
+  pr: number,
+  event: "COMMENT" | "APPROVE" | "REQUEST_CHANGES",
+  body: string,
+): void {
+  try {
+    const correlationId = crypto.randomUUID();
+    ctx.bus.publish(REVIEW_TOPICS.QUINN_REVIEW_SUBMITTED, {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic: REVIEW_TOPICS.QUINN_REVIEW_SUBMITTED,
+      timestamp: Date.now(),
+      payload: {
+        owner,
+        repo: name,
+        prNumber: pr,
+        event,
+        prUrl: `https://github.com/${owner}/${name}/pull/${pr}`,
+        bodyPreview: body.slice(0, 600),
+      },
+    });
+  } catch (err) {
+    console.warn(
+      `[pr-inspector] failed to publish quinn.review.submitted: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+}
+
 async function submitReview(
   owner: string,
   name: string,
@@ -295,7 +334,7 @@ async function setPrState(
   return `${verb} PR#${pr} in ${owner}/${name}.`;
 }
 
-export function createRoutes(_ctx: ApiContext): Route[] {
+export function createRoutes(ctx: ApiContext): Route[] {
   return [
     {
       method: "POST",
@@ -362,15 +401,18 @@ export function createRoutes(_ctx: ApiContext): Route[] {
                 return Response.json({ success: false, error: "body required for review_comment" }, { status: 400 });
               }
               result = await submitReview(owner, name, pr_number!, "COMMENT", body);
+              publishReviewSubmitted(ctx, owner, name, pr_number!, "COMMENT", body);
               break;
             case "review_approve":
               result = await submitReview(owner, name, pr_number!, "APPROVE", body ?? "");
+              publishReviewSubmitted(ctx, owner, name, pr_number!, "APPROVE", body ?? "");
               break;
             case "review_request_changes":
               if (!body) {
                 return Response.json({ success: false, error: "body required for review_request_changes" }, { status: 400 });
               }
               result = await submitReview(owner, name, pr_number!, "REQUEST_CHANGES", body);
+              publishReviewSubmitted(ctx, owner, name, pr_number!, "REQUEST_CHANGES", body);
               break;
             case "close_pr":
               result = await setPrState(owner, name, pr_number!, "closed", comment, false);

--- a/src/event-bus/all-topics.ts
+++ b/src/event-bus/all-topics.ts
@@ -65,3 +65,16 @@ export const SECURITY_TOPICS = {
   /** Published when a security incident is detected. */
   SECURITY_INCIDENT_REPORTED: "security.incident.reported",
 } as const;
+
+export const REVIEW_TOPICS = {
+  /**
+   * Published by `pr-inspector` after a `review_comment` / `review_approve` /
+   * `review_request_changes` action succeeds. Fire-and-forget signal for any
+   * notifier (Discord embed, dashboard activity feed, etc.) that wants to
+   * react to Quinn's review verdicts without subscribing to every github API
+   * response. See `quinn-review-notifier-plugin` for the Discord side.
+   *
+   * Payload shape: { owner, repo, prNumber, event, reviewId?, prUrl? }.
+   */
+  QUINN_REVIEW_SUBMITTED: "quinn.review.submitted",
+} as const;

--- a/src/event-bus/topics.ts
+++ b/src/event-bus/topics.ts
@@ -11,18 +11,21 @@ export {
   MESSAGE_TOPICS,
   ACTION_TOPICS,
   SECURITY_TOPICS,
+  REVIEW_TOPICS,
 } from "./all-topics.ts";
 
 import {
   MESSAGE_TOPICS,
   ACTION_TOPICS,
   SECURITY_TOPICS,
+  REVIEW_TOPICS,
 } from "./all-topics.ts";
 
 export const TOPICS = {
   ...MESSAGE_TOPICS,
   ...ACTION_TOPICS,
   ...SECURITY_TOPICS,
+  ...REVIEW_TOPICS,
 } as const;
 
 export type TopicValue = (typeof TOPICS)[keyof typeof TOPICS];

--- a/src/index.ts
+++ b/src/index.ts
@@ -257,6 +257,20 @@ const pluginRegistry: PluginRegistryEntry[] = [
     },
   },
   {
+    // Routes Quinn's REQUEST_CHANGES verdicts to Discord. Subscribes to
+    // quinn.review.submitted (published by src/api/pr-inspector.ts after
+    // every review_* action) and republishes blocking verdicts as
+    // message.outbound.discord.alert so the operator sees them in Discord
+    // without refreshing GitHub. APPROVE/COMMENT verdicts are intentionally
+    // silent — only blocking signals get pinged.
+    name: "quinn-review-notifier",
+    condition: () => true,
+    factory: async () => {
+      const { QuinnReviewNotifierPlugin } = await import("./plugins/quinn-review-notifier-plugin.js");
+      return new QuinnReviewNotifierPlugin();
+    },
+  },
+  {
     // Registers FunctionExecutors that bridge `ceremony.*` skills to the
     // matching `ceremony.<id>.execute` bus trigger CeremonyPlugin listens
     // for, so any skill caller (cron, external trigger, agent) can invoke

--- a/src/plugins/__tests__/quinn-review-notifier-plugin.test.ts
+++ b/src/plugins/__tests__/quinn-review-notifier-plugin.test.ts
@@ -1,0 +1,135 @@
+/**
+ * QuinnReviewNotifierPlugin tests — verify REQUEST_CHANGES gets routed to
+ * Discord, APPROVE/COMMENT stay silent, and malformed payloads don't crash.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import type { BusMessage } from "../../../lib/types.ts";
+import { QuinnReviewNotifierPlugin } from "../quinn-review-notifier-plugin.ts";
+import { REVIEW_TOPICS } from "../../event-bus/topics.ts";
+
+function collectAlerts(bus: InMemoryEventBus): BusMessage[] {
+  const captured: BusMessage[] = [];
+  bus.subscribe("message.outbound.discord.alert", "test-collector", (msg) => {
+    captured.push(msg);
+  });
+  return captured;
+}
+
+function makeReviewMsg(
+  event: "COMMENT" | "APPROVE" | "REQUEST_CHANGES",
+  overrides: Partial<{ owner: string; repo: string; prNumber: number; bodyPreview: string }> = {},
+): BusMessage {
+  return {
+    id: crypto.randomUUID(),
+    correlationId: "corr-1",
+    topic: REVIEW_TOPICS.QUINN_REVIEW_SUBMITTED,
+    timestamp: Date.now(),
+    payload: {
+      owner: overrides.owner ?? "protoLabsAI",
+      repo: overrides.repo ?? "protoWorkstacean",
+      prNumber: overrides.prNumber ?? 580,
+      event,
+      prUrl: `https://github.com/${overrides.owner ?? "protoLabsAI"}/${overrides.repo ?? "protoWorkstacean"}/pull/${overrides.prNumber ?? 580}`,
+      bodyPreview: overrides.bodyPreview ?? "VERDICT: FAIL — typecheck broken in lib/foo.ts:42",
+    },
+  };
+}
+
+describe("QuinnReviewNotifierPlugin", () => {
+  test("REQUEST_CHANGES → publishes Discord alert with severity medium", () => {
+    const bus = new InMemoryEventBus();
+    const alerts = collectAlerts(bus);
+    const plugin = new QuinnReviewNotifierPlugin();
+    plugin.install(bus);
+
+    bus.publish(REVIEW_TOPICS.QUINN_REVIEW_SUBMITTED, makeReviewMsg("REQUEST_CHANGES"));
+
+    expect(alerts).toHaveLength(1);
+    const alert = alerts[0]!;
+    const p = alert.payload as Record<string, unknown>;
+    expect(p.actionId).toBe("quinn.review.request_changes");
+    expect((p.text as string)).toContain("Quinn requested changes on protoLabsAI/protoWorkstacean#580");
+    const meta = p.meta as Record<string, unknown>;
+    expect(meta.severity).toBe("medium");
+    expect(meta.agentId).toBe("quinn");
+    const extra = meta.extra as Record<string, unknown>;
+    expect(extra.prNumber).toBe(580);
+    expect(extra.verdict).toBe("REQUEST_CHANGES");
+
+    plugin.uninstall();
+  });
+
+  test("APPROVE → no alert (intentionally silent)", () => {
+    const bus = new InMemoryEventBus();
+    const alerts = collectAlerts(bus);
+    const plugin = new QuinnReviewNotifierPlugin();
+    plugin.install(bus);
+
+    bus.publish(REVIEW_TOPICS.QUINN_REVIEW_SUBMITTED, makeReviewMsg("APPROVE"));
+
+    expect(alerts).toHaveLength(0);
+    plugin.uninstall();
+  });
+
+  test("COMMENT → no alert", () => {
+    const bus = new InMemoryEventBus();
+    const alerts = collectAlerts(bus);
+    const plugin = new QuinnReviewNotifierPlugin();
+    plugin.install(bus);
+
+    bus.publish(REVIEW_TOPICS.QUINN_REVIEW_SUBMITTED, makeReviewMsg("COMMENT"));
+
+    expect(alerts).toHaveLength(0);
+    plugin.uninstall();
+  });
+
+  test("malformed payload (missing prNumber) → drops with warn, does not throw", () => {
+    const bus = new InMemoryEventBus();
+    const alerts = collectAlerts(bus);
+    const plugin = new QuinnReviewNotifierPlugin();
+    plugin.install(bus);
+
+    bus.publish(REVIEW_TOPICS.QUINN_REVIEW_SUBMITTED, {
+      id: crypto.randomUUID(),
+      correlationId: "corr-malformed",
+      topic: REVIEW_TOPICS.QUINN_REVIEW_SUBMITTED,
+      timestamp: Date.now(),
+      payload: { event: "REQUEST_CHANGES", owner: "x" }, // missing repo, prNumber
+    });
+
+    expect(alerts).toHaveLength(0);
+    plugin.uninstall();
+  });
+
+  test("uninstall stops routing", () => {
+    const bus = new InMemoryEventBus();
+    const alerts = collectAlerts(bus);
+    const plugin = new QuinnReviewNotifierPlugin();
+    plugin.install(bus);
+    plugin.uninstall();
+
+    bus.publish(REVIEW_TOPICS.QUINN_REVIEW_SUBMITTED, makeReviewMsg("REQUEST_CHANGES"));
+
+    expect(alerts).toHaveLength(0);
+  });
+
+  test("body preview > 400 chars is truncated", () => {
+    const bus = new InMemoryEventBus();
+    const alerts = collectAlerts(bus);
+    const plugin = new QuinnReviewNotifierPlugin();
+    plugin.install(bus);
+
+    const longBody = "x".repeat(500);
+    bus.publish(REVIEW_TOPICS.QUINN_REVIEW_SUBMITTED, makeReviewMsg("REQUEST_CHANGES", { bodyPreview: longBody }));
+
+    expect(alerts).toHaveLength(1);
+    const text = (alerts[0]!.payload as Record<string, unknown>).text as string;
+    expect(text).toContain("…");
+    // text contains: "[MEDIUM] Quinn requested changes…\n→ url\n\n<400-char preview>…"
+    expect(text.length).toBeLessThan(longBody.length + 200);
+
+    plugin.uninstall();
+  });
+});

--- a/src/plugins/quinn-review-notifier-plugin.ts
+++ b/src/plugins/quinn-review-notifier-plugin.ts
@@ -1,0 +1,121 @@
+/**
+ * QuinnReviewNotifierPlugin — subscribes to `quinn.review.submitted` and
+ * fires a Discord alert when Quinn requests changes on a PR. The verdict
+ * needs human eyes, and waiting for someone to refresh GitHub before they
+ * see it defeats the purpose of having an autonomous QA agent — Discord is
+ * where the operator already looks.
+ *
+ * Inbound:
+ *   quinn.review.submitted — { owner, repo, prNumber, event, prUrl, bodyPreview }
+ *     fired by pr-inspector's review_* actions
+ *
+ * Outbound:
+ *   message.outbound.discord.alert — picked up by WorldEngineAlertPlugin,
+ *     rendered as a severity-colored embed and posted via DISCORD_WEBHOOK_ALERTS
+ *
+ * Filter policy (intentional):
+ *   - REQUEST_CHANGES → fire alert (severity: medium)
+ *   - APPROVE / COMMENT → silent. Approves are the common case; emitting on
+ *     every one would just be noise. Add a separate APPROVE notifier later
+ *     if there's value in seeing "Quinn cleared this" signals — for now,
+ *     only the blocking verdicts get the Discord ping.
+ *
+ * This plugin is a notification surface, not a chokepoint — failure to
+ * publish the outbound alert logs a warn but does not propagate (the
+ * upstream review POST already succeeded by the time this fires).
+ */
+
+import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
+import { REVIEW_TOPICS } from "../event-bus/topics.ts";
+
+interface QuinnReviewSubmittedPayload {
+  owner: string;
+  repo: string;
+  prNumber: number;
+  event: "COMMENT" | "APPROVE" | "REQUEST_CHANGES";
+  prUrl?: string;
+  bodyPreview?: string;
+}
+
+export class QuinnReviewNotifierPlugin implements Plugin {
+  readonly name = "quinn-review-notifier";
+  readonly description =
+    "Routes Quinn's REQUEST_CHANGES verdicts to message.outbound.discord.alert";
+  readonly capabilities = ["review-notification"];
+  readonly subscribes = [REVIEW_TOPICS.QUINN_REVIEW_SUBMITTED];
+  readonly publishes = ["message.outbound.discord.alert"];
+
+  private bus?: EventBus;
+  private readonly subscriptionIds: string[] = [];
+
+  install(bus: EventBus): void {
+    this.bus = bus;
+    const subId = bus.subscribe(
+      REVIEW_TOPICS.QUINN_REVIEW_SUBMITTED,
+      this.name,
+      (msg) => this._handle(msg),
+    );
+    this.subscriptionIds.push(subId);
+    console.log("[quinn-review-notifier] installed — REQUEST_CHANGES verdicts will fire Discord alerts");
+  }
+
+  uninstall(): void {
+    if (this.bus) {
+      for (const id of this.subscriptionIds) this.bus.unsubscribe(id);
+    }
+    this.subscriptionIds.length = 0;
+    this.bus = undefined;
+  }
+
+  private _handle(msg: BusMessage): void {
+    if (!this.bus) return;
+    const payload = (msg.payload ?? {}) as Partial<QuinnReviewSubmittedPayload>;
+    if (payload.event !== "REQUEST_CHANGES") return;
+    if (!payload.owner || !payload.repo || !payload.prNumber) {
+      console.warn(
+        `[quinn-review-notifier] dropping malformed REQUEST_CHANGES event — missing owner/repo/prNumber`,
+      );
+      return;
+    }
+
+    const prRef = `${payload.owner}/${payload.repo}#${payload.prNumber}`;
+    const prUrl = payload.prUrl ?? `https://github.com/${payload.owner}/${payload.repo}/pull/${payload.prNumber}`;
+    const preview = (payload.bodyPreview ?? "").trim();
+    const text =
+      `[MEDIUM] Quinn requested changes on ${prRef}\n` +
+      `→ ${prUrl}` +
+      (preview ? `\n\n${preview.slice(0, 400)}${preview.length > 400 ? "…" : ""}` : "");
+
+    const alertMsg: BusMessage = {
+      id: crypto.randomUUID(),
+      correlationId: msg.correlationId,
+      topic: "message.outbound.discord.alert",
+      timestamp: Date.now(),
+      payload: {
+        text,
+        actionId: "quinn.review.request_changes",
+        goalId: "pr-quality",
+        meta: {
+          severity: "medium",
+          agentId: "quinn",
+          extra: {
+            owner: payload.owner,
+            repo: payload.repo,
+            prNumber: payload.prNumber,
+            prUrl,
+            verdict: payload.event,
+          },
+        },
+      },
+    };
+
+    try {
+      this.bus.publish("message.outbound.discord.alert", alertMsg);
+      console.log(`[quinn-review-notifier] REQUEST_CHANGES on ${prRef} → discord.alert`);
+    } catch (err) {
+      console.warn(
+        `[quinn-review-notifier] failed to publish discord.alert for ${prRef}: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Second piece of the observability sprint. Operator shouldn't have to refresh GitHub to find out Quinn just blocked one of their PRs.

New bus event + small notifier plugin routes REQUEST_CHANGES verdicts into the existing Discord alert pipeline. APPROVE / COMMENT are silently dropped — most PRs get approved, alerting on each would just be noise.

\`\`\`
[MEDIUM] Quinn requested changes on protoLabsAI/protoWorkstacean#580
→ https://github.com/protoLabsAI/protoWorkstacean/pull/580

VERDICT: FAIL — typecheck broken in lib/foo.ts:42
…
\`\`\`

## Changes

- **New bus topic** \`quinn.review.submitted\` in \`src/event-bus/all-topics.ts\` (new \`REVIEW_TOPICS\` group) + barrel re-export. Payload: \`{ owner, repo, prNumber, event, prUrl, bodyPreview }\`.
- **\`src/api/pr-inspector.ts\`** publishes the topic after each \`review_*\` action returns. Threaded \`ctx.bus\` through \`createRoutes\` (was \`_ctx\`). Publish failure logs a warn — never poisons the successful review POST.
- **\`src/plugins/quinn-review-notifier-plugin.ts\`** (new) subscribes, filters for REQUEST_CHANGES, builds the same alert-embed shape as the existing \`alert.*\` path (\`message.outbound.discord.alert\`, severity \`medium\`, agentId \`quinn\`).
- **Wired in \`src/index.ts\`** after \`alert-skill-executor\`, matching the install-order pattern.

## Why this scope (not APPROVE notifications)

The signal-to-noise math: ~one REQUEST_CHANGES per several APPROVEs in a healthy fleet. The blocking signal is what needs to wake the operator. \"Quinn cleared this\" can become a richer dashboard tile later if there's value, but for now the dev channel stays scoped to what needs eyes.

## Test plan

- [x] \`bun test\` — 734/0 (+6 new). REQUEST_CHANGES routes correctly; APPROVE + COMMENT silent; malformed payload drops cleanly; uninstall stops routing; long body preview truncates.
- [x] \`bun tsc --noEmit\` — clean.
- [ ] After merge + image republish: open a test PR, have Quinn return CHANGES_REQUESTED, confirm a single alert lands in Discord with the PR link + verdict block.
- [ ] APPROVE verdict on a follow-up PR — confirm Discord stays silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automated Quinn review notifications. The system now sends Discord alerts whenever Quinn submits a "request changes" verdict on pull requests, including PR details (owner, repository, number) and a formatted preview of the review feedback. Only request changes verdicts trigger notifications; other review types do not generate alerts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/596?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->