### PR TITLE
feat(quinn): verify cross-repo references before assigning severity (#3900)

### DIFF
--- a/src/api/__tests__/pr-inspector-path-exists.test.ts
+++ b/src/api/__tests__/pr-inspector-path-exists.test.ts
@@ -1,0 +1,90 @@
+/**
+ * pr-inspector `path_exists` action (#3900) — lets Quinn verify that a path a
+ * diff depends on (a COPY-from source, a filtered workspace package) actually
+ * exists in the referenced repo before assigning a severity. Cross-repo by
+ * design: the `repo` arg may differ from the PR under review.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { createRoutes, setGithubAuthForTesting } from "../pr-inspector.ts";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import type { ApiContext } from "../types.ts";
+
+let lastUrl: string;
+let nextStatus: number;
+let origFetch: typeof globalThis.fetch;
+
+function ctx(): ApiContext {
+  return { bus: new InMemoryEventBus(), executorRegistry: {} as never } as unknown as ApiContext;
+}
+
+function handler() {
+  const route = createRoutes(ctx()).find((r) => r.path === "/api/pr/inspect" && r.method === "POST");
+  if (!route) throw new Error("route not found");
+  return route.handler;
+}
+
+function inspect(body: Record<string, unknown>): Request {
+  return new Request("http://local/api/pr/inspect", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  setGithubAuthForTesting(async () => "test-token");
+  lastUrl = "";
+  nextStatus = 200;
+  origFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    lastUrl = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    return new Response(nextStatus === 200 ? JSON.stringify({ name: "x" }) : "Not Found", { status: nextStatus });
+  }) as typeof globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = origFetch;
+  setGithubAuthForTesting(undefined);
+});
+
+describe("pr-inspector path_exists (#3900)", () => {
+  test("200 → EXISTS, hits the contents API for the given repo + path + ref", async () => {
+    nextStatus = 200;
+    const res = await handler()(inspect({
+      action: "path_exists", repo: "protoLabsAI/rabbit-hole.io", path: "packages/cli", ref: "main",
+    }), {});
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { success: boolean; data: { result: string } };
+    expect(json.success).toBe(true);
+    expect(json.data.result).toContain("EXISTS");
+    expect(lastUrl).toBe("https://api.github.com/repos/protoLabsAI/rabbit-hole.io/contents/packages/cli?ref=main");
+  });
+
+  test("404 → MISSING, flagged as a real blocker", async () => {
+    nextStatus = 404;
+    const res = await handler()(inspect({
+      action: "path_exists", repo: "protoLabsAI/rabbit-hole.io", path: "packages/cli",
+    }), {});
+    expect(res.status).toBe(200); // the action succeeded; the path just isn't there
+    const json = (await res.json()) as { success: boolean; data: { result: string } };
+    expect(json.data.result).toContain("MISSING");
+    expect(json.data.result).toContain("real blocker");
+    expect(lastUrl).toBe("https://api.github.com/repos/protoLabsAI/rabbit-hole.io/contents/packages/cli");
+  });
+
+  test("strips a leading slash from the path (contents API is repo-relative)", async () => {
+    nextStatus = 200;
+    await handler()(inspect({
+      action: "path_exists", repo: "o/r", path: "/src/packages/cli/dist",
+    }), {});
+    expect(lastUrl).toBe("https://api.github.com/repos/o/r/contents/src/packages/cli/dist");
+  });
+
+  test("missing path arg → 400", async () => {
+    const res = await handler()(inspect({ action: "path_exists", repo: "o/r" }), {});
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { success: boolean; error: string };
+    expect(json.error).toContain("path is required");
+  });
+});

--- a/src/api/pr-inspector.ts
+++ b/src/api/pr-inspector.ts
@@ -17,6 +17,8 @@
  *   check_ci               → resolves head SHA, then check-runs API
  *   coderabbit_threads     → GraphQL query for unresolved review threads
  *   diff_summary           → first 200 lines of the unified diff
+ *   path_exists            → GET contents — does `path` exist in `repo`@`ref`?
+ *                            (cross-repo allowed; verifies COPY/package assumptions)
  *   review_comment         → POST review with state=COMMENT
  *   review_approve         → POST review with state=APPROVE
  *   review_request_changes → POST review with state=REQUEST_CHANGES
@@ -60,6 +62,7 @@ type Action =
   | "check_ci"
   | "coderabbit_threads"
   | "diff_summary"
+  | "path_exists"
   | "review_comment"
   | "review_approve"
   | "review_request_changes"
@@ -72,6 +75,15 @@ interface InspectRequest {
   repo: string;
   pr_number?: number;
   body?: string;
+  /**
+   * For `path_exists`: the repo-relative path to check. The `repo` field
+   * may name a DIFFERENT repo than the PR under review — that's the point,
+   * it's for verifying cross-repo assumptions (a COPY-from path, a filtered
+   * workspace package dir) that a diff depends on.
+   */
+  path?: string;
+  /** For `path_exists`: optional git ref (branch/tag/sha). Defaults to the repo's default branch. */
+  ref?: string;
   /**
    * When closing a PR via close_pr / close_pr_as_not_planned, optionally
    * post a comment explaining why before flipping the state. Quinn uses
@@ -109,6 +121,28 @@ async function ghFetch(
       "User-Agent": "protoquinn",
     },
   });
+}
+
+/**
+ * Verify whether a path exists in a repo at a given ref. Read-only, single
+ * GitHub call — used by Quinn to check cross-repo assumptions a diff depends
+ * on (a `COPY --from` source path, a filtered workspace package directory, a
+ * referenced file) before assigning a verdict severity. Existence is fact;
+ * an unverifiable assumption belongs in "Gaps", not a fabricated HIGH. (#3900)
+ */
+async function pathExists(owner: string, name: string, path: string, ref?: string): Promise<string> {
+  const cleanPath = path.replace(/^\/+/, ""); // contents API is repo-relative
+  const url =
+    `https://api.github.com/repos/${owner}/${name}/contents/${cleanPath}` +
+    (ref ? `?ref=${encodeURIComponent(ref)}` : "");
+  const resp = await ghFetch(owner, name, url);
+  const at = ref ? `@${ref}` : "";
+  if (resp.status === 200) return `EXISTS: \`${cleanPath}\` is present in ${owner}/${name}${at}.`;
+  if (resp.status === 404) {
+    return `MISSING: \`${cleanPath}\` does NOT exist in ${owner}/${name}${at}. ` +
+      `A diff that depends on this path (COPY source, package filter, import) is a real blocker.`;
+  }
+  throw new Error(`GitHub API error checking ${owner}/${name}/${cleanPath}: ${resp.status} ${await resp.text()}`);
 }
 
 async function listOpen(owner: string, name: string): Promise<string> {
@@ -453,7 +487,7 @@ export function createRoutes(ctx: ApiContext): Route[] {
           return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 });
         }
 
