### PR TITLE
feat(dashboard): architectural-column SystemGraph layout (D2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,14 @@ jobs:
         working-directory: dashboard
         run: bun install --frozen-lockfile
 
+      - name: Run dashboard tests
+        # Dashboard owns its own deps (preact/compat, @xyflow/react, …) —
+        # root `bun test` is scoped via root bunfig.toml to lib/ + src/
+        # only, so tests under dashboard/src/**/__tests__/ have to run
+        # here where dashboard node_modules is resolvable.
+        working-directory: dashboard
+        run: bun test
+
       - name: Build dashboard (astro build)
         working-directory: dashboard
         run: bun run build

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,16 @@
+# Root Bun config.
+#
+# [test] root: scope `bun test` discovery to the server side of the repo
+# (lib/ + src/) so we don't accidentally crawl into dashboard/, which is a
+# separate workspace with its own deps + tsconfig. The dashboard's tests
+# get run by the matching CI job in .github/workflows/build.yml — they
+# need `bun install` to happen inside dashboard/ first so dashboard-only
+# deps actually resolve.
+#
+# Without this, `bun test` at the repo root walks every *.test.ts including
+# dashboard/src/lib/__tests__/, which CI's root install can't satisfy and
+# silent test-discovery drift can pollute the "test" job's coverage with
+# tests that don't belong there. See build.yml's dashboard-job comment
+# block for the precedent and the 2026-04-11 incident it cites.
+[test]
+root = ["lib", "src"]

--- a/dashboard/src/components/SystemGraph.tsx
+++ b/dashboard/src/components/SystemGraph.tsx
@@ -32,6 +32,7 @@ import ServiceNode from "./ServiceNode.tsx";
 import MessageDrawer, { type DrawerMessage } from "./MessageDrawer.tsx";
 import QuinnVerdictCounters from "./QuinnVerdictCounters.tsx";
 import LatencyHistogram from "./LatencyHistogram.tsx";
+import { architecturalLayout } from "../lib/layout.ts";
 
 /** Ring-buffer cap for per-topic history shown in the edge drawer. */
 const TOPIC_HISTORY_CAP = 20;
@@ -106,13 +107,17 @@ function topicMatches(pattern: string, topic: string): boolean {
 }
 
 // ── Layout ───────────────────────────────────────────────────────────────────
-// Three concentric rings. Agents at center (smallest radius — they're the
-// focal point); plugins in the middle; services on the outside.
-
-function ringPos(idx: number, count: number, radius: number, cx = 500, cy = 380) {
-  const angle = (idx / Math.max(count, 1)) * Math.PI * 2 - Math.PI / 2; // start at top
-  return { x: cx + Math.cos(angle) * radius, y: cy + Math.sin(angle) * radius };
-}
+// Architectural-column layout (see ../lib/layout.ts). The protoWorkstacean
+// spine is trigger → router → dispatcher → executor → agent → external, so
+// the graph reads strictly left-to-right along that spine. Concentric rings
+// (#555) and force-directed dagre both produced technically-correct but
+// noisy placements that didn't surface the architecture; this version
+// hand-classifies every plugin into a named column and stacks vertically
+// within the column.
+//
+// PLACEHOLDER_POS is what buildGraph stamps on every node; architecturalLayout
+// overwrites all positions at the end so the placeholders never reach React Flow.
+const PLACEHOLDER_POS = { x: 0, y: 0 };
 
 interface BuildArgs {
   plugins: PluginTopologyEntry[];
@@ -130,7 +135,7 @@ function buildGraph({ plugins, agents, agentActivity, activeEdges }: BuildArgs):
     nodes.push({
       id: `agent-${a.name}`,
       type: "agent",
-      position: ringPos(idx, agents.length, 180),
+      position: PLACEHOLDER_POS,
       data: { label: a.name, type: a.type, activity: agentActivity.get(a.name) },
     });
   });
