### PR TITLE
feat(github): emit release.published from the native release webhook

### DIFF
--- a/lib/plugins/__tests__/github-release-event.test.ts
+++ b/lib/plugins/__tests__/github-release-event.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { parseReleasePublished } from "../github.ts";
+
+// A trimmed GitHub `release` webhook payload (action=published).
+function releasePayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    action: "published",
+    release: {
+      tag_name: "v1.4.0",
+      name: "v1.4.0 — Spring cleanup",
+      body: "## What changed\n- thing one\n- thing two",
+      html_url: "https://github.com/protoLabsAI/widget/releases/tag/v1.4.0",
+      draft: false,
+      prerelease: false,
+      published_at: "2026-05-27T12:00:00Z",
+      author: { login: "mabry1985" },
+    },
+    repository: { name: "widget", owner: { login: "protoLabsAI" } },
+    ...overrides,
+  };
+}
+
+describe("parseReleasePublished", () => {
+  test("normalizes a published release into a ReleasePublishedPayload", () => {
+    const out = parseReleasePublished(releasePayload());
+    expect(out).toEqual({
+      owner: "protoLabsAI",
+      repo: "widget",
+      version: "v1.4.0",
+      name: "v1.4.0 — Spring cleanup",
+      body: "## What changed\n- thing one\n- thing two",
+      url: "https://github.com/protoLabsAI/widget/releases/tag/v1.4.0",
+      author: "mabry1985",
+      prerelease: false,
+      publishedAt: "2026-05-27T12:00:00Z",
+    });
+  });
+
+  test("ignores non-published actions (created / edited / deleted)", () => {
+    for (const action of ["created", "edited", "deleted", "prereleased", "released"]) {
+      expect(parseReleasePublished(releasePayload({ action }))).toBeNull();
+    }
+  });
+
+  test("returns null when the tag, repo, or owner is missing (no silent partial event)", () => {
+    expect(parseReleasePublished(releasePayload({ release: { tag_name: "" } }))).toBeNull();
+    expect(parseReleasePublished(releasePayload({ repository: { owner: { login: "x" } } }))).toBeNull();
+    expect(parseReleasePublished(releasePayload({ repository: { name: "widget" } }))).toBeNull();
+    expect(parseReleasePublished({ action: "published" })).toBeNull();
+  });
+
+  test("falls back name→version and tolerates null body/url", () => {
+    const out = parseReleasePublished(
+      releasePayload({
+        release: { tag_name: "v2.0.0", name: null, body: null, html_url: "", prerelease: true, author: null },
+      }),
+    );
+    expect(out?.name).toBe("v2.0.0");
+    expect(out?.body).toBe("");
+    expect(out?.author).toBe("");
+    expect(out?.prerelease).toBe(true);
+    expect(typeof out?.publishedAt).toBe("string"); // fallback timestamp
+  });
+});

--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -35,6 +35,7 @@ import type { SanitizationConfig } from "../sanitize.ts";
 import { makeGitHubAuth } from "../github-auth.ts";
 import { withCircuitBreaker } from "./circuit-breaker.ts";
 import type { ProjectRegistry } from "../../src/plugins/project-registry.ts";
+import type { ReleasePublishedPayload } from "../../src/event-bus/payloads.ts";
 
 // ── Config types ──────────────────────────────────────────────────────────────
 
@@ -162,6 +163,38 @@ interface GitHubEventContext {
   url: string;
   body: string;
   author: string;
+}
+
+/**
+ * Normalize a GitHub `release` webhook payload into a ReleasePublishedPayload,
+ * or null when it isn't a published release worth surfacing (wrong action,
+ * missing owner/repo/tag). Exported for unit testing; called from
+ * `_handleEvent` for `event === "release"`.
+ */
+export function parseReleasePublished(
+  payload: Record<string, unknown>,
+): ReleasePublishedPayload | null {
+  if (payload.action !== "published") return null;
+  const release = payload.release as Record<string, unknown> | undefined;
+  const repo = payload.repository as Record<string, unknown> | undefined;
+  if (!release || !repo) return null;
+
+  const owner = ((repo.owner as Record<string, unknown> | undefined)?.login as string) ?? "";
+  const repoName = (repo.name as string) ?? "";
+  const version = (release.tag_name as string) ?? "";
+  if (!owner || !repoName || !version) return null;
+
+  return {
+    owner,
+    repo: repoName,
+    version,
+    name: (release.name as string | null) ?? version,
+    body: (release.body as string | null) ?? "",
+    url: (release.html_url as string) ?? "",
+    author: ((release.author as Record<string, unknown> | undefined)?.login as string) ?? "",
+    prerelease: Boolean(release.prerelease),
+    publishedAt: (release.published_at as string | null) ?? new Date().toISOString(),
+  };
 }
 
 function extractContext(event: string, payload: Record<string, unknown>): GitHubEventContext | null {
@@ -443,6 +476,29 @@ export class GitHubPlugin implements Plugin {
         });
 
         console.log(`[github] repository.created: ${fullName} → ${topic}`);
