### PR TITLE
chore(docs+yaml): default agent model alias → protolabs/reasoning

### DIFF
--- a/docs/guides/add-an-agent.md
+++ b/docs/guides/add-an-agent.md
@@ -25,8 +25,12 @@ name: my-agent
 # Options: orchestrator | qa | devops | content | research | general
 role: general
 
-# LLM model alias recognised by your gateway.
-model: claude-sonnet-4-6
+# LLM model alias recognised by your gateway. `protolabs/reasoning` is
+# the standard fleet default — LiteLLM resolves it to whichever model
+# is currently provisioned for reasoning workloads. Concrete model
+# names (claude-sonnet-4-6 / claude-opus-4-7 / claude-haiku-4-5-…)
+# also work and bypass the gateway-side alias.
+model: protolabs/reasoning
 
 # Full system prompt injected on every turn.
 systemPrompt: |

--- a/docs/integrations/runtimes/deep-agent.md
+++ b/docs/integrations/runtimes/deep-agent.md
@@ -142,7 +142,7 @@ Tools are defined as LangChain tools with zod schemas in `DeepAgentExecutor`. Ea
 
 ## LLM gateway
 
-All LLM calls route through LiteLLM at `LLM_GATEWAY_URL` (or `OPENAI_BASE_URL`). The executor creates a `ChatOpenAI` instance with the gateway as `baseURL` and `OPENAI_API_KEY` for auth. Model aliases (e.g. `claude-sonnet-4-6`) are resolved by the gateway.
+All LLM calls route through LiteLLM at `LLM_GATEWAY_URL` (or `OPENAI_BASE_URL`). The executor creates a `ChatOpenAI` instance with the gateway as `baseURL` and `OPENAI_API_KEY` for auth. Model aliases (e.g. `protolabs/reasoning`, `claude-sonnet-4-6`) are resolved by the gateway.
 
 ## Observability
 

--- a/docs/reference/agent-skills.md
+++ b/docs/reference/agent-skills.md
@@ -53,7 +53,7 @@ Create `workspace/agents/<name>.yaml`:
 ```yaml
 name: my-agent
 role: general                   # orchestrator | qa | devops | content | research | general
-model: claude-sonnet-4-6
+model: protolabs/reasoning      # gateway alias; e.g. claude-sonnet-4-6 / claude-opus-4-7 also work
 systemPrompt: |
   You are MyAgent. Your job is...
 tools:

--- a/docs/reference/config-files.md
+++ b/docs/reference/config-files.md
@@ -104,8 +104,10 @@ Per-agent definition for the **in-process** `AgentRuntimePlugin`. One file per a
 name: quinn                         # unique agent key — used in skill routing
 role: qa                            # orchestrator | qa | devops | content | research | general
 
-# LLM model alias — resolved by the gateway (LiteLLM Proxy at LLM_GATEWAY_URL)
-model: claude-sonnet-4-6
+# LLM model alias — resolved by the gateway (LiteLLM Proxy at LLM_GATEWAY_URL).
+# `protolabs/reasoning` is the standard fleet default; concrete names like
+# `claude-sonnet-4-6` / `claude-opus-4-7` also work.
+model: protolabs/reasoning
 
 systemPrompt: |
   You are Quinn, the QA Engineer for protoLabs AI.

--- a/docs/reference/workspace-files.md
+++ b/docs/reference/workspace-files.md
@@ -69,7 +69,7 @@ In-process agent definition. One file per agent. Read by `AgentRuntimePlugin`.
 ```yaml
 name: string                    # Must be globally unique and match the filename
 role: orchestrator | qa | devops | content | research | general
-model: string                   # LLM model alias (e.g. "claude-sonnet-4-6")
+model: string                   # LLM model alias (e.g. "protolabs/reasoning", "claude-sonnet-4-6")
 systemPrompt: string            # Full system prompt
 tools:                          # Workstacean bus tools this agent may call
   - string                      # publish_event | get_world_state | get_incidents |
@@ -95,7 +95,7 @@ skills:
 # workspace/agents/ava.yaml
 name: ava
 role: general
