### PR TITLE
fix(linear): 10s thought-ack on agent_session.prompted too (fixes 'did not respond' on comments)

### DIFF
--- a/lib/plugins/linear.ts
+++ b/lib/plugins/linear.ts
@@ -471,16 +471,25 @@ export class LinearPlugin implements Plugin {
   // ── Agent-session activities (post AS Ava via actor=app OAuth) ──────────────
   //
   // Two halves:
-  //   1. On agent_session.created, emit a `thought` within 10s so Linear
-  //      doesn't mark the session unresponsive (the agent's full run is slower).
+  //   1. On agent_session.created AND .prompted, emit a `thought` within 10s so
+  //      Linear doesn't mark the session unresponsive (the agent's full run is
+  //      slower than 10s). Linear sends `created` on assignment and `prompted`
+  //      on every follow-up comment — both need the fast ack, or the session
+  //      shows "did not respond" on each comment whose run runs long.
   //   2. linear.agent_activity.{sessionId} (the reply.topic set on agent-session
   //      dispatches) → emit Ava's final text as a `response` activity.
   private _wireAgentActivity(bus: EventBus, activity: LinearAgentActivityClient): void {
-    // 1. 10-second thought ack on session start.
-    bus.subscribe("message.inbound.linear.agent_session.created", "linear-agent-activity", (msg: BusMessage) => {
+    // 1. 10-second thought ack on session start AND every follow-up prompt.
+    bus.subscribe("message.inbound.linear.agent_session.#", "linear-agent-activity", (msg: BusMessage) => {
+      const topic = msg.topic ?? "";
+      // created → assignment; prompted → a follow-up comment. Both need the ack.
+      if (!topic.endsWith(".created") && !topic.endsWith(".prompted")) return;
       const sessionId = (msg.payload as { sessionId?: string })?.sessionId;
       if (!sessionId) return;
-      void activity.thought(sessionId, "On it — taking a look and routing this.").catch((err) => {
+      const ack = topic.endsWith(".created")
+        ? "On it — taking a look and routing this."
+        : "Got it — looking at that now.";
+      void activity.thought(sessionId, ack).catch((err) => {
         console.error(`[linear] agent-activity thought ack failed (session ${sessionId}): ${err instanceof Error ? err.message : String(err)}`);
       });
     });


### PR DESCRIPTION
## Summary
**"Ava did not respond" on every other comment.** The 10-second unresponsive-timeout ack (#656) only fired on `agent_session.created` (initial assignment). Linear sends `agent_session.prompted` on **every follow-up comment** in an active session — those had **no fast ack**, so whenever Ava's deep-agent run took >10s (nearly always), Linear flagged the session unresponsive, even though her response activity landed seconds later.

Fix: subscribe the thought-ack to `agent_session.#` and ack on both `.created` and `.prompted`. Per Linear's guidance — emit an activity within 10s of the event; follow-ups then have 30 min. The reply path already posts her final response for `prompted` (reply.topic is set whenever sessionId is present).

## Test plan
- [x] `bunx tsc --noEmit` clean; `bun test` 839 pass
- [ ] Post-deploy: comment repeatedly on an active session → each gets a fast "Got it…" thought then Ava's response; no "did not respond."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent-session acknowledgements now provide timely feedback at additional stages of the session lifecycle, including when prompts are sent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/662?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->