### PR TITLE
fix(a2a): unregister skills dropped from agent card on refresh

### DIFF
--- a/src/executor/__tests__/executor-registry.test.ts
+++ b/src/executor/__tests__/executor-registry.test.ts
@@ -294,4 +294,46 @@ describe("ExecutorRegistry", () => {
       expect(registry.resolve("skill")).toBe(solo);
     });
   });
+
+  describe("unregister", () => {
+    it("removes the matching (skill, agentName) registration and reports the count", () => {
+      const registry = new ExecutorRegistry();
+      const exec = makeExecutor("a2a");
+      registry.register("plan", exec, { agentName: "ava" });
+      registry.register("plan", exec, { agentName: "quinn" });
+      registry.register("review", exec, { agentName: "ava" });
+
+      const removed = registry.unregister("plan", "ava");
+
+      expect(removed).toBe(1);
+      // ava still has "review"
+      expect(registry.resolve("plan", ["ava"])).toBe(exec); // resolves via "review"? no — explicit target by agentName
+      // Actually: target-match scans by agentName regardless of skill. So ["ava"] still matches "review".
+      // The skill-name resolution for "plan" should now only find quinn.
+      expect(registry.resolve("plan", ["quinn"])).toBe(exec);
+      expect(registry.resolve("plan", [])).toBe(exec); // quinn's "plan" registration remains
+    });
+
+    it("returns 0 when nothing matches — no-op safe", () => {
+      const registry = new ExecutorRegistry();
+      registry.register("plan", makeExecutor("a2a"), { agentName: "ava" });
+
+      expect(registry.unregister("ghost_skill", "ava")).toBe(0);
+      expect(registry.unregister("plan", "nobody")).toBe(0);
+      expect(registry.size).toBe(1);
+    });
+
+    it("can unregister anonymous registrations (agentName undefined)", () => {
+      const registry = new ExecutorRegistry();
+      const anon = makeExecutor("function");
+      registry.register("util", anon);
+      expect(registry.size).toBe(1);
+
+      const removed = registry.unregister("util", undefined);
+
+      expect(removed).toBe(1);
+      expect(registry.size).toBe(0);
+      expect(registry.resolve("util", [])).toBeNull();
+    });
+  });
 });

--- a/src/executor/executor-registry.ts
+++ b/src/executor/executor-registry.ts
@@ -84,6 +84,29 @@ export class ExecutorRegistry {
   }
 
   /**
+   * Remove every registration matching (skill, agentName). Returns the number
+   * of entries removed. Used by SkillBrokerPlugin when an A2A agent drops a
+   * skill from its card on refresh — without this, the stale registration
+   * keeps absorbing dispatches that should fall through to another agent
+   * (or fail loud) until the next workstacean restart.
+   *
+   * Pass `agentName: undefined` to remove anonymous registrations (those
+   * registered without an agentName). This is the unique-key shape that
+   * register() supports; we match it.
+   */
+  unregister(skill: string, agentName: string | undefined): number {
+    let removed = 0;
+    for (let i = this._registrations.length - 1; i >= 0; i--) {
+      const r = this._registrations[i]!;
+      if (r.skill === skill && r.agentName === agentName) {
+        this._registrations.splice(i, 1);
+        removed++;
+      }
+    }
+    return removed;
+  }
+
+  /**
    * Resolve the executor for a (skill, targets) pair.
    * Returns null if nothing matches and no default is set.
    */

--- a/src/plugins/skill-broker-plugin.ts
+++ b/src/plugins/skill-broker-plugin.ts
@@ -263,24 +263,44 @@ export class SkillBrokerPlugin implements Plugin {
         );
       }
 
-      const registered = this.registeredSkills.get(agent.name) ?? new Set();
-      let added = 0;
-
+      const previouslyRegistered = this.registeredSkills.get(agent.name) ?? new Set<string>();
+      const currentSkills = new Set<string>();
       for (const cardSkill of card.skills ?? []) {
-        const skillName = cardSkill.id;
-        if (!skillName || registered.has(skillName)) continue;
+        if (cardSkill.id) currentSkills.add(cardSkill.id);
+      }
 
+      // Add skills that are in the new card but not yet registered.
+      let added = 0;
+      for (const skillName of currentSkills) {
+        if (previouslyRegistered.has(skillName)) continue;
         this.executorRegistry.register(skillName, executor, {
           agentName: agent.name,
           priority: 5,
         });
-        registered.add(skillName);
         added++;
       }
 
-      this.registeredSkills.set(agent.name, registered);
+      // Remove skills that were registered but are no longer in the card.
+      // Without this, an agent that drops a skill keeps absorbing dispatches
+      // for it until workstacean restarts — exactly the kind of silent drift
+      // #608's loud-failure fix was meant to prevent.
+      const removed: string[] = [];
+      for (const skillName of previouslyRegistered) {
+        if (currentSkills.has(skillName)) continue;
+        this.executorRegistry.unregister(skillName, agent.name);
+        removed.push(skillName);
+      }
+
+      this.registeredSkills.set(agent.name, currentSkills);
       if (added > 0) {
-        console.log(`[skill-broker] ${agent.name}: discovered ${added} new skill(s) from agent card (${Array.from(registered).join(", ")})`);
+        console.log(
+          `[skill-broker] ${agent.name}: discovered ${added} new skill(s) from agent card (${Array.from(currentSkills).join(", ")})`,
+        );
+      }
+      if (removed.length > 0) {
+        console.warn(
+          `[skill-broker] ${agent.name}: removed ${removed.length} skill(s) no longer in agent card — ${removed.join(", ")}`,
+        );
       }
 
       this._loadHitlModeDeclarations(agent.name, card);


### PR DESCRIPTION
## Summary

Closes the silent-drift gap flagged in \`docs/architecture/flow-a2a-discovery.md\`. Card refresh fires every 10 min; the broker previously only ADDED new skills, never REMOVED ones that disappeared from the card. A remote agent that dropped a skill kept absorbing dispatches for it until workstacean restarted — silent drift, exactly what #608's loud-failure changes were meant to prevent.

## Changes

**\`ExecutorRegistry.unregister(skill, agentName)\`** — new method. Removes every matching entry, returns count removed. Matches the \`(skill, agentName)\` shape that \`register()\` uses; pass \`agentName: undefined\` for anonymous registrations.

**\`SkillBrokerPlugin._discoverSkills\`** — now diffs the new card against the previously-registered set:
- Skills in card but not registered → register (unchanged)
- Skills registered but not in card → unregister + \`console.warn\` (loud removal, same convention as #608)

## Operator visibility

When a card refresh drops a skill, the log line is:

```
[skill-broker] {agentName}: removed N skill(s) no longer in agent card — {skill1, skill2, ...}
```

Distinguishes legitimate skill removal from card-discovery misfire (which fires its own warn line).

## Test plan

- [x] 3 new tests for \`ExecutorRegistry.unregister\` — match-removal, no-op safety, anonymous registrations
- [x] Full suite: 780/0 (up from 777)
- [x] \`bun tsc --noEmit\` — clean
- [ ] After deploy: at the 10-min refresh tick, confirm no spurious removals (current cards stable)

## Follow-up enabled

The dashboard could surface a \"recently-removed skills\" tile sourced from these warn lines (or a new \`a2a.skill.unregistered\` bus topic if we want structured visibility). Deferred — wait to see whether real card drops ever happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Skills are now properly cleaned up and unregistered when removed from agent configurations, preventing orphaned registrations during refresh cycles.

* **Tests**
  * Added comprehensive test coverage for executor registry unregistration functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/625?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->