### PR TITLE
feat(linear): Ava agent OAuth token manager + callback (piece A)

### DIFF
--- a/lib/linear/__tests__/ava-oauth-token-manager.test.ts
+++ b/lib/linear/__tests__/ava-oauth-token-manager.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  LinearAvaTokenManager,
+  buildAuthorizeUrl,
+  needsRefresh,
+} from "../ava-oauth-token-manager.ts";
+
+const CFG = {
+  clientId: "client-abc",
+  clientSecret: "secret-xyz",
+  redirectUri: "https://api.protolabs.studio/api/linear/oauth/callback",
+};
+
+describe("buildAuthorizeUrl", () => {
+  test("includes actor=app, redirect, scopes, state", () => {
+    const url = new URL(buildAuthorizeUrl({ clientId: "c1", redirectUri: "https://x/cb" }, "st8"));
+    expect(url.origin + url.pathname).toBe("https://linear.app/oauth/authorize");
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("client_id")).toBe("c1");
+    expect(url.searchParams.get("redirect_uri")).toBe("https://x/cb");
+    expect(url.searchParams.get("actor")).toBe("app");
+    expect(url.searchParams.get("state")).toBe("st8");
+    expect(url.searchParams.get("scope")).toContain("app:assignable");
+  });
+
+  test("honors custom scopes", () => {
+    const url = new URL(buildAuthorizeUrl({ clientId: "c", redirectUri: "https://x", scopes: "read" }, "s"));
+    expect(url.searchParams.get("scope")).toBe("read");
+  });
+});
+
+describe("needsRefresh", () => {
+  const now = 1_000_000_000_000;
+  test("true when expired", () => expect(needsRefresh({ expiresAt: now - 1 }, now)).toBe(true));
+  test("true when within 5-min margin", () => expect(needsRefresh({ expiresAt: now + 60_000 }, now)).toBe(true));
+  test("false when comfortably valid", () => expect(needsRefresh({ expiresAt: now + 3_600_000 }, now)).toBe(false));
+});
+
+describe("LinearAvaTokenManager", () => {
+  let dataDir: string;
+  let fetchCalls: Array<{ url: string; body: Record<string, string> }>;
+  let nextResponse: () => Response;
+
+  function mockFetch(): typeof fetch {
+    return (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      const body = Object.fromEntries(new URLSearchParams(String(init?.body ?? "")));
+      fetchCalls.push({ url, body });
+      return nextResponse();
+    }) as typeof fetch;
+  }
+
+  function tokenResponse(over: Record<string, unknown> = {}): Response {
+    return new Response(JSON.stringify({ access_token: "at-1", refresh_token: "rt-1", expires_in: 86399, ...over }), { status: 200 });
+  }
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "linear-ava-oauth-"));
+    fetchCalls = [];
+    nextResponse = () => tokenResponse();
+  });
+  afterEach(() => {
+    try { rmSync(dataDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  function mgr() {
+    return new LinearAvaTokenManager(dataDir, CFG, mockFetch());
+  }
+
+  test("isConfigured true with creds; isAuthorized false until a token is stored", () => {
+    const m = mgr();
+    expect(m.isConfigured()).toBe(true);
+    expect(m.isAuthorized()).toBe(false);
+    expect(m.status()).toEqual({ configured: true, authorized: false, expiresAt: null });
+  });
+
+  test("not configured when creds missing", () => {
+    const m = new LinearAvaTokenManager(dataDir, { clientId: "only-id" }, mockFetch());
+    expect(m.isConfigured()).toBe(false);
+  });
+
+  test("startAuthorization persists pendingState and the callback validates it", async () => {
+    const m = mgr();
+    const url = new URL(m.startAuthorization());
+    const state = url.searchParams.get("state")!;
+    expect(state).toBeTruthy();
+
+    // Wrong state → rejected (CSRF guard).
+    await expect(m.handleCallback("code-1", "WRONG")).rejects.toThrow(/state mismatch/i);
+
+    // Correct state → exchange happens.
+    await m.handleCallback("code-1", state);
+    expect(m.isAuthorized()).toBe(true);
+    const exchange = fetchCalls.find(c => c.body.grant_type === "authorization_code")!;
+    expect(exchange.url).toBe("https://api.linear.app/oauth/token");
+    expect(exchange.body).toMatchObject({
+      grant_type: "authorization_code",
+      code: "code-1",
+      client_id: "client-abc",
+      client_secret: "secret-xyz",
+      redirect_uri: CFG.redirectUri,
+    });
+  });
+
+  test("handleCallback throws when no refresh_token comes back", async () => {
+    const m = mgr();
+    nextResponse = () => tokenResponse({ refresh_token: undefined });
+    await expect(m.handleCallback("c", null)).rejects.toThrow(/no refresh_token/i);
+  });
+
+  test("getAccessToken returns stored token without refreshing while valid", async () => {
+    const m = mgr();
+    await m.handleCallback("c", null); // stores at-1, ~24h
+    fetchCalls.length = 0;
+    const tok = await m.getAccessToken();
+    expect(tok).toBe("at-1");
+    expect(fetchCalls).toHaveLength(0); // no refresh needed
+  });
+
+  test("getAccessToken refreshes when expired and rotates the refresh token", async () => {
+    const m = mgr();
+    await m.handleCallback("c", null);
+    fetchCalls.length = 0;
+    nextResponse = () => tokenResponse({ access_token: "at-2", refresh_token: "rt-2" });
+
+    const tok = await m.getAccessToken(Date.now() + 100 * 3_600_000); // far future → expired
+    expect(tok).toBe("at-2");
+    const refresh = fetchCalls.find(c => c.body.grant_type === "refresh_token")!;
+    expect(refresh.body.refresh_token).toBe("rt-1"); // used the original
+    expect(m.status().authorized).toBe(true);
+  });
+
+  test("keeps the old refresh token when refresh response omits a new one", async () => {
+    const m = mgr();
+    await m.handleCallback("c", null);
+    nextResponse = () => tokenResponse({ access_token: "at-3", refresh_token: undefined });
+    await m.getAccessToken(Date.now() + 100 * 3_600_000);
+    // Next refresh must still send rt-1.
+    fetchCalls.length = 0;
+    await m.getAccessToken(Date.now() + 200 * 3_600_000);
+    expect(fetchCalls[0]!.body.refresh_token).toBe("rt-1");
+  });
+
+  test("getAccessToken throws before authorization", async () => {
+    const m = mgr();
+    await expect(m.getAccessToken()).rejects.toThrow(/not authorized/i);
+  });
+
+  test("tokens persist to disk and reload in a fresh instance", async () => {
+    const m1 = mgr();
+    await m1.handleCallback("c", null);
+    expect(existsSync(join(dataDir, "linear-ava-oauth.json"))).toBe(true);
+
+    const m2 = new LinearAvaTokenManager(dataDir, CFG, mockFetch());
+    expect(m2.isAuthorized()).toBe(true);
+    const tok = await m2.getAccessToken();
+    expect(tok).toBe("at-1");
+  });
+
+  test("token file is written with 0600 perms (no world/group read)", async () => {
+    const m = mgr();
+    await m.handleCallback("c", null);
+    const perms = statSync(join(dataDir, "linear-ava-oauth.json")).mode & 0o777;
+    expect(perms).toBe(0o600);
+  });
+});

--- a/lib/linear/ava-oauth-token-manager.ts
+++ b/lib/linear/ava-oauth-token-manager.ts
@@ -1,0 +1,263 @@
+/**
+ * LinearAvaTokenManager — owns Ava's Linear agent (actor=app) OAuth tokens.
+ *
+ * Why this exists: workstacean's default LINEAR_API_KEY is Josh's personal key,
+ * so anything it writes is authored by Josh. To post AS Ava (the Linear agent
+ * app, actor email …@oauthapp.linear.app) we use an actor=app OAuth token.
+ *
+ * Linear migrated all OAuth apps to the refresh-token system on 2026-04-01:
+ * access tokens live ~24h. So there is no static token to store — we hold the
+ * client creds + a long-lived refresh token, and mint short-lived access tokens
+ * on demand (refreshing before expiry). The refresh token is captured once via
+ * the /api/linear/oauth/callback dance and persisted to the data volume so it
+ * survives restarts.
+ *
+ * Piece A (this file + the callback routes) gets the token captured + kept
+ * fresh + exposed via getAccessToken(). Piece B (posting agent activity as Ava)
+ * consumes getAccessToken().
+ *
+ * Endpoints (Linear, verified):
+ *   authorize: GET  https://linear.app/oauth/authorize
+ *   token:     POST https://api.linear.app/oauth/token   (code + refresh grants)
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const AUTHORIZE_URL = "https://linear.app/oauth/authorize";
+const TOKEN_URL = "https://api.linear.app/oauth/token";
+/** Refresh when the access token has less than this left (5 min). */
+const REFRESH_MARGIN_MS = 5 * 60 * 1000;
+/** Default scopes: read/write + agent app actor (assignable + mentionable). */
+const DEFAULT_SCOPES = "read,write,app:assignable,app:mentionable";
+
+export interface LinearAvaOAuthConfig {
+  clientId?: string;
+  clientSecret?: string;
+  redirectUri?: string;
+  scopes?: string;
+}
+
+/** Persisted token state. `expiresAt` is epoch ms for the access token. */
+export interface StoredTokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  /** Pending CSRF state during an in-flight authorize→callback dance. */
+  pendingState?: string;
+}
+
+/** Linear's token endpoint response shape (the fields we use). */
+interface TokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  token_type?: string;
+  scope?: string;
+}
+
+/** Build the authorize URL for the actor=app dance. Pure — exported for tests. */
+export function buildAuthorizeUrl(
+  cfg: Required<Pick<LinearAvaOAuthConfig, "clientId" | "redirectUri">> & { scopes?: string },
+  state: string,
+): string {
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: cfg.clientId,
+    redirect_uri: cfg.redirectUri,
+    scope: cfg.scopes ?? DEFAULT_SCOPES,
+    state,
+    actor: "app",
+    prompt: "consent",
+  });
+  return `${AUTHORIZE_URL}?${params.toString()}`;
+}
+
+/** Whether a stored access token needs refreshing (expired or within margin). */
+export function needsRefresh(tokens: Pick<StoredTokens, "expiresAt">, now: number): boolean {
+  return tokens.expiresAt - now <= REFRESH_MARGIN_MS;
+}
+
+export class LinearAvaTokenManager {
+  private readonly filePath: string;
+  private readonly cfg: LinearAvaOAuthConfig;
+  private tokens: StoredTokens | null = null;
+  /** Coalesces concurrent refreshes into one in-flight request. */
+  private refreshing: Promise<string> | null = null;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(dataDir: string, cfg: LinearAvaOAuthConfig, fetchImpl: typeof fetch = fetch) {
+    this.filePath = join(dataDir, "linear-ava-oauth.json");
+    this.cfg = cfg;
+    this.fetchImpl = fetchImpl;
+    this._load();
+  }
+
+  /** Client creds + redirect are present — the dance can run. */
+  isConfigured(): boolean {
+    return Boolean(this.cfg.clientId && this.cfg.clientSecret && this.cfg.redirectUri);
+  }
+
+  /** A refresh token has been captured — Ava can mint access tokens. */
+  isAuthorized(): boolean {
+    return Boolean(this.tokens?.refreshToken);
+  }
+
+  /** Status for /api/linear/oauth/status — never leaks token material. */
+  status(): { configured: boolean; authorized: boolean; expiresAt: number | null } {
+    return {
+      configured: this.isConfigured(),
+      authorized: this.isAuthorized(),
+      expiresAt: this.tokens?.expiresAt ?? null,
+    };
+  }
+
+  /** Build the authorize URL + persist the CSRF state for callback validation. */
+  startAuthorization(): string {
+    if (!this.cfg.clientId || !this.cfg.redirectUri) {
+      throw new Error("LINEAR_AVA_CLIENT_ID / LINEAR_AVA_REDIRECT_URI not configured");
+    }
+    const state = crypto.randomUUID();
+    // Persist alongside tokens so the dance survives a restart between
+    // authorize and callback.
+    const base: StoredTokens = this.tokens ?? { accessToken: "", refreshToken: "", expiresAt: 0 };
+    this.tokens = { ...base, pendingState: state };
+    this._save();
+    return buildAuthorizeUrl({ clientId: this.cfg.clientId, redirectUri: this.cfg.redirectUri, scopes: this.cfg.scopes }, state);
+  }
+
+  /**
+   * Exchange an authorization code for tokens (the callback handler calls this).
+   * Validates `state` against the persisted pending value (CSRF). Returns when
+   * the refresh token is stored.
+   */
+  async handleCallback(code: string, state: string | null): Promise<void> {
+    if (!this.cfg.clientId || !this.cfg.clientSecret || !this.cfg.redirectUri) {
+      throw new Error("Linear Ava OAuth not configured");
+    }
+    const expected = this.tokens?.pendingState;
+    if (expected && state !== expected) {
+      throw new Error("OAuth state mismatch — possible CSRF, or a stale/duplicate callback");
+    }
+    const body = new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: this.cfg.redirectUri,
+      client_id: this.cfg.clientId,
+      client_secret: this.cfg.clientSecret,
+    });
+    const res = await this.fetchImpl(TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) {
+      throw new Error(`Linear token exchange failed: ${res.status} ${(await res.text()).slice(0, 300)}`);
+    }
+    const data = (await res.json()) as TokenResponse;
+    if (!data.refresh_token) {
+      throw new Error("Linear token exchange returned no refresh_token (is actor=app + a refresh-enabled app?)");
+    }
+    this._store(data);
+  }
+
+  /**
+   * Return a valid access token, refreshing if expired/near-expiry. Throws if
+   * not yet authorized. Concurrent callers share one in-flight refresh.
+   */
+  async getAccessToken(now: number = Date.now()): Promise<string> {
+    if (!this.tokens?.refreshToken) {
+      throw new Error("Linear Ava agent not authorized — run the /api/linear/oauth dance first");
+    }
+    if (this.tokens.accessToken && !needsRefresh(this.tokens, now)) {
+      return this.tokens.accessToken;
+    }
+    if (!this.refreshing) {
+      this.refreshing = this._refresh().finally(() => {
+        this.refreshing = null;
+      });
+    }
+    return this.refreshing;
+  }
+
+  private async _refresh(): Promise<string> {
+    if (!this.cfg.clientId || !this.cfg.clientSecret || !this.tokens?.refreshToken) {
+      throw new Error("Cannot refresh Linear Ava token — missing creds or refresh token");
+    }
+    const body = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: this.tokens.refreshToken,
+      client_id: this.cfg.clientId,
+      client_secret: this.cfg.clientSecret,
+    });
+    const res = await this.fetchImpl(TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) {
+      throw new Error(`Linear token refresh failed: ${res.status} ${(await res.text()).slice(0, 300)}`);
+    }
+    const data = (await res.json()) as TokenResponse;
+    this._store(data);
+    return data.access_token;
+  }
+
+  /** Merge a token response into stored state (handles refresh-token rotation). */
+  private _store(data: TokenResponse): void {
+    const expiresInMs = (data.expires_in ?? 86399) * 1000;
+    this.tokens = {
+      accessToken: data.access_token,
+      // Linear may rotate the refresh token; keep the prior one if absent.
+      refreshToken: data.refresh_token ?? this.tokens?.refreshToken ?? "",
+      expiresAt: Date.now() + expiresInMs,
+      // Consume the pending CSRF state once the dance completes.
+      pendingState: undefined,
+    };
+    this._save();
+  }
+
+  private _load(): void {
+    try {
+      if (existsSync(this.filePath)) {
+        this.tokens = JSON.parse(readFileSync(this.filePath, "utf-8")) as StoredTokens;
+      }
+    } catch (err) {
+      // Corrupt file shouldn't crash boot — surface loudly, start unauthorized.
+      console.warn(`[linear-ava-oauth] failed to load ${this.filePath}: ${err instanceof Error ? err.message : String(err)}`);
+      this.tokens = null;
+    }
+  }
+
+  private _save(): void {
+    if (!this.tokens) return;
+    const dir = dirname(this.filePath);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    writeFileSync(this.filePath, JSON.stringify(this.tokens, null, 2), { mode: 0o600 });
+  }
+}
+
+// ── Singleton accessor ────────────────────────────────────────────────────────
+// One manager per process so the OAuth routes (Piece A) and the agent-activity
+// outbound (Piece B) share the same in-memory token + file.
+
+let singleton: LinearAvaTokenManager | null = null;
+
+export function getLinearAvaTokenManager(dataDir: string): LinearAvaTokenManager {
+  if (!singleton) {
+    singleton = new LinearAvaTokenManager(dataDir, {
+      clientId: process.env.LINEAR_AVA_CLIENT_ID,
+      clientSecret: process.env.LINEAR_AVA_CLIENT_SECRET,
+      redirectUri: process.env.LINEAR_AVA_REDIRECT_URI,
+      scopes: process.env.LINEAR_AVA_SCOPES,
+    });
+  }
+  return singleton;
+}
+
+/** Test-only: reset the singleton between cases. */
+export function resetLinearAvaTokenManagerForTesting(): void {
+  singleton = null;
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -23,6 +23,7 @@ import { createRoutes as operatorRoutes } from "./operator.ts";
 import { createRoutes as openaiCompatRoutes } from "./openai-compat.ts";
 import { createRoutes as googleRoutes } from "./google.ts";
 import { createRoutes as linearRoutes } from "./linear.ts";
+import { createRoutes as linearOAuthRoutes } from "./linear-oauth.ts";
 import { createRoutes as busTopologyRoutes } from "./bus-topology.ts";
 import { createRoutes as prInspectorRoutes } from "./pr-inspector.ts";
 import { createRoutes as clawpatchRoutes } from "./clawpatch.ts";
@@ -50,6 +51,7 @@ export function createAllRoutes(ctx: ApiContext): Route[] {
     ...openaiCompatRoutes(ctx),
     ...googleRoutes(ctx),
     ...linearRoutes(ctx),
+    ...linearOAuthRoutes(ctx),
     ...busTopologyRoutes(ctx),
     ...prInspectorRoutes(ctx),
     ...clawpatchRoutes(ctx),

--- a/src/api/linear-oauth.ts
+++ b/src/api/linear-oauth.ts
@@ -1,0 +1,106 @@
+/**
+ * Linear Ava-agent OAuth routes — capture + expose the actor=app token so Ava
+ * can post AS Ava (not as the operator's personal key). Piece A of the agent
+ * identity work.
+ *
+ *   GET /api/linear/oauth/start     → 302 to Linear's authorize URL (admin)
+ *   GET /api/linear/oauth/callback  → exchange code → store refresh token (public;
+ *                                     CSRF-protected by the `state` param)
+ *   GET /api/linear/oauth/status    → { configured, authorized, expiresAt } (admin)
+ *
+ * The callback is public by necessity (Linear calls it, no API key) — its
+ * protection is the one-time `code` + the `state` check in the token manager.
+ * `start` + `status` are admin-gated.
+ */
+
+import type { Route, ApiContext } from "./types.ts";
+import { getLinearAvaTokenManager } from "../../lib/linear/ava-oauth-token-manager.ts";
+
+function htmlPage(title: string, body: string, status: number): Response {
+  return new Response(
+    `<!doctype html><meta charset="utf-8"><title>${title}</title>` +
+      `<body style="font-family:system-ui;max-width:40rem;margin:4rem auto;padding:0 1rem;line-height:1.5">` +
+      `<h1>${title}</h1>${body}</body>`,
+    { status, headers: { "Content-Type": "text/html; charset=utf-8" } },
+  );
+}
+
+export function createRoutes(ctx: ApiContext): Route[] {
+  // Admin gate mirrors the operations.ts model: open when no apiKey configured;
+  // otherwise require the admin key via header or ?apiKey= (browser-friendly).
+  function isAdmin(req: Request): boolean {
+    if (!ctx.apiKey) return true;
+    const url = new URL(req.url);
+    const headerKey = req.headers.get("X-API-Key");
+    const bearer = req.headers.get("Authorization");
+    const queryKey = url.searchParams.get("apiKey");
+    const key = headerKey ?? (bearer?.startsWith("Bearer ") ? bearer.slice(7) : null) ?? queryKey;
+    return key === ctx.apiKey;
+  }
+
+  const dataDir = ctx.dataDir ?? "./data";
+
+  return [
+    {
+      method: "GET",
+      path: "/api/linear/oauth/start",
+      handler: (req) => {
+        if (!isAdmin(req)) {
+          return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+        }
+        const mgr = getLinearAvaTokenManager(dataDir);
+        if (!mgr.isConfigured()) {
+          return Response.json(
+            { success: false, error: "Linear Ava OAuth not configured — set LINEAR_AVA_CLIENT_ID / _CLIENT_SECRET / _REDIRECT_URI." },
+            { status: 503 },
+          );
+        }
+        const authorizeUrl = mgr.startAuthorization();
+        // 302 so the operator can hit this URL directly in a browser and land
+        // on Linear's consent screen.
+        return new Response(null, { status: 302, headers: { Location: authorizeUrl } });
+      },
+    },
+    {
+      method: "GET",
+      path: "/api/linear/oauth/callback",
+      handler: async (req) => {
+        const url = new URL(req.url);
+        const code = url.searchParams.get("code");
+        const state = url.searchParams.get("state");
+        const error = url.searchParams.get("error");
+        if (error) {
+          return htmlPage("Linear authorization failed", `<p>Linear returned an error: <code>${error}</code>. Re-run <code>/api/linear/oauth/start</code>.</p>`, 400);
+        }
+        if (!code) {
+          return htmlPage("Missing authorization code", `<p>No <code>code</code> in the callback. Start the flow at <code>/api/linear/oauth/start</code>.</p>`, 400);
+        }
+        const mgr = getLinearAvaTokenManager(dataDir);
+        try {
+          await mgr.handleCallback(code, state);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.error(`[linear-ava-oauth] callback failed: ${msg}`);
+          return htmlPage("Authorization failed", `<p>${msg}</p>`, 400);
+        }
+        console.log("[linear-ava-oauth] authorized — refresh token captured; Ava can now post as herself.");
+        return htmlPage(
+          "Ava is connected to Linear ✅",
+          `<p>The agent token was captured and stored. Ava will now post as herself in Linear. You can close this tab.</p>`,
+          200,
+        );
+      },
+    },
+    {
+      method: "GET",
+      path: "/api/linear/oauth/status",
+      handler: (req) => {
+        if (!isAdmin(req)) {
+          return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+        }
+        const mgr = getLinearAvaTokenManager(dataDir);
+        return Response.json({ success: true, data: mgr.status() });
+      },
+    },
+  ];
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -82,6 +82,16 @@ export const EnvSchema = z
     LINEAR_API_KEY:        z.string().optional(),
     LINEAR_WEBHOOK_SECRET: z.string().optional(),
     LINEAR_WEBHOOK_PORT:   z.string().optional(),
+    // Ava's Linear agent OAuth app (actor=app). Backs posting AS Ava via the
+    // Agent Activity API. Access tokens expire in 24h (Linear refresh-token
+    // system since 2026-04-01), so we hold client creds + a refresh token and
+    // mint short-lived access tokens. The refresh token is captured once via
+    // the /api/linear/oauth/callback dance.
+    LINEAR_AVA_CLIENT_ID:     z.string().optional(),
+    LINEAR_AVA_CLIENT_SECRET: z.string().optional(),
+    LINEAR_AVA_REDIRECT_URI:  z.string().optional(),
+    /** Comma-separated OAuth scopes. Default covers read/write + agent app actor. */
+    LINEAR_AVA_SCOPES:        z.string().optional(),
 
     // LLM gateway
     LLM_GATEWAY_URL:   z.string().optional(),


### PR DESCRIPTION
## Summary
Piece A of "Ava posts as Ava" (#109). workstacean's default `LINEAR_API_KEY` is the operator's personal key, so everything Ava writes is authored by **Josh**. Ava is a registered Linear OAuth **agent app** (`actor=app`, `…@oauthapp.linear.app`); to post as her we need an `actor=app` token. Linear migrated to refresh tokens (24h access tokens, 2026-04-01) — so there's no static token: we hold client creds + a refresh token and mint short-lived access tokens on demand.

This piece captures + keeps the token fresh and exposes `getAccessToken()`. **Piece B** (posting agent activity *as Ava* via that token) lands next.

## Changes
- **`LinearAvaTokenManager`** — authorize-URL build (`actor=app` + `app:assignable`/`app:mentionable` scopes), `authorization_code` exchange, `refresh_token` grant with rotation handling, 5-min refresh margin, concurrent-refresh coalescing. Refresh token persisted to `<dataDir>/linear-ava-oauth.json` (mode `0600`).
- **routes** — `GET /api/linear/oauth/{start,callback,status}`. The callback is public (Linear calls it, no API key) and CSRF-guarded by a persisted `state`; `start` + `status` are admin-gated. Redirect URI from `LINEAR_AVA_REDIRECT_URI`.
- **env** — `LINEAR_AVA_CLIENT_ID` / `_CLIENT_SECRET` / `_REDIRECT_URI` / `_SCOPES`.

## Infra (already wired by the operator, last turn)
cloudflared ingress `api.protolabs.studio/api/linear/oauth/*` → `workstacean:3000`; `LINEAR_AVA_*` creds live in the container. Endpoints verified reachable.

## Bootstrap once deployed
Visit `GET /api/linear/oauth/start?apiKey=<admin>` → Linear consent → callback captures the refresh token → `…/status` shows `authorized: true`.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test` — 829 pass, 0 fail (15 new: authorize-URL, refresh decision, code exchange, refresh + rotation, CSRF state, persistence/reload, 0600 perms)
- [ ] Post-deploy: run the start→callback dance; confirm `status.authorized: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled Linear OAuth authentication workflow with authorization and callback endpoints
  * Added automatic token refresh and secure token persistence
  * New status endpoint to check authorization state
  * Admin API key authorization support

* **Tests**
  * Added comprehensive test suite for OAuth token management

* **Chores**
  * Added Linear OAuth configuration environment variables

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->