### PR TITLE
feat(observability): per-skill latency histogram tile + structured bus event (O-3)

### DIFF
--- a/dashboard/src/components/LatencyHistogram.tsx
+++ b/dashboard/src/components/LatencyHistogram.tsx
@@ -1,0 +1,227 @@
+/**
+ * LatencyHistogram — bottom-left floating panel on /system showing per-skill
+ * latency percentiles (count / p50 / p95 / max) since this dashboard tab
+ * opened.
+ *
+ * Subscribes to `agent.skill.latency` (published by SkillDispatcherPlugin
+ * after every webhook-stamped skill completion). Payload carries
+ * `{ skill, totalMs, queueMs, executeMs }` — we accumulate per-skill samples
+ * in a fixed-size ring (last 200 per skill) and re-compute the percentiles
+ * on every new sample. Cheap; the samples-per-skill count is bounded by
+ * webhook fan-in which is in the dozens per day at fleet size.
+ *
+ * "Since tab opened" rather than "rolling 24h" — server-side has no
+ * sliding-window store yet, and the BusHistoryRecorder ring (10k events,
+ * 30-min TTL) is too short for a useful baseline. v2 would seed from a
+ * dedicated latency-history store on the server; v1 starts at zero each
+ * fresh tab.
+ *
+ * Same WS + reconnect shape as QuinnVerdictCounters.
+ */
+
+import { useEffect, useState } from "preact/hooks";
+
+interface LatencyPayload {
+  skill?: string;
+  totalMs?: number;
+  queueMs?: number;
+  executeMs?: number;
+}
+
+/** Max samples retained per skill — newest-last ring. */
+const SAMPLE_CAP = 200;
+
+interface SkillSamples {
+  /** Total-latency samples in ms; ring of up to SAMPLE_CAP, newest-last. */
+  samples: number[];
+}
+
+interface Stats {
+  count: number;
+  p50: number;
+  p95: number;
+  max: number;
+}
+
+function statsFor(samples: number[]): Stats {
+  if (samples.length === 0) return { count: 0, p50: 0, p95: 0, max: 0 };
+  const sorted = [...samples].sort((a, b) => a - b);
+  const pick = (q: number) => sorted[Math.min(sorted.length - 1, Math.floor(q * sorted.length))]!;
+  return {
+    count: samples.length,
+    p50: pick(0.5),
+    p95: pick(0.95),
+    max: sorted[sorted.length - 1]!,
+  };
+}
+
+function fmt(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(ms < 10_000 ? 2 : 1)}s`;
+}
+
+export default function LatencyHistogram() {
+  const [perSkill, setPerSkill] = useState<Map<string, SkillSamples>>(new Map());
+  const [openedAt] = useState<number>(() => Date.now());
+  const [wsStatus, setWsStatus] = useState<"connecting" | "connected" | "disconnected">("connecting");
+
+  useEffect(() => {
+    const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const url = `${proto}//${window.location.host}/api/bus/subscribe?topic=agent.skill.latency`;
+    let ws: WebSocket | null = null;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let stopped = false;
+
+    const connect = () => {
+      ws = new WebSocket(url);
+      ws.onopen = () => setWsStatus("connected");
+      ws.onmessage = (e) => {
+        try {
+          const msg = JSON.parse(e.data) as { payload?: LatencyPayload };
+          const p = msg.payload;
+          if (!p?.skill || typeof p?.totalMs !== "number") return;
+          setPerSkill((cur) => {
+            const next = new Map(cur);
+            const existing = next.get(p.skill!) ?? { samples: [] };
+            const samples = [...existing.samples, p.totalMs!];
+            if (samples.length > SAMPLE_CAP) samples.splice(0, samples.length - SAMPLE_CAP);
+            next.set(p.skill!, { samples });
+            return next;
+          });
+        } catch {
+          // Ignore malformed frames.
+        }
+      };
+      ws.onclose = () => {
+        setWsStatus("disconnected");
+        if (stopped) return;
+        retryTimer = setTimeout(connect, 2000);
+      };
+      ws.onerror = () => ws?.close();
+    };
+    connect();
+
+    return () => {
+      stopped = true;
+      if (retryTimer) clearTimeout(retryTimer);
+      ws?.close();
+    };
+  }, []);
+
+  const rows = [...perSkill.entries()]
+    .map(([skill, s]) => ({ skill, ...statsFor(s.samples) }))
+    .sort((a, b) => b.count - a.count);
+
+  const sinceMin = Math.floor((Date.now() - openedAt) / 60_000);
+
+  return (
+    <aside class="lh-panel" aria-label="Per-skill latency since page load">
+      <header class="lh-head">
+        <h3>Skill latency</h3>
+        <p class="lh-meta">
+          since tab opened {sinceMin}m ago ·{" "}
+          <span class={`lh-status lh-status--${wsStatus}`}>{wsStatus}</span>
+        </p>
+      </header>
+
+      {rows.length === 0 ? (
+        <div class="lh-empty">No webhook-triggered completions observed yet.</div>
+      ) : (
+        <table class="lh-table">
+          <thead>
+            <tr>
+              <th>skill</th>
+              <th class="lh-num" title="sample count">n</th>
+              <th class="lh-num" title="median">p50</th>
+              <th class="lh-num" title="95th percentile">p95</th>
+              <th class="lh-num" title="max observed">max</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.skill}>
+                <td class="lh-skill" title={r.skill}>{r.skill}</td>
+                <td class="lh-num">{r.count}</td>
+                <td class="lh-num">{fmt(r.p50)}</td>
+                <td class="lh-num lh-p95">{fmt(r.p95)}</td>
+                <td class="lh-num lh-max">{fmt(r.max)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <style>{STYLES}</style>
+    </aside>
+  );
+}
+
+const STYLES = `
+  .lh-panel {
+    position: absolute;
+    bottom: 12px;
+    left: 12px;
+    z-index: 5;
+    min-width: 260px;
+    max-width: 360px;
+    background: rgba(13, 17, 23, 0.92);
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    color: #c9d1d9;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 0.8rem;
+    backdrop-filter: blur(4px);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  }
+  .lh-head {
+    padding: 0.5rem 0.75rem 0.4rem;
+    border-bottom: 1px solid #21262d;
+  }
+  .lh-head h3 {
+    margin: 0;
+    font-size: 0.85rem;
+    color: #e6edf3;
+  }
+  .lh-meta {
+    margin: 0.2rem 0 0;
+    color: #8b949e;
+    font-size: 0.7rem;
+  }
+  .lh-status { font-weight: 500; }
+  .lh-status--connected    { color: #3fb950; }
+  .lh-status--connecting   { color: #d29922; }
+  .lh-status--disconnected { color: #f85149; }
+  .lh-empty {
+    padding: 0.75rem;
+    color: #8b949e;
+    font-size: 0.75rem;
+  }
+  .lh-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.75rem;
+  }
+  .lh-table thead th {
+    text-align: left;
+    color: #6e7681;
+    font-weight: 500;
+    padding: 0.4rem 0.5rem;
+    border-bottom: 1px solid #21262d;
+  }
+  .lh-table th.lh-num { text-align: right; }
+  .lh-table td {
+    padding: 0.3rem 0.5rem;
+    border-bottom: 1px dashed #21262d;
+  }
+  .lh-table tbody tr:last-child td { border-bottom: none; }
+  .lh-num { text-align: right; width: 4rem; }
+  .lh-skill {
+    color: #c9d1d9;
+    max-width: 12rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .lh-p95 { color: #d29922; }
+  .lh-max { color: #f85149; }
+`;

--- a/dashboard/src/components/SystemGraph.tsx
+++ b/dashboard/src/components/SystemGraph.tsx
@@ -31,6 +31,7 @@ import AgentNode, { type AgentActivityState } from "./AgentNode.tsx";
 import ServiceNode from "./ServiceNode.tsx";
 import MessageDrawer, { type DrawerMessage } from "./MessageDrawer.tsx";
 import QuinnVerdictCounters from "./QuinnVerdictCounters.tsx";
+import LatencyHistogram from "./LatencyHistogram.tsx";
 
 /** Ring-buffer cap for per-topic history shown in the edge drawer. */
 const TOPIC_HISTORY_CAP = 20;
@@ -497,6 +498,7 @@ export default function SystemGraph() {
         <Controls position="bottom-right" />
       </ReactFlow>
       <QuinnVerdictCounters />
+      <LatencyHistogram />
       {openTopic && (
         <MessageDrawer
           topic={openTopic}

--- a/src/event-bus/all-topics.ts
+++ b/src/event-bus/all-topics.ts
@@ -59,6 +59,22 @@ export const ACTION_TOPICS = {
    * Full topic is `autonomous.outcome.{systemActor}.{skill}`.
    */
   AUTONOMOUS_OUTCOME_PREFIX: "autonomous.outcome",
+
+  /**
+   * Published by SkillDispatcherPlugin after every successful skill
+   * completion that came from a webhook-stamped dispatch (today: github's
+   * `_handleAutoReview`). Structured form of the existing
+   * `[skill-latency]` log line — dashboard tiles + downstream alerting
+   * can subscribe and accumulate without parsing stdout.
+   *
+   * Payload shape: { skill, totalMs, queueMs, executeMs, github? }.
+   *   - totalMs   = webhook arrival → done
+   *   - queueMs   = webhook arrival → dispatch start (bus hops + routing)
+   *   - executeMs = dispatch start → done (LLM + tools)
+   *   - github    = { owner, repo, number } when the original payload
+   *                 carried it (PR reviews, etc.); absent otherwise.
+   */
+  AGENT_SKILL_LATENCY: "agent.skill.latency",
 } as const;
 
 export const SECURITY_TOPICS = {

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -108,6 +108,7 @@ export class SkillDispatcherPlugin implements Plugin {
     "agent.runtime.activity.skill.start",
     "agent.runtime.activity.skill.complete",
     "agent.runtime.activity.skill.error",
+    "agent.skill.latency",
   ];
 
   private bus?: EventBus;
@@ -458,6 +459,34 @@ export class SkillDispatcherPlugin implements Plugin {
             `[skill-latency] ${skill} webhook→done ${(totalMs / 1000).toFixed(2)}s ` +
               `(queue ${queueMs}ms, execute ${(executeMs / 1000).toFixed(2)}s)${repoRef}`,
           );
+
+          // Structured form of the same data for dashboard tiles + future
+          // alerting subscribers (see all-topics.ts AGENT_SKILL_LATENCY).
+          // Best-effort: a publish failure must not poison the success path
+          // we're already on.
+          if (this.bus) {
+            try {
+              this.bus.publish("agent.skill.latency", {
+                id: crypto.randomUUID(),
+                correlationId,
+                topic: "agent.skill.latency",
+                timestamp: now,
+                payload: {
+                  skill,
+                  totalMs,
+                  queueMs,
+                  executeMs,
+                  github: gh?.owner && gh?.repo && gh?.number
+                    ? { owner: gh.owner, repo: gh.repo, number: gh.number }
+                    : undefined,
+                },
+              });
+            } catch (err) {
+              console.warn(
+                `[skill-dispatcher] failed to publish agent.skill.latency: ${err instanceof Error ? err.message : err}`,
+              );
+            }
+          }
         }
 
         this._publishActivity("skill.complete", {


### PR DESCRIPTION
## Summary

Second observability overlay on /system — bottom-left this time — surfaces per-skill latency percentiles (n / p50 / p95 / max) since the tab opened.

\`\`\`
┌─ Skill latency ─────────────┐
│ since tab opened 12m ago    │
│   connected                 │
│ ────────────────────────────│
│ skill         n  p50 p95 max│
│ pr_review     8  9s  18s 31s│
│ bug_triage    3  4s  5s   5s│
└─────────────────────────────┘
\`\`\`

Two halves:

## Server-side (new structured event)

\`src/executor/skill-dispatcher-plugin.ts\` now publishes a structured \`agent.skill.latency\` event alongside the existing \`[skill-latency]\` log line (added in PR-1 yesterday). Payload: \`{ skill, totalMs, queueMs, executeMs, github? }\`. Same trigger as the log — gated on \`payload.meta.webhookArrivedAt\` being set. Best-effort publish; a failure logs a warn but doesn't poison the success path.

Topic declared in \`all-topics.ts\` (ACTION_TOPICS group) + advertised in the dispatcher's \`publishes\` list.

## Dashboard-side

\`dashboard/src/components/LatencyHistogram.tsx\` mirrors QuinnVerdictCounters (O-2) in shape — WS subscription to \`agent.skill.latency\`, in-tab accumulation, 2s reconnect backoff. Per-skill ring of last 200 samples; recomputes p50/p95/max on every new sample. Sorted by sample count desc so the loudest skill is on top.

## Pattern locked in

Three slots on the SystemGraph corner-overlay system now:
- **Top-right** — Quinn verdict counters (O-2, #599)
- **Bottom-left** — Skill latency (O-3, this PR)
- Two corners still open for whatever's next

Same recipe each time: absolute-positioned panel inside SystemGraph's wrapper, subscribe to a single topic, accumulate in-tab.

## Test plan

- [x] \`bun test\` root — 734/0
- [x] \`bun test\` dashboard — 14/0
- [x] \`bun tsc --noEmit\` — clean on both
- [ ] After merge + image republish: open \`http://ava:3333/system\`, confirm latency panel appears bottom-left with \"No webhook-triggered completions observed yet\" placeholder
- [ ] Open a test PR, Quinn reviews → confirm a row appears for \`pr_review\` with n=1, p50/p95/max all equal to that first sample
- [ ] Workstacean stdout includes the existing \`[skill-latency]\` log line AND a \`/api/bus/history\` query for \`agent.skill.latency\` returns the structured event

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bottom-left floating latency histogram panel showing per-skill metrics (count, p50, p95, max)
  * Displays connection status and retries so users see data availability
  * Shows empty-state when no samples exist and sorts skills by sample count
  * Latency panel is now visible alongside the system graph view

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->