### PR TITLE
fix(cost): use per-model MODEL_RATES + warn-once on unknown model

### DIFF
--- a/src/event-bus/payloads.ts
+++ b/src/event-bus/payloads.ts
@@ -322,6 +322,16 @@ export interface AutonomousOutcomePayload {
   };
   /** Wall-clock time from dispatch to terminal state (ms). */
   durationMs: number;
+  /**
+   * LLM model used for this task — captured from the dispatch payload
+   * (`payload.model` per-call override, see #613). Undefined when the
+   * caller didn't specify an override (in that case the executor or
+   * LiteLLM gateway picked a model and we can't tell which one from
+   * the dispatcher). Cost aggregation in AgentFleetHealth uses the
+   * model-specific rate from `MODEL_RATES` when set; falls back to
+   * the default rate otherwise.
+   */
+  model?: string;
   /** World-state delta produced by this task — populated in Arc 4/5. */
   effectDelta?: Record<string, unknown>;
 }

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -182,6 +182,12 @@ export class SkillDispatcherPlugin implements Plugin {
       ?? (typeof payload.meta?.skillHint === "string" ? payload.meta.skillHint : undefined)
       ?? "";
 
+    // Per-call model override — captured for outcome cost attribution.
+    // Undefined when the caller didn't override (then the executor or
+    // gateway picks a model; we can't tell from here, so cost falls back
+    // to the default rate downstream).
+    const requestedModel = typeof payload.model === "string" ? payload.model : undefined;
+
     let targets: string[] = [];
     if (Array.isArray(payload.targets)) {
       targets = payload.targets;
@@ -360,6 +366,7 @@ export class SkillDispatcherPlugin implements Plugin {
               taskState,
               text: content,
               durationMs: Date.now() - dispatchedAt,
+              model: requestedModel,
             });
 
             const gh = payload.github as { title?: string; owner?: string; repo?: string; number?: number; url?: string } | undefined;
@@ -441,6 +448,7 @@ export class SkillDispatcherPlugin implements Plugin {
           text: result.text,
           usage: result.data?.usage,
           durationMs: Date.now() - dispatchedAt,
+          model: requestedModel,
         });
       } else {
         // Log a preview of the response so we can see what the executor actually
@@ -542,6 +550,7 @@ export class SkillDispatcherPlugin implements Plugin {
           text: result.text,
           usage: result.data?.usage,
           durationMs,
+          model: requestedModel,
         });
       }
 
