### PR TITLE
docs(explanation): add operator flows — projects, features, reviews

### DIFF
--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -13,6 +13,7 @@ These docs explain the *why* behind protoWorkstacean's architecture. Read them w
 | [Distributed tracing](./distributed-tracing) | How `correlationId` (trace-id) and `parentId` (span-id) flow from the bus through RouterPlugin, A2AExecutor, external agents, and back |
 | [Plugin system](./plugin-system) | The plugin lifecycle, core vs integration vs workspace plugins, ordering guarantees |
 | [Agent identity](./agent-identity) | How agents identify themselves across Discord, GitHub, A2A, and the bus |
+| [Operator flows](./operator-flows) | End-to-end: onboarding a project, a feature's lifecycle + Linear close-the-loop, and PR review with Quinn — who owns each step |
 
 ## Design philosophy
 

--- a/docs/explanation/operator-flows.md
+++ b/docs/explanation/operator-flows.md
@@ -1,0 +1,75 @@
+---
+title: Operator Flows — Projects, Features, and Reviews
+---
+
+_This is an explanation doc. It describes how the day-to-day flows fit together end-to-end — onboarding a project, a feature's lifecycle, and PR review — and which component owns each step. Read it to understand what to expect when you add a project, label a Linear issue, or ask Quinn for a review._
+
+---
+
+## The shape
+
+protoWorkstacean is a switchboard: it doesn't own project state, it routes. Three external systems hold the intent, and workstacean reacts:
+
+- **protoMaker** owns the list of engineering projects (the source of truth).
+- **Linear** owns higher-level issues and is where close-the-loop comments land.
+- **GitHub** is where PRs live and where Quinn posts reviews.
+
+Everything below is config-light by design: you act in protoMaker / Linear / GitHub, and workstacean fills in registry sync, Discord notifications, the Linear close-the-loop, and merge gating — with no per-project config files to edit.
+
+## Flow 1 — Onboarding a project
+
+1. Add the project in **protoMaker** (name + path). That's the only registration step; there is no `workspace/projects.yaml` (retired — protoMaker is the single registry of intent).
+2. The in-process **`ProjectRegistry`** (`src/plugins/project-registry.ts`) polls protoMaker `GET /api/settings/global` every 5 minutes, authenticating with `AUTOMAKER_API_KEY` (sent as `X-API-Key`). For each project it derives:
+   - `slug` — from the project name (lowercase, non-alphanumerics → `-`),
+   - `github` `{owner, repo}` — from the repo's `.git/config` origin URL,
+   - `defaultBranch` — from `.git/refs/remotes/origin/HEAD`.
+3. Within ≤5 minutes the project is live everywhere that reads the registry: router GitHub-enrichment, the GitHub plugin's monitored-repo set, the clawpatch review allowlist, and `GET /api/projects`.
+
+`ProjectRegistry` is a plain shared object (like `ChannelRegistry`), not a plugin — consumers hold a reference to the registry, never to another plugin, which keeps the bus-is-the-contract rule intact.
+
+> **Known limitation.** `github`/`defaultBranch` are derived by reading the repo's `.git/` *inside the container*, so they only resolve for repos bind-mounted at their protoMaker path. A project that isn't mounted is still registered and routable, but its GitHub-derived behaviours (auto-triage, auto-review, clawpatch) stay dormant until the coordinates resolve. The durable fix is native `github`/`defaultBranch` fields on protoMaker's `ProjectRef` (tracked upstream); until then, mount the repo or expect those features to no-op for it.
+
+## Flow 2 — Feature lifecycle and the Linear close-the-loop
+
+```
+Linear issue (trigger label)
+   → LinearProtoMakerBridge files a board feature in protoMaker
+   → work happens (auto-mode / agents)
+   → feature hits a terminal state
+   → protoMaker POSTs feature.completed | feature.failed → workstacean /publish
+   → feature-notifier  → ✅/❌ to the project's dev Discord channel
+   → LinearProtoMakerBridge → comment back on the originating Linear issue
+```
+
+1. A Linear issue carrying the configured trigger label fires. **`LinearProtoMakerBridge`** files a board feature in protoMaker, and the filing acknowledgement routes back to Linear as a comment.
+2. When that feature reaches a **terminal state**, protoMaker emits a bus event by `POST`ing to workstacean's `/publish` endpoint (`WORKSTACEAN_URL` + `WORKSTACEAN_API_KEY` on protoMaker's side):
+   - topic `feature.completed` (status → done) or `feature.failed` (blocked / escalated),
+   - payload `{ projectSlug, featureId, featureTitle, prNumber?, branchName?, repo?, error? }` — `projectSlug` is required.
+3. Two workstacean consumers subscribe to those topics on the in-memory bus:
+   - **`feature-notifier`** posts a ✅ / ❌ embed to the project's **dev** Discord channel (resolved from `channels.yaml` via the `project:` / `kind:` binding).
+   - **`LinearProtoMakerBridge`** maps the feature back to its originating Linear issue (by `featureId`, falling back to `featureTitle`) and comments "feature shipped / failed."
+
+The net effect: a Linear ticket gets an automatic outcome comment when the board feature it spawned completes — closing the loop that filing alone couldn't.
+
+## Flow 3 — PR review with Quinn
+
+1. A PR is opened or synchronized (auto-review), **or** a maintainer comments **`@protoquinn review`** on the PR — a top-level PR comment routes to the `pr_review` skill (not triage).
+2. Quinn (`workspace/agents/quinn.yaml`, an in-process DeepAgent posting as the `@protoquinn[bot]` GitHub App — no org seat) gathers evidence via the `pr_inspector` tool and a structural `clawpatch_review`, and:
+   - **holds the formal verdict until CI is terminal** — while any check is queued / in-progress she records findings as a non-blocking `COMMENT`, never a FAIL-because-CI-is-pending,
+   - **verifies external references before assigning severity** — `pr_inspector(action: path_exists)` confirms a `COPY --from` source or filtered package actually exists; a missing dependency is a real HIGH/CRITICAL, an unverifiable assumption is a *Gap*, not a fabricated severity.
+3. She submits one formal verdict: `APPROVE` (PASS) / `COMMENT` (WARN) / `REQUEST_CHANGES` (FAIL).
+4. **Merge gating is owned by protoMaker**, not GitHub-native auto-merge: protoMaker merges only when its eligibility check confirms Quinn approved + CI green + review threads resolved. This keeps a green-CI-but-unreviewed PR from racing to merge.
+
+## Flow 4 — Routing and channels
+
+- Inbound GitHub events are enriched by `RouterPlugin` with `projectSlug` + the project's `dev` channel, both resolved from the live registry + `channels.yaml`.
+- Per-project Discord channels are declared in `workspace/channels.yaml` via the optional `project:` / `kind:` fields, looked up with `ChannelRegistry.getProjectChannel(slug, kind)`. Only `dev` bindings exist — release announcements go to a single shared release channel, so per-project `release` bindings were retired. No raw webhook URLs live in tracked config; delivery routes through the connected Discord bot.
+
+## What you touch vs. what's automatic
+
+| You do | The system does |
+|--------|-----------------|
+| Add a project in protoMaker | Sync it into the registry within 5 min; wire enrichment, triage, clawpatch, channels |
+| Label a Linear issue | File the board feature, then comment the outcome back when it completes |
+| `@protoquinn review` (or just open a PR) | Gather CI + diff + structural findings, verify cross-repo refs, post a CI-terminal verdict |
+| Nothing | Notify the project dev channel on feature done/fail; gate the merge on protoMaker's eligibility check |


