### PR TITLE
feat(linear): Ava posts agent activity AS herself in the session (piece B)

### DIFF
--- a/lib/linear/__tests__/agent-activity-client.test.ts
+++ b/lib/linear/__tests__/agent-activity-client.test.ts
@@ -1,0 +1,89 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { LinearAgentActivityClient, buildActivityVariables } from "../agent-activity-client.ts";
+import type { LinearAvaTokenManager } from "../ava-oauth-token-manager.ts";
+
+// Minimal token-manager stub — the client only calls getAccessToken/isAuthorized.
+function fakeTokens(token: string | null): LinearAvaTokenManager {
+  return {
+    isAuthorized: () => token !== null,
+    getAccessToken: async () => {
+      if (token === null) throw new Error("not authorized");
+      return token;
+    },
+  } as unknown as LinearAvaTokenManager;
+}
+
+describe("buildActivityVariables", () => {
+  test("wraps sessionId + content under input", () => {
+    expect(buildActivityVariables("sess-1", { type: "thought", body: "hi" })).toEqual({
+      input: { agentSessionId: "sess-1", content: { type: "thought", body: "hi" } },
+    });
+  });
+});
+
+describe("LinearAgentActivityClient", () => {
+  let calls: Array<{ url: string; auth: string | null; body: any }>;
+  let nextResponse: () => Response;
+
+  function mockFetch(): typeof fetch {
+    return (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      calls.push({
+        url,
+        auth: new Headers(init?.headers).get("Authorization"),
+        body: JSON.parse(String(init?.body ?? "{}")),
+      });
+      return nextResponse();
+    }) as typeof fetch;
+  }
+
+  beforeEach(() => {
+    calls = [];
+    nextResponse = () => new Response(JSON.stringify({ data: { agentActivityCreate: { success: true } } }), { status: 200 });
+  });
+
+  test("isReady reflects the token manager", () => {
+    expect(new LinearAgentActivityClient(fakeTokens("at"), mockFetch()).isReady()).toBe(true);
+    expect(new LinearAgentActivityClient(fakeTokens(null), mockFetch()).isReady()).toBe(false);
+  });
+
+  test("thought posts agentActivityCreate with Bearer token + thought content", async () => {
+    const c = new LinearAgentActivityClient(fakeTokens("ava-token"), mockFetch());
+    await c.thought("sess-9", "On it.");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe("https://api.linear.app/graphql");
+    expect(calls[0]!.auth).toBe("Bearer ava-token");
+    expect(calls[0]!.body.query).toContain("agentActivityCreate");
+    expect(calls[0]!.body.variables).toEqual({ input: { agentSessionId: "sess-9", content: { type: "thought", body: "On it." } } });
+  });
+
+  test("response posts a response activity", async () => {
+    const c = new LinearAgentActivityClient(fakeTokens("t"), mockFetch());
+    await c.response("s", "done — filed PROJ-12");
+    expect(calls[0]!.body.variables.input.content).toEqual({ type: "response", body: "done — filed PROJ-12" });
+  });
+
+  test("throws on GraphQL errors", async () => {
+    nextResponse = () => new Response(JSON.stringify({ errors: [{ message: "no access to session" }] }), { status: 200 });
+    const c = new LinearAgentActivityClient(fakeTokens("t"), mockFetch());
+    await expect(c.thought("s", "x")).rejects.toThrow(/no access to session/);
+  });
+
+  test("throws on success=false", async () => {
+    nextResponse = () => new Response(JSON.stringify({ data: { agentActivityCreate: { success: false } } }), { status: 200 });
+    const c = new LinearAgentActivityClient(fakeTokens("t"), mockFetch());
+    await expect(c.response("s", "x")).rejects.toThrow(/success=false/);
+  });
+
+  test("throws on HTTP error", async () => {
+    nextResponse = () => new Response("nope", { status: 403 });
+    const c = new LinearAgentActivityClient(fakeTokens("t"), mockFetch());
+    await expect(c.thought("s", "x")).rejects.toThrow(/HTTP 403/);
+  });
+
+  test("propagates not-authorized from the token manager", async () => {
+    const c = new LinearAgentActivityClient(fakeTokens(null), mockFetch());
+    await expect(c.thought("s", "x")).rejects.toThrow(/not authorized/);
+    expect(calls).toHaveLength(0); // never hit the network
+  });
+});