@@ -578,6 +587,7 @@ export class SkillDispatcherPlugin implements Plugin {
         taskState: "failed",
         text: errorMsg,
         durationMs: Date.now() - dispatchedAt,
+        model: requestedModel,
       });
       this._publishResponse(replyTopic, correlationId, undefined, errorMsg);
     } finally {
@@ -640,6 +650,7 @@ export class SkillDispatcherPlugin implements Plugin {
     text?: string;
     usage?: AutonomousOutcomePayload["usage"];
     durationMs: number;
+    model?: string;
   }): void {
     if (!this.bus) return;
     const topic = `autonomous.outcome.${opts.systemActor}.${opts.skill}`;
@@ -656,6 +667,7 @@ export class SkillDispatcherPlugin implements Plugin {
       textPreview: opts.text ? opts.text.slice(0, 500) : undefined,
       usage: opts.usage,
       durationMs: opts.durationMs,
+      model: opts.model,
     };
     this.bus.publish(topic, {
       id: crypto.randomUUID(),

--- a/src/plugins/agent-fleet-health-plugin.test.ts
+++ b/src/plugins/agent-fleet-health-plugin.test.ts
@@ -35,6 +35,7 @@ const makeOutcomeMsg = (payload: Partial<AutonomousOutcomePayload> & { systemAct
     durationMs: payload.durationMs ?? 500,
     taskState: payload.taskState,
     usage: payload.usage,
+    model: payload.model,
   } satisfies AutonomousOutcomePayload,
 });
 
@@ -431,5 +432,72 @@ describe("AgentFleetHealthPlugin", () => {
     }).not.toThrow();
     const snapshot = plugin.getFleetHealth();
     expect(snapshot.agents).toHaveLength(0);
+  });
+
+  describe("per-model cost attribution (MODEL_RATES lookup)", () => {
+    test("uses Opus rate when payload.model='claude-opus-4-6' (5x default)", async () => {
+      bus.publish("autonomous.outcome.completed", makeOutcomeMsg({
+        systemActor: "ava",
+        skill: "plan",
+        success: true,
+        durationMs: 500,
+        usage: { input_tokens: 1000, output_tokens: 1000 },
+        model: "claude-opus-4-6",
+      }));
+      await new Promise(r => setTimeout(r, 10));
+
+      const ava = plugin.getFleetHealth().agents.find(a => a.agentName === "ava")!;
+      // Opus: 0.000015 in + 0.000075 out per token → 1000*(0.000015+0.000075) = 0.09
+      // Default would be: 0.000003 + 0.000015 → 0.018. So Opus reads 5x default.
+      expect(ava.costPerSuccessfulOutcome).toBeCloseTo(0.09, 3);
+    });
+
+    test("uses Haiku rate when payload.model='claude-haiku-4-5' (~1/12 default)", async () => {
+      bus.publish("autonomous.outcome.completed", makeOutcomeMsg({
+        systemActor: "ava",
+        skill: "plan",
+        success: true,
+        durationMs: 500,
+        usage: { input_tokens: 1000, output_tokens: 1000 },
+        model: "claude-haiku-4-5",
+      }));
+      await new Promise(r => setTimeout(r, 10));
+
+      const ava = plugin.getFleetHealth().agents.find(a => a.agentName === "ava")!;
+      // Haiku: 0.00000025 + 0.00000125 per token → 1000*(0.0000015) = 0.0015
+      expect(ava.costPerSuccessfulOutcome).toBeCloseTo(0.0015, 4);
+    });
+
+    test("falls back to default rate when model is undefined (caller didn't override)", async () => {
+      bus.publish("autonomous.outcome.completed", makeOutcomeMsg({
+        systemActor: "ava",
+        skill: "plan",
+        success: true,
+        durationMs: 500,
+        usage: { input_tokens: 1000, output_tokens: 1000 },
+        // no model field
+      }));
+      await new Promise(r => setTimeout(r, 10));
+
+      const ava = plugin.getFleetHealth().agents.find(a => a.agentName === "ava")!;
+      // Default: 0.000003 + 0.000015 per token → 0.018
+      expect(ava.costPerSuccessfulOutcome).toBeCloseTo(0.018, 4);
+    });
+
+    test("unknown model falls back to default and is acceptable (warn-once side-effect not asserted here)", async () => {
+      bus.publish("autonomous.outcome.completed", makeOutcomeMsg({
+        systemActor: "ava",
+        skill: "plan",
+        success: true,
+        durationMs: 500,
+        usage: { input_tokens: 1000, output_tokens: 1000 },
+        model: "made-up-model-that-does-not-exist",
+      }));
+      await new Promise(r => setTimeout(r, 10));
+
+      const ava = plugin.getFleetHealth().agents.find(a => a.agentName === "ava")!;
+      // Falls back to default rate
+      expect(ava.costPerSuccessfulOutcome).toBeCloseTo(0.018, 4);
+    });
   });
 });

--- a/src/plugins/agent-fleet-health-plugin.ts
+++ b/src/plugins/agent-fleet-health-plugin.ts
@@ -32,6 +32,35 @@ const WINDOW_1H_MS = 60 * 60 * 1_000; // 1 hour
 const MAX_RECENT_FAILURES = 10;
 const DEFAULT_RATES = MODEL_RATES["default"];
 
