### PR TITLE
feat(linear): Ava's comment replies post AS Ava via her actor=app token

### DIFF
--- a/lib/linear/__tests__/agent-activity-client.test.ts
+++ b/lib/linear/__tests__/agent-activity-client.test.ts
@@ -63,6 +63,22 @@ describe("LinearAgentActivityClient", () => {
     expect(calls[0]!.body.variables.input.content).toEqual({ type: "response", body: "done — filed PROJ-12" });
   });
 
+  test("createComment posts commentCreate AS Ava (Bearer token) with issueId+body", async () => {
+    nextResponse = () => new Response(JSON.stringify({ data: { commentCreate: { success: true } } }), { status: 200 });
+    const c = new LinearAgentActivityClient(fakeTokens("ava-token"), mockFetch());
+    await c.createComment("issue-7", "routed to protocli — PROTO-12");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.auth).toBe("Bearer ava-token");
+    expect(calls[0]!.body.query).toContain("commentCreate");
+    expect(calls[0]!.body.variables).toEqual({ input: { issueId: "issue-7", body: "routed to protocli — PROTO-12" } });
+  });
+
+  test("createComment throws on success=false", async () => {
+    nextResponse = () => new Response(JSON.stringify({ data: { commentCreate: { success: false } } }), { status: 200 });
+    const c = new LinearAgentActivityClient(fakeTokens("t"), mockFetch());
+    await expect(c.createComment("i", "x")).rejects.toThrow(/success=false/);
+  });
+
   test("throws on GraphQL errors", async () => {
     nextResponse = () => new Response(JSON.stringify({ errors: [{ message: "no access to session" }] }), { status: 200 });
     const c = new LinearAgentActivityClient(fakeTokens("t"), mockFetch());

--- a/lib/linear/agent-activity-client.ts
+++ b/lib/linear/agent-activity-client.ts
@@ -48,34 +48,49 @@ export class LinearAgentActivityClient {
     return this.tokens.isAuthorized();
   }
 
+  /** POST a GraphQL op authenticated AS Ava (actor=app token). Throws loudly. */
+  private async _gql(opName: string, query: string, variables: unknown): Promise<Record<string, unknown>> {
+    const accessToken = await this.tokens.getAccessToken();
+    const res = await this.fetchImpl(GRAPHQL_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
+      body: JSON.stringify({ query, variables }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) {
+      throw new Error(`${opName} HTTP ${res.status}: ${(await res.text()).slice(0, 300)}`);
+    }
+    const json = (await res.json()) as { data?: Record<string, unknown>; errors?: Array<{ message?: string }> };
+    if (json.errors?.length) {
+      throw new Error(`${opName} GraphQL error: ${json.errors.map(e => e.message).join("; ")}`);
+    }
+    return json.data ?? {};
+  }
+
   /**
    * Post an activity into the session. Throws on auth/transport/GraphQL error so
    * callers surface it (fire-and-forget callers catch + log).
    */
   async createActivity(sessionId: string, content: AgentActivityContent): Promise<void> {
-    const accessToken = await this.tokens.getAccessToken();
-    const res = await this.fetchImpl(GRAPHQL_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${accessToken}`,
-      },
-      body: JSON.stringify({ query: MUTATION, variables: buildActivityVariables(sessionId, content) }),
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (!res.ok) {
-      throw new Error(`agentActivityCreate HTTP ${res.status}: ${(await res.text()).slice(0, 300)}`);
-    }
-    const json = (await res.json()) as {
-      data?: { agentActivityCreate?: { success?: boolean } };
-      errors?: Array<{ message?: string }>;
-    };
-    if (json.errors?.length) {
-      throw new Error(`agentActivityCreate GraphQL error: ${json.errors.map(e => e.message).join("; ")}`);
-    }
-    if (!json.data?.agentActivityCreate?.success) {
-      throw new Error("agentActivityCreate returned success=false");
-    }
+    const data = await this._gql("agentActivityCreate", MUTATION, buildActivityVariables(sessionId, content));
+    const ok = (data.agentActivityCreate as { success?: boolean } | undefined)?.success;
+    if (!ok) throw new Error("agentActivityCreate returned success=false");
+  }
+
+  /**
+   * Post a normal issue comment AS Ava (actor=app), independent of any agent
+   * session. This is what makes Ava's Linear replies show up authored by her
+   * instead of by the operator's personal LINEAR_API_KEY — on the reliable
+   * issue/comment path, not the flaky agent-session path.
+   */
+  async createComment(issueId: string, body: string): Promise<void> {
+    const data = await this._gql(
+      "commentCreate",
+      "mutation($input: CommentCreateInput!){ commentCreate(input: $input){ success } }",
+      { input: { issueId, body } },
+    );
+    const ok = (data.commentCreate as { success?: boolean } | undefined)?.success;
+    if (!ok) throw new Error("commentCreate returned success=false");
   }
 
   thought(sessionId: string, body: string): Promise<void> {

--- a/lib/plugins/linear.ts
+++ b/lib/plugins/linear.ts
@@ -233,20 +233,21 @@ export class LinearPlugin implements Plugin {
     const dedup = new DeliveryDedup();
     const client: LinearClient | null = apiKey ? new LinearClient(apiKey) : null;
 
-    if (client) this._wireOutbound(bus, client);
-    else console.warn("[linear] LINEAR_API_KEY not set — outbound Linear mutations disabled");
-
-    // Ava agent-session activities — post AS Ava via her actor=app OAuth token
-    // (independent of the personal LINEAR_API_KEY above). Wired whenever the
-    // OAuth app is configured; getAccessToken() throws at call time until the
-    // one-time authorize dance is done, which the handlers catch + log.
+    // Ava's actor=app client — posts AS Ava (agent activities + plain comments)
+    // via her OAuth token, independent of the personal LINEAR_API_KEY. Wired
+    // whenever the OAuth app is configured; getAccessToken() throws at call time
+    // until the one-time authorize dance is done, which callers catch + log.
     const dataDir = process.env.DATA_DIR || join(process.cwd(), "data");
     const tokenManager = getLinearAvaTokenManager(dataDir);
-    if (tokenManager.isConfigured()) {
-      this._wireAgentActivity(bus, new LinearAgentActivityClient(tokenManager));
-    } else {
-      console.warn("[linear] LINEAR_AVA_CLIENT_ID/_SECRET not set — agent-session activity (post as Ava) disabled");
-    }
+    const avaClient = tokenManager.isConfigured() ? new LinearAgentActivityClient(tokenManager) : null;
+    if (!avaClient) console.warn("[linear] LINEAR_AVA_CLIENT_ID/_SECRET not set — post-as-Ava disabled (replies fall back to personal key)");
+
+    // Outbound comments prefer Ava's identity; create/update still use the
+    // personal-key client (team/state resolution lives there).
+    if (client || avaClient) this._wireOutbound(bus, client, avaClient);
+    else console.warn("[linear] no LINEAR_API_KEY and no Ava OAuth — outbound Linear mutations disabled");
+
+    if (avaClient) this._wireAgentActivity(bus, avaClient);
 
     try {
       this.server = Bun.serve({
@@ -621,9 +622,11 @@ export class LinearPlugin implements Plugin {
   // so callers (agents) can confirm their action landed instead of silently
   // assuming success.
 
-  private _wireOutbound(bus: EventBus, client: LinearClient): void {
+  private _wireOutbound(bus: EventBus, client: LinearClient | null, avaClient: LinearAgentActivityClient | null): void {
     // linear.reply.{issueId} — post a comment using the standard
-    // reply-on-topic convention agents already know.
+    // reply-on-topic convention agents already know. Prefer Ava's actor=app
+    // token so the comment is authored AS Ava; fall back to the personal-key
+    // client if she isn't authorized or her post fails.
     bus.subscribe("linear.reply.#", "linear-outbound", async (msg: BusMessage) => {
       const topic = msg.topic ?? "";
       // Result topics from this family must not re-enter this subscriber.
@@ -646,14 +649,35 @@ export class LinearPlugin implements Plugin {
         });
         return;
       }
+      // 1) As Ava (actor=app token) when authorized.
+      if (avaClient?.isReady()) {
+        try {
+          await avaClient.createComment(issueId, body);
+          publishResult(bus, msg.correlationId, "linear.reply.result", { success: true, issueId, as: "ava" });
+          console.log(`[linear] Comment posted AS Ava on issue ${issueId}`);
+          return;
+        } catch (err) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          console.warn(`[linear] post-as-Ava comment failed on ${issueId} (${errMsg}) — falling back to personal key`);
+        }
+      }
+      // 2) Fall back to the personal-key client.
+      if (!client) {
+        publishResult(bus, msg.correlationId, "linear.reply.result", {
+          success: false, issueId, error: "no Ava token and no LINEAR_API_KEY — cannot post comment",
+        });
+        console.error(`[linear] cannot post comment on ${issueId} — no Ava token and no personal key`);
+        return;
+      }
       try {
         const ok = await client.addComment(issueId, body);
         publishResult(bus, msg.correlationId, "linear.reply.result", {
           success: ok,
           issueId,
+          as: "personal-key",
           error: ok ? undefined : "client.addComment returned false",
         });
-        if (ok) console.log(`[linear] Comment posted on issue ${issueId}`);
+        if (ok) console.log(`[linear] Comment posted (personal key) on issue ${issueId}`);
         else console.warn(`[linear] Failed to post comment on issue ${issueId}`);
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : String(err);
@@ -672,6 +696,12 @@ export class LinearPlugin implements Plugin {
       // Result topics are linear.update.issue.result.{correlationId} — skip
       // to avoid re-entering this subscriber.
       if (topic.startsWith("linear.update.issue.result.")) return;
+      if (!client) {
+        publishResult(bus, msg.correlationId, "linear.update.issue.result", {
+          success: false, error: "LINEAR_API_KEY not set — issue mutations disabled",
+        });
+        return;
+      }
       const issueId = topic.startsWith("linear.update.issue.")
         ? topic.slice("linear.update.issue.".length)
         : "";
@@ -715,6 +745,12 @@ export class LinearPlugin implements Plugin {
     // issue id back on linear.create.issue.result.{correlationId} so agents
     // can await their own creations.
     bus.subscribe("linear.create.issue", "linear-outbound", async (msg: BusMessage) => {
+      if (!client) {
+        publishResult(bus, msg.correlationId, "linear.create.issue.result", {
+          success: false, error: "LINEAR_API_KEY not set — issue creation disabled",
+        });
+        return;
+      }
       const payload = (msg.payload ?? {}) as {
         teamKey?: string;
         title?: string;


### PR DESCRIPTION
## Summary
The agent-session path (which posts as Ava) is **unreliable on Linear's side** — sessions get created but `agent_session.created` webhooks deliver only intermittently. Meanwhile the **issue/comment path is reliable** but posted replies through the shared `LINEAR_API_KEY`, so Ava's comments showed up authored by the operator ("posted as me").

This **decouples "posts as Ava" from the flaky agent-session delivery**: route Ava's outbound Linear comments through her **actor=app OAuth token**. Per Linear's actor authorization, `commentCreate` with the app token is authored by the app (Ava).

## Changes
- **`LinearAgentActivityClient.createComment(issueId, body)`** — posts a normal issue comment via the actor=app token (extracted a shared `_gql` helper; `createActivity` reuses it).
- **`LinearPlugin._wireOutbound`** — `linear.reply.{issueId}` now **prefers** `avaClient.createComment` (as Ava) when authorized, and **falls back** to the personal-key client on not-authorized-or-error so replies always land. Result payload carries `as: "ava" | "personal-key"`.
- `client` (personal key) is now nullable — guarded the create/update handlers.

## Result
On the reliable comment path, **Ava posts as herself.** The native in-thread agent-session UX remains gated on Linear's (flaky) agent-session delivery — separate, their side; tracked for a support ticket.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test` — 839 pass, 0 fail (new: `createComment` Bearer-auth + variables + success=false)
- [ ] Post-deploy: trigger an Ava Linear reply → confirm the comment shows authored by **Ava**, and logs show `Comment posted AS Ava`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Linear agent can now post comments directly to issues.
  * Fallback to manual API key when agent posting fails.
  * Improved failure handling with explicit result publishing for unavailable operations.

* **Tests**
  * Added test coverage for comment creation functionality.

* **Refactor**
  * Centralized GraphQL request handling for better maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->