### PR TITLE
fix(agents.yaml): correct protomaker hostname, retire protopen (#593 root cause)

### DIFF
--- a/workspace/agents.yaml
+++ b/workspace/agents.yaml
@@ -35,21 +35,26 @@ agents:
   #     - message.inbound.discord.#
   #     - message.inbound.github.#
 
-  # protoMaker — Automaker-server agent (apps/server in protoLabsAI/ava).
-  # Hosts the project board, auto-mode runtime, and feature/PR pipeline.
-  # Reached on the docker-ai network as automaker-server:3008/a2a; advertises
+  # protoMaker — board + auto-mode + feature/PR pipeline agent.
+  # Reached on the docker-ai network as protomaker-server:3008/a2a; advertises
   # 10 skills (chat, sitrep, manage_feature, auto_mode, board_health,
   # bug_triage, onboard_project, provision_discord, plan, plan_resume).
   # Auth: AVA_API_KEY (the same Ava-app key used for HTTP /api/* — protoMaker
   # validates X-API-Key against its per-app key table).
   #
-  # No subscribesTo: protoMaker is reached via explicit GOAP `targets:
+  # Hostname history: originally `automaker-server` in the legacy
+  # protoLabsAI/ava monorepo. Renamed to `protomaker-server` when the
+  # container was lifted into its own image (homelab-iac/stacks/ai). This
+  # yaml lagged behind the rename, causing weeks of silent zero-skill
+  # registrations (#593). Re-aligned 2026-05-26.
+  #
+  # No subscribesTo: protoMaker is reached via explicit `targets:
   # [protomaker]` dispatches (board_health, auto_mode, bug_triage etc.) — it
   # is not a broadcast inbound listener. Quinn already subscribes to GitHub
   # inbound and triages on protoMaker's behalf via `bug_triage`; adding a
   # second subscriber here would duplicate dispatch with no extra value.
   - name: protomaker
-    url: http://automaker-server:3008/a2a
+    url: http://protomaker-server:3008/a2a
     auth:
       scheme: apiKey
       credentialsEnv: AVA_API_KEY
@@ -58,15 +63,21 @@ agents:
   # protopen — security/pentest/RF recon. Remote via Tailscale
   # (PROTOPEN_BASE_URL defaults to http://steamdeck:7870 in homelab-iac).
   # Serves the legacy /.well-known/agent.json path; advertises streaming:true.
-  - name: protopen
-    url: ${PROTOPEN_BASE_URL}/a2a
-    auth:
-      scheme: apiKey
-      credentialsEnv: PROTOPEN_API_KEY
-    streaming: true
-    # Runs off-docker on steamdeck via Tailscale — push-notification callback
-    # URLs must use WORKSTACEAN_BASE_URL (the operator-configured Tailscale
-    # hostname) rather than the docker-internal workstacean:3000.
-    external: true
-    subscribesTo:
-      - message.inbound.discord.#
+  #
+  # COMMENTED OUT 2026-05-26 — `steamdeck` tailnet node is offline (last seen
+  # 10d ago per `tailscale status`), so card discovery 404'd silently for
+  # the whole fleet. Same rationale as the `frank` entry above: don't
+  # register a dead executor + spam card-discovery 404s every 10 min while
+  # the host is down. Reinstate this block when steamdeck comes back online
+  # (verify with `tailscale status | grep steamdeck` shows `active`, not
+  # `offline`).
+  #
+  # - name: protopen
+  #   url: ${PROTOPEN_BASE_URL}/a2a
+  #   auth:
+  #     scheme: apiKey
+  #     credentialsEnv: PROTOPEN_API_KEY
+  #   streaming: true
+  #   external: true
+  #   subscribesTo:
+  #     - message.inbound.discord.#


### PR DESCRIPTION
## Summary

Substantive fix for **#593** (\"A2A agent card advertises zero skills\"). Diagnostic PR #608 made the failure cause loggable; direct probe from inside the workstacean container surfaced it before #608 even finished its deploy.

Two distinct reasons both A2A peers had card discovery 404'ing in silence:

### protomaker — stale hostname
yaml's url \`http://automaker-server:3008/a2a\` dereferences \`automaker-server\`, which **doesn't resolve** in the current docker network. The actual container is \`protomaker-server\` (renamed when the image was lifted out of the legacy protoLabsAI/ava monorepo); the yaml lagged behind.

\`\`\`
docker exec workstacean curl -sS http://protomaker-server:3008/.well-known/agent-card.json
→ HTTP 200, 10 skills as advertised
\`\`\`

### protopen — host offline
\`PROTOPEN_BASE_URL=http://steamdeck:7870\`. \`tailscale status\` shows steamdeck as **\"offline, last seen 10d ago\"**. The whole machine is down — no amount of routing will make it answer. Same situation \`frank\` is already in (commented out in this file), so this PR follows that pattern: comment out the entry with a comment telling future-me when to reinstate (when \`tailscale status | grep steamdeck\` shows \`active\`).

## Effect after deploy

- **protomaker** registers 10 skills on next workstacean restart. \`/api/agents/runtime\` drops the \`pendingDiscovery: true\` flag; downstream \`chat_with_agent\` dispatches to protomaker stop 404'ing.
- **protopen** stops emitting the new \"card discovery failed\" warning every 10-min refresh cycle (which #608 just made loud).

## Related

- Closes #593, #594.
- Probably closes #592 (fleet-health auto-triage false-orphans for protomaker once it registers).
- #608 stays in dev as the always-on safety net for the next time card discovery silently regresses.

## Test plan

- [x] \`bun test\` — 740/0 (no test changes; yaml-only)
- [x] \`bun tsc --noEmit\` clean
- [ ] Live after merge + watchtower pull: \`docker logs workstacean | grep skill-broker\` shows \`protomaker: discovered N new skill(s)\` instead of the new \`card discovery failed\` warning
- [ ] \`/api/agents/runtime\` shows protomaker with non-empty \`skills\` array + no \`pendingDiscovery\` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)