### PR TITLE
fix(registry): prefer protoMaker's native github/defaultBranch over .git derivation

### DIFF
--- a/src/plugins/__tests__/project-registry.test.ts
+++ b/src/plugins/__tests__/project-registry.test.ts
@@ -106,7 +106,7 @@ describe("ProjectRegistry", () => {
   let registry: ProjectRegistry | undefined;
   let tempDir: string;
   let server: ReturnType<typeof Bun.serve> | undefined;
-  let fakeProjects: Array<{ id: string; name: string; path: string }>;
+  let fakeProjects: Array<{ id: string; name: string; path: string; github?: { owner: string; repo: string }; defaultBranch?: string }>;
   let fetchCount: number;
   let lastApiKeyHeader: string | null;
   let requireApiKey: string | undefined;
@@ -195,6 +195,43 @@ describe("ProjectRegistry", () => {
     const p = registry.getProjects()[0]!;
     expect(p.github).toBeUndefined();
     expect(p.defaultBranch).toBeUndefined();
+  });
+
+  test("prefers protoMaker's native github/defaultBranch over .git derivation (rename-safe)", async () => {
+    // The clone's remote still says the OLD repo name (contentMachine), but
+    // protoMaker carries the renamed truth (protoContent). Native field wins.
+    const projPath = join(tempDir, "contentmachine");
+    makeGitRepo(projPath, "protoLabsAI/contentMachine", "master");
+    fakeProjects.push({
+      id: "p3",
+      name: "contentMachine",
+      path: projPath,
+      github: { owner: "protoLabsAI", repo: "protoContent" },
+      defaultBranch: "main",
+    });
+
+    registry = newRegistry();
+    await registry.refreshNow();
+
+    const p = registry.getProjects()[0]!;
+    expect(p.github).toEqual({ owner: "protoLabsAI", repo: "protoContent" });
+    expect(p.defaultBranch).toBe("main");
+    // getByGithub resolves on the live name, not the stale derived one.
+    expect(registry.getByGithub("protoLabsAI/protoContent")?.slug).toBe("contentmachine");
+    expect(registry.getByGithub("protoLabsAI/contentMachine")).toBeUndefined();
+  });
+
+  test("falls back to .git derivation when protoMaker omits github/defaultBranch", async () => {
+    const projPath = join(tempDir, "legacy");
+    makeGitRepo(projPath, "protoLabsAI/legacyRepo", "main");
+    fakeProjects.push({ id: "p4", name: "legacyRepo", path: projPath }); // no native fields
+
+    registry = newRegistry();
+    await registry.refreshNow();
+
+    const p = registry.getProjects()[0]!;
+    expect(p.github).toEqual({ owner: "protoLabsAI", repo: "legacyRepo" });
+    expect(p.defaultBranch).toBe("main");
   });
 
   test("unreachable protoMaker server → registry stays empty, lastError set", async () => {

--- a/src/plugins/project-registry.ts
+++ b/src/plugins/project-registry.ts
@@ -47,6 +47,17 @@ export interface RegistryProject {
   defaultBranch?: string;
 }
 
+/** A project as protoMaker returns it from `/api/settings/global`. `github` +
+ *  `defaultBranch` are native ProjectRef fields (protoMaker#3883) — present for
+ *  current protoMaker, optional so we can still derive from .git as a fallback. */
+interface RawProtoMakerProject {
+  id: string;
+  name: string;
+  path: string;
+  github?: { owner: string; repo: string };
+  defaultBranch?: string;
+}
+
 export interface ProjectRegistryOptions {
   /** protoMaker HTTP base URL. Default: `http://protomaker-server:3008`. */
   apiBase?: string;
@@ -181,7 +192,7 @@ export class ProjectRegistry {
    *   { success: true, settings: { projects: ProjectRef[] } }
    * Per protoMaker `apps/server/src/routes/settings/index.ts:14` (GET /global).
    */
-  private async _fetchProjects(): Promise<Array<{ id: string; name: string; path: string }>> {
+  private async _fetchProjects(): Promise<RawProtoMakerProject[]> {
     const url = `${this.apiBase}/api/settings/global`;
     const headers: Record<string, string> = {};
     if (this.apiKey) headers["X-API-Key"] = this.apiKey;
@@ -191,7 +202,7 @@ export class ProjectRegistry {
     }
     const body = (await res.json()) as {
       success?: boolean;
-      settings?: { projects?: Array<{ id: string; name: string; path: string }> };
+      settings?: { projects?: RawProtoMakerProject[] };
     };
     if (!body.success) {
       throw new Error(`protoMaker returned success=false`);
@@ -199,33 +210,47 @@ export class ProjectRegistry {
     return body.settings?.projects ?? [];
   }
 
-  private _enrichProject(p: { id: string; name: string; path: string }): RegistryProject {
+  private _enrichProject(p: RawProtoMakerProject): RegistryProject {
     const enriched: RegistryProject = {
       id: p.id,
       name: p.name,
       slug: deriveSlug(p.name),
       path: p.path,
     };
-    const gitConfigPath = join(p.path, ".git", "config");
-    if (existsSync(gitConfigPath)) {
-      try {
-        const config = readFileSync(gitConfigPath, "utf8");
-        const github = parseGithubFromGitConfig(config);
-        if (github) enriched.github = github;
-      } catch {
-        // Silent — non-essential enrichment.
+
+    // Prefer protoMaker's native github/defaultBranch (ProjectRef, protoMaker#3883).
+    // It's the source of truth and survives GitHub repo renames — deriving from
+    // the local clone's .git/config drifts on rename (e.g. contentMachine →
+    // protoContent silently broke board routing until the remote was re-pointed).
+    // Fall back to .git derivation only when protoMaker omits the field.
+    if (p.github?.owner && p.github?.repo) {
+      enriched.github = { owner: p.github.owner, repo: p.github.repo };
+    } else {
+      const gitConfigPath = join(p.path, ".git", "config");
+      if (existsSync(gitConfigPath)) {
+        try {
+          const github = parseGithubFromGitConfig(readFileSync(gitConfigPath, "utf8"));
+          if (github) enriched.github = github;
+        } catch {
+          // Silent — non-essential enrichment.
+        }
       }
     }
-    const headRefPath = join(p.path, ".git", "refs", "remotes", "origin", "HEAD");
-    if (existsSync(headRefPath)) {
-      try {
-        const ref = readFileSync(headRefPath, "utf8").trim();
-        const branch = parseDefaultBranchFromHead(ref);
-        if (branch) enriched.defaultBranch = branch;
-      } catch {
-        // Silent — non-essential enrichment.
+
+    if (p.defaultBranch) {
+      enriched.defaultBranch = p.defaultBranch;
+    } else {
+      const headRefPath = join(p.path, ".git", "refs", "remotes", "origin", "HEAD");
+      if (existsSync(headRefPath)) {
+        try {
+          const branch = parseDefaultBranchFromHead(readFileSync(headRefPath, "utf8").trim());
+          if (branch) enriched.defaultBranch = branch;
+        } catch {
+          // Silent — non-essential enrichment.
+        }
       }
     }
+
     return enriched;
   }
 }


### PR DESCRIPTION
## Summary
The robust fix for the bug that dropped protoContent intake. protoMaker now serves `github` + `defaultBranch` natively on every ProjectRef (**protoMaker#3883**), but the registry ignored them and derived from the local clone's `.git/config` — which **drifts on GitHub repo renames**.

Concretely: `contentMachine` was renamed to `protoContent`; the clone's remote still said `contentMachine`, so the registry indexed `protoLabsAI/contentMachine`, and the board bridge's `getByGithub("protoLabsAI/protoContent")` silently missed — dropping every protoContent issue intake. (Verified live: re-pointing the remote unblocked it; this makes it impossible to recur.)

## Change
- `_enrichProject` uses protoMaker's native `github`/`defaultBranch` when present (source of truth, rename-safe, no dependency on repos being mounted with correct remotes). Falls back to `.git/config` derivation only when protoMaker omits the field.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test` — 813 pass, 0 fail
  - native fields win over a stale `.git` remote; `getByGithub` resolves the live name (not the stale derived one); fallback to derivation when native fields absent.
- [x] Verified live this session — protoContent#13 round-trip lands on the contentMachine board (GitHub → bridge → protoMaker → FeatureLoader → PMAgent PRD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project registry to properly prioritize native project metadata over derived data, ensuring accurate repository information is used.

* **Tests**
  * Extended test coverage for project metadata resolution and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->