### PR TITLE
feat(observability): leading "Quinn is reviewing…" PR comment on open (PR-3)

### DIFF
--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -571,7 +571,7 @@ export class GitHubPlugin implements Plugin {
     // verdict. Dedup'd via recentDispatches so a fast-updating branch doesn't
     // flood the bus.
     if (event === "pull_request" && (payload.action === "opened" || payload.action === "synchronize")) {
-      this._handleAutoReview(event, payload, ctx, bus, { skipDedup: false });
+      this._handleAutoReview(event, payload, ctx, bus, getToken, { skipDedup: false });
       return;
     }
 
@@ -583,7 +583,7 @@ export class GitHubPlugin implements Plugin {
       const reviewer = payload.requested_reviewer as Record<string, unknown> | undefined;
       const login = (reviewer?.login as string | undefined)?.toLowerCase();
       if (login === "protoquinn" || login === "protoquinn[bot]") {
-        this._handleAutoReview(event, payload, ctx, bus, { skipDedup: true });
+        this._handleAutoReview(event, payload, ctx, bus, getToken, { skipDedup: true });
       }
       return;
     }
@@ -667,6 +667,7 @@ export class GitHubPlugin implements Plugin {
     payload: Record<string, unknown>,
     ctx: GitHubEventContext,
     bus: EventBus,
+    getToken: (owner: string, repo: string) => Promise<string>,
     opts: { skipDedup: boolean } = { skipDedup: false },
   ): void {
     const action = payload.action as string;
@@ -736,6 +737,29 @@ export class GitHubPlugin implements Plugin {
     });
 
     console.log(`[github] Auto-review: ${ctx.owner}/${ctx.repo}#${ctx.number} (${action}) → pr_review`);
+
+    // Leading acknowledgment comment so the PR shows Quinn engagement
+    // immediately, not minutes later when the formal verdict review
+    // lands. GitHub Apps can't be added as requested reviewers
+    // (collaborator-only), so an explicit timeline comment is the
+    // closest equivalent UI signal. Same pattern Renovate / Dependabot
+    // / CodeRabbit use.
+    //
+    // Gated on `opened` only — `synchronize` and `review_requested`
+    // already happen against PRs that have a prior leading comment,
+    // so re-posting would be noise. Best-effort: a failure here must
+    // never block the actual dispatch above.
+    if (action === "opened") {
+      void this._postComment(
+        getToken,
+        { owner: ctx.owner, repo: ctx.repo, number: ctx.number },
+        "👀 Quinn is reviewing — verdict (PASS / WARN / FAIL) + findings to follow.",
+      ).catch((err) => {
+        console.warn(
+          `[github] Auto-review: leading-comment post failed for ${ctx.owner}/${ctx.repo}#${ctx.number}: ${err instanceof Error ? err.message : err}`,
+        );
+      });
+    }
   }
 
   private _handleAutoTriage(


### PR DESCRIPTION
## Summary

Third piece of the observability sprint. GitHub Apps can't be added as requested reviewers (collaborator-only, returns 422 — confirmed in earlier research), so an explicit timeline comment on \`pull_request.opened\` is the closest equivalent UI signal. Same pattern Renovate / Dependabot / CodeRabbit use. PRs now show Quinn engagement immediately, not minutes later when the formal verdict review lands.

\`\`\`
👀 Quinn is reviewing — verdict (PASS / WARN / FAIL) + findings to follow.
\`\`\`

## Implementation

- \`lib/plugins/github.ts:_handleAutoReview()\` now takes \`getToken\`, posts a leading comment via the existing \`_postComment\` helper (which already routes through the github-api circuit breaker).
- **Gated on \`action === "opened"\` only.** Synchronize + review_requested re-fire against PRs that already have the leading comment, so re-posting would be noise.
- Best-effort: a comment-post failure logs a warn but never blocks the actual review dispatch.

## When to revert

If PR-1's latency data eventually shows turnaround is sub-30s on the happy path, the leading comment becomes redundant noise — at that point we'd revert this. Until we have that measurement, the leading comment is the bird-in-the-hand for \"Quinn engagement is visible on the PR immediately.\"

## Test plan

- [x] \`bun test\` — 728/0
- [x] \`bun tsc --noEmit\` — clean
- [ ] After merge + image republish: open a test PR, confirm a \"Quinn is reviewing…\" comment appears within seconds of opening
- [ ] Synchronize event (push more commits) does NOT post another leading comment — only the formal verdict review follows
- [ ] Comment-post failure (e.g. revoked installation token) doesn't block the actual review pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-review now posts an acknowledgment comment when pull requests are opened.

* **Improvements**
  * Enhanced system resilience to prevent review dispatch failures if comment posting encounters issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/597?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->