### PR TITLE
feat(dispatcher): dispatch.dropped.* telemetry at chokepoint drop sites

### DIFF
--- a/src/event-bus/all-topics.ts
+++ b/src/event-bus/all-topics.ts
@@ -75,6 +75,16 @@ export const ACTION_TOPICS = {
    *                 carried it (PR reviews, etc.); absent otherwise.
    */
   AGENT_SKILL_LATENCY: "agent.skill.latency",
+
+  /**
+   * Prefix for dispatcher drop events. Full topic is
+   * `dispatch.dropped.{reason}` where reason ∈ {no_skill, target_unresolved,
+   * cooldown}. Published by SkillDispatcherPlugin at each chokepoint drop
+   * site so subscribers (dashboard, drop-rate alerts) can count + filter
+   * by reason without scraping stdout. Payload shape:
+   * see `DispatchDroppedPayload` in src/event-bus/payloads.ts.
+   */
+  DISPATCH_DROPPED_PREFIX: "dispatch.dropped",
 } as const;
 
 export const SECURITY_TOPICS = {

--- a/src/event-bus/payloads.ts
+++ b/src/event-bus/payloads.ts
@@ -174,6 +174,37 @@ export interface FlowItemPayload {
   meta?: Record<string, unknown>;
 }
 
+// ── dispatch.dropped.* ───────────────────────────────────────────────────────
+
+/** Reason for a dropped dispatch — matches the trailing segment of the topic. */
+export type DispatchDropReason = "no_skill" | "target_unresolved" | "cooldown";
+
+/**
+ * Payload for `dispatch.dropped.{reason}`. Published by SkillDispatcherPlugin
+ * when a skill request reaches the chokepoint but is rejected before any
+ * executor runs. Subscribers (dashboard tiles, drop-rate alerts) can match
+ * `dispatch.dropped.cooldown` for cooldown-only or `dispatch.dropped.#` for
+ * all drops.
+ *
+ * Reason-specific fields are optional — uniform shape, single subscriber path.
+ */
+export interface DispatchDroppedPayload {
+  reason: DispatchDropReason;
+  correlationId: string;
+  /** The dispatcher's human-readable drop message — same content as the console.warn line. */
+  message: string;
+  /** Skill name (absent only when reason="no_skill"). */
+  skill?: string;
+  /** Explicit targets from the dispatch request (empty when none specified). */
+  targets?: string[];
+  /** Cooldown bucket key — populated only when reason="cooldown". */
+  cooldownKey?: string;
+  /** Configured cooldown window in ms — populated only when reason="cooldown". */
+  cooldownWindowMs?: number;
+  /** Remaining cooldown in ms when the drop fired — populated only when reason="cooldown". */
+  cooldownRemainingMs?: number;
+}
+
 // ── security.incident.reported ───────────────────────────────────────────────
 
 /** Severity level for security incidents. */

--- a/src/executor/__tests__/skill-dispatcher-plugin.test.ts
+++ b/src/executor/__tests__/skill-dispatcher-plugin.test.ts
@@ -149,4 +149,70 @@ describe("SkillDispatcherPlugin", () => {
     const reply = bus.published.find(m => m.topic === defaultTopic);
     expect(reply).toBeDefined();
   });
+
+  describe("dispatch.dropped.* telemetry", () => {
+    it("publishes dispatch.dropped.no_skill when skill is missing", async () => {
+      const msg = makeMsg({ payload: {} }); // no skill, no skillHint
+      bus.publish("agent.skill.request", msg);
+      await new Promise(r => setTimeout(r, 10));
+
+      const drop = bus.published.find(m => m.topic === "dispatch.dropped.no_skill");
+      expect(drop).toBeDefined();
+      const p = drop!.payload as Record<string, unknown>;
+      expect(p.reason).toBe("no_skill");
+      expect(p.correlationId).toBe("trace-abc");
+      expect(typeof p.message).toBe("string");
+    });
+
+    it("publishes dispatch.dropped.target_unresolved when no executor matches", async () => {
+      const msg = makeMsg({
+        payload: { skill: "ghost_skill", targets: ["nobody"] },
+      });
+      bus.publish("agent.skill.request", msg);
+      await new Promise(r => setTimeout(r, 10));
+
+      const drop = bus.published.find(m => m.topic === "dispatch.dropped.target_unresolved");
+      expect(drop).toBeDefined();
+      const p = drop!.payload as Record<string, unknown>;
+      expect(p.reason).toBe("target_unresolved");
+      expect(p.skill).toBe("ghost_skill");
+      expect(p.targets).toEqual(["nobody"]);
+    });
+
+    it("publishes dispatch.dropped.cooldown with cooldownKey + remainingMs when cooldown trips", async () => {
+      const fn = mock(async (req: SkillRequest): Promise<SkillResult> => ({
+        text: "ok",
+        isError: false,
+        correlationId: req.correlationId,
+      }));
+      // bug_triage has a 30s default cooldown
+      registry.register("bug_triage", new FunctionExecutor(fn));
+
+      // First dispatch — should succeed and seed lastDispatchAt
+      bus.publish("agent.skill.request", makeMsg({
+        correlationId: "trace-first",
+        payload: { skill: "bug_triage", meta: { owner: "protoLabsAI", repo: "foo" } },
+      }));
+      await new Promise(r => setTimeout(r, 10));
+
+      // Second dispatch in-window — should drop with cooldown reason
+      bus.publish("agent.skill.request", makeMsg({
+        correlationId: "trace-second",
+        payload: { skill: "bug_triage", meta: { owner: "protoLabsAI", repo: "foo" } },
+      }));
+      await new Promise(r => setTimeout(r, 10));
+
+      const drops = bus.published.filter(m => m.topic === "dispatch.dropped.cooldown");
+      expect(drops).toHaveLength(1);
+      const p = drops[0].payload as Record<string, unknown>;
+      expect(p.reason).toBe("cooldown");
+      expect(p.skill).toBe("bug_triage");
+      expect(typeof p.cooldownKey).toBe("string");
+      expect(typeof p.cooldownWindowMs).toBe("number");
+      expect(typeof p.cooldownRemainingMs).toBe("number");
+      expect(p.correlationId).toBe("trace-second");
+      // executor should NOT have been called for the dropped dispatch
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -22,6 +22,8 @@ import type {
   FlowItemPayload,
   AgentActivityPayload,
   AgentActivityType,
+  DispatchDroppedPayload,
+  DispatchDropReason,
 } from "../event-bus/payloads.ts";
 import { IdentityRegistry } from "../../lib/identity/identity-registry.ts";
 import { ContextMailbox } from "../../lib/dm/context-mailbox.ts";
@@ -200,7 +202,9 @@ export class SkillDispatcherPlugin implements Plugin {
 
     if (!skill) {
       this.activeExecutions.delete(correlationId);
-      console.warn("[skill-dispatcher] Received skill request with no skill — dropping");
+      const dropMsg = "Received skill request with no skill — dropping";
+      console.warn(`[skill-dispatcher] ${dropMsg}`);
+      this._publishDispatchDropped("no_skill", correlationId, dropMsg, { targets });
       this._publishResponse(replyTopic, correlationId, undefined, "No skill specified");
       return;
     }
@@ -212,7 +216,9 @@ export class SkillDispatcherPlugin implements Plugin {
       const searched = targets.length > 0
         ? `targets [${targets.join(", ")}] or skill "${skill}"`
         : `skill "${skill}"`;
-      console.warn(`[skill-dispatcher] No executor found for ${searched} — dropping`);
+      const dropMsg = `No executor found for ${searched} — dropping`;
+      console.warn(`[skill-dispatcher] ${dropMsg}`);
+      this._publishDispatchDropped("target_unresolved", correlationId, dropMsg, { skill, targets });
       this._publishResponse(replyTopic, correlationId, undefined, `No executor registered for ${searched}`);
       return;
     }
@@ -228,11 +234,18 @@ export class SkillDispatcherPlugin implements Plugin {
       const key = cooldownKeyFor(skill, payload as Record<string, unknown>);
       const last = this.lastDispatchAt.get(key);
       if (last !== undefined && Date.now() - last < cooldownMs) {
-        const remaining = cooldownMs - (Date.now() - last);
+        const elapsed = Date.now() - last;
+        const remaining = cooldownMs - elapsed;
         this.activeExecutions.delete(correlationId);
-        console.warn(
-          `[skill-dispatcher] Cooldown drop: "${key}" dispatched ${Date.now() - last}ms ago (window=${cooldownMs}ms, ${remaining}ms remaining)`,
-        );
+        const dropMsg = `Cooldown drop: "${key}" dispatched ${elapsed}ms ago (window=${cooldownMs}ms, ${remaining}ms remaining)`;
+        console.warn(`[skill-dispatcher] ${dropMsg}`);
+        this._publishDispatchDropped("cooldown", correlationId, dropMsg, {
+          skill,
+          targets,
+          cooldownKey: key,
+          cooldownWindowMs: cooldownMs,
+          cooldownRemainingMs: remaining,
+        });
         this._publishResponse(replyTopic, correlationId, undefined, `Cooldown: ${key} (${remaining}ms remaining)`);
         return;
       }
@@ -768,6 +781,35 @@ export class SkillDispatcherPlugin implements Plugin {
       topic: replyTopic,
       timestamp: Date.now(),
       payload: { content: result, error, correlationId },
+    });
+  }
+
+  /**
+   * Publish a dispatch-dropped telemetry event at the matching chokepoint
+   * site. Topic is `dispatch.dropped.{reason}` so subscribers can filter
+   * by reason. The console.warn is kept alongside this for log-tail
+   * visibility — both paths fire independently.
+   */
+  private _publishDispatchDropped(
+    reason: DispatchDropReason,
+    correlationId: string,
+    message: string,
+    extra: Omit<DispatchDroppedPayload, "reason" | "correlationId" | "message">,
+  ): void {
+    if (!this.bus) return;
+    const topic = `dispatch.dropped.${reason}`;
+    const payload: DispatchDroppedPayload = {
+      reason,
+      correlationId,
+      message,
+      ...extra,
+    };
+    this.bus.publish(topic, {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic,
+      timestamp: Date.now(),
+      payload,
     });
   }
 }


### PR DESCRIPTION
## Summary

Closes the visibility gap flagged in \`docs/architecture/chokepoint-invariants.md\` (#618):

> None of the four invariants publish a bus event on trip today. Dashboard tiles for \"cooldown drops in last hour\" or \"target-unresolved warnings\" require either a \`dispatch.dropped.{reason}\` bus topic [...] or BusHistoryRecorder scraping console.warn (fragile).

This PR ships the first option — bus topic.

## Change

Three drop sites in \`SkillDispatcherPlugin._dispatch\` now publish \`dispatch.dropped.{reason}\` alongside the existing \`console.warn\`:

| Topic | Trigger | File:line |
|---|---|---|
| \`dispatch.dropped.no_skill\` | payload missing \`skill\` field | \`skill-dispatcher-plugin.ts:201-208\` |
| \`dispatch.dropped.target_unresolved\` | \`ExecutorRegistry.resolve\` returned null | \`:212-223\` |
| \`dispatch.dropped.cooldown\` | per-skill-per-repo cooldown trip | \`:236-249\` |

Uniform payload shape (\`DispatchDroppedPayload\` in \`src/event-bus/payloads.ts\`) — single subscriber path, no per-reason union types. Subscribers can match \`dispatch.dropped.cooldown\` for cooldown-only or \`dispatch.dropped.#\` for all drops.

The cooldown payload carries \`cooldownKey\` + \`cooldownWindowMs\` + \`cooldownRemainingMs\` so a downstream \"drop rate exceeded threshold\" alert can react with full context (e.g., folding into the HITL pipe shipped in #619 — escalate to operator if N drops in M minutes).

## Why bus + console.warn instead of replacing the warn

Log-tail visibility is independent of the bus path. Ops want both. The warn is the source of truth for live debugging; the bus event is for accumulation + dashboard + downstream subscribers.

## Test plan

- [x] 3 new tests in \`src/executor/__tests__/skill-dispatcher-plugin.test.ts\` covering each drop reason
- [x] Full suite: 766/0 (up from 763)
- [x] \`bun tsc --noEmit\` — clean
- [ ] After deploy: confirm \`dispatch.dropped.#\` events show up in BusHistoryRecorder live event log (via dashboard) when a stale-repo PR webhook triggers cooldown trip

## Follow-up enabled by this

- Dashboard tile for drop rate (separate PR)
- HITL escalation when drops exceed threshold (alongside #619)
- \"Stuck-in-cooldown\" detection — same repo dropped N times in a row may signal a real problem the rate-limit is masking (re: #86 in task backlog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dispatch failure events now publish detailed telemetry when skills cannot be executed, capturing failure reasons (missing skill, unresolved targets, cooldown violations) and contextual information for monitoring and debugging.

* **Tests**
  * Added comprehensive test coverage for dispatch failure telemetry across all scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/620?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->