--- a/lib/linear/agent-activity-client.ts
+++ b/lib/linear/agent-activity-client.ts
@@ -1,0 +1,90 @@
+/**
+ * LinearAgentActivityClient — posts agent activities into a Linear agent
+ * session AS Ava, using her actor=app OAuth token (not the operator's personal
+ * LINEAR_API_KEY). This is what makes a session reply show up authored by the
+ * agent in Linear's native agent-session thread.
+ *
+ * Linear marks a session unresponsive if the agent doesn't emit an activity
+ * within 10s of `agent_session.created`, so the thought-ack must fire fast and
+ * independently of the agent's full run.
+ *
+ * Activity content types (Linear): thought | response | error | elicitation
+ * (all `{ type, body }`) and action (`{ type, action, parameter, result? }`).
+ * See https://linear.app/developers/agent-interaction.
+ */
+
+import type { LinearAvaTokenManager } from "./ava-oauth-token-manager.ts";
+
+const GRAPHQL_URL = "https://api.linear.app/graphql";
+
+const MUTATION =
+  "mutation AgentActivityCreate($input: AgentActivityCreateInput!) {" +
+  " agentActivityCreate(input: $input) { success } }";
+
+/** A Linear agent-activity content payload. */
+export type AgentActivityContent =
+  | { type: "thought"; body: string }
+  | { type: "response"; body: string }
+  | { type: "error"; body: string }
+  | { type: "elicitation"; body: string }
+  | { type: "action"; action: string; parameter: string; result?: string };
+
+/** Build the agentActivityCreate variables — pure, exported for tests. */
+export function buildActivityVariables(sessionId: string, content: AgentActivityContent) {
+  return { input: { agentSessionId: sessionId, content } };
+}
+
+export class LinearAgentActivityClient {
+  private readonly tokens: LinearAvaTokenManager;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(tokenManager: LinearAvaTokenManager, fetchImpl: typeof fetch = fetch) {
+    this.tokens = tokenManager;
+    this.fetchImpl = fetchImpl;
+  }
+
+  /** True when Ava's agent token is available (the dance has been completed). */
+  isReady(): boolean {
+    return this.tokens.isAuthorized();
+  }
+
+  /**
+   * Post an activity into the session. Throws on auth/transport/GraphQL error so
+   * callers surface it (fire-and-forget callers catch + log).
+   */
+  async createActivity(sessionId: string, content: AgentActivityContent): Promise<void> {
+    const accessToken = await this.tokens.getAccessToken();
+    const res = await this.fetchImpl(GRAPHQL_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ query: MUTATION, variables: buildActivityVariables(sessionId, content) }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) {
+      throw new Error(`agentActivityCreate HTTP ${res.status}: ${(await res.text()).slice(0, 300)}`);
+    }
+    const json = (await res.json()) as {
+      data?: { agentActivityCreate?: { success?: boolean } };
+      errors?: Array<{ message?: string }>;
+    };
+    if (json.errors?.length) {
+      throw new Error(`agentActivityCreate GraphQL error: ${json.errors.map(e => e.message).join("; ")}`);
+    }
+    if (!json.data?.agentActivityCreate?.success) {
+      throw new Error("agentActivityCreate returned success=false");
+    }
+  }
+
+  thought(sessionId: string, body: string): Promise<void> {
+    return this.createActivity(sessionId, { type: "thought", body });
+  }
+  response(sessionId: string, body: string): Promise<void> {
+    return this.createActivity(sessionId, { type: "response", body });
+  }
+  error(sessionId: string, body: string): Promise<void> {
+    return this.createActivity(sessionId, { type: "error", body });
+  }
+}