+      }
+      return;
+    }
+
+    // ── Release published → release.published (fleet lifecycle primitive) ─────
+    // GitHub fires `release` on publish regardless of how the release was cut
+    // (auto-release.yml `gh release create`, release-tools, or by hand). We
+    // surface one canonical bus topic; content surfacing, changelog
+    // aggregation, deploy verification, and announce subscribe without knowing
+    // the mechanism. Requires the GitHub App to subscribe to `release` events.
+    if (event === "release") {
+      const rel = parseReleasePublished(payload);
+      if (rel) {
+        const correlationId = crypto.randomUUID();
+        bus.publish("release.published", {
+          id: `release-${rel.owner}-${rel.repo}-${rel.version}-${correlationId.slice(0, 8)}`,
+          correlationId,
+          topic: "release.published",
+          timestamp: Date.now(),
+          payload: rel,
+          source: { interface: "github" as const },
+        });
+        console.log(`[github] release.published: ${rel.owner}/${rel.repo} ${rel.version} → release.published`);
       }
       return;
     }

--- a/src/event-bus/all-topics.ts
+++ b/src/event-bus/all-topics.ts
@@ -92,6 +92,18 @@ export const SECURITY_TOPICS = {
   SECURITY_INCIDENT_REPORTED: "security.incident.reported",
 } as const;
 
+export const RELEASE_TOPICS = {
+  /**
+   * Published by the GitHub plugin when a GitHub Release is published (native
+   * `release` webhook, action=published). Mechanism-agnostic — fires whether
+   * the release was cut by auto-release.yml `gh release create`, release-tools,
+   * or by hand. A general fleet lifecycle primitive: content surfacing,
+   * changelog aggregation, deploy verification, and announce subscribe here.
+   * Payload shape: see `ReleasePublishedPayload` in src/event-bus/payloads.ts.
+   */
+  RELEASE_PUBLISHED: "release.published",
+} as const;
+
 export const REVIEW_TOPICS = {
   /**
    * Published by `pr-inspector` after a `review_comment` / `review_approve` /

--- a/src/event-bus/payloads.ts
+++ b/src/event-bus/payloads.ts
@@ -224,6 +224,33 @@ export interface IncidentReportedPayload {
   };
 }
 
+// ── release.published ────────────────────────────────────────────────────────
+
+/**
+ * Payload for `release.published` — a GitHub Release was published. Sourced
+ * from the native `release` webhook, so it fires regardless of how the release
+ * was cut (auto-release.yml `gh release create`, release-tools, or by hand).
+ * A general fleet lifecycle primitive: content surfacing, changelog
+ * aggregation, deploy verification, and announce can all subscribe.
+ */
+export interface ReleasePublishedPayload {
+  owner: string;
+  repo: string;
+  /** The release tag, e.g. "v1.4.0". */
+  version: string;
+  /** Release title; falls back to the version when GitHub leaves it null. */
+  name: string;
+  /** Release notes body (markdown). Empty string when none. */
+  body: string;
+  /** Canonical GitHub Release URL. */
+  url: string;
+  /** Login of the actor who published the release. */
+  author: string;
+  prerelease: boolean;
+  /** ISO timestamp from GitHub, or publish-handling time as a fallback. */
+  publishedAt: string;
+}
+
 // ── ceremony.*.execute ───────────────────────────────────────────────────────
 
 /** Payload for `ceremony.{id}.execute` — manual or scheduled ceremony trigger. */

--- a/src/event-bus/topics.ts
+++ b/src/event-bus/topics.ts
@@ -11,6 +11,7 @@ export {
   MESSAGE_TOPICS,
   ACTION_TOPICS,
   SECURITY_TOPICS,
+  RELEASE_TOPICS,
   REVIEW_TOPICS,
 } from "./all-topics.ts";
 
@@ -18,6 +19,7 @@ import {
   MESSAGE_TOPICS,
   ACTION_TOPICS,
   SECURITY_TOPICS,
+  RELEASE_TOPICS,
   REVIEW_TOPICS,
 } from "./all-topics.ts";
 
@@ -25,6 +27,7 @@ export const TOPICS = {
   ...MESSAGE_TOPICS,
   ...ACTION_TOPICS,
   ...SECURITY_TOPICS,
+  ...RELEASE_TOPICS,
   ...REVIEW_TOPICS,
 } as const;
 


### PR DESCRIPTION
## Summary
A GitHub Release is the most content-worthy fleet moment (release notes, announcements, "what shipped" digests), but there was no bus signal for it. Rather than couple to a specific release mechanism (a new emitter, a GHA), this taps GitHub's **native `release` webhook** — it fires on publish regardless of how the release was cut (`auto-release.yml` `gh release create`, release-tools, or by hand). The github plugin already ingests webhooks; this just adds the `release` case.

`release.published` is a **general lifecycle primitive**, not content-specific — content surfacing (protoContent), changelog aggregation, deploy verification, and announce can all subscribe to the same topic.

## Changes
- `parseReleasePublished()` — exported pure normalizer: `action=published` guard, drops events missing owner/repo/tag (no silent partial events). Unit-tested.
- `_handleEvent` — `release` → publish `release.published` carrying `ReleasePublishedPayload`.
- Register `release.published` in `all-topics.ts` + the `TOPICS` barrel.
- Add `ReleasePublishedPayload` to `payloads.ts`.

## Operational follow-up (settings-side, not code)
The **GitHub App must subscribe to `release` events** for the webhook to arrive. Until that's toggled, the handler is dormant (no events). No code dependency.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test` — 816 pass, 0 fail (4 new in `github-release-event.test.ts`)
- [ ] Post-merge: publish a test release, confirm `[github] release.published: …` in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub release published webhooks are now automatically processed and published as events on the application event bus (`release.published`), enabling subscribers to react to new releases in real-time.

* **Tests**
  * Added comprehensive test coverage for GitHub release event parsing, including validation of required fields, null value handling, missing repository data, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/644?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->