### PR TITLE
docs(architecture): per-flow deep dives + chokepoint cross-cut

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,103 @@
+---
+title: Architecture — Flow Reference
+---
+
+_Architectural deep-dives for every flow in protoWorkstacean. The complement to [CLAUDE.md](../../CLAUDE.md): CLAUDE.md tells you what the system **is**; this section tells you what it **does**, one flow at a time._
+
+---
+
+## What's in here
+
+Nine flows + one cross-cut. Each doc has the same shape:
+
+- **What & why** — one paragraph
+- **ASCII spine** — terminal-readable shape of the flow
+- **Mermaid sequence** — exact bus topics + plugin participation
+- **Topic table** — what each topic is, who publishes, who subscribes
+- **Failure modes & gotchas** — what happens when things break
+
+---
+
+## The spine — every flow lives on it
+
+```
+                                                                  ┌────────────────────┐
+                                                                  │   workspace/*.yaml │
+                                                                  │  (channels, agents,│
+                                                                  │   ceremonies, …)   │
+                                                                  └─────────┬──────────┘
+                                                                            │ declarative config
+                                                                            ▼
+   ┌──────────────┐    message.inbound.*    ┌──────────┐  agent.skill.request   ┌──────────────┐
+   │  TRIGGERS    │ ─────────────────────►  │  ROUTER  │ ─────────────────────► │  DISPATCHER  │
+   │              │                         │          │                        │ (chokepoint) │
+   │ Discord      │                         │ keyword/ │                        │              │
+   │ GitHub       │                         │ channel  │                        │ • cooldown   │
+   │ Linear       │                         │ → skill  │                        │ • registry   │
+   │ Google       │                         │          │                        │ • outcome    │
+   │ Scheduler    │ ── cron.* ──────────────┴──────────┘                        │   publish    │
+   │ Ceremonies   │ ── ceremony.{id}.execute ───────────────────────────────────┤              │
+   │ Alerts/PR-R  │ ── action.*, pr.remediate.* ────────────────────────────────┘              │
+   └──────────────┘                                                              └──────┬───────┘
+                                                                                        │ dispatch
+                                                                                        ▼
+                                                                            ┌──────────────────────┐
+                                                                            │  EXECUTOR REGISTRY   │
+                                                                            │   (priority-sorted)  │
+                                                                            └─────┬──────────┬─────┘
+                                                                                  │          │
+                                                              ┌───────────────────┘          └────────┐
+                                                              ▼                                       ▼
+                                                  ┌────────────────────┐                  ┌──────────────────┐
+                                                  │  DeepAgentExecutor │                  │ FunctionExecutor │
+                                                  │  ProtoSdkExecutor  │                  │  (alert/ceremony │
+                                                  │   A2AExecutor      │                  │   /pr-remediator)│
+                                                  └─────────┬──────────┘                  └────────┬─────────┘
+                                                            │ message.outbound.*                   │
+                                                            │ linear.reply.{id}                    │
+                                                            │ agent.skill.response.{cid}           │
+                                                            ▼                                       │
+                                                  ┌────────────────────┐                            │
+                                                  │  PLATFORM SINKS    │  ◄─────────────────────────┘
+                                                  │  Discord / GitHub  │
+                                                  │  Linear / Google   │
+                                                  └────────────────────┘
+```
+
+Everything else — telemetry, dashboard, HITL, fleet health — observes this spine from the side.
+
+---
+
+## Flow inventory
+
+| # | Doc | Entry trigger | Terminal topic |
+|---|---|---|---|
+| 1 | [flow-inbound-message](flow-inbound-message.md) | `message.inbound.{platform}.*` | `message.outbound.{platform}.*` |
+| 2 | [flow-linear-bridges](flow-linear-bridges.md) | `message.inbound.linear.issue.created` (label-gated) | `linear.reply.{issueId}` |
+| 3 | [flow-ceremonies](flow-ceremonies.md) | cron tick / external trigger | `ceremony.{id}.completed` + `autonomous.outcome.ceremony.{id}.{skill}` |
+| 4 | [flow-pr-review](flow-pr-review.md) | `message.inbound.github.{owner}.{repo}.pull_request.{n}` | GitHub review (APPROVED / COMMENTED / CHANGES_REQUESTED) |
+| 5 | [flow-alert-remediator](flow-alert-remediator.md) | fleet-health threshold trip → `action.*` / `pr.remediate.*` | `message.outbound.discord.alert` / GitHub mutation |
+| 6 | [flow-hitl](flow-hitl.md) | escalation site (stuck PR, destructive verdict) | `operator.message.request` → Discord DM |
+| 7 | [flow-agent-runtime-telemetry](flow-agent-runtime-telemetry.md) | executor lifecycle | `agent.runtime.activity.*`, `agent.skill.progress.*`, `agent.skill.latency`, `autonomous.outcome.*` |
+| 8 | [flow-a2a-discovery](flow-a2a-discovery.md) | process startup | ExecutorRegistry enrollment |
+| 9 | [flow-dashboard](flow-dashboard.md) | BusHistoryRecorder + API routes | dashboard tiles |
+| ✕ | [chokepoint-invariants](chokepoint-invariants.md) (cross-cut) | every `agent.skill.request` | drop + telemetry, or pass-through |
+
+---
+
+## How to read a flow doc
+
+Every flow doc cites file:line for every topic and plugin claim. If something diverges from the doc, **the code is the source of truth** — file an issue (or fix the doc) rather than assuming the doc is right.
+
+Mermaid sequence diagrams use these conventions:
+
+- **Solid arrow** (`->>`) — synchronous bus publish
+- **Dashed arrow** (`-->>`) — async response on a reply topic
+- **Note over X** — a chokepoint check or persistence write
+- **rect** block — a chokepoint or invariant region
+
+---
+
+## Discovering new flows
+
+If you add a new trigger surface or a new self-contained sub-pipeline, add a doc here in the same shape. The index table is the single source of "flows we know about" — keeping it complete is what keeps this folder useful.

