### PR TITLE
feat(plugin): ProtomakerProjectRegistry — parallel-mode project source

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -419,6 +419,21 @@ const pluginRegistry: PluginRegistryEntry[] = [
       return new DispatchDropEscalatorPlugin();
     },
   },
+  {
+    // Phase 1: fetches the canonical project list from protoMaker
+    // (GET /api/settings/global → settings.projects[]) and exposes it
+    // alongside workspace/projects.yaml. Logs parity warnings between
+    // the two sources so we get telemetry on drift before flipping
+    // consumers to read from protoMaker exclusively. See task #88.
+    name: "protomaker-project-registry",
+    condition: () => true,
+    factory: async () => {
+      const { ProtomakerProjectRegistryPlugin } = await import(
+        "./plugins/protomaker-project-registry-plugin.js"
+      );
+      return new ProtomakerProjectRegistryPlugin({ workspaceDir });
+    },
+  },
   // Built-ins: opt-in via ENABLED_PLUGINS=echo,...
   {
     name: "echo",

--- a/src/plugins/__tests__/protomaker-project-registry-plugin.test.ts
+++ b/src/plugins/__tests__/protomaker-project-registry-plugin.test.ts
@@ -1,0 +1,318 @@
+/**
+ * ProtomakerProjectRegistryPlugin tests — covers the pure helpers
+ * (git-config parsing) and the plugin's refresh + parity-check behavior
+ * against a fake protoMaker HTTP server and a temporary workspace dir.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import {
+  ProtomakerProjectRegistryPlugin,
+  parseGithubFromGitConfig,
+  parseDefaultBranchFromHead,
+} from "../protomaker-project-registry-plugin.ts";
+
+describe("parseGithubFromGitConfig", () => {
+  test("SSH origin url → owner/repo", () => {
+    const config = `[remote "origin"]
+\turl = git@github.com:protoLabsAI/protoWorkstacean.git
+\tfetch = +refs/heads/*:refs/remotes/origin/*`;
+    expect(parseGithubFromGitConfig(config)).toEqual({
+      owner: "protoLabsAI",
+      repo: "protoWorkstacean",
+    });
+  });
+
+  test("HTTPS origin url → owner/repo", () => {
+    const config = `[remote "origin"]
+\turl = https://github.com/protoLabsAI/protoMaker.git`;
+    expect(parseGithubFromGitConfig(config)).toEqual({
+      owner: "protoLabsAI",
+      repo: "protoMaker",
+    });
+  });
+
+  test("url without .git suffix", () => {
+    const config = `[remote "origin"]\n\turl = git@github.com:foo/bar`;
+    expect(parseGithubFromGitConfig(config)).toEqual({ owner: "foo", repo: "bar" });
+  });
+
+  test("non-origin remote is ignored", () => {
+    const config = `[remote "upstream"]
+\turl = git@github.com:upstream-org/upstream-repo.git
+[remote "origin"]
+\turl = git@github.com:my-fork/my-repo.git`;
+    expect(parseGithubFromGitConfig(config)).toEqual({
+      owner: "my-fork",
+      repo: "my-repo",
+    });
+  });
+
+  test("no GitHub origin → undefined", () => {
+    const config = `[remote "origin"]\n\turl = https://gitlab.com/foo/bar.git`;
+    expect(parseGithubFromGitConfig(config)).toBeUndefined();
+  });
+
+  test("no origin section → undefined", () => {
+    const config = `[core]\n\trepositoryformatversion = 0`;
+    expect(parseGithubFromGitConfig(config)).toBeUndefined();
+  });
+});
+
+describe("parseDefaultBranchFromHead", () => {
+  test("standard symref → branch name", () => {
+    expect(parseDefaultBranchFromHead("ref: refs/remotes/origin/main")).toBe("main");
+  });
+
+  test("trailing newline", () => {
+    expect(parseDefaultBranchFromHead("ref: refs/remotes/origin/dev\n")).toBe("dev");
+  });
+
+  test("non-symref content → undefined", () => {
+    expect(parseDefaultBranchFromHead("garbage")).toBeUndefined();
+  });
+});
+
+describe("ProtomakerProjectRegistryPlugin", () => {
+  let bus: InMemoryEventBus;
+  let plugin: ProtomakerProjectRegistryPlugin | undefined;
+  let tempDir: string;
+  let server: ReturnType<typeof Bun.serve> | undefined;
+  let fakeProjects: Array<{ id: string; name: string; path: string }>;
+  let fetchCount: number;
+
+  beforeEach(() => {
+    bus = new InMemoryEventBus();
+    tempDir = mkdtempSync(join(tmpdir(), "wsk-pm-registry-test-"));
+    fakeProjects = [];
+    fetchCount = 0;
+    // Fake protoMaker server returning settings.global with the fakeProjects list.
+    server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/api/settings/global") {
+          fetchCount++;
+          return Response.json({ success: true, settings: { projects: fakeProjects } });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+  });
+
+  afterEach(() => {
+    plugin?.uninstall();
+    server?.stop();
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  function newPlugin(opts?: { parityCheck?: boolean; refreshIntervalMs?: number }): ProtomakerProjectRegistryPlugin {
+    return new ProtomakerProjectRegistryPlugin({
+      apiBase: `http://localhost:${server!.port}`,
+      workspaceDir: tempDir,
+      refreshIntervalMs: opts?.refreshIntervalMs ?? 50_000, // long, so test drives refreshes manually via setTimeout below
+      parityCheck: opts?.parityCheck ?? false,
+    });
+  }
+
+  function makeGitRepo(path: string, github: string, defaultBranch: string): void {
+    mkdirSync(join(path, ".git", "refs", "remotes", "origin"), { recursive: true });
+    writeFileSync(
+      join(path, ".git", "config"),
+      `[remote "origin"]\n\turl = git@github.com:${github}.git\n`,
+    );
+    writeFileSync(
+      join(path, ".git", "refs", "remotes", "origin", "HEAD"),
+      `ref: refs/remotes/origin/${defaultBranch}\n`,
+    );
+  }
+
+  test("fetches projects from protoMaker on install + populates registry", async () => {
+    const projPath = join(tempDir, "myproj");
+    makeGitRepo(projPath, "protoLabsAI/myproj", "main");
+    fakeProjects.push({ id: "p1", name: "myproj", path: projPath });
+
+    plugin = newPlugin();
+    plugin.install(bus);
+
+    // Initial fetch is async fire-and-forget — wait briefly for it.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const projects = plugin.getProjects();
+    expect(projects).toHaveLength(1);
+    expect(projects[0]!.id).toBe("p1");
+    expect(projects[0]!.name).toBe("myproj");
+    expect(projects[0]!.path).toBe(projPath);
+    expect(projects[0]!.github).toEqual({ owner: "protoLabsAI", repo: "myproj" });
+    expect(projects[0]!.defaultBranch).toBe("main");
+    expect(projects[0]!.source).toBe("protomaker");
+    expect(fetchCount).toBe(1);
+  });
+
+  test("project without .git/ → registry entry has no github/defaultBranch", async () => {
+    const projPath = join(tempDir, "no-git");
+    mkdirSync(projPath, { recursive: true });
+    fakeProjects.push({ id: "p2", name: "no-git", path: projPath });
+
+    plugin = newPlugin();
+    plugin.install(bus);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const p = plugin.getProjects()[0]!;
+    expect(p.github).toBeUndefined();
+    expect(p.defaultBranch).toBeUndefined();
+  });
+
+  test("unreachable protoMaker server → plugin starts empty, lastError set", async () => {
+    // Point at a port that's not listening — any free port other than the
+    // test server's. Pick a high port and assume it's unused.
+    plugin = new ProtomakerProjectRegistryPlugin({
+      apiBase: "http://localhost:1", // port 1 is reserved + reliably refuses
+      workspaceDir: tempDir,
+      refreshIntervalMs: 50_000,
+      parityCheck: false,
+    });
+    plugin.install(bus);
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(plugin.getProjects()).toHaveLength(0);
+    expect(plugin.getLastError()).toBeDefined();
+  });
+
+  test("server returns success=false → lastError surfaces it", async () => {
+    server!.stop();
+    server = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.json({ success: false, error: "boom" });
+      },
+    });
+
+    plugin = newPlugin();
+    plugin.install(bus);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(plugin.getProjects()).toHaveLength(0);
+    expect(plugin.getLastError()).toBeDefined();
+    expect(plugin.getLastError()!).toContain("success=false");
+  });
+
+  test("parityCheck: logs nothing when no projects.yaml exists", async () => {
+    // No projects.yaml in tempDir → parityCheck silently does nothing.
+    const projPath = join(tempDir, "x");
+    makeGitRepo(projPath, "foo/x", "main");
+    fakeProjects.push({ id: "p1", name: "x", path: projPath });
+
+    const warnLogs: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => warnLogs.push(args.join(" "));
+
+    plugin = newPlugin({ parityCheck: true });
+    plugin.install(bus);
+    await new Promise((r) => setTimeout(r, 50));
+
+    console.warn = origWarn;
+    const parityWarns = warnLogs.filter((l) => l.includes("parity"));
+    expect(parityWarns).toHaveLength(0);
+  });
+
+  test("parityCheck: logs warning when project is only in protoMaker", async () => {
+    const projPath = join(tempDir, "only-pm");
+    makeGitRepo(projPath, "foo/only-pm", "main");
+    fakeProjects.push({ id: "p1", name: "only-pm", path: projPath });
+
+    // projects.yaml present but empty.
+    writeFileSync(join(tempDir, "projects.yaml"), "projects: []\n");
+
+    const warnLogs: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => warnLogs.push(args.join(" "));
+
+    plugin = newPlugin({ parityCheck: true });
+    plugin.install(bus);
+    await new Promise((r) => setTimeout(r, 50));
+
+    console.warn = origWarn;
+    const onlyPmWarn = warnLogs.find((l) => l.includes("only in protoMaker"));
+    expect(onlyPmWarn).toBeDefined();
+    expect(onlyPmWarn!).toContain("only-pm");
+  });
+
+  test("parityCheck: logs warning when project is only in yaml", async () => {
+    // protoMaker returns nothing.
+    writeFileSync(
+      join(tempDir, "projects.yaml"),
+      `projects:
+  - slug: stale-project
+    projectPath: /tmp/stale-project
+    github: foo/stale
+`,
+    );
+
+    const warnLogs: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => warnLogs.push(args.join(" "));
+
+    plugin = newPlugin({ parityCheck: true });
+    plugin.install(bus);
+    await new Promise((r) => setTimeout(r, 50));
+
+    console.warn = origWarn;
+    const onlyYamlWarn = warnLogs.find((l) => l.includes("only in projects.yaml"));
+    expect(onlyYamlWarn).toBeDefined();
+    expect(onlyYamlWarn!).toContain("stale-project");
+  });
+
+  test("parityCheck: logs warning on github mismatch for same path", async () => {
+    const projPath = join(tempDir, "shared");
+    makeGitRepo(projPath, "protoLabsAI/shared", "main"); // git config says protoLabsAI/shared
+
+    fakeProjects.push({ id: "p1", name: "shared", path: projPath });
+
+    // yaml says a different github coordinate.
+    writeFileSync(
+      join(tempDir, "projects.yaml"),
+      `projects:
+  - slug: shared
+    projectPath: ${projPath}
+    github: different-org/different-repo
+`,
+    );
+
+    const warnLogs: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => warnLogs.push(args.join(" "));
+
+    plugin = newPlugin({ parityCheck: true });
+    plugin.install(bus);
+    await new Promise((r) => setTimeout(r, 50));
+
+    console.warn = origWarn;
+    const mismatchWarn = warnLogs.find((l) => l.includes("github mismatch"));
+    expect(mismatchWarn).toBeDefined();
+    expect(mismatchWarn!).toContain("protoLabsAI/shared");
+    expect(mismatchWarn!).toContain("different-org/different-repo");
+  });
+
+  test("uninstall clears refresh timer + project list", async () => {
+    const projPath = join(tempDir, "x");
+    makeGitRepo(projPath, "foo/x", "main");
+    fakeProjects.push({ id: "p1", name: "x", path: projPath });
+
+    plugin = newPlugin();
+    plugin.install(bus);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(plugin.getProjects()).toHaveLength(1);
+
+    plugin.uninstall();
+    expect(plugin.getProjects()).toHaveLength(0);
+    plugin = undefined; // prevent afterEach double-uninstall
+  });
+});

--- a/src/plugins/protomaker-project-registry-plugin.ts
+++ b/src/plugins/protomaker-project-registry-plugin.ts
@@ -1,0 +1,302 @@
+/**
+ * ProtomakerProjectRegistryPlugin — pulls the canonical list of projects from
+ * protoMaker (`GET /api/settings/global` → `settings.projects[]: ProjectRef[]`)
+ * and exposes it as the source of truth for workstacean's project metadata.
+ *
+ * Phase 1 (this PR): the plugin runs in PARALLEL with `workspace/projects.yaml`.
+ * Consumers still read from yaml; this plugin logs parity warnings between
+ * the two sources so we get telemetry on drift before flipping. Phase 2 will
+ * refactor the 13 consumer files to read from `getProjects()` instead, and
+ * Phase 3 deletes `projects.yaml` + `lib/project-schema.ts`.
+ *
+ * protoMaker's `ProjectRef` is intentionally lean (id, name, path, UI prefs).
+ * For workstacean's routing + cache needs we additionally derive:
+ *
+ *   - `github: { owner, repo }` — from `<path>/.git/config` `[remote "origin"]`
+ *   - `defaultBranch`            — from `<path>/.git/refs/remotes/origin/HEAD`
+ *
+ * If those fields ever land natively on `ProjectRef`, the derivation drops
+ * to a fallback. See protoMaker issue (filed alongside this PR) for the
+ * native-field proposal.
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import type { Plugin, EventBus } from "../../lib/types.ts";
+
+const DEFAULT_PROTOMAKER_BASE = "http://protomaker-server:3008";
+const DEFAULT_REFRESH_INTERVAL_MS = 5 * 60_000;
+
+export interface RegistryProject {
+  /** ProjectRef.id from protoMaker. */
+  id: string;
+  /** ProjectRef.name from protoMaker (human-readable). */
+  name: string;
+  /** Absolute filesystem path to the project directory (ProjectRef.path). */
+  path: string;
+  /** Derived from `<path>/.git/config` `[remote "origin"]` url. */
+  github?: { owner: string; repo: string };
+  /** Derived from `<path>/.git/refs/remotes/origin/HEAD` symref. */
+  defaultBranch?: string;
+  /** Provenance marker — distinguishes this from yaml-sourced records during parity logging. */
+  source: "protomaker";
+}
+
+export interface ProtomakerProjectRegistryOptions {
+  /** protoMaker HTTP base URL. Default: `http://protomaker-server:3008`. */
+  apiBase?: string;
+  /** Workspace directory (for parity check against projects.yaml). */
+  workspaceDir: string;
+  /** Refresh interval. Default: 5 min. */
+  refreshIntervalMs?: number;
+  /** When true, log parity warnings vs. workspace/projects.yaml on every refresh. */
+  parityCheck?: boolean;
+}
+
+export class ProtomakerProjectRegistryPlugin implements Plugin {
+  readonly name = "protomaker-project-registry";
+  readonly description =
+    "Fetches the canonical project list from protoMaker + derives git metadata; logs parity vs. projects.yaml";
+  readonly capabilities = ["project-registry"];
+
+  private readonly apiBase: string;
+  private readonly workspaceDir: string;
+  private readonly refreshIntervalMs: number;
+  private readonly parityCheck: boolean;
+
+  private projects: RegistryProject[] = [];
+  private refreshTimer?: ReturnType<typeof setInterval>;
+  private lastRefreshAt = 0;
+  private lastError: string | undefined;
+
+  constructor(opts: ProtomakerProjectRegistryOptions) {
+    this.apiBase = opts.apiBase ?? process.env["PROTOMAKER_API_BASE"] ?? DEFAULT_PROTOMAKER_BASE;
+    this.workspaceDir = opts.workspaceDir;
+    this.refreshIntervalMs = opts.refreshIntervalMs ?? DEFAULT_REFRESH_INTERVAL_MS;
+    this.parityCheck = opts.parityCheck ?? true;
+  }
+
+  install(_bus: EventBus): void {
+    // Fire-and-forget initial refresh — must not block install.
+    void this._refresh();
+    this.refreshTimer = setInterval(() => void this._refresh(), this.refreshIntervalMs);
+    console.log(
+      `[protomaker-project-registry] Installed — apiBase=${this.apiBase}, ` +
+        `refresh=${Math.round(this.refreshIntervalMs / 60_000)}min, ` +
+        `parityCheck=${this.parityCheck}`,
+    );
+  }
+
+  uninstall(): void {
+    if (this.refreshTimer) clearInterval(this.refreshTimer);
+    this.refreshTimer = undefined;
+    this.projects = [];
+  }
+
+  /** Snapshot of currently-known projects. Phase 2 consumers will read this. */
+  getProjects(): readonly RegistryProject[] {
+    return this.projects;
+  }
+
+  /** Last refresh timestamp (0 if never). */
+  getLastRefreshAt(): number {
+    return this.lastRefreshAt;
+  }
+
+  /** Last refresh error, if any. Cleared on next successful refresh. */
+  getLastError(): string | undefined {
+    return this.lastError;
+  }
+
+  private async _refresh(): Promise<void> {
+    try {
+      const raw = await this._fetchProjects();
+      this.projects = raw.map((p) => this._enrichWithGit(p));
+      this.lastRefreshAt = Date.now();
+      this.lastError = undefined;
+      console.log(
+        `[protomaker-project-registry] Refreshed: ${this.projects.length} project(s) — ` +
+          this.projects.map((p) => p.name).join(", "),
+      );
+
+      if (this.parityCheck) {
+        this._logParityVsYaml();
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.lastError = msg;
+      console.warn(
+        `[protomaker-project-registry] Refresh failed (${this.apiBase}): ${msg} — ` +
+          `keeping ${this.projects.length} stale project(s) in memory`,
+      );
+    }
+  }
+
+  /**
+   * Fetch projects from protoMaker. Expected response shape:
+   *   { success: true, settings: { projects: ProjectRef[] } }
+   * Per protoMaker `apps/server/src/routes/settings/index.ts:14` (GET /global).
+   */
+  private async _fetchProjects(): Promise<Array<{ id: string; name: string; path: string }>> {
+    const url = `${this.apiBase}/api/settings/global`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(5_000) });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} from ${url}`);
+    }
+    const body = (await res.json()) as {
+      success?: boolean;
+      settings?: { projects?: Array<{ id: string; name: string; path: string }> };
+    };
+    if (!body.success) {
+      throw new Error(`protoMaker returned success=false`);
+    }
+    return body.settings?.projects ?? [];
+  }
+
+  private _enrichWithGit(p: { id: string; name: string; path: string }): RegistryProject {
+    const enriched: RegistryProject = {
+      id: p.id,
+      name: p.name,
+      path: p.path,
+      source: "protomaker",
+    };
+    const gitConfigPath = join(p.path, ".git", "config");
+    if (existsSync(gitConfigPath)) {
+      try {
+        const config = readFileSync(gitConfigPath, "utf8");
+        const github = parseGithubFromGitConfig(config);
+        if (github) enriched.github = github;
+      } catch {
+        // Silent — non-essential enrichment.
+      }
+    }
+    const headRefPath = join(p.path, ".git", "refs", "remotes", "origin", "HEAD");
+    if (existsSync(headRefPath)) {
+      try {
+        const ref = readFileSync(headRefPath, "utf8").trim();
+        const branch = parseDefaultBranchFromHead(ref);
+        if (branch) enriched.defaultBranch = branch;
+      } catch {
+        // Silent — non-essential enrichment.
+      }
+    }
+    return enriched;
+  }
+
+  /**
+   * Compare protoMaker-sourced projects vs. workspace/projects.yaml.
+   * Logs warnings for: extra projects on either side, github mismatches.
+   * Purely observational — does not mutate either source.
+   */
+  private _logParityVsYaml(): void {
+    const yamlPath = join(this.workspaceDir, "projects.yaml");
+    if (!existsSync(yamlPath)) {
+      // No yaml side to compare — nothing to log (yaml-less is the target state).
+      return;
+    }
+
+    let yamlProjects: Array<{ slug: string; github?: string; path?: string }> = [];
+    try {
+      const parsed = parseYaml(readFileSync(yamlPath, "utf8")) as {
+        projects?: Array<{ slug?: string; github?: string; projectPath?: string }>;
+      };
+      yamlProjects = (parsed.projects ?? [])
+        .filter((p) => typeof p.slug === "string")
+        .map((p) => ({ slug: p.slug as string, github: p.github, path: p.projectPath }));
+    } catch (err) {
+      console.warn(
+        `[protomaker-project-registry] parity-check: failed to parse projects.yaml: ` +
+          (err instanceof Error ? err.message : String(err)),
+      );
+      return;
+    }
+
+    const pmByPath = new Map(this.projects.map((p) => [p.path, p]));
+    const yamlByPath = new Map(yamlProjects.filter((p) => p.path).map((p) => [p.path!, p]));
+
+    const onlyInPm = this.projects.filter((p) => !yamlByPath.has(p.path));
+    const onlyInYaml = yamlProjects.filter((p) => p.path && !pmByPath.has(p.path));
+
+    if (onlyInPm.length > 0) {
+      console.warn(
+        `[protomaker-project-registry] parity: ${onlyInPm.length} project(s) only in protoMaker (not in projects.yaml) — ` +
+          onlyInPm.map((p) => `${p.name}@${p.path}`).join(", "),
+      );
+    }
+    if (onlyInYaml.length > 0) {
+      console.warn(
+        `[protomaker-project-registry] parity: ${onlyInYaml.length} project(s) only in projects.yaml (not in protoMaker) — ` +
+          onlyInYaml.map((p) => `${p.slug}@${p.path}`).join(", "),
+      );
+    }
+
+    // GitHub-field comparison for projects present on both sides.
+    for (const [path, pm] of pmByPath) {
+      const yaml = yamlByPath.get(path);
+      if (!yaml) continue;
+      const pmGithub = pm.github ? `${pm.github.owner}/${pm.github.repo}` : undefined;
+      if (pmGithub && yaml.github && pmGithub !== yaml.github) {
+        console.warn(
+          `[protomaker-project-registry] parity: github mismatch for ${path} — ` +
+            `protoMaker derived "${pmGithub}", yaml says "${yaml.github}"`,
+        );
+      }
+    }
+  }
+}
+
+// ── Exported helpers (pure, testable) ────────────────────────────────────────
+
+/**
+ * Parse the `[remote "origin"]` url from a git config file and extract
+ * owner/repo. Supports SSH (`git@github.com:OWNER/REPO.git`), HTTPS
+ * (`https://github.com/OWNER/REPO.git`), and `.git` suffix optional.
+ * Returns undefined if no GitHub origin remote is found.
+ */
+export function parseGithubFromGitConfig(
+  config: string,
+): { owner: string; repo: string } | undefined {
+  // Find the [remote "origin"] section's url line.
+  // Sections are delimited by [...] headers; we look only inside the origin
+  // section to avoid picking up a non-origin remote that happens to be GH.
+  const lines = config.split("\n");
+  let inOriginSection = false;
+  let originUrl: string | undefined;
+  for (const line of lines) {
+    const sectionMatch = line.match(/^\s*\[(.+)\]\s*$/);
+    if (sectionMatch) {
+      inOriginSection = /remote\s+"origin"/.test(sectionMatch[1]!);
+      continue;
+    }
+    if (!inOriginSection) continue;
+    const urlMatch = line.match(/^\s*url\s*=\s*(.+?)\s*$/);
+    if (urlMatch) {
+      originUrl = urlMatch[1]!;
+      break;
+    }
+  }
+  if (!originUrl) return undefined;
+
+  // SSH: git@github.com:OWNER/REPO(.git)?
+  const sshMatch = originUrl.match(/^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/);
+  if (sshMatch) return { owner: sshMatch[1]!, repo: sshMatch[2]! };
+
+  // HTTPS: https://github.com/OWNER/REPO(.git)?
+  const httpsMatch = originUrl.match(/^https?:\/\/github\.com\/([^/]+)\/(.+?)(?:\.git)?$/);
+  if (httpsMatch) return { owner: httpsMatch[1]!, repo: httpsMatch[2]! };
+
+  return undefined;
+}
+
+/**
+ * Parse `<path>/.git/refs/remotes/origin/HEAD` contents to extract the
+ * default branch name. The file typically contains a symref like
+ * `ref: refs/remotes/origin/main`.
+ */
+export function parseDefaultBranchFromHead(headContent: string): string | undefined {
+  // Trim before matching — file usually ends with \n which the regex below
+  // (no /m flag) won't cross because `.` doesn't match newline.
+  const match = headContent.trim().match(/^ref:\s*refs\/remotes\/origin\/(.+)$/);
+  return match ? match[1]! : undefined;
+}


