### PR TITLE
feat(dispatcher): cooldown key per-number + per-headSha (granular)

### DIFF
--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -688,6 +688,14 @@ export class GitHubPlugin implements Plugin {
       return;
     }
 
+    // Head SHA — threaded through to the dispatcher so cooldown keys can
+    // include it. Without this, two pushes to the same PR within the
+    // cooldown window dropped the second silently; with headSha in the
+    // key, a new commit always reviews (only repeated webhooks for the
+    // same SHA dedup). See flow-pr-review.md.
+    const head = pr?.head as Record<string, unknown> | undefined;
+    const headSha = typeof head?.["sha"] === "string" ? (head["sha"] as string) : undefined;
+
     const correlationId = crypto.randomUUID();
     pendingComments.set(correlationId, { owner: ctx.owner, repo: ctx.repo, number: ctx.number });
 
@@ -729,6 +737,7 @@ export class GitHubPlugin implements Plugin {
           number: ctx.number,
           title: ctx.title,
           url: ctx.url,
+          headSha,
         },
         meta: { webhookArrivedAt },
       },

--- a/src/executor/__tests__/skill-cooldown.test.ts
+++ b/src/executor/__tests__/skill-cooldown.test.ts
@@ -57,12 +57,47 @@ describe("cooldownMsFor", () => {
 });
 
 describe("cooldownKeyFor", () => {
-  test("bucketed by (skill, owner/repo) when github context present", () => {
+  test("includes #number when github.number present", () => {
     const payload = { github: { owner: "protoLabsAI", repo: "protoMaker", number: 100 } };
-    expect(cooldownKeyFor("bug_triage", payload)).toBe("bug_triage:protoLabsAI/protoMaker");
+    expect(cooldownKeyFor("bug_triage", payload)).toBe("bug_triage:protoLabsAI/protoMaker#100");
   });
 
-  test("different repos get separate buckets (the #556 fix point)", () => {
+  test("repo-only when no number", () => {
+    const payload = { github: { owner: "protoLabsAI", repo: "protoMaker" } };
+    expect(cooldownKeyFor("security_triage", payload)).toBe("security_triage:protoLabsAI/protoMaker");
+  });
+
+  test("includes @sha7 when github.headSha present (PR review case)", () => {
+    const payload = {
+      github: {
+        owner: "protoLabsAI",
+        repo: "protoMaker",
+        number: 200,
+        headSha: "abc1234567890def",
+      },
+    };
+    expect(cooldownKeyFor("pr_review", payload)).toBe("pr_review:protoLabsAI/protoMaker#200@abc1234");
+  });
+
+  test("new commit on same PR gets a different key (the #86 fix point)", () => {
+    const before = cooldownKeyFor("pr_review", { github: { owner: "x", repo: "y", number: 1, headSha: "aaaaaaaaaaaa" } });
+    const after = cooldownKeyFor("pr_review", { github: { owner: "x", repo: "y", number: 1, headSha: "bbbbbbbbbbbb" } });
+    expect(before).not.toBe(after);
+  });
+
+  test("different PRs in the same repo get separate keys", () => {
+    const pr1 = cooldownKeyFor("pr_review", { github: { owner: "x", repo: "y", number: 1, headSha: "aaa" } });
+    const pr2 = cooldownKeyFor("pr_review", { github: { owner: "x", repo: "y", number: 2, headSha: "bbb" } });
+    expect(pr1).not.toBe(pr2);
+  });
+
+  test("repeated webhooks for same PR + same SHA share a key (dedup intact)", () => {
+    const a = cooldownKeyFor("pr_review", { github: { owner: "x", repo: "y", number: 5, headSha: "deadbeef1234" } });
+    const b = cooldownKeyFor("pr_review", { github: { owner: "x", repo: "y", number: 5, headSha: "deadbeef1234" } });
+    expect(a).toBe(b);
+  });
+
+  test("different repos get separate buckets (the #556 fix point — preserved)", () => {
     const a = cooldownKeyFor("bug_triage", { github: { owner: "protoLabsAI", repo: "protoMaker" } });
     const b = cooldownKeyFor("bug_triage", { github: { owner: "protoLabsAI", repo: "protoWorkstacean" } });
     expect(a).not.toBe(b);
@@ -71,6 +106,12 @@ describe("cooldownKeyFor", () => {
   test("different skills on the same repo get separate buckets", () => {
     const ctx = { github: { owner: "x", repo: "y" } };
     expect(cooldownKeyFor("bug_triage", ctx)).not.toBe(cooldownKeyFor("pr_review", ctx));
+  });
+
+  test("different issues in the same repo get separate buckets (no more cross-issue back-pressure)", () => {
+    const issue1 = cooldownKeyFor("bug_triage", { github: { owner: "x", repo: "y", number: 100 } });
+    const issue2 = cooldownKeyFor("bug_triage", { github: { owner: "x", repo: "y", number: 101 } });
+    expect(issue1).not.toBe(issue2);
   });
 
   test("falls back to <skill>:_ when no github context", () => {

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -81,18 +81,41 @@ export function cooldownMsFor(skill: string): number {
 }
 
 /**
- * Build the cooldown bucket key for a dispatch. Bucketed by (skill, repo) so
- * `bug_triage` on protoMaker has its own cooldown bucket separate from
- * `bug_triage` on protoWorkstacean — different repos don't share back-pressure.
- * Falls back to `<skill>:_` (no repo) when the payload doesn't carry a github
- * context (chat dispatches, manual /publish calls, etc.).
+ * Build the cooldown bucket key for a dispatch.
+ *
+ * Granularity (most specific to least):
+ *   `<skill>:<owner>/<repo>#<number>@<headSha7>` — pr_review on a specific
+ *      PR commit. New commits always review because the headSha changes;
+ *      repeated webhooks for the same SHA dedup.
+ *   `<skill>:<owner>/<repo>#<number>`            — issue or PR-level
+ *      (no headSha available, e.g. comment events).
+ *   `<skill>:<owner>/<repo>`                     — repo-scoped (skills
+ *      without a number context).
+ *   `<skill>:_`                                  — no github context
+ *      (chat, manual /publish, etc).
+ *
+ * Why each granularity matters:
+ *   - PR-with-headSha keying prevents the "rebase within 30s drops the
+ *     real fix" race that flagged in flow-pr-review.md.
+ *   - Issue-number keying lets bug_triage rate-limit per issue, not
+ *     per repo — two different issues in the same repo opening within
+ *     30s both get triaged.
+ *   - Repo-level fallback covers skills where neither number nor sha
+ *     are meaningful (security_triage at the repo level).
  */
 export function cooldownKeyFor(skill: string, payload: Record<string, unknown> | undefined): string {
   const github = (payload?.["github"] as Record<string, unknown> | undefined);
   const owner = typeof github?.["owner"] === "string" ? github["owner"] : undefined;
   const repo = typeof github?.["repo"] === "string" ? github["repo"] : undefined;
-  const repoKey = owner && repo ? `${owner}/${repo}` : "_";
-  return `${skill}:${repoKey}`;
+  if (!owner || !repo) return `${skill}:_`;
+
+  const number = typeof github?.["number"] === "number" ? github["number"] : undefined;
+  const headSha = typeof github?.["headSha"] === "string" ? (github["headSha"] as string) : undefined;
+
+  let key = `${skill}:${owner}/${repo}`;
+  if (number !== undefined) key += `#${number}`;
+  if (headSha) key += `@${headSha.slice(0, 7)}`;
+  return key;
 }
 
 export class SkillDispatcherPlugin implements Plugin {


### PR DESCRIPTION
## Summary

Closes the dedup-vs-new-commit nuance flagged in \`docs/architecture/flow-pr-review.md\`:

> Cooldown silently drops review #2 within 30s. If a PR is opened and immediately rebased, the second event hits dispatcher cooldown and silently drops. Operator sees no review for the second push.

The old key was \`<skill>:<owner>/<repo>\` — every issue, comment, and PR push on the same repo shared one 30s bucket. Two different PRs opening within 30s would drop one; a force-push to a PR within 30s would drop the new commit's review.

## New key shape (most specific to least)

| Pattern | When | Example |
|---|---|---|
| \`<skill>:<o>/<r>#<n>@<sha7>\` | PR with head SHA | \`pr_review:protoLabsAI/foo#200@abc1234\` |
| \`<skill>:<o>/<r>#<n>\` | issue/PR-level (comment events, no sha) | \`bug_triage:protoLabsAI/foo#100\` |
| \`<skill>:<o>/<r>\` | repo-scoped fallback | \`security_triage:protoLabsAI/foo\` |
| \`<skill>:_\` | no github context (chat / /publish) | \`bug_triage:_\` |

## Behavior changes

| Scenario | Before | After |
|---|---|---|
| pr_review same PR, repeated webhook (same SHA) | dedup ✓ | dedup ✓ (unchanged) |
| pr_review same PR, **new commit (different SHA)** | **dropped ✗** | **reviews ✓** |
| pr_review **different PRs** in same repo | **1 dropped ✗** | **both review ✓** |
| bug_triage **different issues** in same repo | **1 dropped ✗** | **both triage ✓** |
| bug_triage same issue, multiple comments | dedup ✓ | dedup ✓ (unchanged) |

## Implementation

1. \`cooldownKeyFor(skill, payload)\` (\`skill-dispatcher-plugin.ts\`) now builds the key from owner/repo + optional number + optional headSha (sliced to 7 chars).
2. \`GitHubPlugin._handleAutoReview\` (\`github.ts\`) extracts \`pr.head.sha\` from the webhook payload and forwards as \`payload.github.headSha\`.
3. Other webhook surfaces (issues, comments) pass \`number\` but not \`headSha\` — falls naturally to the \`<skill>:<o>/<r>#<n>\` shape.

## Test plan

- [x] 11 cooldown tests total (was 5) — new key shapes + the new-commit fix point + behavior continuity for non-PR skills
- [x] Full suite: 786/0 (up from 781)
- [x] \`bun tsc --noEmit\` — clean
- [ ] After deploy: force-push to an open PR within 30s of opening it → confirm second push triggers a new review

🤖 Generated with [Claude Code](https://claude.com/claude-code)