### PR TITLE
feat(pr-remediator): escalate stuck PRs → operator.message.request (HITL phase 1)

### DIFF
--- a/lib/plugins/__tests__/pr-remediator-hitl-escalation.test.ts
+++ b/lib/plugins/__tests__/pr-remediator-hitl-escalation.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Verifies that pr-remediator's stuck-PR escalation publishes
+ * `operator.message.request` (consumed by OperatorRoutingPlugin in production)
+ * — the Phase 1 reconnect of the HITL flow ripped in f658744.
+ *
+ * The plugin's full state machine is covered by integration paths; this test
+ * exercises _emitStuckHitlEscalation directly to verify the bus contract.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { InMemoryEventBus } from "../../bus.ts";
+import { PrRemediatorPlugin } from "../pr-remediator.ts";
+import type { BusMessage } from "../../types.ts";
+
+type FakeEntry = {
+  kind: string;
+  startedAt: number;
+  correlationId: string;
+  attempts: number;
+  exhausted: boolean;
+  escalated?: boolean;
+};
+
+function withPrInPipeline(plugin: PrRemediatorPlugin, repo: string, number: number, extra: Record<string, unknown> = {}): void {
+  // Inject a minimal pr_pipeline snapshot so the "no longer in pipeline"
+  // suppression path doesn't fire.
+  (plugin as unknown as { latestPrData: { prs: unknown[] } }).latestPrData = {
+    prs: [{ repo, number, headSha: "deadbeef", ciStatus: "fail", ...extra }],
+  };
+}
+
+describe("pr-remediator stuck-PR HITL escalation → operator.message.request", () => {
+  let bus: InMemoryEventBus;
+  let plugin: PrRemediatorPlugin;
+  let captured: BusMessage[];
+
+  beforeEach(() => {
+    bus = new InMemoryEventBus();
+    captured = [];
+    bus.subscribe("operator.message.request", "test-collector", msg => {
+      captured.push(msg);
+    });
+    // Stub the live-CI fetcher so escalation doesn't get suppressed by a
+    // "CI is actually green now" check.
+    plugin = new PrRemediatorPlugin({
+      fetchLiveCiStatus: async () => "fail",
+    });
+    plugin.install(bus);
+  });
+
+  afterEach(() => {
+    plugin.uninstall();
+  });
+
+  test("budget-exhaustion escalation publishes operator.message.request with urgency=normal", async () => {
+    withPrInPipeline(plugin, "protoLabsAI/foo", 123);
+    const entry: FakeEntry = {
+      kind: "fix_ci",
+      startedAt: Date.now() - 5 * 60_000,
+      correlationId: "corr-1",
+      attempts: 3,
+      exhausted: true,
+      escalated: true,
+    };
+
+    await (plugin as unknown as {
+      _emitStuckHitlEscalation: (repo: string, number: number, kind: string, entry: FakeEntry) => Promise<void>;
+    })._emitStuckHitlEscalation("protoLabsAI/foo", 123, "fix_ci", entry);
+
+    expect(captured).toHaveLength(1);
+    const payload = captured[0]!.payload as {
+      type: string;
+      correlationId: string;
+      message: string;
+      urgency: string;
+      topic: string;
+      from: string;
+    };
+    expect(payload.type).toBe("operator_message_request");
+    expect(payload.correlationId).toBe("corr-1");
+    expect(payload.urgency).toBe("normal");
+    expect(payload.from).toBe("pr-remediator");
+    expect(payload.topic).toBe("pr-remediation-stuck/protoLabsAI/foo#123/fix_ci");
+    expect(payload.message).toContain("3/3");
+    expect(payload.message).toContain("fix_ci");
+    expect(payload.message).toContain("https://github.com/protoLabsAI/foo/pull/123");
+  });
+
+  test("conflict-bearing escalation bumps urgency to high and includes the conflict detail", async () => {
+    withPrInPipeline(plugin, "protoLabsAI/foo", 456, {
+      headRef: "feat/x",
+      baseRef: "main",
+    });
+    const entry: FakeEntry = {
+      kind: "update_branch",
+      startedAt: Date.now() - 12 * 60_000,
+      correlationId: "corr-2",
+      attempts: 3,
+      exhausted: true,
+      escalated: true,
+    };
+
+    await (plugin as unknown as {
+      _emitStuckHitlEscalation: (
+        repo: string,
+        number: number,
+        kind: string,
+        entry: FakeEntry,
+        conflictDetails?: string,
+      ) => Promise<void>;
+    })._emitStuckHitlEscalation(
+      "protoLabsAI/foo",
+      456,
+      "update_branch",
+      entry,
+      "Promotion-PR guard tripped: head=feat/x base=main",
+    );
+
+    expect(captured).toHaveLength(1);
+    const payload = captured[0]!.payload as { urgency: string; message: string };
+    expect(payload.urgency).toBe("high");
+    expect(payload.message).toContain("Promotion-PR guard tripped");
+  });
+
+  test("no escalation when the PR has left the pipeline (closed/merged)", async () => {
+    // latestPrData not set → PR not in pipeline → suppressed
+    const entry: FakeEntry = {
+      kind: "fix_ci",
+      startedAt: Date.now(),
+      correlationId: "corr-3",
+      attempts: 3,
+      exhausted: true,
+    };
+
+    await (plugin as unknown as {
+      _emitStuckHitlEscalation: (repo: string, number: number, kind: string, entry: FakeEntry) => Promise<void>;
+    })._emitStuckHitlEscalation("protoLabsAI/foo", 789, "fix_ci", entry);
+
+    expect(captured).toHaveLength(0);
+  });
+
+  test("no escalation when live CI says the PR is actually green (suppression race)", async () => {
+    plugin.uninstall();
+    plugin = new PrRemediatorPlugin({
+      fetchLiveCiStatus: async () => "pass",
+    });
+    plugin.install(bus);
+    withPrInPipeline(plugin, "protoLabsAI/foo", 999);
+
+    const entry: FakeEntry = {
+      kind: "fix_ci",
+      startedAt: Date.now(),
+      correlationId: "corr-4",
+      attempts: 3,
+      exhausted: true,
+    };
+
+    await (plugin as unknown as {
+      _emitStuckHitlEscalation: (repo: string, number: number, kind: string, entry: FakeEntry) => Promise<void>;
+    })._emitStuckHitlEscalation("protoLabsAI/foo", 999, "fix_ci", entry);
+
+    expect(captured).toHaveLength(0);
+  });
+});

