### PR TITLE
fix(quinn): hold formal PR verdict until CI is terminal (#3886)

### DIFF
--- a/src/api/__tests__/pr-inspector-ci-guard.test.ts
+++ b/src/api/__tests__/pr-inspector-ci-guard.test.ts
@@ -1,0 +1,158 @@
+/**
+ * pr-inspector CI-terminal verdict guard (#3886).
+ *
+ * A formal verdict (APPROVE / REQUEST_CHANGES) requires every check on the
+ * PR head to be terminal. While any check is still queued/in_progress the
+ * verdict is held (409) so Quinn can't wedge a PR on a timing artifact
+ * (#3886) or approve into a race with a still-running build (#3881). COMMENT
+ * is always allowed.
+ *
+ * The module resolves `makeGitHubAuth()` at import time, so GITHUB_TOKEN is
+ * set before the dynamic import (PAT path — no network call to mint a token).
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { createRoutes, setGithubAuthForTesting } from "../pr-inspector.ts";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import type { ApiContext } from "../types.ts";
+
+const REPO = "protoLabsAI/widget";
+const [OWNER, NAME] = REPO.split("/");
+const PR = 42;
+const HEAD_SHA = "deadbeefcafe0000deadbeefcafe0000deadbeef";
+
+type CheckRun = { name: string; status: string; conclusion: string | null };
+
+let checkRuns: CheckRun[];
+let reviewsPosted: Array<{ event: string; body: string }>;
+let origFetch: typeof globalThis.fetch;
+
+function ctx(): ApiContext {
+  return { bus: new InMemoryEventBus(), executorRegistry: {} as never } as unknown as ApiContext;
+}
+
+function getHandler() {
+  const routes = createRoutes(ctx());
+  const route = routes.find((r) => r.path === "/api/pr/inspect" && r.method === "POST");
+  if (!route) throw new Error("pr/inspect route not found");
+  return route.handler;
+}
+
+function inspect(body: Record<string, unknown>): Request {
+  return new Request("http://local/api/pr/inspect", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  // Inject a working auth getter via the test seam. We can't rely on the
+  // real makeGitHubAuth() here: the onboarding suite mock.module()s
+  // ../lib/github-auth.ts process-wide, so the resolver pr-inspector would
+  // otherwise hit is whatever that mock was last left returning.
+  setGithubAuthForTesting(async () => "test-token");
+  checkRuns = [];
+  reviewsPosted = [];
+  origFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    const method = init?.method ?? "GET";
+
+    // PR detail → head SHA
+    if (url.endsWith(`/pulls/${PR}`) && method === "GET") {
+      return new Response(JSON.stringify({ head: { sha: HEAD_SHA } }), { status: 200 });
+    }
+    // check-runs for head SHA
+    if (url.includes(`/commits/${HEAD_SHA}/check-runs`)) {
+      return new Response(JSON.stringify({ check_runs: checkRuns }), { status: 200 });
+    }
+    // review submission
+    if (url.endsWith(`/pulls/${PR}/reviews`) && method === "POST") {
+      const parsed = JSON.parse(String(init?.body ?? "{}")) as { event: string; body: string };
+      reviewsPosted.push({ event: parsed.event, body: parsed.body });
+      return new Response(JSON.stringify({ id: 1 }), { status: 200 });
+    }
+    throw new Error(`unexpected fetch in test: ${method} ${url}`);
+  }) as typeof globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = origFetch;
+  setGithubAuthForTesting(undefined); // reset to lazy makeGitHubAuth()
+});
+
+const PENDING: CheckRun[] = [
+  { name: "test", status: "completed", conclusion: "success" },
+  { name: "build", status: "in_progress", conclusion: null },
+];
+const TERMINAL_GREEN: CheckRun[] = [
+  { name: "test", status: "completed", conclusion: "success" },
+  { name: "build", status: "completed", conclusion: "success" },
+];
+const TERMINAL_RED: CheckRun[] = [
+  { name: "test", status: "completed", conclusion: "failure" },
+  { name: "build", status: "completed", conclusion: "success" },
+];
+
+describe("pr-inspector CI-terminal verdict guard (#3886)", () => {
+  test("REQUEST_CHANGES held with 409 while a check is in_progress", async () => {
+    checkRuns = PENDING;
+    const res = await getHandler()(inspect({
+      action: "review_request_changes", repo: REPO, pr_number: PR, body: "needs work",
+    }), {});
+    expect(res.status).toBe(409);
+    const json = (await res.json()) as { success: boolean; error: string };
+    expect(json.success).toBe(false);
+    expect(json.error).toContain("CI is still running");
+    expect(json.error).toContain("build"); // names the pending check
+    expect(reviewsPosted).toHaveLength(0); // verdict NOT submitted
+  });
+
+  test("APPROVE held with 409 while a check is in_progress (anti-#3881 race)", async () => {
+    checkRuns = PENDING;
+    const res = await getHandler()(inspect({
+      action: "review_approve", repo: REPO, pr_number: PR,
+    }), {});
+    expect(res.status).toBe(409);
+    expect(reviewsPosted).toHaveLength(0);
+  });
+
+  test("COMMENT is always allowed, even with pending CI", async () => {
+    checkRuns = PENDING;
+    const res = await getHandler()(inspect({
+      action: "review_comment", repo: REPO, pr_number: PR, body: "interim findings",
+    }), {});
+    expect(res.status).toBe(200);
+    expect(reviewsPosted).toEqual([{ event: "COMMENT", body: "interim findings" }]);
+  });
+
+  test("REQUEST_CHANGES proceeds once every check is terminal", async () => {
+    checkRuns = TERMINAL_RED;
+    const res = await getHandler()(inspect({
+      action: "review_request_changes", repo: REPO, pr_number: PR, body: "test failed",
+    }), {});
+    expect(res.status).toBe(200);
+    expect(reviewsPosted).toEqual([{ event: "REQUEST_CHANGES", body: "test failed" }]);
+  });
+
+  test("APPROVE proceeds once every check is terminal-green", async () => {
+    checkRuns = TERMINAL_GREEN;
+    const res = await getHandler()(inspect({
+      action: "review_approve", repo: REPO, pr_number: PR, body: "lgtm",
+    }), {});
+    expect(res.status).toBe(200);
+    expect(reviewsPosted).toEqual([{ event: "APPROVE", body: "lgtm" }]);
+  });
+
+  test("verdict allowed when the PR has no checks at all (nothing to wait for)", async () => {
+    checkRuns = [];
+    const res = await getHandler()(inspect({
+      action: "review_approve", repo: REPO, pr_number: PR,
+    }), {});
+    expect(res.status).toBe(200);
+    expect(reviewsPosted).toHaveLength(1);
+    expect(reviewsPosted[0]!.event).toBe("APPROVE");
+  });
+});

--- a/src/api/pr-inspector.ts
+++ b/src/api/pr-inspector.ts
@@ -29,7 +29,31 @@ import type { Route, ApiContext } from "./types.ts";
 import { makeGitHubAuth } from "../../lib/github-auth.ts";
 import { REVIEW_TOPICS } from "../event-bus/topics.ts";
 
-const getGithubToken = makeGitHubAuth();
+// Resolve auth lazily + memoized on first use rather than at module load.
+// Module-load capture bound the getter to whatever env existed at import
+// time, which (a) loses credentials injected after import — e.g. a late
+// infisical pass — and (b) made the route untestable since the import order
+// decided whether GITHUB_TOKEN was set. Memoizing on first call preserves
+// the GitHub App's internal token cache (one getter instance reused across
+// requests) while picking up the env present when the first request lands.
+let _authGetter: ((owner: string, repo: string) => Promise<string>) | null | undefined;
+function resolveAuth(): ((owner: string, repo: string) => Promise<string>) | null {
+  if (_authGetter === undefined) _authGetter = makeGitHubAuth();
+  return _authGetter;
+}
+
+/**
+ * Test seam — inject an auth getter (or `null` for the no-credentials path).
+ * Pass `undefined` to reset back to the lazy `makeGitHubAuth()` resolution.
+ * Mirrors clawpatch.ts's `setCheckoutCacheForTesting`. Needed because the
+ * onboarding suite mock.module()s `../lib/github-auth.ts` process-wide, so
+ * a route test can't depend on the real resolver being in place.
+ */
+export function setGithubAuthForTesting(
+  getter: ((owner: string, repo: string) => Promise<string>) | null | undefined,
+): void {
+  _authGetter = getter;
+}
 
 type Action =
   | "list_open"
@@ -71,8 +95,9 @@ async function ghFetch(
   url: string,
   init: RequestInit = {},
 ): Promise<Response> {
-  if (!getGithubToken) throw new Error("no GitHub credentials (QUINN_APP_* or GITHUB_TOKEN)");
-  const token = await getGithubToken(owner, name);
+  const getToken = resolveAuth();
+  if (!getToken) throw new Error("no GitHub credentials (QUINN_APP_* or GITHUB_TOKEN)");
+  const token = await getToken(owner, name);
   return fetch(url, {
     ...init,
     signal: init.signal ?? AbortSignal.timeout(GH_FETCH_TIMEOUT_MS),
@@ -109,7 +134,23 @@ async function listOpen(owner: string, name: string): Promise<string> {
   return lines.join("\n");
 }
 
-async function checkCi(owner: string, name: string, pr: number): Promise<string> {
+interface CheckRun {
+  name: string;
+  status: string;
+  conclusion: string | null;
+}
+
+/**
+ * Resolve a PR's head SHA and fetch its check-runs. Shared by `check_ci`
+ * (formats the result for Quinn) and the CI-terminal verdict guard (reads
+ * the pending set). Throws on any GitHub error so the caller surfaces it
+ * loudly rather than treating an unknown CI state as "all clear".
+ */
+async function fetchCheckRuns(
+  owner: string,
+  name: string,
+  pr: number,
+): Promise<{ headSha: string; runs: CheckRun[] }> {
   const prResp = await ghFetch(owner, name, `https://api.github.com/repos/${owner}/${name}/pulls/${pr}`);
   if (!prResp.ok) throw new Error(`GitHub API error fetching PR#${pr}: ${prResp.status} ${await prResp.text()}`);
   const { head } = (await prResp.json()) as { head: { sha: string } };
@@ -117,19 +158,83 @@ async function checkCi(owner: string, name: string, pr: number): Promise<string>
   const checksResp = await ghFetch(
     owner,
     name,
-    `https://api.github.com/repos/${owner}/${name}/commits/${head.sha}/check-runs?per_page=50`,
+    `https://api.github.com/repos/${owner}/${name}/commits/${head.sha}/check-runs?per_page=100`,
   );
   if (!checksResp.ok) throw new Error(`GitHub API error fetching check-runs: ${checksResp.status} ${await checksResp.text()}`);
-  const { check_runs } = (await checksResp.json()) as {
-    check_runs: Array<{ name: string; status: string; conclusion: string | null }>;
-  };
-  if (check_runs.length === 0) return `No CI checks found for PR#${pr} (head ${head.sha.slice(0, 7)}).`;
-  const lines = [`**CI Checks for PR#${pr}** (head ${head.sha.slice(0, 7)}):`];
-  for (const c of check_runs) {
+  const { check_runs } = (await checksResp.json()) as { check_runs: CheckRun[] };
+  return { headSha: head.sha, runs: check_runs };
+}
+
+/**
+ * Names of checks that haven't reached a terminal state yet. A check is
+ * terminal once `status === "completed"` (its `conclusion` then carries the
+ * pass/fail outcome). `queued` / `in_progress` / anything else = pending.
+ */
+function pendingCheckNames(runs: CheckRun[]): string[] {
+  return runs.filter((c) => c.status !== "completed").map((c) => c.name);
+}
+
+async function checkCi(owner: string, name: string, pr: number): Promise<string> {
+  const { headSha, runs } = await fetchCheckRuns(owner, name, pr);
+  if (runs.length === 0) return `No CI checks found for PR#${pr} (head ${headSha.slice(0, 7)}).`;
+  const lines = [`**CI Checks for PR#${pr}** (head ${headSha.slice(0, 7)}):`];
+  for (const c of runs) {
     const state = c.conclusion ?? c.status;
     lines.push(`- ${c.name}: ${state}`);
   }
   return lines.join("\n");
+}
+
+/**
+ * Chokepoint invariant (#3886): a formal verdict requires terminal CI.
+ *
+ * APPROVE and REQUEST_CHANGES both lock in a settled judgment — APPROVE
+ * enables auto-merge, REQUEST_CHANGES blocks it (sets reviewDecision).
+ * While any check is still queued/in_progress, that judgment reflects a
+ * timing artifact, not the PR's actual state:
+ *   - a REQUEST_CHANGES "because CI is still queued" wedges the PR on a
+ *     transient (#3886);
+ *   - an APPROVE before CI completes lets auto-merge race a red build
+ *     (#3881 incident).
+ *
+ * So while CI is pending, only COMMENT (non-blocking) is allowed; the
+ * formal PASS/FAIL lands on a later pass once checks are terminal. Repos
+ * with no checks at all are terminal by definition (nothing to wait for).
+ *
+ * Returns a 409 Response to reject the verdict, or null to allow it.
+ * Mirrors the cooldown / target-guard / actor-filter / destructive-verdict
+ * chokepoints (#437 / #444 / #459 / #465).
+ */
+async function guardTerminalCi(
+  owner: string,
+  name: string,
+  pr: number,
+  verdict: "APPROVE" | "REQUEST_CHANGES",
+): Promise<Response | null> {
+  // Throws on a GitHub error — surfaced by the route's try/catch as a 500.
+  // We fail closed: an unknown CI state must never be treated as "terminal"
+  // and let a verdict through (that's the #3881 failure mode).
+  const { runs } = await fetchCheckRuns(owner, name, pr);
+  const pending = pendingCheckNames(runs);
+  if (pending.length === 0) return null;
+
+  console.warn(
+    `[pr-inspector] CI-terminal guard: held ${verdict} on ${owner}/${name}#${pr} — ` +
+      `${pending.length} check(s) still running: ${pending.slice(0, 8).join(", ")}`,
+  );
+  const verb = verdict === "APPROVE" ? "approval" : "change-request";
+  return Response.json(
+    {
+      success: false,
+      error:
+        `CI is still running on PR#${pr} — ${pending.length} check(s) not yet complete ` +
+        `(${pending.slice(0, 5).join(", ")}). A formal ${verb} would lock in a verdict on a ` +
+        `timing artifact, so it is held until checks are terminal. Record interim findings now ` +
+        `with action='review_comment' (non-blocking), then re-run check_ci and submit the formal ` +
+        `verdict once every check has completed.`,
+    },
+    { status: 409 },
+  );
 }
 
 async function coderabbitThreads(owner: string, name: string, pr: number): Promise<string> {
@@ -190,8 +295,9 @@ async function coderabbitThreads(owner: string, name: string, pr: number): Promi
 }
 
 async function diffSummary(owner: string, name: string, pr: number): Promise<string> {
-  if (!getGithubToken) throw new Error("no GitHub credentials (QUINN_APP_* or GITHUB_TOKEN)");
-  const token = await getGithubToken(owner, name);
+  const getToken = resolveAuth();
+  if (!getToken) throw new Error("no GitHub credentials (QUINN_APP_* or GITHUB_TOKEN)");
+  const token = await getToken(owner, name);
   const resp = await fetch(`https://api.github.com/repos/${owner}/${name}/pulls/${pr}`, {
     signal: AbortSignal.timeout(GH_FETCH_TIMEOUT_MS),
     headers: {
@@ -403,17 +509,23 @@ export function createRoutes(ctx: ApiContext): Route[] {
               result = await submitReview(owner, name, pr_number!, "COMMENT", body);
               publishReviewSubmitted(ctx, owner, name, pr_number!, "COMMENT", body);
               break;
-            case "review_approve":
+            case "review_approve": {
+              const held = await guardTerminalCi(owner, name, pr_number!, "APPROVE");
+              if (held) return held;
               result = await submitReview(owner, name, pr_number!, "APPROVE", body ?? "");
               publishReviewSubmitted(ctx, owner, name, pr_number!, "APPROVE", body ?? "");
               break;
-            case "review_request_changes":
+            }
+            case "review_request_changes": {
               if (!body) {
                 return Response.json({ success: false, error: "body required for review_request_changes" }, { status: 400 });
               }
+              const held = await guardTerminalCi(owner, name, pr_number!, "REQUEST_CHANGES");
+              if (held) return held;
               result = await submitReview(owner, name, pr_number!, "REQUEST_CHANGES", body);
               publishReviewSubmitted(ctx, owner, name, pr_number!, "REQUEST_CHANGES", body);
               break;
+            }
             case "close_pr":
               result = await setPrState(owner, name, pr_number!, "closed", comment, false);
               break;

--- a/workspace/agents/quinn.yaml
+++ b/workspace/agents/quinn.yaml
@@ -290,6 +290,17 @@ skills:
       **Never skip this step.** Narrative summary without a formal review
       = PR stuck forever.
 
+      **A formal verdict needs terminal CI.** A PASS or FAIL reflects the
+      PR's settled state, so submit `review_approve` / `review_request_changes`
+      once every check has completed. While `check_ci` still shows a
+      `queued` or `in_progress` check, record your findings with
+      `review_comment` (non-blocking) and let the formal verdict land on a
+      later pass once checks are terminal — a "broken CI" FAIL means a
+      check that *completed* with a failure conclusion, not one still
+      running. pr_inspector enforces this: an approve / request-changes
+      call while CI is pending returns a 409 asking you to comment instead,
+      so a re-review after checks finish is the clean path.
+
       ## Step 5 — Submit the formal review
 
       Call `pr_inspector` with the chosen action. Body format:


### PR DESCRIPTION
Closes protoMaker#3886.

## Problem

Quinn returned `CHANGES_REQUESTED` with *"CI checks still queued — I cannot approve until all checks resolve"* — a merge-blocking verdict based on a timing artifact, not a defect. Pushing a fix re-triggered CI + Quinn, which could FAIL again before CI completed → PR wedged in a loop.

## Fix

A **chokepoint invariant** at the `pr-inspector` verdict site — the 5th instance of the pattern (cooldown #437, target-guard #444, actor-filter #459, destructive-verdict #465):

> A formal verdict requires terminal CI.

While any check is `queued`/`in_progress`, `review_approve` and `review_request_changes` are held (HTTP 409) and Quinn is steered to `review_comment` (non-blocking). The formal PASS/FAIL lands on a later pass once checks complete. Repos with no checks are terminal by definition (nothing to wait for).

- **APPROVE is gated too**, not just REQUEST_CHANGES — defense-in-depth for the #3881 incident (approving before CI completes is what let auto-merge race a red build).
- **Fails closed**: if CI state can't be fetched, it surfaces as a 500 rather than treating unknown CI as "all clear".

## Also in this PR

- pr-inspector resolves GitHub auth **lazily + memoized** instead of at module load — picks up credentials present at first request (not import time), and adds a `setGithubAuthForTesting` seam (mirrors clawpatch's `setCheckoutCacheForTesting`) so the route is testable despite the onboarding suite's process-wide `github-auth` `mock.module`.
- `quinn.yaml` prompt (positive framing): record findings via `review_comment` while CI runs; a "broken CI" FAIL means a check that *completed* with a failure conclusion, not one still running.

## Test plan

- [x] `bun test` — 821 pass, 0 fail (6 new guard tests)
- [x] `bunx tsc --noEmit` — clean
- [x] New `pr-inspector-ci-guard.test.ts` covers: pending → 409 (both verdicts), COMMENT always allowed, terminal-green/red → proceeds, no-checks → proceeds
- [ ] Live: open a PR, confirm Quinn comments (not CHANGES_REQUESTED) while CI runs and submits the formal verdict after checks complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CI terminal status validation: formal reviews (approve/request changes) are blocked until all CI checks complete, returning a 409 error. Comment-type reviews remain allowed while CI is pending.

* **Tests**
  * Added comprehensive test coverage for CI guard behavior across pending and terminal check states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->