### PR DESCRIPTION
## Summary

Phase 1 of separating concerns: **workstacean is a switchboard, not a project registry**. protoMaker owns *which engineering projects exist on this system*. This PR adds a new workstacean plugin that pulls the project list from protoMaker and runs **in parallel** with the existing \`workspace/projects.yaml\` — logging parity warnings so we get drift telemetry before flipping consumers.

No consumers are refactored yet. Phase 2 (task #89) will swap the 13 files reading \`projects.yaml\`. Phase 3 deletes \`projects.yaml\` + \`lib/project-schema.ts\`. Task #90 files a protoMaker nice-to-have (native \`github\` field on \`ProjectRef\`) so the local derivation in this PR can eventually go away.

## What it does

```
ProtomakerProjectRegistryPlugin
   ↓
GET http://protomaker-server:3008/api/settings/global
   ↓
settings.projects[] : ProjectRef[]   ← canonical source
   ↓
For each project: read <path>/.git/config → derive github owner/repo
                  read <path>/.git/refs/remotes/origin/HEAD → derive defaultBranch
   ↓
in-memory RegistryProject[]   ← Phase 2 consumers will read here
   ↓
Compare vs. workspace/projects.yaml on every refresh
   ↓
Log parity warnings (only-in-pm / only-in-yaml / github-mismatch)
```

Refresh cadence: 5 min default (env: \`PROTOMAKER_API_BASE\`).

## Why a parallel phase

The 13 files currently reading \`projects.yaml\` all have slightly different shapes of what they need. Before refactoring them, we want to know:

1. **Does protoMaker actually return the projects we expect?** (or is some onboarding-only project missing from protoMaker's settings?)
2. **Does the derived github coordinate match the yaml-declared one?** (catches stale yaml entries, repo renames)
3. **Are there orphan entries in either source?** (projects.yaml has projects protoMaker doesn't know about, or vice versa)

After ~1 week of warn-level parity logs in prod, we'll have signal to make Phase 2 safe.

## Field gap (handled by local derivation)

protoMaker's \`ProjectRef\` shape (\`libs/types/src/project-settings.ts\`):

```ts
{ id, name, path, lastOpened?, theme?, fontFamilySans?, isFavorite?, icon?, ... }
```

That's lean — missing \`github\` + \`defaultBranch\` that workstacean needs. Two derivation paths:

| Field | Derived from |
|---|---|
| \`github: { owner, repo }\` | parse \`[remote \"origin\"] url\` in \`<path>/.git/config\`. SSH + HTTPS supported. |
| \`defaultBranch\` | parse \`ref:\` line in \`<path>/.git/refs/remotes/origin/HEAD\` |

Task #90 will file the nice-to-have on protoMaker so these become native fields. Until then derivation is solid (18 new tests cover SSH/HTTPS/no-suffix/non-origin/no-git cases).

## Test plan

- [x] \`bun test\` — 815/0 (up from 797, +18 in this PR)
- [x] \`bun tsc --noEmit\` — clean
- [ ] After deploy: confirm \`[protomaker-project-registry] Refreshed: N project(s)\` in container logs
- [ ] Confirm parity warnings (if any) surface known yaml-vs-protomaker drift
- [ ] No regressions in the running \`projects.yaml\` consumers — they're untouched

## Follow-ups (separate PRs)

- **Phase 2** (#89) — swap the 13 consumers + delete \`projects.yaml\`
- **protoMaker nice-to-have** (#90) — add \`github?: { owner, repo, defaultBranch? }\` to \`ProjectRef\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)