--- a/lib/plugins/pr-remediator.ts
+++ b/lib/plugins/pr-remediator.ts
@@ -13,7 +13,9 @@
  *   merge_ready:
  *     - If title/author matches auto-merge allowlist (dependabot, promote:,
  *       labeled "auto-merge") → POST /repos/{repo}/pulls/{num}/merge
- *     - Otherwise → publish hitl.request.pr.merge.{id} with an approval card
+ *     - Otherwise → no auto-merge; PR sits until operator action. (See
+ *       _emitStuckHitlEscalation for the operator-DM escalation that fires
+ *       when remediation attempts exhaust.)
  *
  *   fix_ci:
  *     - Publish agent.skill.request to Ava with skillHint="bug_triage" and
@@ -774,16 +776,19 @@ export class PrRemediatorPlugin implements Plugin {
   }
 
   /**
-   * Emit a HITL request when a (PR, kind) tuple exhausts its attempt budget.
+   * Escalate to the operator when a (PR, kind) tuple exhausts its attempt budget.
    *
    * This is the "bottlenecks are growth opportunities" escalation: every stuck
    * remediation is a signal that the auto-remediation capability is missing
-   * something. Notifying a human via HITL both unblocks the immediate case
-   * AND creates a visible record that pattern analysis can turn into
-   * future improvements (new goals, new actions, new skills).
+   * something. Notifying a human both unblocks the immediate case AND creates a
+   * visible record that pattern analysis can turn into future improvements
+   * (new goals, new actions, new skills).
    *
-   * The request goes to topic `hitl.request.pr.remediation_stuck.{correlationId}`
-   * which the HITL plugin routes to its registered renderers (Discord, etc).
+   * Wire: publishes `operator.message.request` which OperatorRoutingPlugin
+   * routes to a Discord DM via the admin identity in `workspace/users.yaml`.
+   * One-way today — the operator decides + acts manually on GitHub. If/when
+   * a bidirectional reply path is wired, it will appear as a separate
+   * `operator.message.response` subscriber here.
    */
   private async _emitStuckHitlEscalation(
     repo: string,
@@ -831,16 +836,42 @@ export class PrRemediatorPlugin implements Plugin {
 
     const durationMs = Date.now() - entry.startedAt;
     const durationMin = Math.round(durationMs / 60_000);
+    const prUrl = `https://github.com/${repo}/pull/${number}`;
 
-    // No approval gate is wired in this build — log loudly and stop trying.
-    // The PR stays in its current state; an operator can re-trigger remediation
-    // by hand or close/merge the PR themselves.
+    // Log loudly for ops tailing container logs — independent of the bus path.
     console.warn(
-      `[pr-remediator] STUCK → giving up: ${repo}#${number} kind=${kind} attempts=${entry.attempts}/${MAX_ATTEMPTS_PER_PR} duration=${durationMin}min. ` +
-      `Auto-remediation budget exhausted, no approval gate wired. ` +
+      `[pr-remediator] STUCK → escalating to operator: ${repo}#${number} kind=${kind} attempts=${entry.attempts}/${MAX_ATTEMPTS_PER_PR} duration=${durationMin}min. ` +
       (conflictDetails ? `Conflict: ${conflictDetails}. ` : "") +
-      `https://github.com/${repo}/pull/${number}`,
+      prUrl,
     );
+
+    const messageLines = [
+      `PR stuck after ${entry.attempts}/${MAX_ATTEMPTS_PER_PR} ${kind} attempts (${durationMin}m). Auto-remediation budget exhausted.`,
+    ];
+    if (conflictDetails) {
+      messageLines.push("", `**Why:** ${conflictDetails}`);
+    }
+    messageLines.push("", prUrl);
+
+    // Conflict-bearing escalations carry diagnostic context from
+    // diagnose_pr_stuck (genuine semantic conflict or promotion-PR guard) —
+    // those need higher urgency than a plain "ran out of retries".
+    const urgency: "normal" | "high" = conflictDetails ? "high" : "normal";
+
+    this.bus.publish("operator.message.request", {
+      id: crypto.randomUUID(),
+      correlationId: entry.correlationId,
+      topic: "operator.message.request",
+      timestamp: Date.now(),
+      payload: {
+        type: "operator_message_request",
+        correlationId: entry.correlationId,
+        message: messageLines.join("\n"),
+        urgency,
+        topic: `pr-remediation-stuck/${repo}#${number}/${kind}`,
+        from: "pr-remediator",
+      },
+    });
   }
 
   private _recordDispatch(


### PR DESCRIPTION
## Summary

Reconnects the HITL escalation path that was ripped in **f658744** (\`chore: rip HITL plugin + Graphiti memory layer\`), but this time as pure bus pub/sub with **no registrar pattern** — exactly what the rip commit message anticipated.

> If approval gates are needed later they'll be implemented as pure bus pub/sub with no registrar pattern.
> — f658744 (Automaker, 2026-05-23)

## The gap (documented in #618)

\`docs/architecture/flow-hitl.md\` mapped it:

> Today this is wire-incomplete — escalation sites log to console but do not publish a bus event. The operator-routing plumbing exists separately for \`operator.message.request\`, but the two are not connected.

\`OperatorRoutingPlugin\` was healthy + installed + tested. pr-remediator was \`console.warn\`-ing at 5 escalation sites. This PR bridges them.

## Change

One method (\`_emitStuckHitlEscalation\` in \`pr-remediator.ts\`) modified — all five escalation sites flow through it (budget exhaustion at 770/744, promotion-PR guard at 1536, genuine-conflict verdict at 1598), so a single edit covers them all.

```ts
// in addition to the existing console.warn (kept for log-tail visibility):
this.bus.publish(\"operator.message.request\", {
  // ...
  payload: {
    type: \"operator_message_request\",
    correlationId: entry.correlationId,
    message: /* PR URL + attempt counts + duration + optional conflict detail */,
    urgency: conflictDetails ? \"high\" : \"normal\",
    topic: \`pr-remediation-stuck/\${repo}#\${number}/\${kind}\`,
    from: \"pr-remediator\",
  },
});
```

OperatorRoutingPlugin already subscribes to that topic and routes to a Discord DM via the admin user's identity in \`workspace/users.yaml\`.

## Urgency mapping

| Trigger | Urgency | Reason |
|---|---|---|
| Budget exhaustion (3/3 attempts) | \`normal\` | We ran out of retries; no specific diagnosis |
| Genuine semantic conflict | \`high\` | LLM diagnosed an actual conflict needing human judgment |
| Promotion-PR destructive-verdict guard (#465) | \`high\` | Release pipeline integrity issue |

## What's still out of scope (Phase 2+)

Per session decision: operator-reply path is **not** part of this PR. Operator gets the DM, decides + acts on GitHub directly. When/if a reply UX is wired, it will be a separate \`operator.message.response\` subscriber alongside this publisher — no changes needed here.

Open follow-up gaps (also in #618):
- \`agent.runtime.activity.tool.call\` and \`agent.skill.latency\` topics still aspirational
- HITL reply path UX undecided (Discord buttons vs. text commands vs. CLI/dashboard)
- Alert thresholds (Goals/Actions YAML) source still unverified

## Test plan

- [x] 4 new focused unit tests in \`lib/plugins/__tests__/pr-remediator-hitl-escalation.test.ts\` — covers normal urgency, high urgency, PR-left-pipeline suppression, and live-CI-flipped-green suppression
- [x] Full suite: 767/0 (up from 763, +4 new)
- [x] \`bun tsc --noEmit\` — clean
- [ ] After deploy + watchtower pull: trigger a stuck PR (or wait for one organically) → confirm Discord DM lands on the admin user with PR URL + correct urgency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added operator escalation for stuck pull requests via human-in-the-loop messaging
  * Operators now receive detailed notifications with PR attempt history, duration, conflict details, and PR URL
  * Escalation urgency automatically adjusts based on conflict presence

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/619?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->