@@ -139,7 +144,7 @@ function buildGraph({ plugins, agents, agentActivity, activeEdges }: BuildArgs):
   plugins.forEach((p, idx) => {
     nodes.push({
       id: `plugin-${p.name}`,
-      position: ringPos(idx, plugins.length, 380),
+      position: PLACEHOLDER_POS,
       data: { label: p.name },
       style: {
         background: "#161b22",
@@ -158,7 +163,7 @@ function buildGraph({ plugins, agents, agentActivity, activeEdges }: BuildArgs):
     nodes.push({
       id: s.id,
       type: "service",
-      position: ringPos(idx, SERVICES.length, 580),
+      position: PLACEHOLDER_POS,
       data: { label: s.label, icon: s.icon, description: s.description },
     });
   });
@@ -251,7 +256,7 @@ function buildGraph({ plugins, agents, agentActivity, activeEdges }: BuildArgs):
   if (orphanEdges.length > 0) {
     nodes.push({
       id: "api-routes",
-      position: ringPos(0, 1, 0, 500, 100), // floats near the top of the canvas
+      position: PLACEHOLDER_POS,
       data: { label: "api-routes" },
       style: {
         background: "#1c2128",
@@ -282,7 +287,7 @@ function buildGraph({ plugins, agents, agentActivity, activeEdges }: BuildArgs):
     }
   }
 
-  return { nodes, edges };
+  return architecturalLayout(nodes, edges);
 }
 
 // ── Activity event → agent state machine ─────────────────────────────────────

--- a/dashboard/src/lib/__tests__/layout.test.ts
+++ b/dashboard/src/lib/__tests__/layout.test.ts
@@ -1,0 +1,87 @@
+import { describe, test, expect } from "bun:test";
+import type { Edge, Node } from "@xyflow/react";
+import { architecturalLayout, COLUMNS } from "../layout.ts";
+
+function pluginNode(name: string): Node {
+  return { id: `plugin-${name}`, position: { x: 0, y: 0 }, data: { label: name } };
+}
+
+function agentNode(name: string): Node {
+  return { id: `agent-${name}`, type: "agent", position: { x: 0, y: 0 }, data: { label: name } };
+}
+
+function serviceNode(id: string): Node {
+  return { id, type: "service", position: { x: 0, y: 0 }, data: { label: id } };
+}
+
+describe("architecturalLayout", () => {
+  test("assigns column-based x coordinates left-to-right along the spine", () => {
+    const nodes: Node[] = [
+      pluginNode("debug"),       // system    — leftmost
+      pluginNode("github"),      // surface
+      pluginNode("router"),      // router
+      pluginNode("skill-dispatcher"), // dispatcher
+      pluginNode("agent-runtime"),    // executor
+      agentNode("quinn"),        // agent
+      serviceNode("svc-litellm"),     // service   — rightmost
+    ];
+    const { nodes: out } = architecturalLayout(nodes, []);
+    const x = (id: string) => out.find(n => n.id === id)!.position.x;
+
+    expect(x("plugin-debug")).toBeLessThan(x("plugin-github"));
+    expect(x("plugin-github")).toBeLessThan(x("plugin-router"));
+    expect(x("plugin-router")).toBeLessThan(x("plugin-skill-dispatcher"));
+    expect(x("plugin-skill-dispatcher")).toBeLessThan(x("plugin-agent-runtime"));
+    expect(x("plugin-agent-runtime")).toBeLessThan(x("agent-quinn"));
+    expect(x("agent-quinn")).toBeLessThan(x("svc-litellm"));
+  });
+
+  test("nodes in the same column share an x and stack vertically", () => {
+    const nodes: Node[] = [
+      pluginNode("github"),
+      pluginNode("linear"),
+      pluginNode("discord"),
+    ];
+    const { nodes: out } = architecturalLayout(nodes, []);
+    const xs = new Set(out.map(n => n.position.x));
+    expect(xs.size).toBe(1); // all surface column
+
+    const ys = out.map(n => n.position.y).sort((a, b) => a - b);
+    expect(ys[0]).not.toBe(ys[1]);
+    expect(ys[1]).not.toBe(ys[2]);
+  });
+
+  test("api-routes pseudo-node lands in the surface column", () => {
+    const nodes: Node[] = [
+      { id: "api-routes", position: { x: 0, y: 0 }, data: { label: "api-routes" } },
+      pluginNode("github"),
+    ];
+    const { nodes: out } = architecturalLayout(nodes, []);
+    const api = out.find(n => n.id === "api-routes")!;
+    const gh  = out.find(n => n.id === "plugin-github")!;
+    expect(api.position.x).toBe(gh.position.x);
+  });
+
+  test("unknown plugin name falls into misc column (rightmost)", () => {
+    const nodes: Node[] = [
+      pluginNode("brand-new-plugin-no-classification"),
+      pluginNode("router"),
+    ];
+    const { nodes: out } = architecturalLayout(nodes, []);
+    const unknown = out.find(n => n.id === "plugin-brand-new-plugin-no-classification")!;
+    const router  = out.find(n => n.id === "plugin-router")!;
+    expect(unknown.position.x).toBeGreaterThan(router.position.x);
+  });
+
+  test("columns array exposes the ordered spine", () => {
+    expect(COLUMNS[0]).toBe("system");
+    expect(COLUMNS[COLUMNS.length - 1]).toBe("misc");
+    expect(COLUMNS.includes("agent")).toBe(true);
+  });
+
+  test("preserves edges array unchanged", () => {
+    const edges: Edge[] = [{ id: "a-b", source: "x", target: "y" }];
+    const out = architecturalLayout([pluginNode("router")], edges);
+    expect(out.edges).toBe(edges);
+  });
+});

--- a/dashboard/src/lib/layout.ts
+++ b/dashboard/src/lib/layout.ts
@@ -1,0 +1,142 @@
+/**
+ * Architectural-column layout for the SystemGraph.
+ *
+ * The protoWorkstacean spine (per CLAUDE.md) is
+ *
+ *   trigger → router → dispatcher → executor → agent → external
+ *
+ * The concentric-ring layout that #555 shipped didn't surface that
+ * shape, and a generic force-directed algorithm (dagre, elk) wouldn't
+ * either — both produce technically-correct-but-noisy placements that
+ * obscure the architecture.
+ *
+ * This layout hand-classifies each node into one of eight columns and
+ * stacks vertically within the column. The result reads strictly
+ * left-to-right along the spine: system internals on the far left,
+ * external services on the far right, agents one column inside that.
+ *
+ * Plugins are matched by name (per-name override table). Anything
+ * unrecognized falls into the `misc` column so it's visible without a
+ * code change — adding a real classification is then a one-line append
+ * to PLUGIN_COLUMN_OVERRIDES.
+ */
+
+import type { Node, Edge } from "@xyflow/react";
+
+export const COLUMNS = [
+  "system",     // debug, logger, recorders
+  "surface",    // inbound surface plugins + the api-routes pseudo-node
+  "bridge",     // cross-surface translators (linear→protomaker, etc.)
+  "router",     // the unique router
+  "dispatcher", // skill-dispatcher + sibling intercept layer
+  "executor",   // skill-executor registrars + skill-side plugins
+  "agent",      // agents from /api/agents/runtime
+  "service",    // external services on the perimeter
+  "misc",       // unclassified — visible but not laid out architecturally
+] as const;
+
+export type Column = (typeof COLUMNS)[number];
+
+/** Hard overrides for plugin names to architectural column. */
+const PLUGIN_COLUMN_OVERRIDES: Record<string, Column> = {
+  "router":                                  "router",
+  "skill-dispatcher":                        "dispatcher",
+  "skill-ab-test":                           "dispatcher",
+  "agent-runtime":                           "executor",
+  "skill-broker":                            "executor",
+  "alert-skill-executor":                    "executor",
+  "ceremony-skill-executor":                 "executor",
+  "pr-remediator-skill-executor":            "executor",
+  "clawpatch-cache-cleanup-skill-executor":  "executor",
+  "quinn-review-notifier":                   "executor",
+  "feature-notifier":                        "executor",
+  "ceremony":                                "executor",
+  "pr-remediator":                           "executor",
+  "agent-fleet-health":                      "executor",
+  "operator-routing":                        "executor",
+  "google":                                  "executor",
+  "a2a-delivery":                            "executor",
+  "linear-protomaker-bridge":                "bridge",
+  "debug":                                   "system",
+  "logger":                                  "system",
+  "bus-history-recorder":                    "system",
+  "event-viewer":                            "system",
+  "cli":                                     "system",
+  "signal":                                  "system",
+  "scheduler":                               "surface",
+  "onboarding":                              "surface",
+  "discord":                                 "surface",
+  "github":                                  "surface",
+  "linear":                                  "surface",
+};
+
+function pluginColumn(name: string): Column {
+  return PLUGIN_COLUMN_OVERRIDES[name] ?? "misc";
+}
+
+function nodeColumn(n: Node): Column {
+  // Surface pseudo-publisher synthesized by SystemGraph (O-4).
+  if (n.id === "api-routes") return "surface";
+  if (n.type === "agent")    return "agent";
+  if (n.type === "service")  return "service";
+  if (n.id.startsWith("plugin-")) return pluginColumn(n.id.slice("plugin-".length));
+  return "misc";
+}
+
+/**
+ * Per-column x offset. Wider gaps between columns where edges cross
+ * heavily (executor → agent) keep the label space breathable.
+ */
+const COLUMN_X: Record<Column, number> = {
+  system:       80,
+  surface:     320,
+  bridge:      560,
+  router:      800,
+  dispatcher: 1040,
+  executor:   1340,
+  agent:      1700,
+  service:    2000,
+  misc:       2280,
+};
+
+const ROW_HEIGHT_BY_TYPE: Record<string, number> = {
+  agent:   120,
+  service: 90,
+};
+const DEFAULT_ROW_HEIGHT = 64;
+
+function rowHeightFor(n: Node): number {
+  return ROW_HEIGHT_BY_TYPE[n.type ?? ""] ?? DEFAULT_ROW_HEIGHT;
+}
+
+/**
+ * Lay out every node into its architectural column. Within a column,
+ * nodes stack vertically in input order with the column centered around
+ * y = 0. React Flow's `fitView` pans the result into view regardless
+ * of where it lands.
+ */
+export function architecturalLayout(
+  nodes: Node[],
+  edges: Edge[],
+): { nodes: Node[]; edges: Edge[] } {
+  const buckets = new Map<Column, Node[]>();
+  for (const col of COLUMNS) buckets.set(col, []);
+  for (const n of nodes) buckets.get(nodeColumn(n))!.push(n);
+
+  const laidOut: Node[] = [];
+  for (const col of COLUMNS) {
+    const stack = buckets.get(col)!;
+    if (stack.length === 0) continue;
+
+    const totalHeight = stack.reduce((acc, n) => acc + rowHeightFor(n), 0);
+    let y = -totalHeight / 2;
+    const x = COLUMN_X[col];
+
+    for (const n of stack) {
+      laidOut.push({ ...n, position: { x, y } });
+      y += rowHeightFor(n);
+    }
+  }
+
+  return { nodes: laidOut, edges };
+}


### PR DESCRIPTION
## Summary

Replaces #555's concentric-ring layout with a hand-classified architectural-column layout that maps directly onto the CLAUDE.md spine. Closes #582 (which kept conflicting on rebase across this morning's PRs — easier to re-open clean).

\`\`\`
[system] → [surface] → [bridge] → [router] → [dispatcher] → [executor] → [agent] → [service] → [misc]
\`\`\`

Every plugin is classified into a column via \`PLUGIN_COLUMN_OVERRIDES\`. Within a column, nodes stack vertically; \`fitView\` pans the whole graph into view. Unclassified plugins land in \`misc\` (rightmost) — visible without a code change, one-line append fixes them.

## Why hand-classified

Dagre / elk produce technically-correct-but-noisy placements that don't surface the architecture. The trigger → router → dispatcher → executor → agent → external flow IS the mental model — the layout should literalize it, not auto-derive it from edge weights. ~50 LOC of hand-classification beats ~150 KB of dagre + node-size heuristics that still wouldn't read as well.

## Changes

- **\`dashboard/src/lib/layout.ts\`** (new) — \`architecturalLayout()\` + \`COLUMNS\` + \`PLUGIN_COLUMN_OVERRIDES\` table
- **\`dashboard/src/components/SystemGraph.tsx\`** — stamps \`PLACEHOLDER_POS\` on every node (was \`ringPos\`), calls \`architecturalLayout\` at the end of \`buildGraph\`
- **\`bunfig.toml\`** (new) — scopes \`bun test\` to \`lib/\`+\`src/\`, so dashboard tests don't get crawled by the root test job (broke when \`layout.test.ts\` imported dashboard-only deps)
- **\`.github/workflows/build.yml\`** — adds dashboard \`bun test\` step so layout tests still get exercised by CI

## Test plan

- [x] \`bun test\` root — 740 / 0
- [x] \`bun test\` dashboard — 20 / 0 (6 new layout tests asserting column ordering, intra-column same-x stacking, misc fallthrough, api-routes-in-surface, edges unchanged)
- [x] \`bun tsc --noEmit\` — clean
- [ ] Live: \`http://ava:3333/system\` renders left-to-right with clean column spacing; api-routes (amber) sits in the surface column above github/linear/discord

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System graph now uses a left-to-right architectural layout with column stacking for clearer topology.

* **Tests**
  * Added unit tests verifying column placement, stacking, special-node placement, and edge preservation.

* **Chores**
  * Updated test discovery configuration and CI to run dashboard-specific tests separately.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->