### PR TITLE
feat(dashboard): Quinn verdict counters overlay on /system (O-2)

### DIFF
--- a/dashboard/src/components/QuinnVerdictCounters.tsx
+++ b/dashboard/src/components/QuinnVerdictCounters.tsx
@@ -1,0 +1,224 @@
+/**
+ * QuinnVerdictCounters — top-right floating panel on /system showing
+ * Quinn's review verdict counts per repo, since this dashboard tab opened.
+ *
+ * Subscribes to `quinn.review.submitted` over the same WS endpoint
+ * SystemGraph uses (`/api/bus/subscribe?topic=…`). Pure browser-side
+ * accumulation — no /api/bus/history backfill on v1, so a fresh tab
+ * starts at 0 across the board. (Future: seed from history once the
+ * /api/bus/history endpoint supports topic-filter queries.)
+ *
+ * Auto-reconnects with a 2s backoff on close, same shape as
+ * SystemGraph's WS handler — keeps the panel populated through workstacean
+ * restarts.
+ */
+
+import { useEffect, useState } from "preact/hooks";
+
+interface Counts {
+  approved: number;
+  requestedChanges: number;
+  commented: number;
+}
+
+interface ReviewSubmittedPayload {
+  owner?: string;
+  repo?: string;
+  prNumber?: number;
+  event?: "COMMENT" | "APPROVE" | "REQUEST_CHANGES";
+}
+
+const EMPTY: Counts = { approved: 0, requestedChanges: 0, commented: 0 };
+
+export default function QuinnVerdictCounters() {
+  // Per-repo counts; key is `${owner}/${repo}`.
+  const [counts, setCounts] = useState<Map<string, Counts>>(new Map());
+  const [openedAt] = useState<number>(() => Date.now());
+  const [wsStatus, setWsStatus] = useState<"connecting" | "connected" | "disconnected">("connecting");
+
+  useEffect(() => {
+    const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const url = `${proto}//${window.location.host}/api/bus/subscribe?topic=quinn.review.submitted`;
+    let ws: WebSocket | null = null;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let stopped = false;
+
+    const connect = () => {
+      ws = new WebSocket(url);
+      ws.onopen = () => setWsStatus("connected");
+      ws.onmessage = (e) => {
+        try {
+          const msg = JSON.parse(e.data) as { payload?: ReviewSubmittedPayload };
+          const p = msg.payload;
+          if (!p?.owner || !p?.repo || !p?.event) return;
+          const key = `${p.owner}/${p.repo}`;
+          setCounts((cur) => {
+            const next = new Map(cur);
+            const existing = { ...(next.get(key) ?? EMPTY) };
+            if (p.event === "APPROVE") existing.approved++;
+            else if (p.event === "REQUEST_CHANGES") existing.requestedChanges++;
+            else if (p.event === "COMMENT") existing.commented++;
+            next.set(key, existing);
+            return next;
+          });
+        } catch {
+          // Ignore malformed frames — WS may emit framing data.
+        }
+      };
+      ws.onclose = () => {
+        setWsStatus("disconnected");
+        if (stopped) return;
+        retryTimer = setTimeout(connect, 2000);
+      };
+      ws.onerror = () => ws?.close();
+    };
+    connect();
+
+    return () => {
+      stopped = true;
+      if (retryTimer) clearTimeout(retryTimer);
+      ws?.close();
+    };
+  }, []);
+
+  // Sort repos by total volume desc; row with the most signal first.
+  const rows = [...counts.entries()]
+    .map(([repo, c]) => ({ repo, ...c, total: c.approved + c.requestedChanges + c.commented }))
+    .sort((a, b) => b.total - a.total);
+
+  const totals = rows.reduce(
+    (acc, r) => ({
+      approved: acc.approved + r.approved,
+      requestedChanges: acc.requestedChanges + r.requestedChanges,
+      commented: acc.commented + r.commented,
+    }),
+    { approved: 0, requestedChanges: 0, commented: 0 },
+  );
+
+  const grandTotal = totals.approved + totals.requestedChanges + totals.commented;
+  const sinceMin = Math.floor((Date.now() - openedAt) / 60_000);
+
+  return (
+    <aside class="qvc-panel" aria-label="Quinn review verdicts since page load">
+      <header class="qvc-head">
+        <div>
+          <h3>Quinn verdicts</h3>
+          <p class="qvc-meta">
+            since tab opened {sinceMin}m ago ·{" "}
+            <span class={`qvc-status qvc-status--${wsStatus}`}>{wsStatus}</span>
+          </p>
+        </div>
+      </header>
+
+      {rows.length === 0 ? (
+        <div class="qvc-empty">No verdicts observed yet.</div>
+      ) : (
+        <table class="qvc-table">
+          <thead>
+            <tr>
+              <th>repo</th>
+              <th class="qvc-num qvc-approve" title="APPROVE">✓</th>
+              <th class="qvc-num qvc-block"   title="REQUEST_CHANGES">✗</th>
+              <th class="qvc-num qvc-comment" title="COMMENT">💬</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.repo}>
+                <td class="qvc-repo" title={r.repo}>{r.repo}</td>
+                <td class="qvc-num qvc-approve">{r.approved || ""}</td>
+                <td class="qvc-num qvc-block">{r.requestedChanges || ""}</td>
+                <td class="qvc-num qvc-comment">{r.commented || ""}</td>
+              </tr>
+            ))}
+            {rows.length > 1 && (
+              <tr class="qvc-total-row">
+                <td class="qvc-repo">total ({grandTotal})</td>
+                <td class="qvc-num qvc-approve">{totals.approved || ""}</td>
+                <td class="qvc-num qvc-block">{totals.requestedChanges || ""}</td>
+                <td class="qvc-num qvc-comment">{totals.commented || ""}</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      )}
+
+      <style>{STYLES}</style>
+    </aside>
+  );
+}
+
+const STYLES = `
+  .qvc-panel {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    z-index: 5;
+    min-width: 220px;
+    max-width: 320px;
+    background: rgba(13, 17, 23, 0.92);
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    color: #c9d1d9;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 0.8rem;
+    backdrop-filter: blur(4px);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  }
+  .qvc-head {
+    padding: 0.5rem 0.75rem 0.4rem;
+    border-bottom: 1px solid #21262d;
+  }
+  .qvc-head h3 {
+    margin: 0;
+    font-size: 0.85rem;
+    color: #e6edf3;
+  }
+  .qvc-meta {
+    margin: 0.2rem 0 0;
+    color: #8b949e;
+    font-size: 0.7rem;
+  }
+  .qvc-status { font-weight: 500; }
+  .qvc-status--connected    { color: #3fb950; }
+  .qvc-status--connecting   { color: #d29922; }
+  .qvc-status--disconnected { color: #f85149; }
+  .qvc-empty {
+    padding: 0.75rem;
+    color: #8b949e;
+    font-size: 0.75rem;
+  }
+  .qvc-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.75rem;
+  }
+  .qvc-table thead th {
+    text-align: left;
+    color: #6e7681;
+    font-weight: 500;
+    padding: 0.4rem 0.5rem;
+    border-bottom: 1px solid #21262d;
+  }
+  .qvc-table td {
+    padding: 0.3rem 0.5rem;
+    border-bottom: 1px dashed #21262d;
+  }
+  .qvc-table tbody tr:last-child td { border-bottom: none; }
+  .qvc-num { text-align: right; width: 2.4rem; }
+  .qvc-approve { color: #3fb950; }
+  .qvc-block   { color: #f85149; }
+  .qvc-comment { color: #58a6ff; }
+  .qvc-repo {
+    color: #c9d1d9;
+    max-width: 14rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .qvc-total-row td {
+    border-top: 1px solid #30363d;
+    color: #e6edf3;
+    font-weight: 500;
+  }
+`;