--- a/docs/architecture/chokepoint-invariants.md
+++ b/docs/architecture/chokepoint-invariants.md
@@ -1,0 +1,164 @@
+---
+title: Cross-cut — Dispatcher chokepoint invariants
+---
+
+_The "four invariants" pattern referred to elsewhere in the codebase. This doc audits what is actually in source vs. what was planned. Three of the four are implemented; one is not generalized; one fleet-side filter lives outside the dispatcher entirely._
+
+---
+
+## What & why
+
+A single chokepoint enforcing invariants is easier to reason about than the same checks scattered across plugins. The `agent.skill.request` topic is that chokepoint — `SkillDispatcherPlugin` is the **sole subscriber**, so anything declared as a "dispatcher invariant" must live in its `_dispatch()` method.
+
+Audit reality:
+
+| # | Invariant | Location in source | Generalized at dispatcher? |
+|---|---|---|---|
+| #437 | Cooldown | `src/executor/skill-dispatcher-plugin.ts:216-230` | ✅ yes |
+| #444 | Target-registry guard | `src/executor/executor-registry.ts:93-97` (inside `resolve()`) | ✅ effectively — dispatcher drops on null resolve |
+| #459 | Synthetic actor filter | `src/plugins/agent-fleet-health-plugin.ts:281-334` | ❌ **outside** the dispatcher (fleet-health aggregation site) |
+| #465 | Destructive verdict guard | `lib/plugins/pr-remediator.ts:1516-1546` | ❌ **specific to pr-remediator**, not a general dispatcher invariant |
+
+Treat #437 and #444 as the actual dispatcher invariants. #459 and #465 are the same architectural *pattern* (single chokepoint for an invariant) applied at *different* chokepoints — outcome-aggregation and verdict-handling respectively.
+
+---
+
+## Dispatcher chokepoint sequence (#437 + #444)
+
+```
+   agent.skill.request
+          │
+          ▼
+   ┌──────────────────────────────────────────┐
+   │ SkillDispatcherPlugin._dispatch()        │
+   │                                          │
+   │ 1. mark activeExecutions   (line 189)    │  ← gate against concurrent DM turns
+   │ 2. skill present?          (line 191)    │  ← drop if missing
+   │ 3. resolve(skill, targets) (line 198)    │  ← #444 lives in resolve()
+   │      ├─ null  ─►  drop + error response  │
+   │      └─ executor                         │
+   │ 4. cooldown check          (line 216)    │  ← #437
+   │      ├─ trip  ─►  drop + error response  │
+   │      └─ pass                             │
+   │ 5. flow.item.created                     │
+   │ 6. await executor.execute()  (line 286)  │  ← no timeout wrapper
+   │ 7. publish outcome           (line 538)  │
+   │ 8. finally: drain mailbox    (line 478)  │
+   └──────────────────────────────────────────┘
+```
+
+Order matters: registry guard fires **before** cooldown so a misdirected request gets the more useful diagnostic. Both fire before any side-effects (no `flow.item.created`, no executor call).
+
+---
+
+## #437 — Cooldown
+
+**Why it exists:** prevents webhook floods from re-triggering the same `(skill, repo)` faster than the agent can respond. A second `pr_review` arriving 5s after the first is almost always a duplicate, not a real new request.
+
+**State:** in-memory `lastDispatchAt: Map<string, number>` ([skill-dispatcher-plugin.ts:124](../../src/executor/skill-dispatcher-plugin.ts)). Key: `{skill}:{owner}/{repo}` or `{skill}:_` if no repo context.
+
+**Defaults:** `bug_triage` 30s, `pr_review` 30s, `security_triage` 60s, others unset (no cooldown). Env override: `WORKSTACEAN_COOLDOWN_MS_<SKILL>` ([line 54–73](../../src/executor/skill-dispatcher-plugin.ts)).
+
+**On trip:**
+- `console.warn` with elapsed/window/remaining (line 223–226)
+- Error response published to `reply.topic` (line 227)
+- **No bus event** for the trip itself — dashboard can't count cooldown drops
+
+**Greenfield rule:** absence of a default = no cooldown. There is no `enabled: false` flag; the absence is the signal.
+
+---
+
+## #444 — Target-registry guard
+
+**Why it exists:** if `payload.targets: ["protomaker"]` points at an agent that isn't enrolled (typo, undeployed, hostname changed — see #608), failing loudly at dispatch beats a silent timeout downstream.
+
+**Implementation:** inside `ExecutorRegistry.resolve(skill, targets)` ([executor-registry.ts:93–97](../../src/executor/executor-registry.ts)):
+
+```
+if targets.length > 0:
+    for each registration:
+        if registration.agentName ∈ targets:
+            return registration.executor
+    return null  ← dispatcher drops on this null
+else:
+    fall through to skill-based routing
+```
+
+**State:** `_registrations: Array<ExecutorRegistration>` ([executor-registry.ts:45](../../src/executor/executor-registry.ts)). Populated at startup by `AgentRuntimePlugin` (in-process agents) and `SkillBrokerPlugin` (A2A discovery, async). 
+
+**On trip:**
+- Dispatcher logs `[skill-dispatcher] No executor found for targets [...] or skill "..." — dropping` ([line 205](../../src/executor/skill-dispatcher-plugin.ts))
+- Error response to `reply.topic`
+- **No HITL escalation**
+
+**Note on the `"all"` sentinel:** memory referenced an `"all"` broadcast opt-out. Not present in current source. Either it was removed or was never implemented. If broadcast is needed, the absence of `targets[]` already triggers skill-based routing — which dispatches to the *first* matching executor, not all of them.
+
+---
+
+## #459 — Synthetic actor filter (lives elsewhere)
+
+**Where:** `AgentFleetHealthPlugin._record` ([agent-fleet-health-plugin.ts:281–334](../../src/plugins/agent-fleet-health-plugin.ts)). Subscribes to `autonomous.outcome.#`, not `agent.skill.request`.
+
+**Why it's not at the dispatcher:** the dispatcher *publishes* outcomes; it cannot also gate them or it would refuse to publish telemetry about itself. The filter belongs at the *consumer* — fleet-health is the consumer that cares about whether `systemActor` is an actual agent vs. a plugin label.
+
+**What it does:**
+
+```
+on autonomous.outcome.{actor}.{skill}:
+    if ExecutorRegistry.list().some(r => r.agentName === actor):
+        → agentWindows[actor].push(outcome)
+        → contributes to agentCount, maxFailureRate1h, orphanedSkillCount
+    else:
+        → systemActorWindows[actor].push(outcome)
+        → exposed separately in FleetHealthSnapshot.systemActors[]
+        → logged once-per-distinct-actor at warn level
+```
+
+**Known synthetic actors:** `pr-remediator`, `auto-triage-sweep`, `goap`, `user`.
+
+**On trip:** one-time `console.warn` per actor, no escalation. The point is bucketing, not blocking.
+
+---
+
+## #465 — Destructive verdict guard (only in pr-remediator)
+
+**Where:** [pr-remediator.ts:1516–1546](../../lib/plugins/pr-remediator.ts), specifically the promotion-PR check inside `diagnose_pr_stuck` verdict handling.
+
+**What it actually does:** when Ava's LLM verdict on a stuck PR is `decomposable` (i.e. "close this and re-cut as smaller PRs"), the handler checks whether the PR is a promotion PR (`head ∈ {dev, staging}` OR `base ∈ {main, staging}` OR title starts with "Promote"). If so, the close is suppressed and an HITL escalation is emitted instead.
+
+**Why it's not generalized:** there is no other destructive verb in the codebase today that an LLM can issue. Closing a PR is the only one. If `delete issue` or `force-update ref` become LLM-driven, *then* generalizing this to a dispatcher invariant becomes worth the abstraction cost. For now, the guard lives next to the only verb that needs it.
+
+**On trip:** `console.warn` + intended HITL escalation. See [flow-hitl](flow-hitl.md) for the gap that the HITL bus topic is *not actually published* — only logged.
+
+---
+
+## Telemetry gap
+
+None of the four invariants publish a bus event on trip today. Dashboard tiles for "cooldown drops in last hour" or "target-unresolved warnings" require either:
+
+1. **`dispatch.dropped.{reason}` bus topic** — would need wiring at each drop site. Simple but invasive.
+2. **`BusHistoryRecorder` scraping `console.warn`** — fragile, breaks if log format changes.
+
+Both are open work. Worth doing before more invariants are added; otherwise we keep losing visibility per check.
+
+---
+
+## When to add a new invariant
+
+If you find yourself adding a check that:
+
+- Must fire before any executor work happens, **and**
+- Applies to *all* `(skill, target)` pairs (not just one skill / one plugin)
+
+…then add it to `_dispatch()` in the same sequence (after registry resolve, before cooldown is fine — the order between these is semantic, see [#437 above](#437--cooldown)).
+
+If the check is **specific to one skill or one verb** (like #465's PR close), put it next to the consumer, not at the dispatcher. The dispatcher is for invariants every skill must respect.
+
+---
+
+## Related
+
+- [flow-inbound-message](flow-inbound-message.md) — full dispatcher sequence with these invariants in context
+- [flow-alert-remediator](flow-alert-remediator.md) — #459's downstream consumer
+- [flow-pr-review](flow-pr-review.md) — #465's home today
+- [flow-hitl](flow-hitl.md) — the (gap) destination for #465 escalations

--- a/docs/architecture/flow-a2a-discovery.md
+++ b/docs/architecture/flow-a2a-discovery.md
@@ -1,0 +1,204 @@
+---
+title: Flow — A2A discovery
+---
+
+_On startup, SkillBrokerPlugin builds one A2AExecutor per agent in `workspace/agents.yaml`, then asynchronously fetches each agent's card to enroll their skills in the ExecutorRegistry. Refresh every 10 minutes; heartbeat every 60 seconds. Fix #608 made card-fetch failures fail loud at warn level._
+
+---
+
+## What & why
+
+`AgentRuntimePlugin` enrolls in-process agents (Ava, Quinn, proto) synchronously at startup. Remote A2A agents (run as separate services on different hosts) can't be enrolled the same way — their skills are defined on the *agent side*, not in our config. Discovery solves this: ask each remote agent "what skills do you advertise?" via `/.well-known/agent-card.json`, register what they say.
+
+Fix #608 ([PR #608](https://github.com/protoLabsAI/protoWorkstacean/pull/608)) made the failure path visible: a failed card fetch used to silent-catch and leave the agent dark with no log. Now it `console.warn`s the actual error.
+
+---
+
+## ASCII spine
+
+```
+   process startup
+        │
+        ▼
+   ┌──────────────────────────┐
+   │ SkillBrokerPlugin.install│
+   │                          │
+   │  1. read agents.yaml     │
+   │  2. for each agent:      │
+   │     a. create A2AExecutor│
+   │     b. register YAML-    │
+   │        declared skills   │
+   │        (synchronous)     │
+   │     c. fire _discover    │
+   │        Skills() async    │
+   │  3. start refresh timer  │  10 min
+   │  4. start heartbeat timer│  60s
+   └──────────────┬───────────┘
+                  │
+        async ────┘
+        per agent
+                  ▼
+   ┌──────────────────────────┐
+   │  _fetchCard(url)         │
+   │                          │
+   │  ClientFactory           │  via @a2a-js/sdk
+   │   .createFromUrl(url)    │  primary: /.well-known/agent-card.json
+   │   .getAgentCard()        │  fallback: /.well-known/agent.json
+   │                          │
+   │  fix #608: fail loud     │  console.warn on either path failure
+   └──────────────┬───────────┘
+                  │
+                  ▼
+   ┌──────────────────────────┐
+   │ _discoverSkills()        │
+   │                          │
+   │  for each card.skills[]: │
+   │    register skill in     │
+   │    ExecutorRegistry      │  priority=5
+   │                          │
+   │  update executor caps    │
+   │    streaming             │
+   │    pushNotifications     │
+   │                          │
+   │  load extensions:        │
+   │    HITL mode             │
+   │    Blast declaration     │
+   └──────────────────────────┘
+```
+
+---
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant SBP as SkillBrokerPlugin
+    participant Y as agents.yaml
+    participant ER as ExecutorRegistry
+    participant Agent as Remote A2A agent
+    participant SDK as @a2a-js/sdk<br/>ClientFactory
+
+    SBP->>Y: read
+    Y-->>SBP: agents[]
+
+    loop per agent
+        SBP->>SBP: new A2AExecutor(url, auth)
+        SBP->>ER: register YAML-declared skills (sync)
+        SBP-->>SBP: void this._discoverSkills(agent)<br/>(async, non-blocking)
+    end
+
+    SBP->>SBP: setInterval(refresh, 10min)
+    SBP->>SBP: setInterval(heartbeat, 60s)
+
+    Note over SBP,Agent: async per agent
+    SBP->>SDK: ClientFactory.createFromUrl(url)
+    SDK->>Agent: GET /.well-known/agent-card.json
+
+    alt 200 OK
+        Agent-->>SDK: AgentCard
+        SDK-->>SBP: card
+        SBP->>ER: register card.skills[] (priority=5)
+        SBP->>SBP: update streaming + pushNotifications flags
+        SBP->>SBP: load HITL + Blast extensions
+    else 404
+        SDK->>Agent: GET /.well-known/agent.json (fallback)
+        Agent-->>SDK: AgentCard | error
+    else error
+        SDK-->>SBP: error
+        SBP->>SBP: console.warn(actual error) #608
+    end
+```
+
+---
+
+## `workspace/agents.yaml` schema
+
+[skill-broker-plugin.ts:40–70](../../src/plugins/skill-broker-plugin.ts):
+
+```yaml
+agents:
+  - name: quinn                       # required
+    url: http://quinn:7870/a2a        # required, A2A endpoint
+    apiKeyEnv: QUINN_API_KEY          # legacy auth
+    auth:                              # preferred (Phase 8)
+      scheme: apiKey | bearer | hmac
+      credentialsEnv: QUINN_API_KEY
+    headers:                           # extra headers (extension opt-in)
+      X-Foo: bar
+    streaming: true                   # bootstrap assumption; card refreshes
+    external: false                   # true if off-docker (Tailscale)
+    skills:                           # yaml-declared overrides
+      - name: bug_triage
+        description: "…"
+      - pr_review                     # short form
+    subscribesTo:                     # future use
+      - message.inbound.discord.#
+```
+
+The `skills:` field is a **bootstrap assumption** — registered synchronously so dispatch works during the async card-fetch window. Once the card arrives, **additional** skills are added but yaml-declared skills are not removed (they win on conflict).
+
+---
+
+## AgentCard shape (from remote)
+
+Inferred from card-handling code at [skill-broker-plugin.ts:253–288](../../src/plugins/skill-broker-plugin.ts):
+
+```ts
+{
+  skills: Array<{
+    id: string,
+    description?: string,
+  }>,
+  capabilities?: {
+    streaming?: boolean,
+    pushNotifications?: boolean,
+    extensions?: Array<{
+      uri: string,                  // identifier, e.g. "x-hitl-mode-v1"
+      params?: Record<string, unknown>,
+    }>,
+  },
+}
+```
+
+The card is the remote agent's source of truth. `streaming` and `pushNotifications` flags override our YAML assumption when the card arrives.
+
+---
+
+## Refresh + heartbeat timers
+
+| Timer | Interval | What it does | File |
+|---|---|---|---|
+| Card refresh | 10 min (`CARD_REFRESH_INTERVAL_MS`) | Re-fetches each card → re-enrolls skills + updates capability flags. New skills added; removed skills... not currently un-enrolled. | `skill-broker-plugin.ts` |
+| Heartbeat | 60s (`HEARTBEAT_INTERVAL_MS`) | Liveness probe; feeds fleet health. | `skill-broker-plugin.ts` |
+
+---
+
+## JSON-RPC envelope
+
+A2A protocol is JSON-RPC 2.0, but `SkillBrokerPlugin` and `A2AExecutor` do **not** construct the envelope directly — `@a2a-js/sdk` does. From our side:
+
+- **Card fetch:** `client.getAgentCard()` → SDK wraps as JSON-RPC method
+- **Skill dispatch:** `A2AExecutor.execute()` → SDK constructs `message/send` JSON-RPC envelope
+- **Auth headers:** `A2AExecutor.buildFetch()` ([line 119–159](../../src/executor/executors/a2a-executor.ts)) stamps `X-API-Key` or `Authorization: Bearer`
+- **Trace headers:** same `buildFetch()` injects `X-Correlation-Id`, `X-Parent-Id`
+
+You can't inspect the raw JSON-RPC envelope without forking the SDK.
+
+---
+
+## Failure modes & gotchas (fix #608 made these visible)
+
+- **Card fetch is async, non-blocking** ([line 121–194](../../src/plugins/skill-broker-plugin.ts)) — if an agent's card is slow at startup, the broker registers zero skills initially and dispatch returns "No executor found" until the async fetch completes. **Mitigation:** declare skills in `workspace/agents.yaml` to bootstrap.
+- **Stale hostnames don't fail loudly until #608** — pre-#608, a DNS-unresolvable agent hostname (e.g. `automaker-server` after rename to `protomaker-server`) silent-caught at `_fetchCard` and the agent was dark forever. Post-#608, `console.warn` fires on every retry.
+- **Both card paths can fail with different errors** — primary at `/.well-known/agent-card.json`, fallback at `/.well-known/agent.json`. Fix #608 captures and logs both ([line 361–398](../../src/plugins/skill-broker-plugin.ts)).
+- **Card refresh doesn't unregister removed skills** — if a remote agent drops a skill from its card, the old registration sticks until restart. Acceptable today (skill removals are rare); revisit if dynamic skill mutation becomes common.
+- **Extensions are optional and silent on miss** — `card.capabilities.extensions` not advertising the HITL or Blast URI = no-op load. Easy to forget you needed to add the extension to a new agent.
+
+---
+
+## Related
+
+- [flow-inbound-message](flow-inbound-message.md) — what happens after an A2A skill is dispatched
+- [chokepoint-invariants](chokepoint-invariants.md) — #444 target guard runs against this registry
+- [flow-agent-runtime-telemetry](flow-agent-runtime-telemetry.md) — telemetry from A2A executions

--- a/docs/architecture/flow-agent-runtime-telemetry.md
+++ b/docs/architecture/flow-agent-runtime-telemetry.md
@@ -1,0 +1,214 @@
+---
+title: Flow — Agent runtime telemetry
+---
+
+_How executors publish "I started", "I'm progressing", "I finished" — and what those signals feed. The story today is simpler than memory suggests: `flow.item.*`, `autonomous.outcome.*`, and opt-in `agent.skill.progress.*` are the real topics. Several often-referenced topics (`agent.runtime.activity.tool.call`, `agent.skill.latency`) are aspirational._
+
+---
+
+## What & why
+
+Three consumers care about executor lifecycle: AgentFleetHealth (rolling-window health snapshots), the dashboard (live tiles), and the cost extension (per-call usage → cost). They observe the dispatcher and executors from the side; the agent runtime doesn't know they're listening.
+
+---
+
+## ASCII spine
+
+```
+                              ┌──────────────────────────┐
+                              │ SkillDispatcher          │
+                              │  publishes lifecycle:    │
+                              │                          │
+                              │  flow.item.created       │ ← dispatch start
+                              │  flow.item.updated       │ ← running / error
+                              │  flow.item.completed     │ ← terminal success
+                              │  autonomous.outcome.     │ ← canonical terminal
+                              │    {actor}.{skill}       │
+                              └──────────┬───────────────┘
+                                         │
+   ┌──────────────────────────┐          │
+   │ Executor (Deep/Proto/A2A)│          │
+   │  may publish (opt-in):   │          │
+   │                          │          │
+   │  agent.skill.progress.   │ ─────────┤
+   │    {correlationId}       │          │
+   └──────────────────────────┘          │
+                                         │
+                              ┌──────────┼───────────┬──────────────────┐
+                              ▼          ▼           ▼                  ▼
+                         ┌─────────┐ ┌──────────┐ ┌─────────────┐ ┌────────────┐
+                         │ Fleet   │ │ Cost     │ │ Dashboard   │ │TaskTracker │
+                         │ Health  │ │ Extension│ │ tiles       │ │(A2A async) │
+                         │         │ │          │ │             │ │            │
+                         │ 24h     │ │ CostSampl│ │ live event  │ │ owns       │
+                         │ window  │ │ es,      │ │ feed via    │ │ outcome    │
+                         │         │ │ autonom. │ │ BusHistory  │ │ publish    │
+                         │         │ │ cost.*   │ │ Recorder    │ │ for long-  │
+                         │         │ │          │ │             │ │ running    │
+                         └─────────┘ └──────────┘ └─────────────┘ └────────────┘
+```
+
+---
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant SD as SkillDispatcher
+    participant E as Executor
+    participant Bus as Bus
+    participant FH as AgentFleetHealth
+    participant CE as Cost Extension
+    participant TT as TaskTracker
+
+    SD->>Bus: flow.item.created
+    SD->>E: execute(req)
+
+    opt streaming progress (opt-in)
+        E->>Bus: agent.skill.progress.{correlationId}
+    end
+
+    alt taskState ∈ {submitted, working}
+        E-->>SD: { taskState: working, taskId }
+        SD->>Bus: flow.item.updated (stage="running")
+        SD->>TT: hand off
+        Note over TT: dispatcher returns early<br/>TaskTracker holds until terminal
+        TT->>Bus: autonomous.outcome.{actor}.{skill}<br/>(eventually)
+    else terminal
+        E-->>SD: { text, taskState: completed/failed, usage }
+        SD->>Bus: flow.item.completed
+        SD->>Bus: autonomous.outcome.{actor}.{skill}
+    end
+
+    Bus->>FH: deliver outcome
+    FH->>FH: _record (filter synthetic actors)
+
+    Bus->>CE: deliver outcome (extension hook)
+    CE->>CE: compute cost = tokens × MODEL_RATES
+    CE->>Bus: autonomous.cost.{actor}.{skill}
+```
+
+---
+
+## Bus topic table
+
+| Topic | Published by | Subscribed by | File:line |
+|---|---|---|---|
+| `flow.item.created` | SkillDispatcher | dashboard / BusHistoryRecorder | `src/executor/skill-dispatcher-plugin.ts:275` |
+| `flow.item.updated` | SkillDispatcher (running/error states) | dashboard | `:370,385,457` |
+| `flow.item.completed` | SkillDispatcher | dashboard | `:418` |
+| `agent.skill.progress.{correlationId}` | executor (opt-in) | dashboard / SSE streamer | `src/event-bus/payloads.ts:86–95` |
+| `autonomous.outcome.{systemActor}.{skill}` | SkillDispatcher (or TaskTracker for async) | AgentFleetHealth, Cost extension | `src/executor/skill-dispatcher-plugin.ts:538` |
+| `autonomous.cost.{systemActor}.{skill}` | Cost extension after-hook | dashboard (fleet-cost tile) | `src/executor/extensions/cost.ts:209` |
+
+---
+
+## `AutonomousOutcomePayload` shape
+
+[src/event-bus/payloads.ts:261–296](../../src/event-bus/payloads.ts):
+
+```ts
+{
+  correlationId: string,
+  parentId?: string,
+  systemActor: string,           // agent name or plugin label
+  skill: string,
+  actionId?: string,             // ceremony or action ID
+  goalId?: string,
+  success: boolean,
+  error?: string,
+  taskState?: string,            // A2A terminal state
+  textPreview?: string,          // first 500 chars
+  usage?: {
+    input_tokens?: number,
+    output_tokens?: number,
+    cache_creation_input_tokens?: number,
+    cache_read_input_tokens?: number,
+  },
+  durationMs: number,
+  effectDelta?: Record<string, unknown>,  // reserved
+}
+```
+
+`durationMs` is wall-clock from dispatch to terminal; `usage` is forwarded from the LLM provider (LiteLLM gateway).
+
+---
+
+## `AgentSkillProgressPayload` shape
+
+[src/event-bus/payloads.ts:86–95](../../src/event-bus/payloads.ts):
+
+```ts
+{
+  text?: string,         // human-readable progress message
+  percent?: number,      // 0–100
+  step?: string,         // named phase (e.g. "fetching", "processing")
+  meta?: Record<string, unknown>,
+}
+```
+
+**Opt-in.** Both DeepAgentExecutor and A2AExecutor have the hook plumbing but neither currently publishes progress. The A2AExecutor's `onStreamUpdate` callback is wired for the SDK side but does **not** translate to bus events. Tile-watching for "what is Quinn doing right now" returns silence today.
+
+---
+
+## TaskTracker hand-off (long-running A2A)
+
+When an executor returns `taskState ∈ {submitted, working}`, the dispatcher hands off ownership to `TaskTracker` and returns early ([skill-dispatcher-plugin.ts:293–378](../../src/executor/skill-dispatcher-plugin.ts)). TaskTracker owns:
+
+- Polling / push-notification handling for the A2A task
+- Publishing `autonomous.outcome.{actor}.{skill}` when the task finally reaches a terminal state
+- Cleaning up `activeExecutions` slot
+
+This means **autonomous.outcome is sometimes published by TaskTracker, not the dispatcher**. Subscribers don't need to care (same payload shape), but if you're tracing a missing outcome, check both.
+
+---
+
+## Aspirational topics (NOT in source)
+
+Memory and some documentation reference these — they are not implemented:
+
+- `agent.runtime.activity.tool.call` — would emit per tool invocation inside the agent. Not published anywhere in src. ([all-topics.ts](../../src/event-bus/all-topics.ts) confirms.)
+- `agent.skill.latency` — referenced as a histogram source. Not published; latency is in `autonomous.outcome.*.durationMs`.
+
+Any tile or alert depending on these is dead code today. Either:
+1. Wire them up (one-line `bus.publish` at the right hook), or
+2. Re-source the dependent tile from `autonomous.outcome.*` / `flow.item.*` instead.
+
+This is tracked as a follow-up — not a blocker for the rest of the system.
+
+---
+
+## Cost extension
+
+[src/executor/extensions/cost.ts](../../src/executor/extensions/cost.ts) hooks the dispatcher *after* the executor returns. Pipeline:
+
+1. `cost.beforeExecute` — records start time
+2. Executor runs
+3. `cost.afterExecute` — reads `result.usage`, computes:
+   ```
+   costUsd = input_tokens × MODEL_RATES[model].input
+           + output_tokens × MODEL_RATES[model].output
+   ```
+4. Publishes `autonomous.cost.{systemActor}.{skill}` ([line 209](../../src/executor/extensions/cost.ts))
+5. CostStore in-memory aggregator collects samples for the `/api/cost-summaries` dashboard route
+
+**Gotcha:** `MODEL_RATES` is hard-coded ([lib/types/budget.ts](../../lib/types/budget.ts)). New models from LiteLLM gateway are zero-cost until the table is updated.
+
+---
+
+## Failure modes & gotchas
+
+- **Progress topics are silent today** — no executor publishes `agent.skill.progress.*`. Dashboard tiles relying on them show nothing.
+- **TaskTracker outcome publish is the canonical path for long-running A2A** — if you're debugging "outcome never fires", check whether the task is parked in TaskTracker (likely) or actually never completed (unlikely).
+- **Latency is `durationMs`, not a histogram** — `autonomous.outcome.*.durationMs` is the only latency signal. If you want p50/p95, aggregate at the consumer ([flow-alert-remediator](flow-alert-remediator.md) does this).
+- **`systemActor` is whatever the dispatcher writes** — it's not validated by the bus. Synthetic actors (`pr-remediator`, `goap`, `user`) coexist with real agents. The synthetic-actor filter at FleetHealth ([#459](chokepoint-invariants.md)) is the source of truth for "is this a real agent."
+
+---
+
+## Related
+
+- [chokepoint-invariants](chokepoint-invariants.md) — #459 synthetic-actor filter consumes these
+- [flow-inbound-message](flow-inbound-message.md) — where the dispatcher actually publishes
+- [flow-alert-remediator](flow-alert-remediator.md) — how outcomes become alerts
+- [flow-dashboard](flow-dashboard.md) — where the topics surface visually

--- a/docs/architecture/flow-alert-remediator.md
+++ b/docs/architecture/flow-alert-remediator.md
@@ -1,0 +1,240 @@
+---
+title: Flow — Alert / PR remediator
+---
+
+_The fleet self-healing path: AgentFleetHealth aggregates outcomes into a snapshot; when thresholds trip, alert skills publish to Discord; pr-remediator handles `pr.remediate.*` topics that propose code mutations. The threshold-evaluation layer is currently external (Goals/Actions YAML) and is a known architectural seam._
+
+---
+
+## What & why
+
+The fleet is a distributed system; agents fail, PRs get stuck, costs spike. Two related paths handle the response:
+
+- **Alerts** — declarative skill executors (20 of them) that turn a `alert.fleet_*` skill dispatch into a Discord message. Fire-and-forget, no LLM.
+- **PR remediator** — five `pr.remediate.*` topics (`update_branch`, `merge_ready`, `fix_ci`, `address_feedback`, `pr.backmerge.dispatch`) that consume an action dispatch and mutate the PR via GitHub API.
+
+Both are `FunctionExecutor`-backed (no LLM at the executor itself; LLM lives one layer deeper in `pr-remediator` for `diagnose_pr_stuck`).
+
+---
+
+## ASCII spine
+
+```
+   autonomous.outcome.# (from every skill execution)
+        │
+        ▼
+   ┌──────────────────────────┐
+   │ AgentFleetHealthPlugin   │  rolling 24h windows
+   │   _record()              │  synthetic actor filter (#459)
+   │                          │
+   │   computes:              │
+   │   • successRate          │
+   │   • failureRate1h        │
+   │   • p50/p95 latency      │
+   │   • cost per outcome     │
+   │   • orphanedSkillCount   │
+   │   • maxFailureRate1h     │
+   └──────────────┬───────────┘
+                  │ exposed via getFleetHealth() collector
+                  ▼  (called by WorldStateEngine every 60s)
+   ┌──────────────────────────┐
+   │  world-state domain:     │
+   │  agent_fleet_health      │
+   └──────────────┬───────────┘
+                  │
+                  ▼   (?) threshold evaluation
+                  │       happens externally — see "Threshold gap" below
+                  ▼
+   ┌──────────────────────────┐  ┌──────────────────────────┐
+   │ alert.fleet_agent_stuck  │  │ action.pr_update_branch  │
+   │ alert.fleet_skill_       │  │ action.pr_fix_ci         │
+   │   orphaned               │  │ action.pr_address_       │
+   │ alert.fleet_cost_over_   │  │   feedback               │
+   │   budget                 │  │ action.pr_merge_ready    │
+   │ … (20 alert skills)      │  │ action.pr_backmerge      │
+   └──────────────┬───────────┘  └──────────────┬───────────┘
+                  │                              │
+                  ▼  SkillDispatcher              ▼  SkillDispatcher
+   ┌──────────────────────────┐  ┌──────────────────────────┐
+   │ AlertSkillExecutorPlugin │  │ PrRemediatorSkillExec.   │
+   │  → message.outbound.     │  │  → pr.remediate.{action} │
+   │      discord.alert       │  │                          │
+   └──────────────────────────┘  └──────────────┬───────────┘
+                                                 │
+                                                 ▼
+                                  ┌──────────────────────────┐
+                                  │ PrRemediatorPlugin       │
+                                  │  reads pr_pipeline state │
+                                  │  publishes GitHub mut.   │
+                                  │  or HITL escalation      │
+                                  └──────────────────────────┘
+```
+
+---
+
+## Sequence (alert path)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant SD as SkillDispatcher
+    participant FH as AgentFleetHealth
+    participant WSE as WorldStateEngine<br/>(60s tick)
+    participant TE as Threshold evaluator<br/>(external)
+    participant AD as ActionDispatcher
+    participant AE as AlertSkillExecutor
+    participant Bus as Bus
+    participant DP as DiscordPlugin
+
+    Note over SD,FH: every skill outcome flows in
+    SD->>Bus: autonomous.outcome.{actor}.{skill}
+    Bus->>FH: deliver
+    FH->>FH: _record(): rolling window + synthetic-actor filter
+
+    Note over WSE,FH: every 60s
+    WSE->>FH: getFleetHealth()
+    FH-->>WSE: FleetHealthSnapshot
+
+    Note over TE: ⚠ threshold evaluation<br/>not in source — see gap section
+    TE->>Bus: agent.skill.request<br/>(skill=alert.fleet_agent_stuck)
+    Bus->>SD: deliver
+    SD->>AE: execute(req)
+    AE->>Bus: message.outbound.discord.alert
+    Bus->>DP: deliver
+    DP->>DP: post to alert webhook channel
+```
+
+## Sequence (PR remediator path)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant TE as Threshold/policy<br/>(external)
+    participant Bus as Bus
+    participant SD as SkillDispatcher
+    participant PRE as PrRemediatorSkillExec
+    participant PR as PrRemediatorPlugin
+    participant GH as GitHub API
+
+    TE->>Bus: agent.skill.request<br/>(skill=action.pr_update_branch)
+    Bus->>SD: deliver
+    SD->>PRE: execute (FunctionExecutor)
+    PRE->>Bus: pr.remediate.update_branch
+    Bus->>PR: deliver
+
+    PR->>PR: read pr_pipeline world state
+    PR->>GH: PATCH /repos/{o}/{r}/pulls/{n}/branch
+    GH-->>PR: response
+
+    alt success
+        PR->>Bus: flow.item.updated / completed
+    else 422 conflict (2+ attempts)
+        PR->>PR: dispatch diagnose_pr_stuck (LLM verdict)
+        alt decomposable + promotion PR
+            Note over PR: #465 destructive guard:<br/>suppress close, escalate HITL
+        else genuine conflict
+            PR->>PR: escalate HITL (console.warn only)
+        end
+    end
+```
+
+---
+
+## Bus topic table
+
+### Fleet health
+
+| Topic | Published by | Subscribed by | File:line |
+|---|---|---|---|
+| `autonomous.outcome.#` | SkillDispatcher | AgentFleetHealthPlugin | `src/plugins/agent-fleet-health-plugin.ts:159` |
+| `agent_fleet_health` (world-state) | FleetHealth.getFleetHealth() collector | WorldStateEngine | `src/plugins/agent-fleet-health-plugin.ts:180` |
+
+### Alerts (20 skills total — sample)
+
+| Skill (on `agent.skill.request`) | Severity | Outbound topic |
+|---|---|---|
+| `alert.fleet_agent_stuck` | high | `message.outbound.discord.alert` |
+| `alert.fleet_skill_orphaned` | medium | `message.outbound.discord.alert` |
+| `alert.fleet_cost_over_budget` | high | `message.outbound.discord.alert` |
+| … (full list in `AlertSkillExecutorPlugin.ALERT_SKILLS`, [line 39–67](../../src/plugins/AlertSkillExecutorPlugin.ts)) | | |
+
+All 20 are `FunctionExecutor` registrations with priority=5, fire-and-forget, no LLM.
+
+### PR remediator
+
+| Skill | Topic published | Handler in `pr-remediator.ts` |
+|---|---|---|
+| `action.pr_update_branch` | `pr.remediate.update_branch` | line 1006+ |
+| `action.pr_merge_ready` | `pr.remediate.merge_ready` | line 985+ |
+| `action.pr_fix_ci` | `pr.remediate.fix_ci` | line 750+ |
+| `action.pr_address_feedback` | `pr.remediate.address_feedback` | line 750+ |
+| `action.pr_backmerge` | `pr.backmerge.dispatch` | line 6+ |
+
+PrRemediatorSkillExecutorPlugin maps skill→topic; PrRemediatorPlugin subscribes to all five.
+
+---
+
+## Synthetic actor filter (#459)
+
+Lives at [AgentFleetHealthPlugin._record:281–334](../../src/plugins/agent-fleet-health-plugin.ts). Detail in [chokepoint-invariants](chokepoint-invariants.md).
+
+Summary: `pr-remediator`, `auto-triage-sweep`, `goap`, `user` are recognized synthetic actors. Their outcomes go into `systemActors[]` bucket (not `agents[]`) so they don't inflate `agentCount` or skew `maxFailureRate1h`.
+
+---
+
+## Threshold gap
+
+**Where threshold evaluation actually happens is not fully visible in the audited source.** The audit found:
+
+- `ALERT_SKILLS` declares 20 alert skill names
+- `FleetHealthSnapshot` exposes the relevant metrics (`maxFailureRate1h`, `orphanedSkillCount`, `totalCostUsd1d`, …)
+- `ActionDispatcherPlugin` presumably dispatches `alert.*` and `action.*` skills when preconditions match — but the **goals/actions YAML files were not found** in the audited tree
+
+This points at a **partial GOAP layer still wired** despite memory saying GOAP is being removed (see [memory: app-is-switchboard](../../.claude/projects/-home-josh-dev-protoWorkstacean/memory/project_app_is_switchboard.md)). One of two states is true:
+
+1. The GOAP layer is fully torn out and threshold evaluation has moved elsewhere (e.g. a simple cron-based threshold-checker) — in which case `AlertSkillExecutorPlugin` no longer fires today
+2. The GOAP layer is partially still in place, driving alerts/actions from `agent_fleet_health` world-state
+
+A maintainer needs to resolve this before the doc can claim a complete picture. **Tracking gap; not blocking the rest of the doc.**
+
+---
+
+## PR remediator state machine
+
+PrRemediatorPlugin (`lib/plugins/pr-remediator.ts`) maintains in-memory `inFlight` Map per PR:
+
+```
+InFlightEntry {
+  attemptCount,
+  escalated,
+  diagnostics?,
+  …
+}
+```
+
+Key transitions ([pr-remediator.ts:604+](../../lib/plugins/pr-remediator.ts)):
+- Fresh PR → enter inFlight, attempt = 0
+- Each `pr.remediate.*` consume → attempt += 1, try GitHub mutation
+- Attempt count ≥ `MAX_ATTEMPTS_PER_PR` (3) → mark escalated, emit HITL (see gap in [flow-hitl](flow-hitl.md))
+- 422 conflict on `update_branch` after 2 attempts → dispatch `diagnose_pr_stuck` for LLM verdict
+- Verdict `genuine` → immediate HITL
+- Verdict `decomposable` + promotion PR → suppress close, HITL (defense-in-depth #465)
+
+---
+
+## Failure modes & gotchas
+
+- **Live CI re-check before fix_ci escalation** ([line 821–830](../../lib/plugins/pr-remediator.ts)) — before emitting HITL for "stuck on CI", pr-remediator hits GitHub live API to confirm CI is still red. If it flipped green between snapshot and escalation, the escalation is silently dropped. Prevents stale-snapshot false alarms.
+- **Alert thresholds are hard-coded in source** — `WINDOW_MS = 24h`, `MAX_RECENT_FAILURES = 10`. No env override. Changing these requires a rebuild.
+- **Cost calculation depends on `MODEL_RATES`** ([lib/types/budget.ts](../../lib/types/budget.ts)) — hard-coded model price table. When LiteLLM gateway adds a new model, this table must be updated or `costUsd` is zero for that model.
+- **Outcome attribution is write-time, not read-time** ([line 281](../../src/plugins/agent-fleet-health-plugin.ts)) — `systemActor` is bucketed *as outcomes arrive*. If `ExecutorRegistry` enrolls a new agent later, prior outcomes for that name stay in `systemActors[]`. Restart required to re-bucket.
+- **`agent.runtime.activity.tool.call` and `agent.skill.latency` topics are referenced in some commentary but NOT in source** ([all-topics.ts](../../src/event-bus/all-topics.ts)) — see [flow-agent-runtime-telemetry](flow-agent-runtime-telemetry.md). If a tile or alert depends on them, it's broken today.
+
+---
+
+## Related
+
+- [chokepoint-invariants](chokepoint-invariants.md) — #459 synthetic actor filter, #465 destructive verdict guard
+- [flow-hitl](flow-hitl.md) — the escalation path (with the wire-incomplete gap)
+- [flow-agent-runtime-telemetry](flow-agent-runtime-telemetry.md) — what feeds the snapshot
+- [flow-dashboard](flow-dashboard.md) — how the snapshot is rendered

--- a/docs/architecture/flow-ceremonies.md
+++ b/docs/architecture/flow-ceremonies.md
@@ -1,0 +1,174 @@
+---
+title: Flow — Ceremonies
+---
+
+_Cron-triggered fleet rituals: a YAML declaration says "every 3 hours, run skill X on target Y", CeremonyPlugin fires `ceremony.{id}.execute`, dispatches `agent.skill.request`, persists outcome. Same shape as inbound flow but with declarative scheduling instead of webhook entry._
+
+---
+
+## What & why
+
+Some fleet work doesn't have a natural webhook trigger — sweeping a board for stale issues, posting a daily summary, running security checks. Ceremonies declare these as YAML, the plugin schedules them, and the result enters the same dispatcher chokepoint as a chat message would. On-demand triggering also works (publish `ceremony.{id}.execute` directly).
+
+Ceremonies are **scheduled fleet rituals**, not orchestrated multi-step workflows. There is no DAG, no retry policy, no branching logic at the ceremony level — that's a skill's responsibility.
+
+---
+
+## ASCII spine
+
+```
+   workspace/ceremonies/*.yaml          .proto/projects/{slug}/ceremonies/
+        ┌────┴───────────────────────────┴────┐
+        │  ceremonyYamlLoader (5s hot-reload) │
+        │  merge: project overrides global    │
+        └─────────────────┬───────────────────┘
+                          │
+                          ▼
+   ┌──────────────────────────┐
+   │  CeremonyPlugin          │
+   │   _scheduleCeremony()    │  ← cron-expression-parser
+   │                          │
+   │   subscribes to:         │  on tick → _fireCeremony()
+   │     ceremony.{id}.execute│  on external publish → _fireCeremony()
+   └──────────────┬───────────┘
+                  │
+                  ▼
+   ┌──────────────────────────┐
+   │  ceremony.{id}.execute   │  payload.type ∈ {"ceremony.execute", "external.trigger"}
+   └──────────────┬───────────┘
+                  │  (plugin re-subscribes to its own published topic)
+                  ▼
+   ┌──────────────────────────┐
+   │  _dispatchSkillAndCompl. │
+   │                          │
+   │  publishes agent.skill.  │ → SkillDispatcher → executor
+   │  request                 │
+   │                          │
+   │  subscribes to           │ ← waits for executor response
+   │  agent.skill.response.   │
+   │  {runId}                 │
+   └──────────────┬───────────┘
+                  │
+        ┌─────────┴─────────┐
+        ▼                   ▼
+   ┌──────────────┐  ┌──────────────────────┐
+   │ ceremony.{id}│  │ autonomous.outcome.  │
+   │ .completed   │  │ ceremony.{id}.{skill}│   ← canonical
+   │ (back-compat)│  │                      │
+   └──────────────┘  └──────────────────────┘
+```
+
+---
+
+## YAML schema
+
+[CeremonyPlugin.types.ts:8–25](../../src/plugins/CeremonyPlugin.types.ts):
+
+```yaml
+id: security-sweep                # required, unique
+name: Security Sweep              # required, human label
+schedule: "0 */3 * * *"           # required, cron expression
+skill: security_triage            # required, what to dispatch
+targets: ["quinn"]                # required, executor target(s)
+notifyChannel: 1234567890         # optional, Discord channel for summary
+enabled: true                     # optional, default true
+timeoutMs: 600000                 # optional, no timeout if absent
+```
+
+**Locations searched** ([CeremonyPlugin.ts:104,107](../../src/plugins/CeremonyPlugin.ts)):
+1. `workspace/ceremonies/*.yaml` — global
+2. `.proto/projects/{slug}/ceremonies/*.yaml` — per-project overrides
+
+Merge: project overrides global by `id`.
+
+**Hot-reload:** 5s file watcher (`HOT_RELOAD_INTERVAL_MS = 5000`).
+
+---
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Cron as cron tick
+    participant CP as CeremonyPlugin
+    participant Bus as Bus
+    participant SD as SkillDispatcher
+    participant E as Executor
+
+    alt scheduled
+        Cron->>CP: _fireCeremony() (tick)
+    else external
+        Note over Bus,CP: someone publishes<br/>ceremony.{id}.execute with<br/>type="external.trigger"
+        Bus->>CP: deliver
+    end
+
+    CP->>Bus: ceremony.{id}.execute<br/>(type="ceremony.execute" for cron)
+    Bus->>CP: re-deliver (self-subscribed)
+
+    CP->>Bus: agent.skill.request<br/>(reply.topic=agent.skill.response.{runId})
+    Bus->>SD: deliver
+    SD->>E: execute
+    E-->>SD: { text, error?, taskState }
+    SD->>Bus: agent.skill.response.{runId}
+    Bus->>CP: deliver (run completion subscriber)
+
+    CP->>Bus: ceremony.{id}.completed<br/>(back-compat)
+    CP->>Bus: autonomous.outcome.ceremony.{id}.{skill}<br/>(canonical)
+
+    Note over CP,Bus: CeremonyStateExtension consumes outcome<br/>→ ceremony.state.snapshot
+```
+
+---
+
+## Bus topic table
+
+| Topic | Published by | Subscribed by | File:line |
+|---|---|---|---|
+| `ceremony.{id}.execute` | CeremonyPlugin (cron) / CeremonySkillExecutorPlugin (external) | CeremonyPlugin (self) | `src/plugins/CeremonyPlugin.ts:344` |
+| `agent.skill.request` | CeremonyPlugin._dispatchSkillAndComplete | SkillDispatcher | `src/plugins/CeremonyPlugin.ts:394` |
+| `agent.skill.response.{runId}` | SkillDispatcher | CeremonyPlugin | `src/plugins/CeremonyPlugin.ts:372` |
+| `ceremony.{id}.completed` | CeremonyPlugin | (back-compat consumers) | `src/plugins/CeremonyPlugin.ts:448` |
+| `autonomous.outcome.ceremony.{id}.{skill}` | CeremonyPlugin | AgentFleetHealth, CeremonyStateExtension | `src/plugins/CeremonyPlugin.ts:439` |
+| `ceremony.state.snapshot` | CeremonyStateExtension | world-state aggregator | extension header docstring |
+
+---
+
+## On-demand triggering
+
+External publishes to `ceremony.{id}.execute` with `payload.type = "external.trigger"` fire the same path as cron. This is how chat commands like "/ceremony run security-sweep" work — they don't bypass cron, they participate as another publisher.
+
+**Why two payload types:** when the cron path also publishes on the same topic, the self-subscription would fire twice. `payload.type` lets the handler distinguish self-triggered (drop) from externally-triggered (run) without breaking the self-subscription contract.
+
+---
+
+## Executor mapping
+
+[CeremonySkillExecutorPlugin.ts:40–55](../../src/plugins/CeremonySkillExecutorPlugin.ts) maintains an explicit `CEREMONY_SKILLS` table:
+
+```
+ceremony.security_triage  →  ceremonyId: security-sweep
+ceremony.…                →  ceremonyId: …
+```
+
+Each entry registers a `FunctionExecutor` with `ExecutorRegistry` (priority=5) that publishes `ceremony.{ceremonyId}.execute` when its skill is dispatched. This is how a *skill name* on `agent.skill.request` becomes a *ceremony trigger* on `ceremony.{id}.execute`.
+
+The skill→ceremonyId mapping is explicit (not derived) so renames don't silently break dispatches.
+
+---
+
+## Failure modes & gotchas
+
+- **Disabled ceremonies are unregistered from ExecutorRegistry** ([line 263–268](../../src/plugins/CeremonyPlugin.ts)) — external triggers cannot fire a disabled ceremony, even though the YAML still parses. Re-enabling requires the next hot-reload tick.
+- **`timeoutMs` is per-ceremony** ([line 386](../../src/plugins/CeremonyPlugin.ts)) — if unset, no timeout. The dispatcher itself has no timeout (see [chokepoint-invariants](chokepoint-invariants.md)). For long ceremonies, set `timeoutMs` explicitly or the run can hang.
+- **Project overrides global** ([ceremonyYamlLoader.ts:60–66](../../src/plugins/ceremonyYamlLoader.ts)) — if both define `id: x`, project wins. This is intentional but can confuse if you forgot a project-level file existed.
+- **Cron format is parser-dependent** ([CeremonyPlugin.ts:285](../../src/plugins/CeremonyPlugin.ts)) — uses `cron-expression-parser`. Standard 5-field cron (`* * * * *`); no 6-field (seconds) support.
+- **The `ceremony.{id}.completed` topic is back-compat only** — new consumers should subscribe to `autonomous.outcome.ceremony.{id}.{skill}` which is the canonical telemetry path and matches the fleet-health attribution model.
+
+---
+
+## Related
+
+- [flow-inbound-message](flow-inbound-message.md) — what `agent.skill.request` does next
+- [flow-agent-runtime-telemetry](flow-agent-runtime-telemetry.md) — what `autonomous.outcome.*` feeds
+- [flow-alert-remediator](flow-alert-remediator.md) — alerts are also FunctionExecutor-backed and share the same dispatch pattern

--- a/docs/architecture/flow-dashboard.md
+++ b/docs/architecture/flow-dashboard.md
@@ -1,0 +1,165 @@
+---
+title: Flow — Dashboard data path
+---
+
+_The dashboard is a separate Astro + React frontend at `http://ava:3333` (Tailscale-only). It reads from API routes that aggregate live bus events plus rolling-window snapshots. The bus → API → tile chain is one-way; the dashboard does not write to the bus._
+
+---
+
+## What & why
+
+Operators need a single pane to see "what is the fleet doing right now" without tailing logs. The dashboard is intentionally **read-only** and **debug-oriented** — not a control surface. (Memory: "we dont really want to use this as a ui anyhow, more for debugging".)
+
+Three classes of data feed the tiles:
+
+- **Live bus events** via `BusHistoryRecorder` → API → SSE/poll → tile
+- **Rolling-window snapshots** computed in plugins (`AgentFleetHealth`, `CostStore`) → API JSON → tile
+- **External state** (GitHub PR pipeline, Linear) via per-plugin APIs
+
+---
+
+## ASCII spine
+
+```
+                     Bus events                  External APIs
+                          │                            │
+              ┌───────────┴────────┐                   │
+              ▼                    ▼                   ▼
+   ┌──────────────────┐  ┌──────────────────┐  ┌────────────────┐
+   │ BusHistory       │  │ AgentFleetHealth │  │ GitHubPlugin   │
+   │ Recorder         │  │ rolling 24h      │  │ pr-pipeline    │
+   │ (in-mem ring)    │  │ window           │  │ snapshot       │
+   └────────┬─────────┘  └─────────┬────────┘  └────────┬───────┘
+            │                      │                    │
+            ▼                      ▼                    ▼
+   ┌──────────────────────────────────────────────────────────┐
+   │ src/api/  HTTP routes (per-module)                       │
+   │                                                          │
+   │  /api/bus-events       (BusHistoryRecorder)              │
+   │  /api/agent-health     (AgentFleetHealth)                │
+   │  /api/outcomes         (AgentFleetHealth)                │
+   │  /api/cost-summaries   (CostStore)                       │
+   │  /api/pr-pipeline      (GitHubPlugin)                    │
+   │  /api/ceremonies       (CeremonyPlugin)                  │
+   │  /api/a2a-status       (SkillBrokerPlugin)               │
+   └────────────────────────┬─────────────────────────────────┘
+                            │
+                            ▼  HTTPS over Tailscale
+                            │  (http://ava:3333)
+                            ▼
+   ┌──────────────────────────────────────────────────────────┐
+   │ dashboard/  (Astro + React)                              │
+   │                                                          │
+   │  pages/                    fetch via:                    │
+   │   • system.astro             dashboard/src/lib/api.ts    │
+   │   • agents.astro             TTL: 15s fleet health       │
+   │   • outcomes.astro                  30s cost             │
+   │   • fleet-cost.astro                live SSE for events  │
+   │   • pr-pipeline.astro                                    │
+   │   • ceremonies.astro                                     │
+   └──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Sequence (a single tile fetch)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant T as Tile (React)
+    participant API as src/api/* route
+    participant Plugin as Source plugin
+    participant Bus as Bus<br/>(live or recorded)
+
+    T->>API: GET /api/agent-health
+    API->>Plugin: collector.getFleetHealth()
+    Plugin->>Plugin: aggregate rolling window<br/>(filters synthetic actors per #459)
+    Plugin-->>API: FleetHealthSnapshot
+    API-->>T: JSON
+
+    Note over T: cache 15s TTL
+    Note over T: SSE / poll for live events<br/>via /api/bus-events
+```
+
+---
+
+## API routes table
+
+| Route | Source plugin | Cache TTL | Tile |
+|---|---|---|---|
+| `/api/bus-events` | BusHistoryRecorder | live (SSE / 1s poll) | Live event log, D1 dashboard |
+| `/api/agent-health` | AgentFleetHealth | 15s | Agents tile, agent rows |
+| `/api/outcomes` | AgentFleetHealth | 15s | Outcomes tile, D2/D3 dashboards |
+| `/api/cost-summaries` | CostStore | 30s | Fleet cost tile |
+| `/api/pr-pipeline` | GitHubPlugin | 30s | PR-1/-2/-3 review pipeline tiles |
+| `/api/ceremonies` | CeremonyPlugin | 30s | Ceremony status tile |
+| `/api/a2a-status` | SkillBrokerPlugin | 60s | A2A health tile |
+
+Per [dashboard/src/lib/api.ts:85–95](../../dashboard/src/lib/api.ts).
+
+---
+
+## BusHistoryRecorder
+
+[src/event-bus/bus-history-recorder.ts](../../src/event-bus/bus-history-recorder.ts) subscribes broadly to `agent.skill.*`, `flow.item.*`, `autonomous.outcome.*`, `ceremony.*`, and `message.inbound.*` / `message.outbound.*` (selectively). Keeps a bounded in-memory ring of recent events. Exposed via `/api/bus-events` for the live event log and dashboard inspector.
+
+**State:** in-memory. Restart wipes history. **There is no durable persistence** — the dashboard is a snapshot of *current process*, not a historical archive.
+
+**Bus topics observed (selection):**
+
+| Pattern | Used for |
+|---|---|
+| `agent.skill.request` | "what just dispatched" |
+| `agent.skill.response.#` | response payloads (text preview) |
+| `flow.item.#` | PR-1/-2/-3 lifecycle tiles |
+| `autonomous.outcome.#` | outcomes feed |
+| `autonomous.cost.#` | cost feed |
+| `ceremony.#.completed` | ceremony status |
+
+---
+
+## Tile inventory (current)
+
+| Tile | Page | Data source |
+|---|---|---|
+| Live event log | `system.astro` | `/api/bus-events` (SSE) |
+| Agent grid | `agents.astro` | `/api/agent-health` |
+| Outcomes by skill | `outcomes.astro` | `/api/outcomes` |
+| Fleet cost / token usage | `fleet-cost.astro` | `/api/cost-summaries` |
+| PR review pipeline (PR-1/-2/-3) | `pr-pipeline.astro` | `/api/pr-pipeline` + `flow.item.*` |
+| Ceremony status | `ceremonies.astro` | `/api/ceremonies` |
+| Architectural-column overlay | `system.astro` | static layout + live agent positions |
+
+D1/D2/D3 (dashboard sub-pages) and O-2/-3/-4 (corner overlay tiles) are sub-views of the above sources, not independent data paths.
+
+---
+
+## Tailscale-only deployment
+
+The dashboard is **never internet-exposed**:
+
+- Bound to `0.0.0.0:3333` inside the container
+- Tailscale serve maps to `http://ava:3333` (MagicDNS)
+- `ava.proto-labs.ai` (public) uses a Caddyfile + cloudflared allowlist that **excludes** `/dashboard` and `/system` paths
+
+This means dashboard data — including PR contents, agent token usage, internal channel IDs — never leaves the tailnet.
+
+---
+
+## Failure modes & gotchas
+
+- **History is in-memory only** — restart wipes the event log. No "what happened last night while I was asleep" view without external logging.
+- **Aspirational topics show empty tiles** — anything depending on `agent.runtime.activity.tool.call` or `agent.skill.latency` is empty (see [flow-agent-runtime-telemetry](flow-agent-runtime-telemetry.md)).
+- **Cost can be zero for new models** — `MODEL_RATES` table is hard-coded; LiteLLM adding a model = zero cost recorded until updated.
+- **PR-pipeline tile depends on GitHubPlugin's local cache** — `pr_pipeline` snapshot is built on-demand by hitting GitHub API. Heavy refresh load if many tiles open simultaneously.
+- **Synthetic actors don't show in agent grid** — by design ([#459 chokepoint](chokepoint-invariants.md)) — they appear in a separate "system actors" panel on the fleet-health page, not under "agents".
+
+---
+
+## Related
+
+- [flow-inbound-message](flow-inbound-message.md) — source of most bus events the dashboard shows
+- [flow-agent-runtime-telemetry](flow-agent-runtime-telemetry.md) — direct upstream
+- [flow-alert-remediator](flow-alert-remediator.md) — feeds the fleet health tile
+- [flow-pr-review](flow-pr-review.md) — feeds the PR-1/-2/-3 tiles

--- a/docs/architecture/flow-hitl.md
+++ b/docs/architecture/flow-hitl.md
@@ -1,0 +1,150 @@
+---
+title: Flow — HITL escalation
+---
+
+_When an autonomous loop gets stuck or hits a destructive-verdict guard, the intended escape valve is a Human-In-The-Loop escalation: ping the operator, surface the context, wait for direction. **Today this is wire-incomplete** — escalation sites log to console but do not publish a bus event. The operator-routing plumbing exists separately for `operator.message.request`, but the two are not connected._
+
+---
+
+## What & why
+
+Bottlenecks are growth signals (see [memory: bottlenecks-are-growth](../../.claude/projects/-home-josh-dev-protoWorkstacean/memory/feedback_bottlenecks_are_growth.md)). A stuck autonomous loop should **escalate, not silently drop** — each escalation is a feature-request for the next layer of autonomy. HITL is the structural place to surface those.
+
+The system has two pieces of HITL infrastructure, but they're not currently bridged:
+
+| Piece | What it does | Source |
+|---|---|---|
+| **Escalation trigger sites** | Detect "this loop is stuck" or "this verdict is destructive on a protected target" and emit a warning | `lib/plugins/pr-remediator.ts:770,788,1072,1598` etc. |
+| **Operator routing** | `OperatorRoutingPlugin` subscribes to `operator.message.request` and routes a payload to a Discord DM | `lib/plugins/operator-routing.ts:75–127` |
+
+The gap: pr-remediator (and other escalation sites) **log to `console.warn`** but do not publish `operator.message.request`. So escalations are only visible to whoever is reading container logs — not surfaced to an operator interactively.
+
+---
+
+## ASCII spine (intended)
+
+```
+   stuck loop / destructive verdict / cooldown trip
+                │
+                ▼
+   ┌──────────────────────────┐
+   │  Escalation site         │  e.g. pr-remediator._emitStuckHitlEscalation()
+   │   (multiple, scattered)  │
+   │                          │
+   │   today: console.warn    │  ← GAP: no bus event
+   │   intended: publish      │
+   │     hitl.request.*       │
+   └──────────────┬───────────┘
+                  │  (intended)
+                  ▼
+   ┌──────────────────────────┐
+   │  operator.message.       │  topic shape OperatorMessageRequest
+   │  request                 │  { message, urgency, topic, from }
+   └──────────────┬───────────┘
+                  ▼
+   ┌──────────────────────────┐
+   │  OperatorRoutingPlugin   │  reads workspace/users.yaml
+   │   resolves operator      │  routes to:
+   │   userId                 │
+   └──────────────┬───────────┘
+                  ▼
+   ┌──────────────────────────┐
+   │  message.outbound.       │
+   │  discord.dm.user.{userId}│
+   └──────────────┬───────────┘
+                  ▼
+            Operator's Discord DM
+                  │
+                  ▼  (response path not implemented today)
+            ⚠ no inbound subscriber for operator reply
+```
+
+---
+
+## What actually fires today
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant PR as PrRemediatorPlugin
+    participant Bus as Bus
+    participant Log as console
+    participant OP as Operator (intended)
+
+    Note over PR: stuck PR detected<br/>(attempts ≥ 3 OR genuine conflict)
+    PR->>Log: console.warn(escalation message + PR URL)
+    Note over Bus,OP: ⚠ NO bus publish today<br/>operator.message.request not emitted<br/>OperatorRoutingPlugin never fires<br/>Operator never sees the DM
+```
+
+---
+
+## Bus topic table (intended vs actual)
+
+| Topic | Intended publisher | Actual publisher (audited) | Subscriber | Status |
+|---|---|---|---|---|
+| `operator.message.request` | pr-remediator escalation sites, dispatcher chokepoint trips | _(none in current source)_ | OperatorRoutingPlugin | ⚠ gap |
+| `message.outbound.discord.dm.user.{userId}` | OperatorRoutingPlugin | OperatorRoutingPlugin | DiscordPlugin DM sink | ✅ wired |
+| `hitl.request.pr.remediation_stuck.{correlationId}` | _docstring says pr-remediator emits this_ | _(none)_ | _(none)_ | ❌ aspirational |
+| `hitl.response.*` | _(operator → bus)_ | _(none)_ | _(none)_ | ❌ aspirational |
+
+The `OperatorRoutingPlugin` at [operator-routing.ts:75–127](../../lib/plugins/operator-routing.ts) is healthy and tested — it just has no current upstream publisher.
+
+---
+
+## Escalation trigger sites (today)
+
+[pr-remediator.ts](../../lib/plugins/pr-remediator.ts):
+
+| Site | Condition | What fires |
+|---|---|---|
+| `_emitStuckHitlEscalation` (line 770, 788) | attempt count ≥ `MAX_ATTEMPTS_PER_PR` (3) | `console.warn(PR URL + reason)` |
+| `update_branch` 422 conflict handler (line 1072) | 422 from GitHub after 2+ attempts | dispatch `diagnose_pr_stuck` → LLM verdict |
+| diagnose verdict "genuine" (line 1598) | LLM judges conflict is semantic | `console.warn` + `entry.escalated = true` |
+| diagnose verdict "decomposable" on promotion PR (line 1536) | #465 destructive verdict guard | `console.warn` + suppress close |
+
+None of these publish `operator.message.request` today.
+
+---
+
+## Operator-routing details (the half that works)
+
+[operator-routing.ts](../../lib/plugins/operator-routing.ts):
+
+```
+on operator.message.request:
+    payload: { message, urgency, topic, from }
+    look up operator userId from workspace/users.yaml
+    publish message.outbound.discord.dm.user.{userId}
+        with payload.content = formatted message
+```
+
+[`workspace/users.yaml`](../../workspace/users.yaml) — operator list with Discord user IDs. The plugin reads this at install and routes by `urgency` field (could escalate to multiple operators in future; today it picks the first).
+
+---
+
+## Closing the gap
+
+Minimum viable wiring to make escalation actually escalate:
+
+1. **At each escalation site, publish `operator.message.request`** with the existing context (PR URL, reason, urgency). One-line additions next to each `console.warn`.
+2. **Decide the inbound HITL path** — does an operator's Discord DM reply re-enter the bus as `hitl.response.*`? Or do they manually run a CLI / dashboard action? Not yet decided.
+
+Both are open work. The escalation sites are the more urgent half — without them, the operator is in the dark by default.
+
+---
+
+## Failure modes & gotchas
+
+- **Promotion-PR destructive guard is the most surface-visible HITL path today** (`#465`) — when Ava's verdict is `decomposable` on a release-pipeline PR, the close is suppressed but no operator notification fires. The PR sits with the LLM verdict text in a comment, no further action.
+- **Live CI re-check before escalating `fix_ci`** (line 821–830) — prevents spurious "stuck on CI" escalation if CI flipped green. Good. But also masks the case where CI flipped green *because* something else fixed it, not because the original issue was resolved.
+- **`InFlightEntry.escalated` is a one-shot flag** ([line 196](../../lib/plugins/pr-remediator.ts)) — once set, no further escalations on the same PR. If a real new failure mode appears, it's not re-escalated. Acceptable today (we don't have multiple operators); revisit if HITL becomes a queue.
+- **`operator.message.request` is fire-and-forget** ([line 76](../../lib/plugins/operator-routing.ts)) — no acknowledgment topic. If the DM send fails, the publisher doesn't know. The OperatorRoutingPlugin logs failures but doesn't notify upstream.
+
+---
+
+## Related
+
+- [chokepoint-invariants](chokepoint-invariants.md) — #465 is the most well-formed HITL escalation site
+- [flow-alert-remediator](flow-alert-remediator.md) — pr-remediator hosts most escalation sites
+- [flow-dashboard](flow-dashboard.md) — once escalations are bussed, the dashboard can count them
+- [memory: bottlenecks-are-growth](../../.claude/projects/-home-josh-dev-protoWorkstacean/memory/feedback_bottlenecks_are_growth.md) — the design principle behind this flow

--- a/docs/architecture/flow-inbound-message.md
+++ b/docs/architecture/flow-inbound-message.md
@@ -1,0 +1,167 @@
+---
+title: Flow — Inbound Message
+---
+
+_The central spine: a message arrives from a platform, the router resolves a skill, the dispatcher runs it, the executor produces a reply, the platform plugin posts it back. Every other flow either feeds this one or observes it._
+
+---
+
+## What & why
+
+Discord/GitHub/Linear/Google webhooks land as `message.inbound.*` topics. [RouterPlugin](../../src/router/router-plugin.ts) deterministically resolves keyword + channel → skill and re-publishes as `agent.skill.request`. [SkillDispatcherPlugin](../../src/executor/skill-dispatcher-plugin.ts) is the **sole subscriber** to that topic and the system's main chokepoint: it enforces cooldown, resolves an executor, runs it, and publishes outcome telemetry. Reply text routes back to the originating platform via `message.outbound.{platform}.*`.
+
+No LLM in the routing layer. Routing is keyword/channel YAML; LLM-driven decisions happen *inside* executors.
+
+---
+
+## ASCII spine
+
+```
+   Discord/GitHub/Linear/Google
+              │
+              ▼
+   ┌──────────────────────────┐
+   │ message.inbound.{plat}.* │  ← published by trigger plugin
+   └──────────────┬───────────┘
+                  │
+                  ▼
+        ┌─────────────────┐
+        │ RouterPlugin    │       channels.yaml + keyword tables
+        │   resolve skill │       (no LLM)
+        └────────┬────────┘
+                 │
+                 ▼
+   ┌──────────────────────────┐
+   │  agent.skill.request     │  payload: { skill, content, targets?, reply.topic, meta }
+   └──────────────┬───────────┘
+                  │  (sole subscriber)
+                  ▼
+   ┌──────────────────────────┐
+   │  SkillDispatcherPlugin   │  CHOKEPOINT
+   │  ─────────────────────   │  1. mark activeExecutions
+   │  cooldown check          │  2. ExecutorRegistry.resolve(skill, targets)
+   │  resolve executor        │  3. publish flow.item.created
+   │  await executor.execute  │  4. await (no timeout)
+   │  publish outcome         │  5. publish autonomous.outcome + flow.item.completed
+   └──────────────┬───────────┘
+                  │
+        ┌─────────┼─────────┐
+        ▼         ▼         ▼
+    DeepAgent  ProtoSdk   A2A   FunctionExecutor
+    Executor   Executor   Exec  (alert/ceremony/pr-r)
+        │         │         │         │
+        └─────────┴─────────┴─────────┘
+                  │
+                  ▼
+   ┌──────────────────────────┐
+   │  message.outbound.{plat} │  or `linear.reply.{issueId}`
+   │      .{channel}          │  or `agent.skill.response.{correlationId}`
+   └──────────────┬───────────┘
+                  │  (platform plugin subscribes)
+                  ▼
+              External API
+        (Discord / GitHub / Linear)
+```
+
+---
+
+## Sequence (Discord chat path — representative)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Ext as Discord (external)
+    participant DP as DiscordPlugin
+    participant Bus as Bus
+    participant R as RouterPlugin
+    participant SD as SkillDispatcher
+    participant ER as ExecutorRegistry
+    participant E as Executor
+
+    Ext->>DP: MessageCreate event
+    DP->>Bus: message.inbound.discord.{channelId}
+    Bus->>R: deliver
+    R->>R: resolve skill (channels.yaml + keywords)
+    R->>Bus: agent.skill.request<br/>(reply.topic = message.outbound.discord.{ch})
+    Bus->>SD: deliver
+
+    rect rgb(240, 230, 220)
+        Note over SD: CHOKEPOINT
+        SD->>SD: mark activeExecutions
+        SD->>SD: cooldown check (#437)
+        SD->>ER: resolve(skill, targets)
+        ER-->>SD: executor | null
+        SD->>Bus: flow.item.created
+    end
+
+    SD->>E: execute(req)
+    E-->>SD: { text, error?, taskState }
+
+    alt taskState ∈ {submitted, working}
+        SD->>SD: hand off to TaskTracker<br/>(returns early; outcome published later)
+    else terminal
+        SD->>Bus: agent.skill.response.{correlationId}<br/>(or req.reply.topic)
+        SD->>Bus: message.outbound.discord.{ch}
+        SD->>Bus: autonomous.outcome.{systemActor}.{skill}
+        SD->>Bus: flow.item.completed
+    end
+
+    Bus->>DP: deliver outbound
+    DP->>Ext: discord.js send()
+```
+
+---
+
+## Bus topic table
+
+| Topic | Published by | Subscribed by | File:line |
+|---|---|---|---|
+| `message.inbound.discord.{channelId}` | DiscordPlugin | RouterPlugin | `lib/plugins/discord/inbound.ts:130,247,283` |
+| `message.inbound.github.{owner}.{repo}.{event}.{n}` | GitHubPlugin | RouterPlugin, PR-review handler | `lib/plugins/github.ts:635,700,795,939` |
+| `message.inbound.linear.{event}` | LinearPlugin | RouterPlugin, linear-protomaker-bridge, linear-proto-bridge | `lib/plugins/linear.ts` |
+| `agent.skill.request` | RouterPlugin, bridges, ActionDispatcher, SkillDispatcher (drain) | **SkillDispatcherPlugin (sole)** | `src/router/router-plugin.ts:272,322`; `src/executor/skill-dispatcher-plugin.ts:507` |
+| `flow.item.created` | SkillDispatcher | telemetry / dashboard | `src/executor/skill-dispatcher-plugin.ts:275` |
+| `flow.item.updated` | SkillDispatcher (running / error) | telemetry / dashboard | `src/executor/skill-dispatcher-plugin.ts:370,385,457` |
+| `agent.skill.progress.{correlationId}` | executor (opt-in) | dashboard / streaming | `src/event-bus/payloads.ts:86-95` |
+| `agent.skill.response.{correlationId}` *(default reply)* | SkillDispatcher | platform plugins via correlationId match | `src/executor/skill-dispatcher-plugin.ts:644,649` |
+| `message.outbound.discord.{channelId}` | SkillDispatcher / executor | DiscordPlugin outbound | `lib/plugins/discord/outbound.ts:43,129` |
+| `message.outbound.github.{owner}.{repo}.{n}` | SkillDispatcher / executor | GitHubPlugin | `lib/plugins/github.ts:298,375` |
+| `linear.reply.{issueId}` | SkillDispatcher / executor | LinearPlugin | `lib/plugins/linear.ts:561,565` |
+| `autonomous.outcome.{systemActor}.{skill}` | SkillDispatcher | AgentFleetHealth | `src/executor/skill-dispatcher-plugin.ts:538` |
+| `flow.item.completed` | SkillDispatcher | telemetry / dashboard | `src/executor/skill-dispatcher-plugin.ts:418` |
+
+---
+
+## Chokepoint details
+
+The dispatcher enforces invariants in this order ([skill-dispatcher-plugin.ts:166–480](../../src/executor/skill-dispatcher-plugin.ts)):
+
+1. **activeExecutions** set **before any `await`** — line 189. Blocks concurrent DM turn queuing.
+2. **Skill presence** — drops if missing (line 191–196).
+3. **Executor resolution** via `ExecutorRegistry.resolve(skill, targets)` — drops if null (line 198–208). This is the de-facto target-registry guard ([chokepoint-invariants.md](chokepoint-invariants.md)).
+4. **Cooldown** — per-skill-per-repo key, default 30s for `bug_triage`/`pr_review`, 60s for `security_triage`, env-override `WORKSTACEAN_COOLDOWN_MS_<SKILL>` (line 216–230). Drops with `console.warn`, no bus event.
+5. **`flow.item.created`** publish (line 275) — telemetry side-effect, not gating.
+6. **`await executor.execute(req)`** — **no timeout wrapper**. A2A executors can hang indefinitely; see Failure modes.
+7. **TaskTracker hand-off** if `taskState ∈ {submitted, working}` (line 291–379) — long-running A2A; dispatcher returns early.
+8. **Outcome publish** on terminal (line 418, 538) — both `flow.item.completed` and `autonomous.outcome.*`.
+9. **`finally`** drains ContextMailbox (line 478).
+
+---
+
+## Failure modes & gotchas
+
+- **No execute() timeout** — `await executor.execute()` at line 286 is unguarded. A2A hangs leave the dispatcher slot occupied indefinitely. Mitigation lives inside individual executors (A2A SDK has its own timeouts).
+- **Cooldown drop is silent on the bus** — only `console.warn`. Dashboard cannot count cooldown trips today. Reply topic still gets an error response (line 223–227).
+- **Synthetic actors pollute fleet metrics if unfiltered** — `systemActor` whitelisting happens at [AgentFleetHealthPlugin._record](../../src/plugins/agent-fleet-health-plugin.ts) (line 281–334), **not** at the dispatcher. See [chokepoint-invariants.md](chokepoint-invariants.md).
+- **Self-cascade guard on GitHub events** — DiscordPlugin/GitHubPlugin filter bot-authored events (`protoquinn[bot]`, `ava[bot]`, `protobot[bot]`) at webhook time to prevent infinite Quinn → issue → webhook → Quinn loops ([github.ts:524–542](../../lib/plugins/github.ts)). PR events are intentionally NOT filtered — Quinn-authored PRs still get reviewed.
+- **`bug_triage` success has a deferred side-effect** — async board filing if `projectPath` is set (line 332–334). Doesn't block the response; failures here are invisible to the requester.
+- **`correlationId` is the only reply linkage** — if the correlationId is dropped between inbound and outbound, the reply lands but is orphaned (no thread, no parent). Trigger plugins must preserve it on `msg.reply?.topic`.
+
+---
+
+## Related flows
+
+- [flow-linear-bridges](flow-linear-bridges.md) — Linear inbound bypasses RouterPlugin for label-triggered dispatches.
+- [flow-pr-review](flow-pr-review.md) — GitHub PR events follow this flow but with a fixed `skillHint=pr_review`.
+- [chokepoint-invariants](chokepoint-invariants.md) — the four invariants that sit inside the dispatcher.
+- [flow-agent-runtime-telemetry](flow-agent-runtime-telemetry.md) — what the dispatcher's outcome topics feed.

--- a/docs/architecture/flow-linear-bridges.md
+++ b/docs/architecture/flow-linear-bridges.md
@@ -1,0 +1,193 @@
+---
+title: Flow — Linear bridges (protomaker + proto)
+---
+
+_Two near-identical bridges turn label-tagged Linear issues into agent dispatches. They bypass RouterPlugin and use a `reply.topic` contract to round-trip the agent's response back to the Linear issue as a comment, with no bridge-side state._
+
+---
+
+## What & why
+
+`RouterPlugin` resolves chat messages via channels + keywords — neither concept fits a Linear *label* gate (which inspects the issue payload itself). Two bridges fill the gap:
+
+- **`linear-protomaker-bridge`** ([lib/plugins/linear-protomaker-bridge.ts](../../lib/plugins/linear-protomaker-bridge.ts)) — issues with the team's configured trigger label dispatch `manage_feature` to `protomaker`. Configured per-team via `workspace/linear-board-mappings.yaml`.
+- **`linear-proto-bridge`** ([lib/plugins/linear-proto-bridge.ts](../../lib/plugins/linear-proto-bridge.ts)) — issues with the `proto-task` label dispatch `code.execute` to the in-process `proto` agent. Single global label gate; override via `LINEAR_PROTO_BRIDGE_LABEL` env.
+
+Both follow the same shape; only the gating logic and the target skill/agent differ.
+
+---
+
+## ASCII spine
+
+```
+   Linear webhook
+        │
+        ▼
+   ┌──────────────────────────┐
+   │ LinearPlugin (inbound)   │  validates, dedupes
+   └──────────────┬───────────┘
+                  │
+                  ▼
+   ┌──────────────────────────┐
+   │ message.inbound.linear.  │
+   │   issue.created          │
+   └──────┬──────────────┬────┘
+          │              │
+          ▼              ▼
+   ┌────────────┐  ┌────────────┐
+   │ protomaker │  │   proto    │   each bridge subscribes
+   │   bridge   │  │   bridge   │   independently
+   │            │  │            │
+   │ label gate │  │ label gate │   (different label per bridge)
+   │ team       │  │ env-       │
+   │ mapping    │  │ overridable│
+   └─────┬──────┘  └─────┬──────┘
+         │               │
+         └───────┬───────┘
+                 ▼
+   ┌──────────────────────────┐
+   │  agent.skill.request     │  reply.topic = linear.reply.{issueId}
+   └──────────────┬───────────┘
+                  ▼
+              SkillDispatcher  (→ [flow-inbound-message](flow-inbound-message.md))
+                  │
+                  ▼
+   ┌──────────────────────────┐
+   │  linear.reply.{issueId}  │  ← executor publishes here
+   └──────────────┬───────────┘
+                  │  LinearPlugin subscribes (wildcard linear.reply.#)
+                  ▼
+            Linear API
+        createComment(issueId, content)
+```
+
+---
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Ext as Linear (external)
+    participant LP as LinearPlugin
+    participant Bus as Bus
+    participant B as Bridge<br/>(proto OR protomaker)
+    participant SD as SkillDispatcher
+    participant E as Executor<br/>(proto / protomaker)
+
+    Ext->>LP: webhook (Issue.Create)
+    LP->>LP: validate + dedupe
+    LP->>Bus: message.inbound.linear.issue.created
+    Bus->>B: deliver
+
+    rect rgb(240, 230, 220)
+        Note over B: label gate
+        alt label matches
+            B->>B: build content + meta
+            B->>Bus: agent.skill.request<br/>(reply.topic = linear.reply.{issueId})
+        else label miss
+            Note over B: silent drop
+        end
+    end
+
+    Bus->>SD: deliver
+    SD->>E: execute(req)
+    E-->>Bus: linear.reply.{issueId}<br/>(payload.content = result)
+
+    Bus->>LP: deliver (subscriber: linear.reply.#)
+    LP->>LP: extract issueId from topic
+    LP->>Ext: client.createComment(issueId, content)
+    LP->>Bus: linear.reply.result.{correlationId}<br/>(record API result)
+```
+
+---
+
+## Bus topic table
+
+| Topic | Published by | Subscribed by | File:line |
+|---|---|---|---|
+| `message.inbound.linear.issue.created` | LinearPlugin (webhook) | RouterPlugin, linear-protomaker-bridge, linear-proto-bridge | `lib/plugins/linear.ts` |
+| `agent.skill.request` (manage_feature, protomaker) | linear-protomaker-bridge | SkillDispatcher | `lib/plugins/linear-protomaker-bridge.ts:178` |
+| `agent.skill.request` (code.execute, proto) | linear-proto-bridge | SkillDispatcher | `lib/plugins/linear-proto-bridge.ts:106` |
+| `linear.reply.{issueId}` | SkillDispatcher / executor (writes payload.content) | LinearPlugin._wireOutbound | `lib/plugins/linear.ts:561` |
+| `linear.reply.result.{correlationId}` | LinearPlugin (after API call) | telemetry | `lib/plugins/linear.ts:567` |
+
+---
+
+## Gate logic
+
+### linear-protomaker-bridge
+
+Configured by **`workspace/linear-board-mappings.yaml`** ([line 96–100](../../lib/plugins/linear-protomaker-bridge.ts)):
+
+```yaml
+mappings:
+  - linearTeamKey: ENG
+    protoMakerProjectSlug: protoworkstacean
+    triggerLabel: feature
+```
+
+Hot-reload: 5s file watcher. Schema validation is **fail-loud** — one malformed mapping rejects the whole file.
+
+Gate sequence ([line 147–211](../../lib/plugins/linear-protomaker-bridge.ts)):
+1. Drop if `issueId || teamKey || title` missing (line 149)
+2. Look up mapping by `teamKey` — drop if not found (line 151)
+3. Check `issue.labels.includes(mapping.triggerLabel)` — drop if absent (line 155)
+4. Build `agent.skill.request` with skill `manage_feature`, targets `["protomaker"]`, reply.topic `linear.reply.${issueId}`
+
+### linear-proto-bridge
+
+Single global label, env-overridable:
+
+```
+default: proto-task
+override: LINEAR_PROTO_BRIDGE_LABEL=<custom>
+```
+
+Gate sequence ([line 81–140](../../lib/plugins/linear-proto-bridge.ts)):
+1. Drop if `issueId || title` missing (line 83)
+2. Check `issue.labels.includes(this.triggerLabel)` — drop if absent (line 86–92)
+3. Build `agent.skill.request` with skill `code.execute`, targets `["proto"]`, reply.topic `linear.reply.${issueId}`
+
+No team mapping — proto is a single fleet-wide agent, not per-board.
+
+---
+
+## Reply round-trip
+
+Both bridges set `reply.topic = linear.reply.{issueId}` on dispatch. SkillDispatcher publishes the executor's response to that topic. LinearPlugin subscribes to `linear.reply.#` (excluding `linear.reply.result.*` to avoid feedback loop) and:
+
+1. Extracts `issueId` from the topic ([linear.ts:565](../../lib/plugins/linear.ts))
+2. Calls `LinearClient.createComment(issueId, msg.payload.content)`
+3. Publishes `linear.reply.result.{correlationId}` with API result for audit
+
+The bridges hold **no state** for round-trip — `reply.topic` is the entire close-the-loop contract.
+
+---
+
+## Why two bridges, not one
+
+Greenfield rule: "absence of a default = no behavior". The bridges differ in:
+
+- **Configuration shape** (per-team mappings yaml vs. single env var)
+- **Skill** (`manage_feature` vs. `code.execute`)
+- **Target** (`protomaker` vs. `proto`)
+
+A unified bridge would either need a routing table (over-engineering for two cases) or per-bridge configuration that essentially looks like the current two files. Two small bridges is the simpler shape — and both are no-op when their gate misses, so installing both unconditionally is safe.
+
+---
+
+## Failure modes & gotchas
+
+- **Both bridges silent-drop on non-matching label** — by design. RouterPlugin's chat path still handles the issue via `channels.yaml` if a team's channel routes to a default agent. Bridges and router can coexist on the same inbound event.
+- **No "feature completed" close-the-loop** — when the agent's work eventually merges, no automatic comment lands on the originating Linear issue. The bridge only handles the *first* dispatch reply; if the agent's reply is "I'll work on this and PR shortly", there's no async follow-up. See [protoMaker#3810](https://github.com/protoLabsAI/protoMaker/issues/3810) for the lifecycle event work that would close this.
+- **Mapping yaml hot-reload re-validates everything** — a single bad mapping rejects the whole file. Restart-safe but operator gets one chance to see the warning.
+- **`correlationId` convention** — `linear-bridge-${issueId}` (protomaker) or `linear-proto-${issueId}` (proto). Not used for reply routing (that's `reply.topic`); used for tracing and `linear.reply.result.*` correlation.
+
+---
+
+## Related
+
+- [flow-inbound-message](flow-inbound-message.md) — what happens after the bridge publishes `agent.skill.request`
+- [flow-pr-review](flow-pr-review.md) — the analogous label-gated dispatch for GitHub PRs (no separate bridge, lives inside GitHubPlugin)
+- [flow-hitl](flow-hitl.md) — what happens if the dispatched agent escalates (HITL gap applies)

--- a/docs/architecture/flow-pr-review.md
+++ b/docs/architecture/flow-pr-review.md
@@ -1,0 +1,191 @@
+---
+title: Flow — PR review pipeline
+---
+
+_Quinn reviews every PR opened against fleet repos. GitHub webhook → dispatch with `skillHint=pr_review` → Quinn issues a verdict (PASS / WARN / FAIL) via tool call → GitHub review (APPROVED / COMMENTED / CHANGES_REQUESTED). The self-cascade guard prevents agent-authored PRs from re-triggering the loop._
+
+---
+
+## What & why
+
+GitHub PR events arrive on the same `message.inbound.github.*` topic as everything else, but with `skillHint=pr_review` pinned by `GitHubPlugin._handleAutoReview` ([github.ts:566–581](../../lib/plugins/github.ts)). That hint guarantees `pr_review` is dispatched even if RouterPlugin's keyword table would have routed elsewhere.
+
+Quinn's executor (DeepAgent) executes `pr_review` and decides one of three verdicts via tool call:
+
+| Quinn tool call | GitHub review event |
+|---|---|
+| `review_approve` | APPROVED |
+| `review_comment` | COMMENTED |
+| `review_request_changes` | CHANGES_REQUESTED |
+
+The verdict tool call publishes to `message.outbound.github.{owner}.{repo}.{number}` and GitHubPlugin posts to the GitHub API.
+
+---
+
+## ASCII spine
+
+```
+   GitHub PR webhook
+        │
+        ▼
+   ┌──────────────────────────┐
+   │ GitHubPlugin             │  ← self-cascade guard:
+   │  _handleAutoReview()     │     drop if author ∈ {protoquinn[bot],
+   │                          │       ava[bot], protobot[bot], …}
+   │                          │     for non-PR events only
+   │  dedup window 60s        │  ← drop duplicate PR pushes within window
+   └──────────────┬───────────┘
+                  │
+                  ▼
+   ┌──────────────────────────┐
+   │ message.inbound.github.  │  payload: { skillHint: "pr_review",
+   │   {owner}.{repo}.        │             reply.topic: outbound.github.… }
+   │   pull_request.{n}       │
+   └──────────────┬───────────┘
+                  │
+                  ▼  RouterPlugin (pass-through, skillHint wins)
+                  ▼
+   ┌──────────────────────────┐
+   │  agent.skill.request     │  skill: pr_review
+   │                          │  targets: [quinn]
+   └──────────────┬───────────┘
+                  ▼
+            SkillDispatcher  (cooldown 30s per-repo, see #437)
+                  │
+                  ▼
+   ┌──────────────────────────┐
+   │  Quinn (DeepAgent)       │  prompted: "Issue your verdict (PASS/WARN/FAIL)
+   │                          │             via review_approve /
+   │                          │             review_comment /
+   │                          │             review_request_changes."
+   └──────────────┬───────────┘
+                  │ tool call
+                  ▼
+   ┌──────────────────────────┐
+   │ message.outbound.github. │  payload: { type: "review_approve" | … ,
+   │   {owner}.{repo}.{n}     │             body, event }
+   └──────────────┬───────────┘
+                  ▼
+            GitHubPlugin._postComment()
+                  │
+                  ▼
+            GitHub REST API
+        POST /repos/{owner}/{repo}/pulls/{n}/reviews
+```
+
+---
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant GH as GitHub
+    participant GP as GitHubPlugin
+    participant Bus as Bus
+    participant R as RouterPlugin
+    participant SD as SkillDispatcher
+    participant Q as Quinn (DeepAgent)
+
+    GH->>GP: webhook (pull_request.opened / synchronize / review_requested)
+
+    rect rgb(240, 230, 220)
+        Note over GP: webhook-time filters
+        GP->>GP: self-cascade guard (bot login filter)
+        GP->>GP: dedup window 60s
+    end
+
+    GP->>Bus: message.inbound.github.{o}.{r}.pull_request.{n}<br/>(skillHint=pr_review)
+    Bus->>R: deliver
+    R->>Bus: agent.skill.request<br/>(skill=pr_review, targets=[quinn])
+    Bus->>SD: deliver
+
+    rect rgb(240, 230, 220)
+        Note over SD: dispatcher chokepoint<br/>cooldown 30s per-repo
+    end
+
+    SD->>Q: execute(req)
+    Q->>Q: read PR diff via tools
+    Q->>Q: analyze (LLM)
+
+    alt PASS
+        Q->>Bus: review_approve tool call → message.outbound.github.{o}.{r}.{n}
+    else WARN
+        Q->>Bus: review_comment tool call → message.outbound.github.{o}.{r}.{n}
+    else FAIL
+        Q->>Bus: review_request_changes tool call → message.outbound.github.{o}.{r}.{n}
+    end
+
+    Bus->>GP: deliver outbound (correlationId match in pendingComments)
+    GP->>GH: POST /repos/{o}/{r}/pulls/{n}/reviews
+```
+
+---
+
+## Bus topic table
+
+| Topic | Published by | Subscribed by | File:line |
+|---|---|---|---|
+| `message.inbound.github.{o}.{r}.pull_request.{n}` | GitHubPlugin._handleAutoReview | RouterPlugin | `lib/plugins/github.ts:697,632` |
+| `agent.skill.request` (skill=pr_review) | RouterPlugin (re-emits with target) | SkillDispatcher | `src/router/router-plugin.ts:272` |
+| `agent.skill.response.{correlationId}` | SkillDispatcher | GitHubPlugin (pendingComments match) | `src/executor/skill-dispatcher-plugin.ts:96,182,195` |
+| `message.outbound.github.{o}.{r}.{n}` | Quinn (via tool call) | GitHubPlugin._postComment | `lib/plugins/github.ts:298,375` |
+| `flow.item.{created,updated,completed}` | SkillDispatcher | telemetry / dashboard PR-1/2/3 tiles | `src/executor/skill-dispatcher-plugin.ts:275,370,418` |
+
+---
+
+## "PR-1 / PR-2 / PR-3" — what those phases mean
+
+The dashboard's PR review tiles aren't pipeline *phases* — they're three **states** in the `flow.item` lifecycle, observed by [flow-dashboard](flow-dashboard.md):
+
+- **PR-1** — `flow.item.created` (dispatch started, Quinn assigned)
+- **PR-2** — `flow.item.updated` (Quinn running, may publish progress)
+- **PR-3** — `flow.item.completed` (verdict posted, GitHub review created)
+
+Each tile counts items in each state. There is **no formal phase boundary** in source — the names are dashboard nomenclature.
+
+---
+
+## Self-cascade guard
+
+[github.ts:524–542](../../lib/plugins/github.ts) drops webhook events authored by known bots:
+
+```
+authorLogins to drop: protoquinn[bot], ava[bot], protobot[bot], …
+```
+
+**Critical:** PR events are *intentionally not filtered*. If Quinn opens a PR (e.g. autonomous tech-debt PR), Quinn still gets to review it. Filtering is only on issue/comment events — preventing Quinn → file issue → webhook → Quinn-files-another-issue cascade ([protoWorkstacean#556](https://github.com/protoLabsAI/protoWorkstacean/issues/556)).
+
+---
+
+## Dedup window
+
+60s sliding window keyed by `(owner/repo, number)` ([github.ts:656](../../lib/plugins/github.ts)). Prevents fast-rebase floods (`git push --force` storms) from triggering N reviews. **Race:** if a real new commit lands within the 60s window, it doesn't trigger a review until the window clears. Acceptable today (PR review is best-effort, not real-time); revisit if it bites.
+
+Note this is separate from #437 cooldown (which is per-skill-per-repo and 30s) — both apply, dedup at the webhook tier and cooldown at the dispatcher tier.
+
+---
+
+## Correlation ID chain
+
+`correlationId` flows: webhook → inbound → router → dispatcher → outbound. GitHubPlugin stores `(owner, repo, number)` keyed by correlationId in `pendingComments` Map ([github.ts:621,683–684](../../lib/plugins/github.ts)) so the outbound subscriber knows which PR a reply belongs to.
+
+**Fragile if dropped:** if any layer fails to forward `correlationId`, the reply still gets posted but to the wrong endpoint (or the lookup fails and it's orphaned). RouterPlugin and SkillDispatcher both preserve it by convention — but there's no enforcement.
+
+---
+
+## Failure modes & gotchas
+
+- **Cooldown silently drops review #2 within 30s** — if a PR is opened and immediately rebased, the second event hits dispatcher cooldown and silently drops. Operator sees no review for the second push. Visible only in `console.warn`. See [chokepoint-invariants](chokepoint-invariants.md) re: missing dispatch-drop telemetry.
+- **No timeout on Quinn's execution** — same as the general dispatcher gap; Quinn could hang indefinitely on a large diff. Mitigation: DeepAgent has its own `maxTurns` limit and per-tool timeouts.
+- **Verdict tool calls are advisory** — Quinn could in principle issue no verdict (just a chat reply). The PR-review prompt instructs the verdict, but it's an LLM, not a formal contract. If no verdict is issued, GitHubPlugin posts the text response as a comment (default outbound path) and no formal review event is created on GitHub.
+- **Self-cascade guard does NOT apply to PRs** — by design. Quinn-authored PRs *should* be reviewed. If Quinn ever starts auto-resolving its own reviews (approving her own PR), it would loop. Watch for that.
+
+---
+
+## Related
+
+- [flow-inbound-message](flow-inbound-message.md) — the underlying transport
+- [chokepoint-invariants](chokepoint-invariants.md) — #465 destructive-verdict guard, which sits inside `pr-remediator` (not Quinn), but related to the verdict pattern
+- [flow-alert-remediator](flow-alert-remediator.md) — PR remediator handles `update_branch` / `fix_ci` / `address_feedback` actions that follow up on review verdicts
+- [flow-dashboard](flow-dashboard.md) — PR-1/-2/-3 tiles


### PR DESCRIPTION
## Summary

Ten new docs in \`docs/architecture/\` — one per system flow plus the dispatcher chokepoint cross-cut. Each has the same shape (ASCII spine, Mermaid sequence diagram, bus-topic table with file:line citations, chokepoint details, failure modes, cross-refs).

\`docs/architecture/README.md\` is the index — the master ASCII spine + flow inventory table.

## What's documented

| Doc | Flow |
|---|---|
| flow-inbound-message | Discord/GitHub/Linear/Google → Router → SkillDispatcher → Executor → outbound |
| flow-linear-bridges | linear-protomaker + linear-proto label gates, \`linear.reply.{issueId}\` round-trip |
| flow-ceremonies | cron / \`ceremony.{id}.execute\` → CeremonyPlugin → dispatch → outcome |
| flow-pr-review | GitHub PR → Quinn verdict → review (with dedup + self-cascade guard) |
| flow-alert-remediator | \`autonomous.outcome.*\` → FleetHealth → alert/pr-remediator skills |
| flow-hitl | escalation sites → \`operator.message.request\` → Discord DM (with gap analysis) |
| flow-agent-runtime-telemetry | \`flow.item.*\`, \`autonomous.outcome.*\`, progress, cost |
| flow-a2a-discovery | startup card-fetch, 10min refresh, fix #608 fail-loud |
| flow-dashboard | BusHistoryRecorder + API routes → Astro tiles (Tailscale-only) |
| chokepoint-invariants | the four-invariants pattern, corrected |

## Findings that surfaced during audit

These are gaps the docs flag — not blockers for this PR, but follow-up work worth tracking:

- **HITL is wire-incomplete.** Escalation sites at \`pr-remediator.ts:770, 788, 1072, 1598\` only \`console.warn\`. \`OperatorRoutingPlugin\` still subscribes to \`operator.message.request\` but no production code publishes it. Closing this gap is the next session's work.
- **\`agent.runtime.activity.tool.call\` and \`agent.skill.latency\` topics are aspirational** — not published anywhere in source despite being referenced in commentary. Real telemetry is \`flow.item.*\` + \`autonomous.outcome.*\` + opt-in \`agent.skill.progress.*\`.
- **#465 destructive-verdict guard is NOT a general dispatcher invariant** — only lives in \`pr-remediator\` (promotion-PR close suppression). The \"four invariants at the dispatcher\" memory was conflating two patterns: dispatcher-level (#437 cooldown, #444 target guard) vs. site-specific (#459 fleet-health filter, #465 pr-remediator guard).
- **Alert threshold evaluation source not found** — \`AlertSkillExecutorPlugin\` declares 20 alert skills but the threshold-checker (GOAP-era Goals/Actions YAML?) wasn't located in the audited tree. Possible partial-GOAP leftover; needs investigation.

## Process

Audited via 5 parallel Explore agents against actual source, cross-referenced citations into each doc. Memory was deliberately not used as a source of truth — every claim has a \`file:line\` reference.

Diagrams are Mermaid (renders in GH + Astro Starlight); ASCII spines for terminal/CLAUDE.md readability.

## Test plan

- [ ] After merge, verify \`docs/architecture/*.md\` renders in Astro Starlight build
- [ ] Spot-check 3 random file:line citations to confirm accuracy
- [ ] Confirm Mermaid diagrams render in GH PR preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architecture documentation covering system design patterns, including dispatcher invariants, executor telemetry flows, agent discovery, alert remediation, ceremony triggering, dashboard data sourcing, human-in-the-loop escalation, inbound message routing, external platform integrations, and PR review pipelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/618?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->