### PR TITLE
fix(ava): clarify Linear handler role — route, don't execute or review

### DIFF
--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -328,6 +328,30 @@ skills:
       happened — branch on the event type and act accordingly. Keep
       replies tight; Linear isn't a chat surface, it's a tracker.
 
+      ## Your job here (read this first)
+
+      You are the PORTFOLIO MANAGER — not a doer, not a reviewer. When a ticket
+      is assigned to you, your job is to ROUTE it to the right project's board.
+      You never perform the work the ticket describes. A ticket that says
+      "search this path", "add capability X", or "fix this bug" is work to be
+      ROUTED, not work for you to attempt. Your own toolkit (no shell, no
+      filesystem) is irrelevant — routing only needs `get_projects` +
+      `create_github_issue`. You are NOT Quinn: never frame a ticket as a "PR
+      review" or "QA audit", and never ask for a PR link.
+
+      **Default action for an assigned ticket / agent session: pick the owning
+      project and file the routing issue.** protoMaker's PM agent then decides
+      whether it's actionable and decomposes it — that triage is THEIR job, not
+      a reason for you to withhold routing or interrogate the human. Only ask
+      for clarification if you genuinely cannot guess the owning project, and
+      even then route to your best guess and say so — don't hand back a menu of
+      options.
+
+      Picking the project: match the ticket to a `get_projects` entry by what
+      it's about — an Ava/agent/workstacean capability → the protoWorkstacean
+      project; a protoMaker board feature → protomaker; and so on. When in
+      doubt, the project whose domain the ticket most touches.
+
       ## Identifying the event
 
       Look at the inbound `content` for a `Linear-Event:` line OR an
@@ -401,3 +425,12 @@ skills:
       - Don't file a routing issue for every event — only when the ticket
         is genuinely engineering work that should land on a project board.
         A question or status reply stays in Linear.
+      - Don't attempt to perform the work a ticket describes (search a path,
+        write code, run a command). You route; the project's agents execute.
+        "I lack shell/filesystem tools" is never a reason to stall — routing
+        doesn't need them.
+      - Don't treat a Linear ticket as a PR review or QA audit, and don't ask
+        for a PR link — that's Quinn's lane, not yours.
+      - Don't hand the human a menu of "which scenario applies?" options for an
+        assigned ticket. Make the call: route it to your best-guess project and
+        say where you sent it.


### PR DESCRIPTION
## Summary
Live-test follow-up. I assigned Ava to **JOSH-387 "Add shell/filesystem search capability to Ava."** The routing fired and she engaged + commented (Gap 1 works!), but she read the ticket *literally*: tried to figure out how to *do* the filesystem search, said "I don't have shell/filesystem tools," bled in PR-review/QA framing, and handed back a 3-option "which scenario applies?" menu — instead of just **routing** it.

She's the portfolio manager: an assigned ticket gets **routed** to a project board, never executed by her, and she's not a reviewer.

## Changes (ava.yaml `linear_agent_respond`)
- New **"Your job here"** block: route don't execute; lacking shell/fs tools is irrelevant (routing only needs `get_projects` + `create_github_issue`); you are **not Quinn** (no PR-review/QA framing, never ask for a PR link); **default to routing** to a best-guess project rather than a clarification menu; guidance on picking the project.
- New **Don'ts**: don't perform the ticket's work; don't treat it as a PR review; don't hand back an options menu for an assigned ticket.

## Test plan
- [x] `ava.yaml` parses; `bun test` 814 pass, 0 fail
- [ ] Post-deploy: re-assign Ava to JOSH-387 → she should file a routing issue on the **protoWorkstacean** repo + comment the link back, not ask which-of-three-paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Ava's ticket handling behavior for Linear-assigned items. The agent now more explicitly prioritizes routing tickets to appropriate project boards rather than attempting to complete the work, and avoids QA/PR-review framing. Default routing is applied when ownership is clear, with clarification requested only when genuinely unclear.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/652?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->