--- a/dashboard/src/components/SystemGraph.tsx
+++ b/dashboard/src/components/SystemGraph.tsx
@@ -26,6 +26,7 @@ import "@xyflow/react/dist/style.css";
 import AgentNode, { type AgentActivityState } from "./AgentNode.tsx";
 import ServiceNode from "./ServiceNode.tsx";
 import MessageDrawer, { type DrawerMessage } from "./MessageDrawer.tsx";
+import QuinnVerdictCounters from "./QuinnVerdictCounters.tsx";
 
 /** Ring-buffer cap for per-topic history shown in the edge drawer. */
 const TOPIC_HISTORY_CAP = 20;
@@ -408,7 +409,7 @@ export default function SystemGraph() {
   );
 
   return (
-    <div style={{ width: "100%", height: "calc(100vh - 64px)", background: "#0d1117" }}>
+    <div style={{ width: "100%", height: "calc(100vh - 64px)", background: "#0d1117", position: "relative" }}>
       <ReactFlow
         nodes={nodes}
         edges={edges}
@@ -426,6 +427,7 @@ export default function SystemGraph() {
         <Background color="#21262d" gap={16} />
         <Controls position="bottom-right" />
       </ReactFlow>
+      <QuinnVerdictCounters />
       {openTopic && (
         <MessageDrawer
           topic={openTopic}


### PR DESCRIPTION
## Summary

First in-React-Flow observability tile of today's sprint. Floating top-right panel on the SystemGraph canvas that tallies Quinn's review verdicts per repo since the tab opened:

\`\`\`
┌─ Quinn verdicts ─────────┐
│ since tab opened 8m ago  │
│   connected              │
│ ─────────────────────────│
│ repo                ✓ ✗ 💬│
│ protoWorkstacean    4 1  2│
│ protoCLI            2 0  0│
│ ─────────────────────────│
│ total (9)           6 1  2│
└──────────────────────────┘
\`\`\`

Subscribes to the \`quinn.review.submitted\` bus topic (shipped yesterday in PR-2) via the same WS endpoint SystemGraph uses (\`/api/bus/subscribe?topic=quinn.review.submitted\`). Pure browser-side accumulation — no backfill on v1, fresh tab starts at 0. Future v2 would seed from \`/api/bus/history\` once that endpoint supports topic-filter queries.

Same overlay pattern will apply to O-3 (latency histogram). Picked the corner-on-SystemGraph shape over a separate \`/reviews\` page so the verdict signal lives alongside the live graph traffic, not one click away.

## Changes

- **\`dashboard/src/components/QuinnVerdictCounters.tsx\`** (new) — WS subscription, per-repo \`Map<owner/repo, Counts>\`, sorted by total volume, total row when >1 repo has activity. Auto-reconnect with 2s backoff matches SystemGraph's WS shape, so a workstacean restart doesn't kill the panel forever.
- **\`dashboard/src/components/SystemGraph.tsx\`** — mounts the panel inside the canvas wrapper (which now carries \`position: relative\` so the panel's absolute positioning anchors to it instead of the page body).

## Test plan

- [x] \`bun test\` (dashboard) — 14/0
- [x] \`bun test\` (root) — 734/0
- [x] \`bun tsc --noEmit\` (dashboard) — clean for new file
- [ ] After merge + image republish: open \`http://ava:3333/system\`, confirm panel appears top-right with \"connected\" status and "No verdicts observed yet" placeholder
- [ ] Open a test PR, Quinn submits a review → confirm the panel's count for that repo increments
- [ ] Workstacean restart while panel open → confirm status briefly flips to \"connecting\" / \"disconnected\" then back to \"connected\", counts persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a floating verdict counter panel displaying real-time Quinn review verdicts organized by repository, showing approval counts, change requests, and comments sorted by activity volume.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->