-model: claude-sonnet-4-6
+model: protolabs/reasoning
 systemPrompt: |
   You are Ava, a conversational protoAgent. Your job is to be a
   thoughtful chat partner. You have no tools — when a request needs

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -77,7 +77,7 @@ chat-only Ava:
 ```yaml
 name: ava
 role: general
-model: claude-sonnet-4-6
+model: protolabs/reasoning
 systemPrompt: |
   You are Ava, a conversational protoAgent. You answer questions
   and think out loud with the user. You have no tools — when a

--- a/src/agent-runtime/types.ts
+++ b/src/agent-runtime/types.ts
@@ -73,7 +73,12 @@ export interface AgentDefinition {
 
   /**
    * LLM model alias as recognised by the gateway.
-   * Example: "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"
+   * Fleet default: "protolabs/reasoning" (LiteLLM resolves it to whichever
+   * concrete model is currently provisioned for reasoning workloads).
+   * Concrete names also work — e.g. "claude-opus-4-7", "claude-sonnet-4-6",
+   * "claude-haiku-4-5-20251001" — and bypass the gateway-side alias.
+   * Per-call override: dispatch payload may carry `model: "<alias>"` to
+   * temporarily swap this for one invocation (wired in #613).
    */
   model: string;
 

--- a/workspace/agents/proto.yaml
+++ b/workspace/agents/proto.yaml
@@ -27,9 +27,12 @@ name: proto
 role: general
 runtime: proto-sdk
 
-# Sonnet 4.6 for cost/quality balance. Override per-call via
-# payload.model when a heavier task warrants Opus.
-model: claude-sonnet-4-6
+# Default to the gateway's `protolabs/reasoning` alias — matches Ava /
+# Quinn and lets the LiteLLM gateway pick the right backing model based
+# on its current routing config. Override per-call via payload.model
+# (e.g. claude-opus-4-7 for an Opus escalation, claude-haiku-4-5-… for
+# a cheap one-shot) — wired in #613.
+model: protolabs/reasoning
 
 systemPrompt: |
   You are proto, the protoLabs fleet's in-process coding and research

--- a/workspace/agents/quinn.yaml.example
+++ b/workspace/agents/quinn.yaml.example
@@ -8,7 +8,7 @@
 name: quinn
 role: qa
 
-model: claude-sonnet-4-6
+model: protolabs/reasoning
 
 systemPrompt: |
   You are Quinn, the QA Engineer for protoLabs AI.


### PR DESCRIPTION
## Summary

proto.yaml shipped (#612) with \`claude-sonnet-4-6\` as its declared default, but the fleet convention everywhere else (Ava, Quinn) is **\`protolabs/reasoning\`** — the LiteLLM gateway alias that resolves to whichever concrete model is currently provisioned. Aligning proto with the convention and updating every doc + example yaml that still showed \`claude-sonnet-4-6\` so new agents land with the right pattern by copy-paste.

## Files touched

| File | What |
|---|---|
| \`workspace/agents/proto.yaml\` | model default + comment block updated |
| \`workspace/agents/quinn.yaml.example\` | example fixture |
| \`docs/integrations/runtimes/deep-agent.md\` | gateway-alias prose |
| \`docs/reference/agent-skills.md\` | agent yaml example |
| \`docs/reference/workspace-files.md\` | type docstring + example |
| \`docs/reference/config-files.md\` | example with new comment block |
| \`docs/tutorials/getting-started.md\` | getting-started example |
| \`docs/guides/add-an-agent.md\` | primary onboarding doc — expanded comment explaining alias vs concrete model |
| \`src/agent-runtime/types.ts\` | AgentDefinition.model JSDoc + pointer to per-call payload.model override from #613 |

Concrete model names (\`claude-opus-4-7\` / \`claude-sonnet-4-6\` / \`claude-haiku-4-5-…\`) still work; they're documented as bypass options. **No behavioural change** — just default-pattern alignment + doc sweep.

## Test plan

- [x] \`bun test\` — 756/0
- [x] \`bun tsc --noEmit\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)