### PR TITLE
feat(board-bridge): propagate Langfuse trace id to protoMaker (e2e trace join)

### DIFF
--- a/lib/plugins/__tests__/protomaker-board-bridge.test.ts
+++ b/lib/plugins/__tests__/protomaker-board-bridge.test.ts
@@ -30,7 +30,7 @@ function fakeRegistry(known: Record<string, { slug: string; path: string }>): Pr
 
 describe("buildBoardIngestSignal", () => {
   test("source=github, content=title+body, channelContext carries projectPath + dedup keys", () => {
-    expect(buildBoardIngestSignal(ISSUE, "/home/josh/dev/contentMachine")).toEqual({
+    expect(buildBoardIngestSignal(ISSUE, "/home/josh/dev/contentMachine", "trace-abc")).toEqual({
       source: "github",
       content: "feat: content-idea intake endpoint\n\nPOST a ContentIdea → idea stage.",
       channelContext: {
@@ -38,11 +38,12 @@ describe("buildBoardIngestSignal", () => {
         issueNumber: 12,
         repository: "protoLabsAI/protoContent",
       },
+      trace: { traceId: "trace-abc", caller: "workstacean", source: "github.issue.opened" },
     });
   });
 
   test("falls back to a title when body is empty", () => {
-    const out = buildBoardIngestSignal({ ...ISSUE, body: "" }, "/p");
+    const out = buildBoardIngestSignal({ ...ISSUE, body: "" }, "/p", "trace-x");
     expect(out.content).toBe("feat: content-idea intake endpoint");
   });
 });
@@ -85,7 +86,19 @@ describe("ProtoMakerBoardBridge — forward", () => {
       source: "github",
       content: "feat: content-idea intake endpoint\n\nPOST a ContentIdea → idea stage.",
       channelContext: { projectPath: "/home/josh/dev/contentMachine", issueNumber: 12, repository: "protoLabsAI/protoContent" },
+      trace: { traceId: "t", caller: "workstacean", source: "github.issue.opened" },
     });
+  });
+
+  test("propagates the inbound correlationId as the trace id", async () => {
+    const bus = new InMemoryEventBus();
+    const registry = fakeRegistry({ "protolabsai/protocontent": { slug: "contentmachine", path: "/p" } });
+    new ProtoMakerBoardBridgePlugin(registry, { baseUrl: "http://x", apiKey: "k" }).install(bus);
+    bus.publish("github.issue.opened", {
+      id: "i", correlationId: "trace-9f3", topic: "github.issue.opened", timestamp: Date.now(), payload: ISSUE,
+    });
+    await Bun.sleep(15);
+    expect((calls[0]!.body as { trace: { traceId: string } }).trace.traceId).toBe("trace-9f3");
   });
 
   test("unregistered repo → no POST (workstacean triage owns it)", async () => {

--- a/lib/plugins/protomaker-board-bridge.ts
+++ b/lib/plugins/protomaker-board-bridge.ts
@@ -34,6 +34,18 @@ export interface BoardIngestSignal {
     issueNumber: number;
     repository: string;
   };
+  /**
+   * Cross-system Langfuse trace linkage. `traceId` is the originating
+   * correlationId (the trace id for this issue's flow). protoMaker sets it as
+   * the trace id / `caller_trace_id` on its signal→FeatureLoader→PMAgent spans
+   * so the whole GitHub→board→PRD flow is one trace. Mirrors the `a2a.trace`
+   * convention used for cross-agent A2A linking.
+   */
+  trace: {
+    traceId: string;
+    caller: "workstacean";
+    source: "github.issue.opened";
+  };
 }
 
 /**
@@ -43,6 +55,7 @@ export interface BoardIngestSignal {
 export function buildBoardIngestSignal(
   issue: GithubIssueOpenedPayload,
   projectPath: string,
+  traceId: string,
 ): BoardIngestSignal {
   const repository = `${issue.owner}/${issue.repo}`;
   const title = issue.title || `Issue #${issue.number}`;
@@ -51,6 +64,7 @@ export function buildBoardIngestSignal(
     source: "github",
     content,
     channelContext: { projectPath, issueNumber: issue.number, repository },
+    trace: { traceId, caller: "workstacean", source: "github.issue.opened" },
   };
 }
 
@@ -101,7 +115,10 @@ export class ProtoMakerBoardBridgePlugin implements Plugin {
       return;
     }
 
-    const signal = buildBoardIngestSignal(issue, project.path);
+    // correlationId is the trace id for this issue's flow (set when the github
+    // plugin published github.issue.opened) — propagate it so protoMaker links.
+    const traceId = msg.correlationId || crypto.randomUUID();
+    const signal = buildBoardIngestSignal(issue, project.path, traceId);
     const resp = await fetch(`${this.baseUrl}/api/engine/signal/submit`, {
       method: "POST",
       headers: { "Content-Type": "application/json", "X-API-Key": this.apiKey },


### PR DESCRIPTION
## Summary
First piece of e2e Langfuse tracing for the org→execution flow: make a `GitHub issue → board → PMAgent PRD` flow resolvable as **one trace**.

The board bridge now includes a `trace` block in the `signal/submit` body carrying the originating **correlationId as the trace id** — the same convention as the existing `a2a.trace` extension (correlationId *is* the trace id; downstream links via `caller_trace_id`).

```jsonc
{ "source": "github", "content": "…", "channelContext": { … },
  "trace": { "traceId": "<correlationId>", "caller": "workstacean", "source": "github.issue.opened" } }
```

## Changes
- `buildBoardIngestSignal` takes `traceId` and emits `trace: { traceId, caller, source }`.
- `_forward` propagates `msg.correlationId` (the trace id set when `github.issue.opened` was published).
- Tests: trace block present; correlationId propagated as `traceId`.

## The other half (protoMaker — coordinate)
protoMaker reads `trace.traceId` and sets it as the trace / `caller_trace_id` on its `signal → FeatureLoader → PMAgent` spans. Then the whole flow is one Langfuse trace, searchable by the issue's correlationId.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test` — 812 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event trace tracking to enable improved correlation of GitHub issues as they move through the board intake system, with automatic ID propagation across system boundaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->