### PR TITLE
fix(fleet-alerts): satisfy ceremony yaml schema with targets: [function]

### DIFF
--- a/workspace/ceremonies/fleet-alerts.yaml
+++ b/workspace/ceremonies/fleet-alerts.yaml
@@ -21,6 +21,14 @@ description: >
 
 schedule: "* * * * *"  # every minute
 skill: evaluate_fleet_thresholds
-targets: []
+# CeremonyPlugin's yaml schema requires `targets` to be a non-empty array
+# (ceremonyYamlLoader rejects empty ones). The dispatcher's ExecutorRegistry
+# falls through to skill-name resolution when no registration matches a named
+# target, so "function" here is a schema-satisfying placeholder that lets the
+# FunctionExecutor registered for evaluate_fleet_thresholds pick up the
+# dispatch via skill-name routing. Same pattern as
+# clawpatch-cache-cleanup.yaml.
+targets:
+  - function
 notifyChannel: ""
 enabled: true


### PR DESCRIPTION
## Summary

Follow-up to **#621**. Live verification on prod (after deploy) revealed the ceremony was silently skipped at load time:

```
[ceremony-loader] Skipping /workspace/ceremonies/fleet-alerts.yaml
  (global): 'targets' must be a non-empty array
```

\`CeremonyPlugin\`'s yaml loader validates \`targets\` as non-empty array before scheduling. My original yaml had \`targets: []\` — semantically correct (the FunctionExecutor for \`evaluate_fleet_thresholds\` is registered without an agentName, so it routes via skill-name match), but the loader's schema doesn't accept empty.

## Fix

Following the pattern in \`clawpatch-cache-cleanup.yaml\`: use \`targets: [function]\` as a schema-satisfying placeholder. The dispatcher's \`ExecutorRegistry.resolve\` falls through to skill-name matching when no registration has \`agentName=\"function\"\`, so effective routing is unchanged.

## Test plan

- [x] \`bun test\` — 790/0
- [x] \`bun tsc --noEmit\` — clean
- [ ] After merge + watchtower pull: confirm log shows \`[ceremony] Plugin installed — loaded 5 ceremony(ies)\` (up from 4) and no \"Skipping fleet-alerts.yaml\" line

🤖 Generated with [Claude Code](https://claude.com/claude-code)