### PR TITLE
feat(dashboard): api-routes pseudo-publisher in SystemGraph (O-4)

### DIFF
--- a/dashboard/src/components/SystemGraph.tsx
+++ b/dashboard/src/components/SystemGraph.tsx
@@ -13,6 +13,10 @@
  * Phase 3 (D3): clicking an edge opens MessageDrawer with the last
  *   TOPIC_HISTORY_CAP messages observed on that topic + jump-to-trace
  *   links into /trace?correlationId=… (D1).
+ * O-4: synthesize an `api-routes` pseudo-publisher node for topics that
+ *   some plugin subscribes to but no Plugin declares as published —
+ *   typically HTTP-route-fired (src/api/*) signals. Without this, an
+ *   entire class of bus traffic is invisible in /system.
  *
  * Layout: three concentric zones.
  *   center  — agents (the action)
@@ -210,6 +214,71 @@ function buildGraph({ plugins, agents, agentActivity, activeEdges }: BuildArgs):
       animated: live,
       style: { stroke: live ? "#3fb950" : "#30363d", strokeWidth: live ? 2 : 1 },
     });
+  }
+
+  // 7. Orphan-publisher synthesis. Topics that some plugin subscribes to
+  // but no plugin publishes are typically fired from HTTP route handlers
+  // (src/api/*.ts) — not Plugin instances, so they're invisible in
+  // /api/bus/topology. Without surfacing them, an entire class of bus
+  // traffic has no edge in /system (e.g. quinn.review.submitted today).
+  //
+  // We collect the orphan literal topics here, draw a single synthetic
+  // `api-routes` pseudo-publisher node, and wire one edge per
+  // (topic, subscriber). The edge inherits the same active-animation
+  // behavior as the plugin↔plugin edges, so when an API route fires the
+  // topic the edge pulses too.
+  //
+  // Wildcard subscriptions ("#", "foo.#", "foo.*") are skipped — they
+  // match by-design and a wildcard with no matching publisher isn't
+  // necessarily an orphan, just a permissive listener.
+  const publishedTopics = new Set<string>();
+  for (const plugin of plugins) {
+    for (const topic of plugin.publishes ?? []) publishedTopics.add(topic);
+  }
+  const orphanEdges: Array<{ topic: string; subscriberName: string }> = [];
+  for (const subscriber of plugins) {
+    for (const subPattern of subscriber.subscribes ?? []) {
+      if (subPattern.includes("#") || subPattern.includes("*")) continue;
+      const matched = [...publishedTopics].some(
+        (p) => p === subPattern || topicMatches(p, subPattern),
+      );
+      if (!matched) {
+        orphanEdges.push({ topic: subPattern, subscriberName: subscriber.name });
+      }
+    }
+  }
+  if (orphanEdges.length > 0) {
+    nodes.push({
+      id: "api-routes",
+      position: ringPos(0, 1, 0, 500, 100), // floats near the top of the canvas
+      data: { label: "api-routes" },
+      style: {
+        background: "#1c2128",
+        color: "#d29922",
+        border: "1px dashed #d29922",
+        borderRadius: 6,
+        padding: "6px 10px",
+        fontSize: 11,
+        fontFamily: "ui-monospace, SFMono-Regular, monospace",
+      },
+    });
+    for (const { topic, subscriberName } of orphanEdges) {
+      const active = activeEdges.has(topic);
+      edges.push({
+        id: `api-routes->${subscriberName}:${topic}`,
+        source: "api-routes",
+        target: `plugin-${subscriberName}`,
+        label: topic,
+        animated: active,
+        style: {
+          stroke: active ? "#3fb950" : "#d29922",
+          strokeWidth: active ? 1.5 : 1,
+          strokeDasharray: active ? undefined : "4 4",
+          opacity: active ? 1 : 0.7,
+        },
+        labelStyle: { fill: "#d29922", fontSize: 9, fontFamily: "ui-monospace, monospace" },
+      });
+    }
   }
 
   return { nodes, edges };


### PR DESCRIPTION
## Summary

**Verification finding turned fix.** O-4 was meant to verify that \`quinn.review.submitted\` animates an edge in SystemGraph after PR-2 landed. Answer: **no**, because the publish happens from \`src/api/pr-inspector.ts\` (an HTTP route handler, not a Plugin) and \`/api/bus/topology\` only draws plugin-↔-plugin edges.

This isn't unique to that topic — any future HTTP-route-published signal will be invisible the same way. Fix: synthesize an \`api-routes\` pseudo-publisher node and wire one edge per orphan (topic, subscriber) pair.

\`\`\`
            ┌─ api-routes (amber, dashed) ─┐
            │                              │
            └──── quinn.review.submitted ──┴──→ quinn-review-notifier
            └──── (future routes...) ──────────→ (their subscribers)
\`\`\`

## Implementation

In \`buildGraph\` after the existing plugin↔plugin / plugin↔service / plugin↔agent edges:
- Collect \`publishedTopics\` from every \`plugin.publishes\`
- For each \`plugin.subscribes\` **literal** topic (skip \`#\` / wildcard patterns — they're permissive listeners, not orphan-fed), check whether any \`publishedTopic\` matches via the existing \`topicMatches\` helper
- Emit one edge per orphan with the same active-animation behavior as other edges
- Add the \`api-routes\` node only if at least one orphan exists

Visual treatment: dashed amber border + amber edges (vs solid blue for services, solid green for active traffic). Clicking opens MessageDrawer (D3) for that topic identically to plugin↔plugin edges.

## What this surfaces today

- \`quinn.review.submitted\` → \`quinn-review-notifier-plugin\` (the O-4 motivating case)

Future HTTP-route-published topics automatically pick up edges with no further code change.

## Test plan

- [x] \`bun test\` root — 734/0
- [x] \`bun test\` dashboard — 14/0
- [x] \`bun tsc --noEmit\` — clean
- [ ] After merge + image republish: \`http://ava:3333/system\` shows an amber \`api-routes\` node near the top, with a dashed edge to \`quinn-review-notifier\` labeled \`quinn.review.submitted\`
- [ ] Open a test PR with REQUEST_CHANGES verdict → confirm the edge pulses green during the publish
- [ ] Click the edge → MessageDrawer opens with the recent publish payload + jump-to-trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * System topology graph now displays pseudo-publisher connections for topics with subscribers but no declared publishers, including real-time animation reflecting system activity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/601?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->