### PR DESCRIPTION
## Summary

New explanation doc `docs/explanation/operator-flows.md` capturing the end-to-end flows that landed across the projects.yaml rip (#633), Quinn review fixes (#634/#636), @-mention review (#635), and the Linear close-the-loop (#482):

- **Onboarding** — add a project in protoMaker → `ProjectRegistry` syncs it (5-min poll, `AUTOMAKER_API_KEY`) → enrichment/triage/clawpatch/channels light up. Notes the known `github`-derivation limitation (only mounted repos).
- **Feature lifecycle** — Linear label → board feature → terminal-state bus event (`feature.completed`/`feature.failed` via `/publish`) → dev-channel notify + Linear close-the-loop comment.
- **PR review** — `@protoquinn review` / auto-review, CI-terminal verdict, cross-repo `path_exists` verification, protoMaker-owned merge gating.
- **Routing/channels** — registry + `channels.yaml` `project:`/`kind:` bindings; single shared release channel; no committed webhooks.

Linked from the explanation index. Docs-only.

## Test plan

- [x] Frontmatter + relative `./operator-flows` link match the explanation-doc convention
- [x] No broken internal links introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation on operator flows covering end-to-end operational workflows, including project onboarding procedures, feature lifecycle management, code review processes, channel routing behavior, and responsibility matrices
  * Updated the documentation index to include and link to the new operator flows guide, improving discoverability of architecture rationale documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->