### PR TITLE
docs(architecture): post-merge corrections after #619/#620/#621/#622

### DIFF
--- a/docs/architecture/chokepoint-invariants.md
+++ b/docs/architecture/chokepoint-invariants.md
@@ -132,14 +132,19 @@ on autonomous.outcome.{actor}.{skill}:
 
 ---
 
-## Telemetry gap
+## Telemetry (resolved by #620 + #622)
 
-None of the four invariants publish a bus event on trip today. Dashboard tiles for "cooldown drops in last hour" or "target-unresolved warnings" require either:
+The dispatcher publishes `dispatch.dropped.{reason}` at each chokepoint drop site (shipped in **#620**), and the `dispatch-drop-escalator` plugin watches for storms — N drops on the same key in M minutes → operator DM via `operator.message.request` (shipped in **#622**).
 
-1. **`dispatch.dropped.{reason}` bus topic** — would need wiring at each drop site. Simple but invasive.
-2. **`BusHistoryRecorder` scraping `console.warn`** — fragile, breaks if log format changes.
+| Topic | Published at | Subscribed by |
+|---|---|---|
+| `dispatch.dropped.no_skill` | `skill-dispatcher-plugin.ts:201-208` | dashboard, dispatch-drop-escalator |
+| `dispatch.dropped.target_unresolved` | `:212-223` | dashboard, dispatch-drop-escalator |
+| `dispatch.dropped.cooldown` | `:236-249` | dashboard, dispatch-drop-escalator |
 
-Both are open work. Worth doing before more invariants are added; otherwise we keep losing visibility per check.
+Payload shape: `DispatchDroppedPayload` in `src/event-bus/payloads.ts` — uniform across reasons, with reason-specific optional fields (`cooldownKey`, `cooldownWindowMs`, `cooldownRemainingMs`). The console.warn at each site is kept for log-tail visibility — bus and stdout fire independently.
+
+The synthetic-actor filter (#459) still doesn't publish a "filtered" event — by design, since synthetic actors are *expected* and the bucketing is the signal. If we ever need to detect a *new* synthetic actor appearing, that's worth surfacing — open follow-up.
 
 ---
 

--- a/docs/architecture/flow-agent-runtime-telemetry.md
+++ b/docs/architecture/flow-agent-runtime-telemetry.md
@@ -164,18 +164,21 @@ This means **autonomous.outcome is sometimes published by TaskTracker, not the d
 
 ---
 
-## Aspirational topics (NOT in source)
+## Runtime activity + skill latency topics
 
-Memory and some documentation reference these — they are not implemented:
+The dispatcher and runtime publish a richer set of lifecycle events than `autonomous.outcome.*` alone:
 
-- `agent.runtime.activity.tool.call` — would emit per tool invocation inside the agent. Not published anywhere in src. ([all-topics.ts](../../src/event-bus/all-topics.ts) confirms.)
-- `agent.skill.latency` — referenced as a histogram source. Not published; latency is in `autonomous.outcome.*.durationMs`.
+| Topic | Published at | What it carries |
+|---|---|---|
+| `agent.runtime.activity.skill.start` | `skill-dispatcher-plugin.ts:110` (declared in `publishes`) | dispatch start — agent name, skill, correlationId |
+| `agent.runtime.activity.skill.complete` | same | dispatch terminal — outcome + duration |
+| `agent.runtime.activity.skill.error` | same | dispatch failure — error + duration |
+| `agent.runtime.activity.tool.call` | `agent-runtime-plugin.ts:94` (via `_publishToolCall` hook fed by DeepAgent at `deep-agent-executor.ts:743` and ProtoSdk at `proto-sdk-executor.ts:100`) | per-tool invocation — agent, correlationId, skill, toolNames[] |
+| `agent.skill.latency` | `skill-dispatcher-plugin.ts:482` | structured latency — skill, totalMs, queueMs, executeMs, optional github {owner,repo,number} |
 
-Any tile or alert depending on these is dead code today. Either:
-1. Wire them up (one-line `bus.publish` at the right hook), or
-2. Re-source the dependent tile from `autonomous.outcome.*` / `flow.item.*` instead.
+The `_publishToolCall` callback is wired uniformly in `AgentRuntimePlugin.install()` and passed into both DeepAgent and ProtoSdk executor constructors — same hook, same topic, regardless of runtime.
 
-This is tracked as a follow-up — not a blocker for the rest of the system.
+`agent.skill.latency` is best-effort (`try`/`catch` at line 497) — a publish failure can't poison the success path.
 
 ---
 
@@ -201,7 +204,7 @@ This is tracked as a follow-up — not a blocker for the rest of the system.
 
 - **Progress topics are silent today** — no executor publishes `agent.skill.progress.*`. Dashboard tiles relying on them show nothing.
 - **TaskTracker outcome publish is the canonical path for long-running A2A** — if you're debugging "outcome never fires", check whether the task is parked in TaskTracker (likely) or actually never completed (unlikely).
-- **Latency is `durationMs`, not a histogram** — `autonomous.outcome.*.durationMs` is the only latency signal. If you want p50/p95, aggregate at the consumer ([flow-alert-remediator](flow-alert-remediator.md) does this).
+- **Latency is `durationMs` on outcomes + structured `agent.skill.latency` on success** — `autonomous.outcome.*.durationMs` is wall-clock; `agent.skill.latency` adds queueMs/executeMs split + optional GitHub PR context. Aggregate at the consumer for p50/p95 ([flow-alert-remediator](flow-alert-remediator.md) does this from outcomes).
 - **`systemActor` is whatever the dispatcher writes** — it's not validated by the bus. Synthetic actors (`pr-remediator`, `goap`, `user`) coexist with real agents. The synthetic-actor filter at FleetHealth ([#459](chokepoint-invariants.md)) is the source of truth for "is this a real agent."
 
 ---

--- a/docs/architecture/flow-alert-remediator.md
+++ b/docs/architecture/flow-alert-remediator.md
@@ -2,7 +2,7 @@
 title: Flow — Alert / PR remediator
 ---
 
-_The fleet self-healing path: AgentFleetHealth aggregates outcomes into a snapshot; when thresholds trip, alert skills publish to Discord; pr-remediator handles `pr.remediate.*` topics that propose code mutations. The threshold-evaluation layer is currently external (Goals/Actions YAML) and is a known architectural seam._
+_The fleet self-healing path: AgentFleetHealth aggregates outcomes into a snapshot; the `fleet_alerts` ceremony polls thresholds every minute and dispatches `alert.*` skills on violation; pr-remediator handles `pr.remediate.*` topics that propose code mutations._
 
 ---
 
@@ -43,7 +43,7 @@ Both are `FunctionExecutor`-backed (no LLM at the executor itself; LLM lives one
    └──────────────┬───────────┘
                   │
                   ▼   (?) threshold evaluation
-                  │       happens externally — see "Threshold gap" below
+                  │       fleet_alerts ceremony polls every 60s
                   ▼
    ┌──────────────────────────┐  ┌──────────────────────────┐
    │ alert.fleet_agent_stuck  │  │ action.pr_update_branch  │
@@ -95,7 +95,7 @@ sequenceDiagram
     WSE->>FH: getFleetHealth()
     FH-->>WSE: FleetHealthSnapshot
 
-    Note over TE: ⚠ threshold evaluation<br/>not in source — see gap section
+    Note over TE: FleetAlertsEvaluatorPlugin<br/>(fleet_alerts ceremony, every 60s)
     TE->>Bus: agent.skill.request<br/>(skill=alert.fleet_agent_stuck)
     Bus->>SD: deliver
     SD->>AE: execute(req)
@@ -182,20 +182,34 @@ Summary: `pr-remediator`, `auto-triage-sweep`, `goap`, `user` are recognized syn
 
 ---
 
-## Threshold gap
+## Threshold evaluation (via fleet_alerts ceremony)
 
-**Where threshold evaluation actually happens is not fully visible in the audited source.** The audit found:
+Resolved by **#621** — the GOAP layer that previously evaluated thresholds was ripped in **#518** (2026-05-23), leaving the 20 `alert.*` skills as orphaned dead code for 3 days. The reconnect uses the existing ceremony spine instead of resurrecting GOAP:
 
-- `ALERT_SKILLS` declares 20 alert skill names
-- `FleetHealthSnapshot` exposes the relevant metrics (`maxFailureRate1h`, `orphanedSkillCount`, `totalCostUsd1d`, …)
-- `ActionDispatcherPlugin` presumably dispatches `alert.*` and `action.*` skills when preconditions match — but the **goals/actions YAML files were not found** in the audited tree
+```
+workspace/ceremonies/fleet-alerts.yaml
+  schedule: * * * * *               every minute
+  skill: evaluate_fleet_thresholds
 
-This points at a **partial GOAP layer still wired** despite memory saying GOAP is being removed (see [memory: app-is-switchboard](../../.claude/projects/-home-josh-dev-protoWorkstacean/memory/project_app_is_switchboard.md)). One of two states is true:
+src/plugins/fleet-alerts-evaluator-plugin.ts
+  registers evaluate_fleet_thresholds (FunctionExecutor)
 
-1. The GOAP layer is fully torn out and threshold evaluation has moved elsewhere (e.g. a simple cron-based threshold-checker) — in which case `AlertSkillExecutorPlugin` no longer fires today
-2. The GOAP layer is partially still in place, driving alerts/actions from `agent_fleet_health` world-state
+  on dispatch (every minute):
+    1. snapshot = AgentFleetHealthPlugin.getFleetHealth()
+    2. for each tripped threshold:
+         bus.publish("agent.skill.request", { skill: "alert.X", meta: { metric, value, threshold } })
+    3. per-alert cooldown (15min default) suppresses repeats
+```
 
-A maintainer needs to resolve this before the doc can claim a complete picture. **Tracking gap; not blocking the rest of the doc.**
+**Three thresholds wired today** (env-overridable):
+
+| Alert | Trigger | Default | Env |
+|---|---|---|---|
+| `alert.fleet_agent_stuck` | `maxFailureRate1h > 0.5` | 50% | `WORKSTACEAN_FLEET_FAILURE_RATE_THRESHOLD` |
+| `alert.fleet_cost_over_budget` | `totalCostUsd1d > $50` | $50/day | `WORKSTACEAN_FLEET_DAILY_BUDGET_USD` |
+| `alert.fleet_skill_orphaned` | `orphanedSkillCount > 0` | 0 | (fixed) |
+
+**The other 17 alert skills** remain unwired — they need data sources outside fleet-health (GitHub branch protection, CI failure history, security state). Same state as before #621; surfacing as known work, not regression.
 
 ---
 

--- a/docs/architecture/flow-hitl.md
+++ b/docs/architecture/flow-hitl.md
@@ -2,7 +2,7 @@
 title: Flow — HITL escalation
 ---
 
-_When an autonomous loop gets stuck or hits a destructive-verdict guard, the intended escape valve is a Human-In-The-Loop escalation: ping the operator, surface the context, wait for direction. **Today this is wire-incomplete** — escalation sites log to console but do not publish a bus event. The operator-routing plumbing exists separately for `operator.message.request`, but the two are not connected._
+_When an autonomous loop gets stuck, escalation sites publish `operator.message.request` which `OperatorRoutingPlugin` routes to a Discord DM. **Phase 1 outbound is shipped** (#619, #622); the operator-reply path back into the bus (Phase 2) is still open design — text commands vs. buttons vs. CLI/dashboard, decision pending real usage data._
 
 ---
 
@@ -10,33 +10,33 @@ _When an autonomous loop gets stuck or hits a destructive-verdict guard, the int
 
 Bottlenecks are growth signals (see [memory: bottlenecks-are-growth](../../.claude/projects/-home-josh-dev-protoWorkstacean/memory/feedback_bottlenecks_are_growth.md)). A stuck autonomous loop should **escalate, not silently drop** — each escalation is a feature-request for the next layer of autonomy. HITL is the structural place to surface those.
 
-The system has two pieces of HITL infrastructure, but they're not currently bridged:
+Two production-wired escalation sources today, both pushing to the same `operator.message.request` topic:
 
-| Piece | What it does | Source |
-|---|---|---|
-| **Escalation trigger sites** | Detect "this loop is stuck" or "this verdict is destructive on a protected target" and emit a warning | `lib/plugins/pr-remediator.ts:770,788,1072,1598` etc. |
-| **Operator routing** | `OperatorRoutingPlugin` subscribes to `operator.message.request` and routes a payload to a Discord DM | `lib/plugins/operator-routing.ts:75–127` |
+| Source | What it escalates | Source | Shipped in |
+|---|---|---|---|
+| **pr-remediator** | Stuck PRs (budget exhausted, genuine semantic conflict, promotion-PR destructive-verdict guard) | `lib/plugins/pr-remediator.ts:_emitStuckHitlEscalation` | #619 |
+| **dispatch-drop-escalator** | Drop storms (N drops on same key in M min — cooldown trips, target-unresolved, no-skill) | `src/plugins/dispatch-drop-escalator-plugin.ts` | #622 |
+| **Operator routing** | Subscriber that takes any `operator.message.request` and routes to the admin Discord DM via `users.yaml` identity | `lib/plugins/operator-routing.ts:75–127` | pre-existing |
 
-The gap: pr-remediator (and other escalation sites) **log to `console.warn`** but do not publish `operator.message.request`. So escalations are only visible to whoever is reading container logs — not surfaced to an operator interactively.
+The previous `lib/plugins/hitl.ts` was ripped in commit `f658744` (2026-05-23) because it violated bus-is-the-contract — DiscordPlugin held a direct reference to `hitlPlugin.registerRenderer()`. The rip commit explicitly anticipated this reconnect: "If approval gates are needed later they'll be implemented as pure bus pub/sub with no registrar pattern." Phase 1 honors that — both #619 and #622 are pure publish-only.
 
 ---
 
-## ASCII spine (intended)
+## ASCII spine
 
 ```
-   stuck loop / destructive verdict / cooldown trip
-                │
-                ▼
-   ┌──────────────────────────┐
-   │  Escalation site         │  e.g. pr-remediator._emitStuckHitlEscalation()
-   │   (multiple, scattered)  │
-   │                          │
-   │   today: console.warn    │  ← GAP: no bus event
-   │   intended: publish      │
-   │     hitl.request.*       │
-   └──────────────┬───────────┘
-                  │  (intended)
-                  ▼
+   stuck PR (3 attempts)    drop storm (N drops in M min)    [future sources]
+        │                          │                              │
+        ▼                          ▼                              ▼
+   ┌────────────┐         ┌────────────────────┐
+   │ pr-        │         │ dispatch-drop-     │
+   │ remediator │         │ escalator          │
+   │            │         │                    │
+   │ #619       │         │ #622               │
+   └─────┬──────┘         └─────────┬──────────┘
+         │                          │
+         └──────────────┬───────────┘
+                        ▼
    ┌──────────────────────────┐
    │  operator.message.       │  topic shape OperatorMessageRequest
    │  request                 │  { message, urgency, topic, from }
@@ -61,52 +61,66 @@ The gap: pr-remediator (and other escalation sites) **log to `console.warn`** bu
 
 ---
 
-## What actually fires today
+## Sequence
 
 ```mermaid
 sequenceDiagram
     autonumber
-    participant PR as PrRemediatorPlugin
+    participant Source as Escalation source<br/>(pr-remediator OR<br/>dispatch-drop-escalator)
     participant Bus as Bus
-    participant Log as console
-    participant OP as Operator (intended)
+    participant OR as OperatorRoutingPlugin
+    participant DP as DiscordPlugin
+    participant OP as Operator
 
-    Note over PR: stuck PR detected<br/>(attempts ≥ 3 OR genuine conflict)
-    PR->>Log: console.warn(escalation message + PR URL)
-    Note over Bus,OP: ⚠ NO bus publish today<br/>operator.message.request not emitted<br/>OperatorRoutingPlugin never fires<br/>Operator never sees the DM
+    Note over Source: stuck-loop signal detected
+    Source->>Bus: operator.message.request<br/>{ message, urgency, topic, from }
+    Source->>Source: console.warn (kept for log-tail visibility)
+    Bus->>OR: deliver
+    OR->>OR: lookup admin Discord ID<br/>via users.yaml
+    OR->>Bus: message.outbound.discord.dm.user.{adminId}
+    Bus->>DP: deliver
+    DP->>OP: Discord DM
+    Note over OP: Phase 2 reply path TBD — text commands<br/>vs. buttons vs. CLI/dashboard
 ```
 
 ---
 
-## Bus topic table (intended vs actual)
+## Bus topic table
 
-| Topic | Intended publisher | Actual publisher (audited) | Subscriber | Status |
-|---|---|---|---|---|
-| `operator.message.request` | pr-remediator escalation sites, dispatcher chokepoint trips | _(none in current source)_ | OperatorRoutingPlugin | ⚠ gap |
-| `message.outbound.discord.dm.user.{userId}` | OperatorRoutingPlugin | OperatorRoutingPlugin | DiscordPlugin DM sink | ✅ wired |
-| `hitl.request.pr.remediation_stuck.{correlationId}` | _docstring says pr-remediator emits this_ | _(none)_ | _(none)_ | ❌ aspirational |
-| `hitl.response.*` | _(operator → bus)_ | _(none)_ | _(none)_ | ❌ aspirational |
-
-The `OperatorRoutingPlugin` at [operator-routing.ts:75–127](../../lib/plugins/operator-routing.ts) is healthy and tested — it just has no current upstream publisher.
+| Topic | Publisher(s) | Subscriber | Status |
+|---|---|---|---|
+| `operator.message.request` | pr-remediator (#619), dispatch-drop-escalator (#622) | OperatorRoutingPlugin | ✅ wired |
+| `operator.message.failed.{correlationId}` | OperatorRoutingPlugin (when no transport available) | _(no subscriber yet — for future HTTP callers)_ | ✅ wired publisher side |
+| `message.outbound.discord.dm.user.{userId}` | OperatorRoutingPlugin | DiscordPlugin DM sink | ✅ wired |
+| `operator.message.response` | _Phase 2 — not yet implemented_ | _Phase 2 — pr-remediator would consume_ | ❌ aspirational |
 
 ---
 
 ## Escalation trigger sites (today)
 
-[pr-remediator.ts](../../lib/plugins/pr-remediator.ts):
+All sites publish `operator.message.request` AND keep their `console.warn` (log-tail visibility is independent of the bus path).
 
-| Site | Condition | What fires |
+### pr-remediator ([pr-remediator.ts](../../lib/plugins/pr-remediator.ts), all flow through `_emitStuckHitlEscalation`):
+
+| Site | Condition | Urgency |
 |---|---|---|
-| `_emitStuckHitlEscalation` (line 770, 788) | attempt count ≥ `MAX_ATTEMPTS_PER_PR` (3) | `console.warn(PR URL + reason)` |
-| `update_branch` 422 conflict handler (line 1072) | 422 from GitHub after 2+ attempts | dispatch `diagnose_pr_stuck` → LLM verdict |
-| diagnose verdict "genuine" (line 1598) | LLM judges conflict is semantic | `console.warn` + `entry.escalated = true` |
-| diagnose verdict "decomposable" on promotion PR (line 1536) | #465 destructive verdict guard | `console.warn` + suppress close |
+| Budget exhaustion (line 770, 744) | `attempts ≥ MAX_ATTEMPTS_PER_PR (3)` | `normal` |
+| diagnose verdict "genuine" (line 1598) | LLM judges semantic conflict | `high` |
+| diagnose verdict "decomposable" on promotion PR (line 1536) | #465 destructive verdict guard | `high` |
 
-None of these publish `operator.message.request` today.
+### dispatch-drop-escalator ([dispatch-drop-escalator-plugin.ts](../../src/plugins/dispatch-drop-escalator-plugin.ts)):
+
+| Drop reason | Threshold | Urgency |
+|---|---|---|
+| `cooldown` | 10 drops on same key in 10min | `normal` |
+| `target_unresolved` | same | `high` |
+| `no_skill` | same | `high` |
+
+All thresholds + windows + cooldowns env-tunable. Per-key escalation cooldown (default 30min) prevents DM spam.
 
 ---
 
-## Operator-routing details (the half that works)
+## Operator-routing details
 
 [operator-routing.ts](../../lib/plugins/operator-routing.ts):
 
@@ -122,20 +136,21 @@ on operator.message.request:
 
 ---
 
-## Closing the gap
+## Phase 2 — operator reply UX (open design)
 
-Minimum viable wiring to make escalation actually escalate:
+The outbound path is shipped. The inbound path — operator's Discord DM reply re-entering the bus as a structured `operator.message.response` — is undecided. Three viable shapes:
 
-1. **At each escalation site, publish `operator.message.request`** with the existing context (PR URL, reason, urgency). One-line additions next to each `console.warn`.
-2. **Decide the inbound HITL path** — does an operator's Discord DM reply re-enter the bus as `hitl.response.*`? Or do they manually run a CLI / dashboard action? Not yet decided.
+1. **Text commands** in DM (`pr-remediator: merge #123`) → parsed by DiscordPlugin DM handler, published as `operator.message.response`. Pure bus, no Discord UI dependencies.
+2. **Discord buttons / interaction handlers** — richer UX, but the old HITL plugin used a registrar pattern for buttons that was the explicit reason for the f658744 rip. Reintroducing buttons requires designing a bus-pure rendering protocol.
+3. **CLI / dashboard action** — separate surface entirely; operator runs `wsk operator reply <correlationId> <decision>` or clicks in the dashboard.
 
-Both are open work. The escalation sites are the more urgent half — without them, the operator is in the dark by default.
+Decision deferred until ~1 week of Phase 1 escalation data informs which shape fits real usage patterns.
 
 ---
 
 ## Failure modes & gotchas
 
-- **Promotion-PR destructive guard is the most surface-visible HITL path today** (`#465`) — when Ava's verdict is `decomposable` on a release-pipeline PR, the close is suppressed but no operator notification fires. The PR sits with the LLM verdict text in a comment, no further action.
+- **Promotion-PR destructive guard now escalates loudly** (`#465`) — the LLM-decomposable verdict on a release PR suppresses the close AND fires an operator DM at `urgency: high` (since Phase 1 shipped in #619). Previously this was the most-visible "wire-incomplete" surface; now it's the most-visible "wired" surface.
 - **Live CI re-check before escalating `fix_ci`** (line 821–830) — prevents spurious "stuck on CI" escalation if CI flipped green. Good. But also masks the case where CI flipped green *because* something else fixed it, not because the original issue was resolved.
 - **`InFlightEntry.escalated` is a one-shot flag** ([line 196](../../lib/plugins/pr-remediator.ts)) — once set, no further escalations on the same PR. If a real new failure mode appears, it's not re-escalated. Acceptable today (we don't have multiple operators); revisit if HITL becomes a queue.
 - **`operator.message.request` is fire-and-forget** ([line 76](../../lib/plugins/operator-routing.ts)) — no acknowledgment topic. If the DM send fails, the publisher doesn't know. The OperatorRoutingPlugin logs failures but doesn't notify upstream.

--- a/docs/architecture/flow-inbound-message.md
+++ b/docs/architecture/flow-inbound-message.md
@@ -151,7 +151,7 @@ The dispatcher enforces invariants in this order ([skill-dispatcher-plugin.ts:16
 ## Failure modes & gotchas
 
 - **No execute() timeout** — `await executor.execute()` at line 286 is unguarded. A2A hangs leave the dispatcher slot occupied indefinitely. Mitigation lives inside individual executors (A2A SDK has its own timeouts).
-- **Cooldown drop is silent on the bus** — only `console.warn`. Dashboard cannot count cooldown trips today. Reply topic still gets an error response (line 223–227).
+- **Cooldown drops emit `dispatch.dropped.cooldown`** (since #620) — dashboard tiles + `dispatch-drop-escalator` (#622) consume this. Reply topic also gets an error response. Console.warn preserved for log-tail visibility.
 - **Synthetic actors pollute fleet metrics if unfiltered** — `systemActor` whitelisting happens at [AgentFleetHealthPlugin._record](../../src/plugins/agent-fleet-health-plugin.ts) (line 281–334), **not** at the dispatcher. See [chokepoint-invariants.md](chokepoint-invariants.md).
 - **Self-cascade guard on GitHub events** — DiscordPlugin/GitHubPlugin filter bot-authored events (`protoquinn[bot]`, `ava[bot]`, `protobot[bot]`) at webhook time to prevent infinite Quinn → issue → webhook → Quinn loops ([github.ts:524–542](../../lib/plugins/github.ts)). PR events are intentionally NOT filtered — Quinn-authored PRs still get reviewed.
 - **`bug_triage` success has a deferred side-effect** — async board filing if `projectPath` is set (line 332–334). Doesn't block the response; failures here are invisible to the requester.


### PR DESCRIPTION
## Summary

Updates the architecture docs shipped in #618 to reflect what's actually in source after today's wave of merges. Several \"gaps\" the original docs flagged are now closed; two were never gaps — the audit agent missed the publish sites.

Closes both **#78** (update flow-hitl.md after #619) and **#81** (resolve agent.runtime.activity.* topics) in one batch since they all stem from the same wave of merges.

## Corrections

| File | What changed |
|---|---|
| \`flow-agent-runtime-telemetry.md\` | Removed \"aspirational topics\" section. \`agent.runtime.activity.*\` + \`agent.skill.latency\` ARE published today by SkillDispatcher + AgentRuntimePlugin's \`_publishToolCall\` hook. Replaced with actual publish topic table + file:line refs. |
| \`flow-hitl.md\` | Phase 1 outbound shipped (#619 + #622). Two production-wired escalation sources documented. Phase 2 reply UX still open with three candidate shapes spelled out. |
| \`flow-alert-remediator.md\` | Threshold gap resolved: GOAP fully torn out (commit 01a1bec / #518). Re-wired via \`fleet_alerts\` cron ceremony (#621). 3 of 20 alerts wired; 17 still pending different data sources. |
| \`chokepoint-invariants.md\` | Telemetry gap resolved: \`dispatch.dropped.*\` (#620) + storm escalator (#622). |
| \`flow-inbound-message.md\` | One-line fix: cooldown drops are no longer silent on the bus. |

## Why a batched doc PR

These corrections all stem from the same wave of merges (#619 → #622). Bundling them keeps the docs internally consistent within a single PR rather than producing a stretched cleanup window where some flows are accurate and others stale.

## Test plan

- [x] \`bun test\` — 777/0 (no test changes)
- [x] \`bun tsc --noEmit\` — clean
- [x] All cross-references verified (\`[link](other-doc.md)\` targets exist)
- [ ] After merge, spot-check 3 cited file:line refs to confirm accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)