### PR TITLE
fix(linear): route Agent Session events to Ava (assignment fires)

### DIFF
--- a/lib/plugins/__tests__/linear.test.ts
+++ b/lib/plugins/__tests__/linear.test.ts
@@ -256,6 +256,9 @@ describe("LinearPlugin — inbound webhooks", () => {
     expect(p.action).toBe("created");
     expect(p.sessionId).toBe("session-1");
     expect(p.issueId).toBe("issue-abc");
+    // Must carry the skill hint so the router routes it to Ava (assigning Ava
+    // to a ticket otherwise drops at "no skill match").
+    expect(p.skillHint).toBe("linear_agent_respond");
   });
 
   test("AgentSessionEvent.prompted carries agentActivity through to the payload", async () => {

--- a/lib/plugins/linear.ts
+++ b/lib/plugins/linear.ts
@@ -432,6 +432,10 @@ export class LinearPlugin implements Plugin {
       topic,
       timestamp: Date.now(),
       payload: {
+        // Route agent-session events to Ava's Linear handler. Without an
+        // explicit hint the router has no skill to resolve (no keyword content)
+        // and drops the event — so assigning Ava to a ticket silently no-ops.
+        skillHint: "linear_agent_respond",
         action,
         sessionId,
         issueId,

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -343,6 +343,19 @@ skills:
         with the Linear identifier + URL in the body). The board bridge ingests
         it; protoMaker decomposes. Then comment back on the Linear issue with
         the GitHub issue link.
+      - `agent_session.created` — you were assigned via Linear's Agent Session
+        (the "connected" event). Same portfolio-intake trigger as
+        `issueAssignedToYou`. The payload carries `issueId` + `sessionId` (NOT
+        the issue fields directly), so read the issue with
+        `linear_get_issue(issueId)` for context, then route it onto the owning
+        project's board exactly as above (`get_projects` →
+        `create_github_issue` → comment the GitHub link back via
+        `linear_add_comment(issueId, …)`).
+      - `agent_session.prompted` — someone sent you a prompt inside the agent
+        session. The ask is in the payload's `agentActivity` (prompt body); the
+        ticket is `issueId`. Read the issue for context and act on the prompt:
+        route it onto the board if it's engineering work, or reply with
+        `linear_add_comment` if it's a question.
       - `issueNewComment` — a comment was added to an issue you're
         assigned to. Decide if it needs a reply.
       - generic `create` / `update` event on a team-scoped Linear


### PR DESCRIPTION
## Summary
Assigning Ava to a Linear ticket fires Linear's **Agent Session API** (`agent_session.created` — the "connected" you saw), but the LinearPlugin published it with **no `skillHint`** and no keyword content, so the router resolved no skill and dropped it:
```
[router] No skill match for topic "message.inbound.linear.agent_session.created" — dropping
```
Net: assigning Ava silently no-op'd. This routes it.

## Changes
- **LinearPlugin** — stamp `skillHint: "linear_agent_respond"` on `agent_session.*` events so the router routes them to Ava (the skill resolves to her executor with or without a channel match).
- **ava.yaml `linear_agent_respond`** — handle:
  - `agent_session.created` — same portfolio-intake trigger as `issueAssignedToYou`: read the issue via `linear_get_issue(issueId)` (payload carries `issueId`/`sessionId`, not issue fields), route onto the owning project's board (`get_projects` → `create_github_issue`), comment the GitHub link back.
  - `agent_session.prompted` — act on the prompt in `agentActivity`.
- **test** — agent_session.created publish carries the skill hint.

## Follow-up (Gap 2, separate)
Native Agent Session UX — streaming Ava's response *into Linear's agent thread* — needs outbound **Agent Activity API** support (workstacean only has issue comment/create/update today). Tracked separately; gated on **INC-023 "Linear Account Disabled"** being resolved (outbound mutations need a healthy `LINEAR_API_KEY`).

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test` — 814 pass, 0 fail
- [ ] Post-deploy: re-assign Ava to a ticket → confirm she acks + files a routing issue + comments the link (and no "no skill match" drop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Linear integration with automatic handling of new agent session events. Incoming sessions now trigger portfolio intake workflows, enable intelligent issue analysis for work routing, and support question answering with automatic comment updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/651?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->