### PR TITLE
docs(decisions): lock the org→execution architecture as ADRs

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -39,6 +39,10 @@ export default defineConfig({
           autogenerate: { directory: 'explanation' },
         },
         {
+          label: 'Decisions',
+          autogenerate: { directory: 'decisions' },
+        },
+        {
           label: 'Contributing',
           autogenerate: { directory: 'contributing' },
         },

--- a/docs/decisions/0001-org-to-execution-pipeline.md
+++ b/docs/decisions/0001-org-to-execution-pipeline.md
@@ -1,0 +1,45 @@
+---
+title: "ADR-0001: Org-to-execution pipeline"
+---
+
+# ADR-0001: Org-to-execution pipeline
+
+- **Status:** Accepted — 2026-05-27
+- **Deciders:** Josh (operator)
+- **Related:** [ADR-0002](./0002-workstacean-protomaker-integration-boundary), [ADR-0003](./0003-content-surfacing-into-protocontent), protoMaker#3975
+
+## Context
+
+The protoLabs fleet needs a single, legible path from a high-level idea to executed engineering work across multiple projects. The moving parts:
+
+- **Linear** — where org/portfolio planning happens.
+- **protoWorkstacean** — the switchboard; hosts Ava (helm) and Quinn (QA).
+- **protoMaker** — the engineering-project system; owns project boards, decomposition, and per-project execution (auto-mode / proto / the per-project **Roxy** PM agent).
+- **GitHub** — where issues and PRs live.
+
+Earlier drafts had Ava decomposing an initiative into per-repo GitHub issues herself. That puts decomposition in the wrong place and makes Ava fat.
+
+## Decision
+
+A two-tier pipeline with a strict separation of responsibilities.
+
+**Roles:**
+
+- **Linear = org/portfolio planning.** It holds *initiatives*, not granular engineering tickets. Granular engineering work never has its terminal home in Linear.
+- **Ava (protoWorkstacean) = portfolio manager.** She receives intake, decides which project it belongs to, and **forwards**. She does **not** decompose.
+- **protoMaker = decomposition + execution.** It turns an initiative into **project → epics → milestones → features**, and drives the work (Roxy as per-project PM, proto as hands).
+- **Quinn (protoWorkstacean) = QA gate** on the resulting PRs.
+
+**Two intakes, coexisting:**
+
+1. **Initiative-level (create-project).** A Linear ticket *assigned to the Ava agent* is the trigger. Ava forwards it into protoMaker's **create-project intake**. protoMaker creates the project and decomposes it into epics → milestones → features. Use for new projects / substantial initiatives.
+2. **Issue-level (incremental).** A GitHub issue on a project's repo → protoMaker's webhook ingestion → a backlog `idea` on *that project's* board. Use for incremental work on existing projects. Keystone: **protoMaker#3975** (route issues to the right project by repo, not a default).
+
+**Reporting flows back up:** protoMaker → protoWorkstacean via `POST /publish` (`feature.completed` / `feature.failed`); GitHub → `release.published`; Quinn audits PRs and reports verdicts. protoWorkstacean's scheduler + GitHub reads provide the check-in loop that keeps in-progress work unblocked.
+
+## Consequences
+
+- Ava stays thin: routing and forwarding, never decomposition. Decomposition hierarchy is owned in one place (protoMaker).
+- Linear stays high-level; we don't pollute the org layer with engineering features. (This is why an engineering task filed as a Linear ticket gets re-homed, not kept.)
+- Net-new work this implies: a **create-project intake** on protoMaker (initiative-level) and **#3975** (issue-level routing). Delivery mechanism is set by [ADR-0002](./0002-workstacean-protomaker-integration-boundary).
+- The fleet is dogfooded: the build-out of this pipeline is itself tracked in the Linear "Portfolio fan-out" project.

--- a/docs/decisions/0002-workstacean-protomaker-integration-boundary.md
+++ b/docs/decisions/0002-workstacean-protomaker-integration-boundary.md
@@ -1,0 +1,42 @@
+---
+title: "ADR-0002: protoWorkstacean ↔ protoMaker integration boundary"
+---
+
+# ADR-0002: protoWorkstacean ↔ protoMaker integration boundary
+
+- **Status:** Accepted — 2026-05-27
+- **Deciders:** Josh (operator)
+- **Related:** [ADR-0001](./0001-org-to-execution-pipeline), protoMaker#3975
+
+## Context
+
+protoMaker advertises an A2A agent card, so protoWorkstacean's SkillBroker auto-discovered its skills and registered A2A executors for them. But protoMaker **serves no `/a2a` JSON-RPC endpoint** — `/a2a` returns 404, and the card's advertised URL (`ava:3008/a2a`) resolves to the protoWorkstacean container itself. So every workstacean→protoMaker A2A dispatch failed silently:
+
+- the `board.health` ceremony failed every 30 min (since retired),
+- the Linear→protoMaker `manage_feature` bridge never delivered,
+- a dead `bug_triage` A2A executor shadowed Quinn's working in-process one via health-weighted resolution.
+
+We need a durable contract for how the two systems talk, before building the [ADR-0001](./0001-org-to-execution-pipeline) intakes on top of it.
+
+## Decision
+
+**protoWorkstacean ↔ protoMaker communicate over HTTP + GitHub webhooks + bus `POST /publish`. Never A2A. There is no skill-dispatch chain from protoWorkstacean into protoMaker's agents.**
+
+- **protoWorkstacean → protoMaker:**
+  - *Create-project intake* — Ava calls a protoMaker HTTP endpoint to start the create-project → decompose flow (ADR-0001, initiative-level).
+  - *GitHub issues* — protoMaker ingests issues via GitHub's native webhooks (ADR-0001, issue-level; protoMaker#3975).
+- **protoMaker → protoWorkstacean:**
+  - Lifecycle events via `POST /publish` (`feature.completed` / `feature.failed`), consumed by `feature-notifier` + the Linear bridge.
+- **Reads:** protoWorkstacean polls protoMaker `GET /api/settings/global` for the project registry (the source of truth for projects).
+- **protoMaker owns its own execution** — Roxy and proto run inside protoMaker. protoWorkstacean does not dispatch into them.
+
+**Retirements that follow from this:**
+
+- Remove the dead `protomaker` A2A entry from `workspace/agents.yaml` (stops the dead-executor pollution + the `bug_triage` shadow).
+- Retire the `linear-protomaker-bridge` `manage_feature` A2A dispatch — superseded by issue ingestion + the create-project intake. Keep the reverse `feature.completed` / `feature.failed` consumer.
+
+## Consequences
+
+- No more dead A2A pollution; contracts are explicit and each side is self-contained (protoMaker resolves its own repo→project routing from its own `.automaker/settings.json`, not from a protoWorkstacean file).
+- This **decides the open question on the bridge**: retire it, do *not* rebuild `manage_feature` over HTTP — the two ADR-0001 intakes replace it.
+- Aligns with the broader "no dispatch chain to protoMaker" direction. If multi-node messaging is ever needed, that's a bus-bridge concern, not a reason to revive A2A here.

--- a/docs/decisions/0003-content-surfacing-into-protocontent.md
+++ b/docs/decisions/0003-content-surfacing-into-protocontent.md
@@ -1,0 +1,36 @@
+---
+title: "ADR-0003: Content surfacing into protoContent"
+---
+
+# ADR-0003: Content surfacing into protoContent
+
+- **Status:** Accepted — 2026-05-27
+- **Deciders:** Josh (operator)
+- **Related:** [ADR-0001](./0001-org-to-execution-pipeline), [ADR-0002](./0002-workstacean-protomaker-integration-boundary)
+
+## Context
+
+**protoContent** is the Payload-CMS marketing hub + content pipeline (idea → outline → draft → cuts → schedule → publish → engage → capture). Brand voice lives there as data. We want fleet activity — shipped features, releases, milestones — to feed the content pipeline, without protoWorkstacean ever *generating* content (voice and authoring are protoContent's domain).
+
+## Decision
+
+**protoWorkstacean *surfaces* content ideas from fleet lifecycle events; it does not author content.** It feeds protoContent's `idea` stage and stops there.
+
+- **`release.published` is the first tap and a first-class fleet primitive.** Sourced from GitHub's *native* `release` webhook (shipped in protoWorkstacean#644), so it fires regardless of how the release was cut (auto-release.yml, release-tools, or by hand). It is general-purpose — content is one subscriber among changelog aggregation, announce, and deploy verification.
+- **A content-surfacing plugin** subscribes to content-worthy topics, normalizes a `ContentIdea` (`{ source, headline, whatHappened, links[], suggestedSurface, occurredAt }`), and POSTs it to protoContent's intake endpoint — HTTP, fire-and-forget, the same boundary discipline as [ADR-0002](./0002-workstacean-protomaker-integration-boundary).
+
+**Which events to tap, tiered by signal strength:**
+
+- **Tier 1 — "we shipped something":** `release.published`, `feature.completed`. Start here.
+- **Tier 2 — narrative:** narrative `ceremony.*.completed` (weekly retro / standup digest), `autonomous.outcome.*` milestones (first autonomous merge, Nth feature).
+- **Tier 3 — engage/capture:** community signal (Discord threads, GitHub discussions). Gate hard.
+- **Do not tap:** `security.incident.reported` (sensitive), `feature.failed` / red CI (internal), raw `message.inbound.#` (firehose).
+
+**Ideas are human-gated into the pipeline initially** — brand-voice stakes outweigh full automation until the loop is proven.
+
+## Consequences
+
+- Clean separation: protoWorkstacean surfaces, protoContent authors. No brand-voice logic leaks into the switchboard.
+- Net-new work: a content intake endpoint on protoContent, and the content-surfacing plugin (gated on that endpoint).
+- Operational: the GitHub App must subscribe to `release` events for `release.published` to fire.
+- The same `release.published` primitive is reusable well beyond content — treat it as a lifecycle event, not a content-specific hook.

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -1,0 +1,19 @@
+---
+title: Decisions (ADRs)
+---
+
+Architecture Decision Records — the load-bearing choices about *where protoLabs is heading*, written down so they don't have to be re-litigated. Each ADR captures the context at decision time, the decision itself, and the consequences we accepted.
+
+These are cross-system by nature: protoLabs is a fleet (protoWorkstacean, protoMaker, protoContent, the agents), and the decisions here define how the pieces fit. They live in protoWorkstacean's docs because it's the switchboard — the hub the contracts pass through — but they bind the whole fleet.
+
+| ADR | Decision |
+|-----|----------|
+| [ADR-0001](./0001-org-to-execution-pipeline) | The org→execution pipeline: Linear → Ava → protoMaker → execution, with two coexisting intakes. Ava forwards; protoMaker decomposes. |
+| [ADR-0002](./0002-workstacean-protomaker-integration-boundary) | protoWorkstacean ↔ protoMaker talk over HTTP + webhooks + bus `/publish`, never A2A. |
+| [ADR-0003](./0003-content-surfacing-into-protocontent) | protoWorkstacean *surfaces* content ideas from fleet lifecycle events; protoContent authors. `release.published` is the first tap. |
+
+## Status legend
+
+- **Accepted** — decided and in effect; build to it.
+- **Proposed** — drafted, not yet ratified.
+- **Superseded** — replaced by a later ADR (linked).

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -14,6 +14,7 @@ These docs explain the *why* behind protoWorkstacean's architecture. Read them w
 | [Plugin system](./plugin-system) | The plugin lifecycle, core vs integration vs workspace plugins, ordering guarantees |
 | [Agent identity](./agent-identity) | How agents identify themselves across Discord, GitHub, A2A, and the bus |
 | [Operator flows](./operator-flows) | End-to-end: onboarding a project, a feature's lifecycle + Linear close-the-loop, and PR review with Quinn — who owns each step |
+| [Decisions (ADRs)](../decisions/) | The locked, load-bearing direction: the org→execution pipeline, the protoMaker integration boundary, and content surfacing. Where the fleet is heading. |
 
 ## Design philosophy
 


### PR DESCRIPTION
## Summary
Locks the load-bearing fleet-direction decisions as ADRs so they don't get re-litigated. New `docs/decisions/` section (registered in the Starlight sidebar + cross-linked from the explanation index).

- **ADR-0001 — Org→execution pipeline.** Linear (org planning) → Ava (portfolio manager, *forwards*) → protoMaker (*decomposes* project → epics → milestones → features) → execution → Quinn QA. **Two coexisting intakes:** initiative-level (create-project, Linear→Ava→protoMaker) and issue-level (GitHub issue → protoMaker webhook ingestion, protoMaker#3975).
- **ADR-0002 — protoWorkstacean ↔ protoMaker boundary.** HTTP + GitHub webhooks + bus `/publish`, **never A2A** (protoMaker serves no `/a2a`). Decides the `linear-protomaker-bridge` + dead A2A-entry retirement.
- **ADR-0003 — Content surfacing into protoContent.** protoWorkstacean *surfaces* ideas from lifecycle events (`release.published` first, shipped in #644); protoContent authors. workstacean never generates content.

## Notes
- Cross-system by nature; homed in protoWorkstacean because it's the switchboard the contracts pass through.
- No code change — docs + one sidebar config line.

## Test plan
- [ ] CI: Starlight docs build succeeds with the new `decisions` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Decisions" section to the documentation site featuring Architecture Decision Records (ADRs) that document key system design choices and architectural direction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->