### PR TITLE
feat(github): route @protoquinn PR-comment mentions to pr_review

### DIFF
--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -622,7 +622,17 @@ export class GitHubPlugin implements Plugin {
       if (!res.ok) console.error(`[github] reaction failed ${res.status}: ${await res.text()}`);
     })().catch(err => console.error("[github] reaction error:", err));
 
-    const skillHint = config.skillHints[event];
+    // A top-level comment on a PR arrives as an `issue_comment` event — GitHub
+    // models PR conversation comments as issue comments. The default
+    // issue_comment route is bug_triage, but when the mention is on a PR the
+    // operator wants a review, so route to the pull_request skill (pr_review)
+    // instead. Review-thread replies already arrive as pull_request_review_comment.
+    const isPrComment =
+      event === "issue_comment" &&
+      !!(payload.issue as Record<string, unknown> | undefined)?.pull_request;
+    const skillHint = isPrComment
+      ? (config.skillHints.pull_request ?? config.skillHints[event])
+      : config.skillHints[event];
     const correlationId = crypto.randomUUID();
 
     pendingComments.set(correlationId, { owner: ctx.owner, repo: ctx.repo, number: ctx.number });

--- a/tests/github-mention-routing.test.ts
+++ b/tests/github-mention-routing.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @protoquinn mention routing — a top-level comment on a PR (issue_comment
+ * event with issue.pull_request set) should route to pr_review, not the
+ * default issue_comment skill (bug_triage).
+ */
+
+import { describe, test, expect, mock, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { GitHubPlugin } from "../lib/plugins/github.ts";
+import type { EventBus, BusMessage } from "../lib/types.ts";
+
+let workspaceDir: string;
+let origFetch: typeof globalThis.fetch;
+
+beforeAll(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "gh-mention-test-"));
+});
+afterAll(() => {
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  // The mention path fires a fire-and-forget "eyes" reaction via global
+  // fetch; stub it so the test never touches the network.
+  origFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response("{}", { status: 200 })) as typeof globalThis.fetch;
+});
+afterEach(() => {
+  globalThis.fetch = origFetch;
+});
+
+const config = {
+  mentionHandle: "@protoquinn",
+  admins: ["mabry1985"],
+  skillHints: {
+    issues: "bug_triage",
+    issue_comment: "bug_triage",
+    pull_request: "pr_review",
+    pull_request_review_comment: "pr_review",
+  },
+};
+
+function makeMockBus(): { bus: EventBus; published: Array<{ topic: string; msg: BusMessage }> } {
+  const published: Array<{ topic: string; msg: BusMessage }> = [];
+  const bus: EventBus = {
+    publish: mock((topic: string, msg: BusMessage) => { published.push({ topic, msg }); }),
+    subscribe: mock(() => "sub"),
+    unsubscribe: mock(() => {}),
+    topics: mock(() => []),
+    consumers: mock(() => []),
+  };
+  return { bus, published };
+}
+
+const getToken = mock(async () => "tok");
+
+function fire(payload: Record<string, unknown>) {
+  const { bus, published } = makeMockBus();
+  const plugin = new GitHubPlugin(workspaceDir);
+  (plugin as unknown as { _handleEvent: Function })._handleEvent(
+    "issue_comment", payload, config, bus, getToken,
+  );
+  return published;
+}
+
+function prCommentPayload(body: string, author = "mabry1985") {
+  return {
+    action: "created",
+    issue: {
+      number: 99,
+      title: "Add the thing",
+      html_url: "https://github.com/protoLabsAI/widget/pull/99",
+      pull_request: { url: "https://api.github.com/repos/protoLabsAI/widget/pulls/99" },
+    },
+    comment: { id: 5, body, html_url: "https://github.com/...#c5", user: { login: author } },
+    repository: { name: "widget", owner: { login: "protoLabsAI" } },
+  };
+}
+
+describe("@protoquinn mention routing", () => {
+  test("comment on a PR routes to pr_review (not bug_triage)", () => {
+    const published = fire(prCommentPayload("@protoquinn please review this"));
+    const skillReq = published.find((p) => p.topic.startsWith("message.inbound.github."));
+    expect(skillReq).toBeDefined();
+    expect((skillReq!.msg.payload as Record<string, unknown>).skillHint).toBe("pr_review");
+  });
+
+  test("comment on a plain issue still routes to bug_triage", () => {
+    const issuePayload = {
+      action: "created",
+      issue: {
+        number: 12,
+        title: "Something is broken",
+        html_url: "https://github.com/protoLabsAI/widget/issues/12",
+        // no pull_request field → it's a real issue
+      },
+      comment: { id: 7, body: "@protoquinn take a look", html_url: "x", user: { login: "mabry1985" } },
+      repository: { name: "widget", owner: { login: "protoLabsAI" } },
+    };
+    const published = fire(issuePayload);
+    const skillReq = published.find((p) => p.topic.startsWith("message.inbound.github."));
+    expect(skillReq).toBeDefined();
+    expect((skillReq!.msg.payload as Record<string, unknown>).skillHint).toBe("bug_triage");
+  });
+
+  test("non-admin mention on a PR is ignored", () => {
+    const published = fire(prCommentPayload("@protoquinn review", "random-user"));
+    const skillReq = published.find((p) => p.topic.startsWith("message.inbound.github."));
+    expect(skillReq).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Lets operators trigger a formal Quinn review by commenting **`@protoquinn review`** on a PR.

Today that doesn't work as expected: a top-level PR comment arrives as an `issue_comment` event (GitHub models PR conversation comments as issue comments), which routed to `skillHints.issue_comment = bug_triage`. So @-mentioning Quinn on a PR ran a triage pass, not a review. Only review-thread replies (`pull_request_review_comment`) reached `pr_review`.

This PR disambiguates: when the `issue_comment`'s issue carries a `pull_request` field, route to the `pull_request` skill (`pr_review`). Plain-issue comments still route to `bug_triage`; non-admin mentions are still ignored.

## Notes

- GitHub Apps can't be added as *requested reviewers* (collaborator-only), so the native "Request review from @protoquinn[bot]" button is limited — a comment mention is the reliable trigger. (The `review_requested` webhook path for `@protoquinn[bot]` already exists for cases where the App *is* a collaborator.)
- Auto-review on `pull_request` opened/synchronize is unchanged — this only affects the explicit comment-mention path.

## Test plan

- [x] `bun test` — 818 pass, 0 fail (3 new routing tests)
- [x] `bunx tsc --noEmit` — clean
- [x] New `tests/github-mention-routing.test.ts`: PR comment → pr_review, issue comment → bug_triage, non-admin → ignored
- [ ] Live: comment `@protoquinn review` on an open PR, confirm a formal review (not a triage) runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request comment detection to correctly identify and route PR-related interactions to the appropriate handler, ensuring context-aware processing rather than generic event-based routing.

* **Tests**
  * Added test coverage for GitHub mention routing to verify correct behavior across different interaction types and permission levels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->