### PR TITLE
feat(escalator): wire dispatch-drop storms → operator.message.request

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -405,6 +405,20 @@ const pluginRegistry: PluginRegistryEntry[] = [
       );
     },
   },
+  {
+    // Watches dispatch.dropped.# (from SkillDispatcher) for storms — N drops
+    // on same key in M min. Escalates to operator.message.request (same pipe
+    // as #619 pr-remediator stuck-PR escalations). Per-key cooldown prevents
+    // DM flood.
+    name: "dispatch-drop-escalator",
+    condition: () => true,
+    factory: async () => {
+      const { DispatchDropEscalatorPlugin } = await import(
+        "./plugins/dispatch-drop-escalator-plugin.js"
+      );
+      return new DispatchDropEscalatorPlugin();
+    },
+  },
   // Built-ins: opt-in via ENABLED_PLUGINS=echo,...
   {
     name: "echo",

--- a/src/plugins/__tests__/dispatch-drop-escalator-plugin.test.ts
+++ b/src/plugins/__tests__/dispatch-drop-escalator-plugin.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Verifies the dispatch-drop storm escalator: counts drops per key within a
+ * rolling window, escalates once per cooldown when threshold trips, suppresses
+ * follow-on escalations until the cooldown clears.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { DispatchDropEscalatorPlugin } from "../dispatch-drop-escalator-plugin.ts";
+import type { BusMessage } from "../../../lib/types.ts";
+import type { DispatchDroppedPayload } from "../../event-bus/payloads.ts";
+
+function publishDrop(bus: InMemoryEventBus, payload: Partial<DispatchDroppedPayload>): void {
+  const full: DispatchDroppedPayload = {
+    reason: "cooldown",
+    correlationId: crypto.randomUUID(),
+    message: "test drop",
+    ...payload,
+  };
+  bus.publish(`dispatch.dropped.${full.reason}`, {
+    id: crypto.randomUUID(),
+    correlationId: full.correlationId,
+    topic: `dispatch.dropped.${full.reason}`,
+    timestamp: Date.now(),
+    payload: full,
+  });
+}
+
+describe("DispatchDropEscalatorPlugin", () => {
+  let bus: InMemoryEventBus;
+  let plugin: DispatchDropEscalatorPlugin;
+  let escalations: BusMessage[];
+
+  beforeEach(() => {
+    bus = new InMemoryEventBus();
+    escalations = [];
+    bus.subscribe("operator.message.request", "test-collector", msg => {
+      escalations.push(msg);
+    });
+    // Lower threshold + window for tests
+    process.env["WORKSTACEAN_DISPATCH_DROP_THRESHOLD"] = "3";
+    process.env["WORKSTACEAN_DISPATCH_DROP_WINDOW_MS"] = "60000";
+    process.env["WORKSTACEAN_DISPATCH_DROP_ESCALATION_COOLDOWN_MS"] = "60000";
+    plugin = new DispatchDropEscalatorPlugin();
+    plugin.install(bus);
+  });
+
+  afterEach(() => {
+    plugin.uninstall();
+    delete process.env["WORKSTACEAN_DISPATCH_DROP_THRESHOLD"];
+    delete process.env["WORKSTACEAN_DISPATCH_DROP_WINDOW_MS"];
+    delete process.env["WORKSTACEAN_DISPATCH_DROP_ESCALATION_COOLDOWN_MS"];
+  });
+
+  test("below threshold → no escalation", () => {
+    publishDrop(bus, { skill: "bug_triage", cooldownKey: "bug_triage:protoLabsAI/foo" });
+    publishDrop(bus, { skill: "bug_triage", cooldownKey: "bug_triage:protoLabsAI/foo" });
+    expect(escalations).toHaveLength(0);
+  });
+
+  test("threshold reached on same key → exactly one escalation with full context", () => {
+    for (let i = 0; i < 3; i++) {
+      publishDrop(bus, {
+        skill: "bug_triage",
+        cooldownKey: "bug_triage:protoLabsAI/foo",
+        cooldownWindowMs: 30000,
+        cooldownRemainingMs: 25000,
+        message: `Cooldown drop attempt ${i + 1}`,
+      });
+    }
+    expect(escalations).toHaveLength(1);
+    const payload = escalations[0].payload as Record<string, unknown>;
+    expect(payload.type).toBe("operator_message_request");
+    expect(payload.from).toBe("dispatch-drop-escalator");
+    expect(payload.urgency).toBe("normal");
+    const message = payload.message as string;
+    expect(message).toContain("cooldown:bug_triage:bug_triage:protoLabsAI/foo");
+    expect(message).toContain("3 times");
+    expect(message).toContain("Cooldown trips");
+    expect(message).toContain("WORKSTACEAN_COOLDOWN_MS_");
+  });
+
+  test("further drops within escalation cooldown → no second escalation", () => {
+    for (let i = 0; i < 6; i++) {
+      publishDrop(bus, { skill: "bug_triage", cooldownKey: "bug_triage:protoLabsAI/foo" });
+    }
+    expect(escalations).toHaveLength(1);
+  });
+
+  test("different drop keys → separate escalations", () => {
+    for (let i = 0; i < 3; i++) {
+      publishDrop(bus, { skill: "bug_triage", cooldownKey: "bug_triage:protoLabsAI/foo" });
+    }
+    for (let i = 0; i < 3; i++) {
+      publishDrop(bus, { skill: "pr_review", cooldownKey: "pr_review:protoLabsAI/bar" });
+    }
+    expect(escalations).toHaveLength(2);
+  });
+
+  test("target_unresolved is high urgency (config error, not rate-limit noise)", () => {
+    for (let i = 0; i < 3; i++) {
+      publishDrop(bus, {
+        reason: "target_unresolved",
+        skill: "ghost_skill",
+        targets: ["nobody"],
+      });
+    }
+    expect(escalations).toHaveLength(1);
+    const payload = escalations[0].payload as Record<string, unknown>;
+    expect(payload.urgency).toBe("high");
+    expect((payload.message as string)).toContain("Target executor not in ExecutorRegistry");
+  });
+
+  test("no_skill drops also escalate (caller bug)", () => {
+    for (let i = 0; i < 3; i++) {
+      publishDrop(bus, { reason: "no_skill" });
+    }
+    expect(escalations).toHaveLength(1);
+    const payload = escalations[0].payload as Record<string, unknown>;
+    expect(payload.urgency).toBe("high");
+    expect((payload.message as string)).toContain("no skill field");
+  });
+
+  test("uninstall clears state — drops after uninstall do not escalate", () => {
+    plugin.uninstall();
+    for (let i = 0; i < 5; i++) {
+      publishDrop(bus, { skill: "bug_triage", cooldownKey: "bug_triage:protoLabsAI/foo" });
+    }
+    expect(escalations).toHaveLength(0);
+  });
+});

--- a/src/plugins/dispatch-drop-escalator-plugin.ts
+++ b/src/plugins/dispatch-drop-escalator-plugin.ts
@@ -1,0 +1,176 @@
+/**
+ * DispatchDropEscalatorPlugin — escalates dispatch-drop storms to the operator.
+ *
+ * A single dispatch drop is rarely interesting — cooldowns are by design,
+ * target-unresolved on first attempt may just be a startup race, and
+ * no-skill is usually a misconfigured caller. But the SAME drop key firing
+ * 10+ times in 10min is a stuck loop signal: webhooks keep hammering the
+ * dispatcher, and either the rate-limit is too aggressive for legitimate
+ * traffic OR the caller is in a tight retry loop that won't drain on its
+ * own.
+ *
+ * Per the bottlenecks-are-growth principle, that escalates: drop-storms
+ * surface as `operator.message.request` via the existing OperatorRoutingPlugin
+ * pipe (same as pr-remediator stuck-PR escalations in #619). The operator
+ * decides whether to bump the cooldown, fix the caller, or stop the loop.
+ *
+ * Subscribes to: dispatch.dropped.# (from SkillDispatcherPlugin, #620)
+ * Publishes to:  operator.message.request (consumed by OperatorRoutingPlugin)
+ *
+ * Per-key cooldown prevents a sustained storm from filling the operator's
+ * DM. One escalation per (key, cooldown window) regardless of subsequent
+ * drops in the same window.
+ */
+
+import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
+import type { DispatchDroppedPayload } from "../event-bus/payloads.ts";
+
+/** Drops in this rolling window count toward the storm threshold. */
+const STORM_WINDOW_MS_DEFAULT = 10 * 60_000;
+/** Drop count within the window that trips an escalation. */
+const STORM_THRESHOLD_DEFAULT = 10;
+/** Minimum interval between escalations for the same drop key. */
+const ESCALATION_COOLDOWN_MS_DEFAULT = 30 * 60_000;
+
+interface DropRecord {
+  timestamps: number[];
+  /** Most recent drop payload for context in the escalation message. */
+  lastPayload: DispatchDroppedPayload;
+}
+
+export class DispatchDropEscalatorPlugin implements Plugin {
+  readonly name = "dispatch-drop-escalator";
+  readonly description =
+    "Escalates dispatch-drop storms (N drops on same key in M min) to the operator via operator.message.request";
+  readonly capabilities = ["dispatch-drop-escalator"];
+
+  private bus?: EventBus;
+  private subscriptionId?: string;
+  private readonly drops = new Map<string, DropRecord>();
+  private readonly lastEscalatedAt = new Map<string, number>();
+
+  private readonly windowMs: number;
+  private readonly threshold: number;
+  private readonly escalationCooldownMs: number;
+
+  constructor() {
+    this.windowMs =
+      Number(process.env["WORKSTACEAN_DISPATCH_DROP_WINDOW_MS"]) || STORM_WINDOW_MS_DEFAULT;
+    this.threshold =
+      Number(process.env["WORKSTACEAN_DISPATCH_DROP_THRESHOLD"]) || STORM_THRESHOLD_DEFAULT;
+    this.escalationCooldownMs =
+      Number(process.env["WORKSTACEAN_DISPATCH_DROP_ESCALATION_COOLDOWN_MS"]) ||
+      ESCALATION_COOLDOWN_MS_DEFAULT;
+  }
+
+  install(bus: EventBus): void {
+    this.bus = bus;
+    this.subscriptionId = bus.subscribe("dispatch.dropped.#", this.name, (msg: BusMessage) => {
+      this._onDrop(msg);
+    });
+    console.log(
+      `[dispatch-drop-escalator] Installed — threshold=${this.threshold} drops / ` +
+        `${Math.round(this.windowMs / 60_000)}min, escalationCooldown=${Math.round(this.escalationCooldownMs / 60_000)}min`,
+    );
+  }
+
+  uninstall(): void {
+    if (this.bus && this.subscriptionId !== undefined) {
+      this.bus.unsubscribe(this.subscriptionId);
+    }
+    this.bus = undefined;
+    this.subscriptionId = undefined;
+    this.drops.clear();
+    this.lastEscalatedAt.clear();
+  }
+
+  private _onDrop(msg: BusMessage): void {
+    const payload = msg.payload as DispatchDroppedPayload | undefined;
+    if (!payload || !payload.reason) return;
+
+    const key = this._dropKey(payload);
+    const now = Date.now();
+
+    const record = this.drops.get(key) ?? { timestamps: [], lastPayload: payload };
+    record.lastPayload = payload;
+    // Prune outside the rolling window. Bounded — never more than threshold+a-few entries.
+    record.timestamps = record.timestamps.filter(t => now - t < this.windowMs);
+    record.timestamps.push(now);
+    this.drops.set(key, record);
+
+    if (record.timestamps.length < this.threshold) return;
+
+    const lastEscalation = this.lastEscalatedAt.get(key);
+    if (lastEscalation !== undefined && now - lastEscalation < this.escalationCooldownMs) return;
+
+    this.lastEscalatedAt.set(key, now);
+    this._escalate(key, record);
+  }
+
+  /**
+   * Build the de-dup key. (reason, skill, target_or_bucket) — drops sharing
+   * all three count toward the same storm. Cooldown-key is preferred when
+   * available (it already encodes skill+repo for cooldown reason); falls back
+   * to first target or "?" for no-skill drops.
+   */
+  private _dropKey(p: DispatchDroppedPayload): string {
+    const skill = p.skill ?? "?";
+    const target = p.cooldownKey ?? (p.targets && p.targets.length > 0 ? p.targets.join(",") : "?");
+    return `${p.reason}:${skill}:${target}`;
+  }
+
+  private _escalate(key: string, record: DropRecord): void {
+    if (!this.bus) return;
+
+    const count = record.timestamps.length;
+    const oldest = record.timestamps[0]!;
+    const ageMin = Math.max(1, Math.round((Date.now() - oldest) / 60_000));
+    const reasonHuman = this._reasonHuman(record.lastPayload.reason);
+
+    const lines = [
+      `Dispatch-drop storm: \`${key}\` triggered ${count} times in last ${ageMin}m.`,
+      "",
+      `**Reason:** ${reasonHuman}`,
+      `**Sample message:** ${record.lastPayload.message}`,
+    ];
+    if (record.lastPayload.reason === "cooldown" && record.lastPayload.cooldownWindowMs) {
+      lines.push(
+        `**Cooldown window:** ${record.lastPayload.cooldownWindowMs}ms — if this is legitimate traffic, ` +
+          `consider raising via WORKSTACEAN_COOLDOWN_MS_<SKILL>.`,
+      );
+    }
+
+    const correlationId = `dispatch-drop-${key}-${Date.now()}`;
+    this.bus.publish("operator.message.request", {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic: "operator.message.request",
+      timestamp: Date.now(),
+      payload: {
+        type: "operator_message_request",
+        correlationId,
+        message: lines.join("\n"),
+        urgency: record.lastPayload.reason === "cooldown" ? "normal" : "high",
+        topic: `dispatch-drop-storm/${record.lastPayload.reason}`,
+        from: "dispatch-drop-escalator",
+      },
+    });
+
+    console.warn(
+      `[dispatch-drop-escalator] STORM → escalating: ${key} (${count} drops in ${ageMin}min)`,
+    );
+  }
+
+  private _reasonHuman(reason: string): string {
+    switch (reason) {
+      case "cooldown":
+        return "Cooldown trips — same skill+repo dispatched faster than its cooldown window allows.";
+      case "target_unresolved":
+        return "Target executor not in ExecutorRegistry — config error, undeployed agent, or stale target name.";
+      case "no_skill":
+        return "Caller published agent.skill.request with no skill field — bug in the caller.";
+      default:
+        return `Unknown reason: ${reason}`;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes the second half of the chokepoint observability gap. **#620** made dispatcher drops visible on the bus (\`dispatch.dropped.*\`). This PR makes *storms* of drops actionable: same key tripping 10+ times in 10 min escalates to the operator DM.

Same destination as **#619**'s pr-remediator stuck-PR escalations (\`operator.message.request\` → OperatorRoutingPlugin → Discord DM). Uniform shape across all stuck-loop surfaces.

## Why not escalate every drop

A single dispatch drop is rarely actionable:
- **Cooldowns** are *by design* — they exist to prevent webhook floods
- **target_unresolved** on startup may just be the SkillBroker still discovering A2A cards
- **no_skill** is occasionally a caller mid-development

But the **same key** tripping repeatedly in a short window is a *stuck-loop* signal — webhooks keep hammering, the dispatcher keeps refusing, and nothing is draining the queue. That's the case operator HITL was designed for.

## Configuration

| Knob | Default | Env |
|---|---|---|
| Drop window | 10 min | \`WORKSTACEAN_DISPATCH_DROP_WINDOW_MS\` |
| Threshold | 10 drops | \`WORKSTACEAN_DISPATCH_DROP_THRESHOLD\` |
| Escalation cooldown per key | 30 min | \`WORKSTACEAN_DISPATCH_DROP_ESCALATION_COOLDOWN_MS\` |

## Urgency mapping

| Reason | Urgency | Why |
|---|---|---|
| cooldown | \`normal\` | Rate-limit signal — likely tunable, not a system bug |
| target_unresolved | \`high\` | Config error, undeployed agent, stale target name |
| no_skill | \`high\` | Caller bug |

## Example operator DM (cooldown storm)

```
⚠️ **[dispatch-drop-storm/cooldown]** Dispatch-drop storm:
\`cooldown:bug_triage:bug_triage:protoLabsAI/foo\` triggered 12 times in last 8m.

**Reason:** Cooldown trips — same skill+repo dispatched faster than its cooldown window allows.
**Sample message:** Cooldown drop: \"bug_triage:protoLabsAI/foo\" dispatched 1200ms ago (window=30000ms, 28800ms remaining)
**Cooldown window:** 30000ms — if this is legitimate traffic, consider raising via WORKSTACEAN_COOLDOWN_MS_<SKILL>.
— dispatch-drop-escalator
```

## Test plan

- [x] 7 new tests in \`dispatch-drop-escalator-plugin.test.ts\`
- [x] Full suite: 777/0
- [x] \`bun tsc --noEmit\` — clean
- [ ] After deploy + watchtower pull: force a cooldown storm (a script that hammers \`agent.skill.request{skill: bug_triage, repo: X}\` 15x) → confirm operator DM lands once

## Follow-up enabled

Phase 2 HITL (operator reply UX) becomes more interesting once we have multiple escalation sources writing into the same DM topic — the reply UX needs to disambiguate \"close PR\" vs. \"raise cooldown\" vs. \"acknowledge alert.\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dispatch drop escalation capability that monitors for unusual activity patterns and automatically notifies operators with configurable urgency levels and built-in cooldown to prevent notification spam.

* **Tests**
  * Added comprehensive tests validating drop storm detection, threshold enforcement, cooldown behavior, and operator notification message formatting and urgency levels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->