+/**
+ * Track which unknown models we've warned about so we don't spam the
+ * log on every outcome. One warn per distinct model name across the
+ * process lifetime — fits the "fail loud once" convention from #459's
+ * synthetic-actor logging.
+ */
+const _warnedUnknownModels = new Set<string>();
+
+/**
+ * Resolve per-token rates for a model. Returns the model-specific entry
+ * from MODEL_RATES when set; falls back to DEFAULT_RATES with a one-time
+ * warn for unknown models so operators notice when LiteLLM is routing
+ * to something we don't have a rate for. Undefined model (no override)
+ * silently uses default — that's the documented "we can't tell" case.
+ */
+function _ratesFor(model: string | undefined): { input: number; output: number } {
+  if (!model) return DEFAULT_RATES;
+  const rates = MODEL_RATES[model];
+  if (rates) return rates;
+  if (!_warnedUnknownModels.has(model)) {
+    _warnedUnknownModels.add(model);
+    console.warn(
+      `[agent-fleet-health] No MODEL_RATES entry for "${model}" — using default rate. ` +
+        `Add the model to lib/types/budget.ts MODEL_RATES table for accurate cost attribution.`,
+    );
+  }
+  return DEFAULT_RATES;
+}
+
 // ── Internal record ───────────────────────────────────────────────────────────
 
 interface OutcomeRecord {
@@ -279,9 +308,10 @@ export class AgentFleetHealthPlugin implements Plugin {
   // ── Private ─────────────────────────────────────────────────────────────────
 
   private _record(p: AutonomousOutcomePayload): void {
+    const rates = _ratesFor(p.model);
     const costUsd = p.usage
-      ? (p.usage.input_tokens ?? 0) * DEFAULT_RATES.input +
-        (p.usage.output_tokens ?? 0) * DEFAULT_RATES.output
+      ? (p.usage.input_tokens ?? 0) * rates.input +
+        (p.usage.output_tokens ?? 0) * rates.output
       : 0;
 
     const record: OutcomeRecord = {


### PR DESCRIPTION
## Summary

The audit framing in flow-agent-runtime-telemetry.md said \"new LiteLLM models = \$0 cost until MODEL_RATES is updated\". Going to source revealed a bigger issue: \`MODEL_RATES\` has per-model entries (Opus 5x Sonnet, Haiku ~1/12 Sonnet) but \`AgentFleetHealthPlugin.record()\` was hard-coded to \`DEFAULT_RATES\` — so even known models were costed wrong.

## Change

| Layer | Change |
|---|---|
| \`AutonomousOutcomePayload\` | New optional \`model?: string\` field |
| \`SkillDispatcherPlugin._dispatch\` | Captures \`payload.model\` at top, threads through all 4 \`_publishAutonomousOutcome\` call sites |
| \`AgentFleetHealthPlugin\` | New \`_ratesFor(model)\` helper: returns \`MODEL_RATES[model]\` when set, falls back to default with one-time \`console.warn\` per unknown model (matches #459's warn-once convention) |

## Behavior

| `payload.model` | Cost rate used | Side effect |
|---|---|---|
| `\"claude-opus-4-6\"` | Opus (5x default) | none |
| `\"claude-haiku-4-5\"` | Haiku (~1/12 default) | none |
| `\"made-up\"` | default | `console.warn` once per process lifetime |
| unset / undefined | default | none (silent — see limitation) |

## Known limitation

When the caller doesn't set \`payload.model\` (the common case — only explicit overrides per #613 set this), we can't tell which model the LiteLLM gateway or executor ultimately picked. Default rate applies. Closing this requires executors (DeepAgent / ProtoSdk / A2A) to report the resolved model in their \`SkillResult\` — separate PR if cost attribution accuracy ever bites us in practice.

Documented in the payload field comment.

## Test plan

- [x] 4 new tests in \`agent-fleet-health-plugin.test.ts\` covering Opus, Haiku, default-fallback, unknown-model paths
- [x] Full suite: 781/0 (up from 777)
- [x] \`bun tsc --noEmit\` — clean
- [ ] After deploy: dispatch a task with \`payload.model=\"claude-opus-4-6\"\` and verify \`/api/cost-summaries\` reports ~5x the cost of the same task at default rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)