--- a/lib/plugins/__tests__/linear.test.ts
+++ b/lib/plugins/__tests__/linear.test.ts
@@ -259,6 +259,10 @@ describe("LinearPlugin — inbound webhooks", () => {
     // Must carry the skill hint so the router routes it to Ava (assigning Ava
     // to a ticket otherwise drops at "no skill match").
     expect(p.skillHint).toBe("linear_agent_respond");
+    // reply.topic routes Ava's result to a `response` agent-activity (as Ava),
+    // not a comment.
+    expect(msg.reply?.topic).toBe("linear.agent_activity.session-1");
+    expect(msg.reply?.format).toBe("markdown");
   });
 
   test("AgentSessionEvent.prompted carries agentActivity through to the payload", async () => {

--- a/lib/plugins/linear.ts
+++ b/lib/plugins/linear.ts
@@ -39,9 +39,12 @@
  */
 
 import { createHmac, timingSafeEqual } from "node:crypto";
+import { join } from "node:path";
 import { z } from "zod";
 import type { EventBus, BusMessage, Plugin } from "../types.ts";
 import { LinearClient, type LinearPriority } from "../linear-client.ts";
+import { getLinearAvaTokenManager } from "../linear/ava-oauth-token-manager.ts";
+import { LinearAgentActivityClient } from "../linear/agent-activity-client.ts";
 
 // ── Limits ───────────────────────────────────────────────────────────────────
 
@@ -232,6 +235,18 @@ export class LinearPlugin implements Plugin {
 
     if (client) this._wireOutbound(bus, client);
     else console.warn("[linear] LINEAR_API_KEY not set — outbound Linear mutations disabled");
+
+    // Ava agent-session activities — post AS Ava via her actor=app OAuth token
+    // (independent of the personal LINEAR_API_KEY above). Wired whenever the
+    // OAuth app is configured; getAccessToken() throws at call time until the
+    // one-time authorize dance is done, which the handlers catch + log.
+    const dataDir = process.env.DATA_DIR || join(process.cwd(), "data");
+    const tokenManager = getLinearAvaTokenManager(dataDir);
+    if (tokenManager.isConfigured()) {
+      this._wireAgentActivity(bus, new LinearAgentActivityClient(tokenManager));
+    } else {
+      console.warn("[linear] LINEAR_AVA_CLIENT_ID/_SECRET not set — agent-session activity (post as Ava) disabled");
+    }
 
     try {
       this.server = Bun.serve({
@@ -442,8 +457,55 @@ export class LinearPlugin implements Plugin {
         agentSession,
         agentActivity,
       },
+      // Ava's dispatch result rounds back here → a `response` agent-activity in
+      // the session (posted AS Ava), not a comment. Only when we have a
+      // sessionId to target.
+      ...(sessionId
+        ? { reply: { topic: `linear.agent_activity.${sessionId}`, format: "markdown" as const } }
+        : {}),
     });
     console.log(`[linear] agent_session.${action}${sessionId ? ` session=${sessionId}` : ""}`);
+  }
+
+  // ── Agent-session activities (post AS Ava via actor=app OAuth) ──────────────
+  //
+  // Two halves:
+  //   1. On agent_session.created, emit a `thought` within 10s so Linear
+  //      doesn't mark the session unresponsive (the agent's full run is slower).
+  //   2. linear.agent_activity.{sessionId} (the reply.topic set on agent-session
+  //      dispatches) → emit Ava's final text as a `response` activity.
+  private _wireAgentActivity(bus: EventBus, activity: LinearAgentActivityClient): void {
+    // 1. 10-second thought ack on session start.
+    bus.subscribe("message.inbound.linear.agent_session.created", "linear-agent-activity", (msg: BusMessage) => {
+      const sessionId = (msg.payload as { sessionId?: string })?.sessionId;
+      if (!sessionId) return;
+      void activity.thought(sessionId, "On it — taking a look and routing this.").catch((err) => {
+        console.error(`[linear] agent-activity thought ack failed (session ${sessionId}): ${err instanceof Error ? err.message : String(err)}`);
+      });
+    });
+
+    // 2. Ava's dispatch result → a `response` activity.
+    bus.subscribe("linear.agent_activity.#", "linear-agent-activity", (msg: BusMessage) => {
+      const topic = msg.topic ?? "";
+      if (topic.startsWith("linear.agent_activity.result.")) return; // don't re-enter on our own result
+      const sessionId = topic.startsWith("linear.agent_activity.")
+        ? topic.slice("linear.agent_activity.".length)
+        : "";
+      if (!sessionId) return;
+      const payload = (msg.payload ?? {}) as { text?: string; content?: string; summary?: string };
+      const body = payload.text ?? payload.content ?? payload.summary ?? "";
+      if (!body) return;
+      void activity.response(sessionId, body)
+        .then(() => {
+          publishResult(bus, msg.correlationId, "linear.agent_activity.result", { success: true, sessionId });
+          console.log(`[linear] response activity posted to session ${sessionId}`);
+        })
+        .catch((err) => {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          publishResult(bus, msg.correlationId, "linear.agent_activity.result", { success: false, sessionId, error: errMsg });
+          console.error(`[linear] response activity failed (session ${sessionId}): ${errMsg}`);
+        });
+    });
   }
 
   private _publishIssue(issue: LinearIssueData, action: string, bus: EventBus): void {

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -372,14 +372,18 @@ skills:
         `issueAssignedToYou`. The payload carries `issueId` + `sessionId` (NOT
         the issue fields directly), so read the issue with
         `linear_get_issue(issueId)` for context, then route it onto the owning
-        project's board exactly as above (`get_projects` →
-        `create_github_issue` → comment the GitHub link back via
-        `linear_add_comment(issueId, …)`).
+        project's board (`get_projects` → `create_github_issue`).
+        **Your final reply text IS your response in the Linear session** — it
+        posts back as an agent activity AS you, automatically. So end with a
+        concise summary (what you did + the GitHub issue link). Do NOT also call
+        `linear_add_comment` for an agent session — that double-posts and from
+        the wrong identity.
       - `agent_session.prompted` — someone sent you a prompt inside the agent
         session. The ask is in the payload's `agentActivity` (prompt body); the
-        ticket is `issueId`. Read the issue for context and act on the prompt:
-        route it onto the board if it's engineering work, or reply with
-        `linear_add_comment` if it's a question.
+        ticket is `issueId`. Read the issue for context and act on the prompt
+        (route it onto the board if it's engineering work). As with
+        `created`, your final reply text becomes your session response — don't
+        `linear_add_comment`.
       - `issueNewComment` — a comment was added to an issue you're
         assigned to. Decide if it needs a reply.
       - generic `create` / `update` event on a team-scoped Linear


### PR DESCRIPTION
## Summary
Completes "Ava posts as Ava" on top of Piece A's (#653) actor=app OAuth token. When a Linear **agent session** opens, Ava now responds in Linear's native session thread **as the agent app**, not as the operator's personal `LINEAR_API_KEY`.

## Changes
- **`LinearAgentActivityClient`** — `agentActivityCreate` via Ava's actor=app access token (`getLinearAvaTokenManager().getAccessToken()`). `thought` / `response` / `error` helpers.
- **LinearPlugin**:
  - On `agent_session.created` → emit a `thought` within **10s** (Linear marks the session unresponsive otherwise), independent of Ava's slower run.
  - Subscribe `linear.agent_activity.{sessionId}` → emit Ava's final text as a `response` activity.
  - `_publishAgentSession` sets `reply.topic = linear.agent_activity.{sessionId}`, so the dispatch result rounds back as an activity (not a comment) — same reply-topic convention as `linear.reply.{issueId}`.
- **ava.yaml** — for agent-session events her final reply *is* the session response (posted as her automatically); she no longer `linear_add_comment`s (avoids a double-post from the wrong identity).
- Gated on `LINEAR_AVA_*` configured; `getAccessToken` throws (caught + logged) until the authorize dance is done — which it now is (`status.authorized: true`).

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test` — 837 pass, 0 fail (new: activity client — Bearer auth, content shapes, GraphQL/HTTP/success=false errors, not-authorized; + reply.topic assertion on agent_session.created)
- [ ] Post-deploy live: assign Ava to a ticket → within 10s a "On it…" **thought** appears in the session **as Ava**, then a **response** activity with her routing summary + GitHub link — no Josh-authored comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent session activities (acknowledgements and responses) are now automatically posted to Linear
  * Agent-session event responses now route through Linear's agent activity system for improved integration
  * Added support for posting agent thoughts, responses, and errors as activity records

* **Tests**
  * Added comprehensive test coverage for agent activity client
  * Extended Linear plugin integration tests for agent-session workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->