-        const { action, repo, pr_number, body, comment } = payload;
+        const { action, repo, pr_number, body, comment, path, ref } = payload;
         if (!action || !repo) {
           return Response.json(
             { success: false, error: "action and repo are required" },
@@ -486,12 +520,21 @@ export function createRoutes(ctx: ApiContext): Route[] {
             { status: 400 },
           );
         }
+        if (action === "path_exists" && (typeof path !== "string" || !path.trim())) {
+          return Response.json(
+            { success: false, error: "path is required (non-empty string) for action='path_exists'" },
+            { status: 400 },
+          );
+        }
 
         try {
           let result: string;
           switch (action) {
             case "list_open":
               result = await listOpen(owner, name);
+              break;
+            case "path_exists":
+              result = await pathExists(owner, name, path!, ref);
               break;
             case "check_ci":
               result = await checkCi(owner, name, pr_number!);

--- a/workspace/agents/quinn.yaml
+++ b/workspace/agents/quinn.yaml
@@ -260,6 +260,35 @@ skills:
       observation and proceed with the regular diff-based review.
       Clawpatch is a finding-source, not a gate.
 
+      ## Step 2c — Verify external references the diff depends on
+
+      A diff is often only correct if something *outside* the diff exists.
+      Before you assign a severity to any claim about an external reference,
+      confirm the reference with a fact, not a guess. Verify when the diff:
+
+      - copies from a path in another repo (`COPY --from`, a build that
+        clones `repo` then references `packages/x/dist`),
+      - filters or installs a workspace package by name
+        (`pnpm --filter @scope/pkg`, `import "@scope/pkg"`),
+      - references a file, action ref, or directory you cannot see in the
+        diff itself.
+
+      Use `pr_inspector(action='path_exists', repo='owner/name', path='packages/x', ref='<branch>')`
+      to check existence — `repo` may be a DIFFERENT repo than the PR under
+      review (that's the point). The result is authoritative:
+
+      - **MISSING** → the dependency does not exist. That is the real
+        blocker — tag it HIGH or CRITICAL and let it drive a FAIL.
+      - **EXISTS** → the assumption holds; do not invent a problem around it.
+      - **Can't verify** (tool error, repo not reachable) → record it as a
+        **Gap** ("unverified: assumes `packages/x` exists in repo Y"). A Gap
+        is honest; a fabricated severity on an unchecked assumption is not.
+
+      Grounding rule: every HIGH/CRITICAL you assign about an external
+      reference must rest on an EXISTS/MISSING fact you actually fetched, or
+      it is a Gap, not a severity. Internal-plausibility reasoning ("this
+      probably won't resolve") is a Gap until verified.
+
       ## Step 3 — Apply the rubric
 
       Grade the PR on whether the code does what the PR claims, is


### PR DESCRIPTION
Closes protoMaker#3900.

## Problem

Quinn reviews a diff's internal plausibility but never verifies **external** assumptions. On PR #3896 she:
- fabricated a HIGH (`--frozen-lockfile` "deadlocks" on a shallow clone — wrong, the lockfile is committed), and
- **missed the real blocker** — the PR copies `@protolabsai/rabbit-hole-cli` / `packages/cli/dist`, which doesn't exist in rabbit-hole.io yet.

Same class of false-positive blocking we hit on #633.

## Fix (two parts)

1. **`pr_inspector` gains a `path_exists` action** — read-only `GET /repos/{owner}/{repo}/contents/{path}?ref=`. Cross-repo by design (the `repo` arg can differ from the PR under review), so Quinn can confirm a `COPY --from` source or a filtered workspace package actually exists. One bounded call — no delegation/search agent loop, so the pr_review toolset keeps its anti-thrash property (the action rides the `pr_inspector` tool Quinn already has; no new tool added).

2. **`quinn.yaml` pr_review prompt — Step 2c.** When a diff depends on an external reference, verify with `path_exists` before assigning a severity:
   - **MISSING** → the real HIGH/CRITICAL blocker (drives FAIL)
   - **EXISTS** → don't invent a problem around it
   - **can't verify** → a **Gap**, not a fabricated severity

   Grounding rule: every HIGH/CRITICAL about an external reference must rest on an EXISTS/MISSING fact actually fetched.

Pairs with #634 (#3886 — don't FAIL on pending CI); both cut false blocking verdicts.

## Test plan

- [x] `bun test src/api/__tests__/pr-inspector-path-exists.test.ts` — 4 pass (EXISTS / MISSING / leading-slash strip / missing-path 400)
- [x] `bunx tsc --noEmit` — clean
- [x] full suite green aside from one **pre-existing** flaky onboarding timing test (fixed-200ms sleep; 2/3 pass, unrelated to this change)
- [ ] live: on a #3896-style PR, Quinn flags the nonexistent package as the blocker instead of a fabricated frozen-lockfile HIGH

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `path_exists` action to verify file and directory existence in repositories via the PR inspector API.
  * Enhanced Quinn PR review agent to verify external references and dependencies exist before assigning severity levels to pull requests.

* **Tests**
  * Added comprehensive test suite for the new path verification action, covering success/failure scenarios and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->