### PR TITLE
feat: ProtoMakerBoardBridge — forward project-repo issues to protoMaker's board

### DIFF
--- a/lib/plugins/__tests__/protomaker-board-bridge.test.ts
+++ b/lib/plugins/__tests__/protomaker-board-bridge.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { InMemoryEventBus } from "../../bus.ts";
+import {
+  ProtoMakerBoardBridgePlugin,
+  buildBoardIngestSignal,
+} from "../protomaker-board-bridge.ts";
+import type { ProjectRegistry } from "../../../src/plugins/project-registry.ts";
+import type { GithubIssueOpenedPayload } from "../../../src/event-bus/payloads.ts";
+
+const ISSUE: GithubIssueOpenedPayload = {
+  owner: "protoLabsAI",
+  repo: "protoContent",
+  number: 12,
+  action: "opened",
+  title: "feat: content-idea intake endpoint",
+  body: "POST a ContentIdea → idea stage.",
+  author: "mabry1985",
+  url: "https://github.com/protoLabsAI/protoContent/issues/12",
+};
+
+// Minimal registry stub — the bridge only calls getByGithub.
+function fakeRegistry(known: Record<string, { slug: string; path: string }>): ProjectRegistry {
+  return {
+    getByGithub: (ownerRepo: string) => {
+      const hit = known[ownerRepo.toLowerCase()];
+      return hit ? ({ id: "x", name: hit.slug, slug: hit.slug, path: hit.path } as never) : undefined;
+    },
+  } as unknown as ProjectRegistry;
+}
+
+describe("buildBoardIngestSignal", () => {
+  test("source=github, content=title+body, channelContext carries projectPath + dedup keys", () => {
+    expect(buildBoardIngestSignal(ISSUE, "/home/josh/dev/contentMachine")).toEqual({
+      source: "github",
+      content: "feat: content-idea intake endpoint\n\nPOST a ContentIdea → idea stage.",
+      channelContext: {
+        projectPath: "/home/josh/dev/contentMachine",
+        issueNumber: 12,
+        repository: "protoLabsAI/protoContent",
+      },
+    });
+  });
+
+  test("falls back to a title when body is empty", () => {
+    const out = buildBoardIngestSignal({ ...ISSUE, body: "" }, "/p");
+    expect(out.content).toBe("feat: content-idea intake endpoint");
+  });
+});
+
+describe("ProtoMakerBoardBridge — forward", () => {
+  let origFetch: typeof globalThis.fetch;
+  let calls: Array<{ url: string; body: unknown; apiKey: string | null }>;
+
+  beforeEach(() => {
+    origFetch = globalThis.fetch;
+    calls = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      const headers = new Headers(init?.headers);
+      calls.push({ url, body: JSON.parse(String(init?.body ?? "{}")), apiKey: headers.get("X-API-Key") });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as typeof globalThis.fetch;
+  });
+  afterEach(() => { globalThis.fetch = origFetch; });
+
+  function publishIssue(bus: InMemoryEventBus, payload: GithubIssueOpenedPayload) {
+    bus.publish("github.issue.opened", {
+      id: "t", correlationId: "t", topic: "github.issue.opened", timestamp: Date.now(),
+      payload,
+    });
+  }
+
+  test("registered project repo → POSTs to /api/engine/signal/submit with resolved projectPath + key", async () => {
+    const bus = new InMemoryEventBus();
+    const registry = fakeRegistry({ "protolabsai/protocontent": { slug: "contentmachine", path: "/home/josh/dev/contentMachine" } });
+    new ProtoMakerBoardBridgePlugin(registry, { baseUrl: "http://protomaker-server:3008", apiKey: "test-key" }).install(bus);
+
+    publishIssue(bus, ISSUE);
+    await Bun.sleep(15);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe("http://protomaker-server:3008/api/engine/signal/submit");
+    expect(calls[0]!.apiKey).toBe("test-key");
+    expect(calls[0]!.body).toEqual({
+      source: "github",
+      content: "feat: content-idea intake endpoint\n\nPOST a ContentIdea → idea stage.",
+      channelContext: { projectPath: "/home/josh/dev/contentMachine", issueNumber: 12, repository: "protoLabsAI/protoContent" },
+    });
+  });
+
+  test("unregistered repo → no POST (workstacean triage owns it)", async () => {
+    const bus = new InMemoryEventBus();
+    const registry = fakeRegistry({}); // nothing registered
+    new ProtoMakerBoardBridgePlugin(registry, { baseUrl: "http://x", apiKey: "k" }).install(bus);
+
+    publishIssue(bus, ISSUE);
+    await Bun.sleep(15);
+
+    expect(calls).toHaveLength(0);
+  });
+
+  test("missing API key → no POST, no throw", async () => {
+    const bus = new InMemoryEventBus();
+    const registry = fakeRegistry({ "protolabsai/protocontent": { slug: "contentmachine", path: "/p" } });
+    new ProtoMakerBoardBridgePlugin(registry, { baseUrl: "http://x", apiKey: "" }).install(bus);
+
+    publishIssue(bus, ISSUE);
+    await Bun.sleep(15);
+
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -503,6 +503,40 @@ export class GitHubPlugin implements Plugin {
       return;
     }
 
+    // ── Issue opened/reopened → github.issue.opened (board-ingestion signal) ──
+    // Additive, fires for EVERY opened/reopened issue regardless of @mention or
+    // auto-triage routing (those member-no-mention issues otherwise produce no
+    // bus event). The ProtoMakerBoardBridge subscribes and forwards issues on
+    // registered project repos into protoMaker's board intake. Falls through —
+    // the @mention / auto-triage handling below still runs.
+    if (event === "issues" && (payload.action === "opened" || payload.action === "reopened")) {
+      const issue = payload.issue as Record<string, unknown> | undefined;
+      const repo = payload.repository as Record<string, unknown> | undefined;
+      if (issue && repo) {
+        const owner = ((repo.owner as Record<string, unknown> | undefined)?.login as string) ?? "";
+        const repoName = (repo.name as string) ?? "";
+        const number = issue.number as number;
+        const correlationId = crypto.randomUUID();
+        bus.publish("github.issue.opened", {
+          id: `github-issue-${owner}-${repoName}-${number}-${correlationId.slice(0, 8)}`,
+          correlationId,
+          topic: "github.issue.opened",
+          timestamp: Date.now(),
+          payload: {
+            owner,
+            repo: repoName,
+            number,
+            action: payload.action as string,
+            title: (issue.title as string) ?? "",
+            body: (issue.body as string | null) ?? "",
+            author: ((issue.user as Record<string, unknown> | undefined)?.login as string) ?? "",
+            url: (issue.html_url as string) ?? "",
+          },
+          source: { interface: "github" as const },
+        });
+      }
+    }
+
     // ── PR lifecycle → flow.item.* (independent of @mention) ─────────────────
     if (event === "pull_request") {
       const action = payload.action as string;

--- a/lib/plugins/protomaker-board-bridge.ts
+++ b/lib/plugins/protomaker-board-bridge.ts
@@ -1,0 +1,120 @@
+/**
+ * ProtoMakerBoardBridge — forwards GitHub issues on registered project repos
+ * into protoMaker's board as backlog ideas.
+ *
+ * The switchboard pattern (ADR-0001 / ADR-0002): protoWorkstacean already
+ * receives every project repo's GitHub webhook AND owns the project registry
+ * (`getByGithub`). So it resolves the project here and POSTs to protoMaker's
+ * dumb HTTP board-ingestion intake — protoMaker stops needing to receive
+ * webhooks or route by repo. Everything flows switchboard → HTTP intake.
+ *
+ * Inbound:  github.issue.opened   (published by GitHubPlugin)
+ * Outbound: POST {PROTOMAKER_API_BASE}/api/engine/signal/submit  (X-API-Key)
+ *
+ * protoMaker's `SignalIntakeService.submitSignal` honors the provided
+ * `channelContext.projectPath` over the default and dedups on
+ * `github:{repository}#{issueNumber}`, so a reopened/redelivered issue won't
+ * double-create.
+ *
+ * Issues on repos NOT in the registry are ignored here (workstacean's own
+ * triage path handles those independently).
+ */
+
+import type { EventBus, BusMessage, Plugin } from "../types.ts";
+import type { ProjectRegistry } from "../../src/plugins/project-registry.ts";
+import type { GithubIssueOpenedPayload } from "../../src/event-bus/payloads.ts";
+
+const DEFAULT_PROTOMAKER_BASE = "http://protomaker-server:3008";
+
+export interface BoardIngestSignal {
+  source: string;
+  content: string;
+  channelContext: {
+    projectPath: string;
+    issueNumber: number;
+    repository: string;
+  };
+}
+
+/**
+ * Pure builder for the protoMaker `signal/submit` body — exported for testing.
+ * `content` is title + body so the board idea is self-describing.
+ */
+export function buildBoardIngestSignal(
+  issue: GithubIssueOpenedPayload,
+  projectPath: string,
+): BoardIngestSignal {
+  const repository = `${issue.owner}/${issue.repo}`;
+  const title = issue.title || `Issue #${issue.number}`;
+  const content = issue.body ? `${title}\n\n${issue.body}` : title;
+  return {
+    source: "github",
+    content,
+    channelContext: { projectPath, issueNumber: issue.number, repository },
+  };
+}
+
+export class ProtoMakerBoardBridgePlugin implements Plugin {
+  readonly name = "protomaker-board-bridge";
+  readonly description =
+    "Forwards GitHub issues on registered project repos to protoMaker's board intake";
+  readonly capabilities = ["protomaker-board-ingest"];
+  readonly subscribes = ["github.issue.opened"];
+
+  private readonly registry: ProjectRegistry;
+  private readonly baseUrl: string;
+  private readonly apiKey?: string;
+
+  constructor(
+    registry: ProjectRegistry,
+    opts: { baseUrl?: string; apiKey?: string } = {},
+  ) {
+    this.registry = registry;
+    this.baseUrl = (opts.baseUrl ?? process.env["PROTOMAKER_API_BASE"] ?? DEFAULT_PROTOMAKER_BASE).replace(/\/$/, "");
+    this.apiKey = opts.apiKey ?? process.env["AUTOMAKER_API_KEY"];
+  }
+
+  install(bus: EventBus): void {
+    bus.subscribe("github.issue.opened", this.name, (msg: BusMessage) => {
+      void this._forward(msg).catch((err) => {
+        // Fire-and-forget subscriber — surface loudly, can't return to a caller.
+        console.error(
+          `[protomaker-board-bridge] forward failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    });
+  }
+
+  uninstall(): void {}
+
+  private async _forward(msg: BusMessage): Promise<void> {
+    const issue = msg.payload as GithubIssueOpenedPayload | undefined;
+    if (!issue?.owner || !issue?.repo || typeof issue.number !== "number") return;
+
+    const project = this.registry.getByGithub(`${issue.owner}/${issue.repo}`);
+    if (!project) return; // not a managed project repo — workstacean triage owns it
+
+    if (!this.apiKey) {
+      console.warn(
+        `[protomaker-board-bridge] AUTOMAKER_API_KEY not set — cannot forward ${issue.owner}/${issue.repo}#${issue.number}`,
+      );
+      return;
+    }
+
+    const signal = buildBoardIngestSignal(issue, project.path);
+    const resp = await fetch(`${this.baseUrl}/api/engine/signal/submit`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-API-Key": this.apiKey },
+      body: JSON.stringify(signal),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!resp.ok) {
+      throw new Error(
+        `protoMaker signal/submit ${resp.status}: ${(await resp.text()).slice(0, 200)}`,
+      );
+    }
+    console.log(
+      `[protomaker-board-bridge] ${issue.owner}/${issue.repo}#${issue.number} → board "${project.slug}" (${project.path})`,
+    );
+  }
+}

--- a/src/event-bus/all-topics.ts
+++ b/src/event-bus/all-topics.ts
@@ -104,6 +104,17 @@ export const RELEASE_TOPICS = {
   RELEASE_PUBLISHED: "release.published",
 } as const;
 
+export const GITHUB_TOPICS = {
+  /**
+   * Published by the GitHub plugin for every opened/reopened issue the webhook
+   * covers — additive, independent of the @mention / auto-triage paths. The
+   * ProtoMakerBoardBridge subscribes and forwards issues on registered project
+   * repos into protoMaker's board intake (workstacean owns repo→project
+   * resolution). Payload shape: see `GithubIssueOpenedPayload`.
+   */
+  GITHUB_ISSUE_OPENED: "github.issue.opened",
+} as const;
+
 export const REVIEW_TOPICS = {
   /**
    * Published by `pr-inspector` after a `review_comment` / `review_approve` /

--- a/src/event-bus/payloads.ts
+++ b/src/event-bus/payloads.ts
@@ -224,6 +224,29 @@ export interface IncidentReportedPayload {
   };
 }
 
+// ── github.issue.opened ──────────────────────────────────────────────────────
+
+/**
+ * Payload for `github.issue.opened` — a GitHub issue was opened or reopened on
+ * any repo the webhook covers. Additive signal published by the GitHub plugin
+ * independent of the @mention / auto-triage paths. The ProtoMakerBoardBridge
+ * subscribes and forwards issues on *registered project repos* into protoMaker's
+ * board intake (workstacean owns the repo→project resolution).
+ */
+export interface GithubIssueOpenedPayload {
+  owner: string;
+  repo: string;
+  number: number;
+  /** "opened" | "reopened". */
+  action: string;
+  title: string;
+  /** Issue body (markdown). Empty string when none. */
+  body: string;
+  /** Login of the issue author. */
+  author: string;
+  url: string;
+}
+
 // ── release.published ────────────────────────────────────────────────────────
 
 /**

--- a/src/event-bus/topics.ts
+++ b/src/event-bus/topics.ts
@@ -12,6 +12,7 @@ export {
   ACTION_TOPICS,
   SECURITY_TOPICS,
   RELEASE_TOPICS,
+  GITHUB_TOPICS,
   REVIEW_TOPICS,
 } from "./all-topics.ts";
 
@@ -20,6 +21,7 @@ import {
   ACTION_TOPICS,
   SECURITY_TOPICS,
   RELEASE_TOPICS,
+  GITHUB_TOPICS,
   REVIEW_TOPICS,
 } from "./all-topics.ts";
 
@@ -28,6 +30,7 @@ export const TOPICS = {
   ...ACTION_TOPICS,
   ...SECURITY_TOPICS,
   ...RELEASE_TOPICS,
+  ...GITHUB_TOPICS,
   ...REVIEW_TOPICS,
 } as const;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,6 +210,20 @@ const pluginRegistry: PluginRegistryEntry[] = [
     },
   },
   {
+    // GitHub issue → protoMaker board bridge. workstacean receives every
+    // project repo's webhook + owns the registry, so it resolves the project
+    // and POSTs to protoMaker's HTTP board intake (ADR-0001/0002). No-op for
+    // issues on unregistered repos. Safe to install unconditionally.
+    name: "protomaker-board-bridge",
+    condition: () => true,
+    factory: async () => {
+      const { ProtoMakerBoardBridgePlugin } = await import(
+        "../lib/plugins/protomaker-board-bridge"
+      );
+      return new ProtoMakerBoardBridgePlugin(projectRegistry);
+    },
+  },
+  {
     // Linear → proto code.execute bridge. Label-gated (default
     // "proto-task", override via LINEAR_PROTO_BRIDGE_LABEL). No yaml
     // config needed; safe to install unconditionally.

--- a/tests/m2-handlers.test.ts
+++ b/tests/m2-handlers.test.ts
@@ -276,11 +276,10 @@ describe("GitHub plugin — repository.created handler", () => {
     expect(typeof msg.timestamp).toBe("number");
   });
 
-  test("non-repository.created event (issues) does not publish", () => {
+  test("issues event publishes github.issue.opened (board signal), never the onboard topic", () => {
     const { bus, publishCalls } = makeMockBus();
     const plugin = new GitHubPlugin(workspaceDir, makeStubProjectRegistry());
 
-    // An 'issues' event without @mention — should not publish
     const payload = {
       action: "opened",
       issue: {
@@ -305,7 +304,11 @@ describe("GitHub plugin — repository.created handler", () => {
       mockGetToken,
     );
 
-    expect(publishCalls).toHaveLength(0);
+    const topics = publishCalls.map((c) => c.topic);
+    // The additive board-ingestion signal fires for every opened issue …
+    expect(topics).toContain("github.issue.opened");
+    // … but the repository.created onboard path must NOT.
+    expect(topics).not.toContain("message.inbound.onboard");
   });
 
   test("repository event with action other than 'created' does not publish to onboard", () => {


### PR DESCRIPTION
## Summary
The switchboard half of the **issue-level intake** (ADR-0001 / ADR-0002). protoWorkstacean already receives every project repo's GitHub webhook **and** owns the project registry — so it resolves the project itself and POSTs to protoMaker's HTTP board intake. protoMaker stops needing to receive webhooks or route by repo, which **dissolves the protoMaker-side routing in #3975**.

Discovered via dogfooding: filing protoContent#12 reached neither protoMaker (no webhook delivery) — the webhooks already flow to *workstacean*. So workstacean forwards.

## Changes
- **github plugin** — publish `github.issue.opened` for every opened/reopened issue (additive; independent of the `@mention` / auto-triage paths, which silently drop member-authored no-mention issues like protoContent#12).
- **ProtoMakerBoardBridge** (new) — subscribes `github.issue.opened`, resolves the project via `registry.getByGithub`, and POSTs to `POST /api/engine/signal/submit` with `{ source, content, channelContext: { projectPath, issueNumber, repository } }` (`X-API-Key`). Issues on **unregistered** repos are ignored — workstacean's own triage owns those (the double-handling gate).
- Register `github.issue.opened` in `all-topics` + barrel; add `GithubIssueOpenedPayload`; register the bridge in `src/index.ts`.

Contract matches protoMaker's `SignalIntakeService.submitSignal` (honors the provided `projectPath`, dedups on `github:repo#issue`) — their passthrough is on `feat/board-ingestion-channelcontext`.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test` — 825 pass, 0 fail (pure `buildBoardIngestSignal` + forward with mocked fetch: registered → POST, unregistered → skip, no key → skip)
- [ ] Post-merge (once protoMaker's passthrough lands + container deployed): re-open protoContent#12, confirm it lands on the contentMachine board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)