### PR TITLE
feat(linear): poll + recover stale agent sessions (webhook delivery is flaky)

### DIFF
--- a/lib/plugins/__tests__/linear-agent-session-poller.test.ts
+++ b/lib/plugins/__tests__/linear-agent-session-poller.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { LinearAgentSessionPoller, fetchStaleSessions } from "../linear-agent-session-poller.ts";
+import { InMemoryEventBus } from "../../bus.ts";
+import type { BusMessage } from "../../types.ts";
+
+function sessionsResponse(nodes: Array<{ id: string; status: string; updatedAt: string; issue?: { id: string; identifier: string } }>) {
+  return new Response(JSON.stringify({ data: { agentSessions: { nodes } } }), { status: 200 });
+}
+
+describe("fetchStaleSessions", () => {
+  test("returns only `stale` sessions, mapping issue", async () => {
+    const fetchImpl = (async () => sessionsResponse([
+      { id: "s-stale", status: "stale", updatedAt: "t1", issue: { id: "i1", identifier: "JOSH-1" } },
+      { id: "s-active", status: "active", updatedAt: "t2", issue: { id: "i2", identifier: "JOSH-2" } },
+      { id: "s-complete", status: "complete", updatedAt: "t3" },
+      { id: "s-pending", status: "pending", updatedAt: "t4" },
+    ])) as unknown as typeof fetch;
+    const out = await fetchStaleSessions("k", fetchImpl);
+    expect(out).toEqual([{ id: "s-stale", updatedAt: "t1", issueId: "i1", issueIdentifier: "JOSH-1" }]);
+  });
+
+  test("throws on GraphQL errors", async () => {
+    const fetchImpl = (async () => new Response(JSON.stringify({ errors: [{ message: "nope" }] }), { status: 200 })) as unknown as typeof fetch;
+    await expect(fetchStaleSessions("k", fetchImpl)).rejects.toThrow(/nope/);
+  });
+});
+
+describe("LinearAgentSessionPoller._poll", () => {
+  let bus: InMemoryEventBus;
+  let got: BusMessage[];
+
+  beforeEach(() => {
+    bus = new InMemoryEventBus();
+    got = [];
+    bus.subscribe("message.inbound.linear.agent_session.created", "test", (m: BusMessage) => { got.push(m); });
+  });
+
+  function poller(nodes: Array<{ id: string; status: string; updatedAt: string; issue?: { id: string; identifier: string } }>) {
+    const fetchImpl = (async () => sessionsResponse(nodes)) as unknown as typeof fetch;
+    return new LinearAgentSessionPoller({ apiKey: "k", fetchImpl });
+  }
+
+  test("dispatches a stale session as an agent_session.created with reply.topic + skillHint", async () => {
+    const p = poller([{ id: "s1", status: "stale", updatedAt: "t1", issue: { id: "i1", identifier: "JOSH-9" } }]);
+    await p._poll(bus);
+    await Bun.sleep(5);
+    expect(got).toHaveLength(1);
+    const m = got[0]!;
+    expect(m.correlationId).toBe("s1");
+    expect((m.payload as any).skillHint).toBe("linear_agent_respond");
+    expect((m.payload as any).sessionId).toBe("s1");
+    expect((m.payload as any).issueId).toBe("i1");
+    expect((m.payload as any).recoveredViaPoll).toBe(true);
+    expect(m.reply?.topic).toBe("linear.agent_activity.s1");
+  });
+
+  test("does not re-dispatch the same session+updatedAt across polls", async () => {
+    const p = poller([{ id: "s1", status: "stale", updatedAt: "t1", issue: { id: "i1", identifier: "JOSH-9" } }]);
+    await p._poll(bus); await Bun.sleep(5);
+    await p._poll(bus); await Bun.sleep(5);
+    expect(got).toHaveLength(1);
+  });
+
+  test("re-dispatches when updatedAt advances (a fresh prompt re-staled)", async () => {
+    let i = 0;
+    const stamps = ["t1", "t2"];
+    const fetchImpl = (async () => sessionsResponse([
+      { id: "s1", status: "stale", updatedAt: stamps[Math.min(i++, 1)]!, issue: { id: "i1", identifier: "JOSH-9" } },
+    ])) as unknown as typeof fetch;
+    const p = new LinearAgentSessionPoller({ apiKey: "k", fetchImpl });
+    await p._poll(bus); await Bun.sleep(5);
+    await p._poll(bus); await Bun.sleep(5);
+    expect(got).toHaveLength(2);
+  });
+
+  test("ignores non-stale sessions", async () => {
+    const p = poller([
+      { id: "a", status: "active", updatedAt: "t", issue: { id: "i", identifier: "J-1" } },
+      { id: "c", status: "complete", updatedAt: "t", issue: { id: "i", identifier: "J-2" } },
+    ]);
+    await p._poll(bus); await Bun.sleep(5);
+    expect(got).toHaveLength(0);
+  });
+});

--- a/lib/plugins/linear-agent-session-poller.ts
+++ b/lib/plugins/linear-agent-session-poller.ts
@@ -1,0 +1,132 @@
+/**
+ * LinearAgentSessionPoller — recovers Linear agent sessions that Linear failed
+ * to deliver a webhook for.
+ *
+ * Linear's agent-session webhook delivery is intermittent: it creates the
+ * session reliably (queryable via the API) but often never POSTs the
+ * `agent_session.created` / `.prompted` webhook to us, so the session times out
+ * to `stale` ("Ava did not respond"). The webhook path is unchanged and still
+ * the fast path when it works; this poller is the safety net.
+ *
+ * Design — poll ONLY `stale` sessions:
+ *   - A working webhook never leaves a session `stale` (the agent responds, so
+ *     it goes active/complete). So polling `stale` can't double-post against a
+ *     working delivery — it only picks up the ones that fell through.
+ *   - For each stale session not already handled (keyed by id+updatedAt so a
+ *     fresh prompt that re-stales gets re-picked), publish the same
+ *     `message.inbound.linear.agent_session.created` event the webhook would
+ *     have, with the reply.topic set — the existing router → linear_agent_respond
+ *     → thought-ack + response-activity pipeline does the rest. Per Linear's
+ *     docs, a stale session is recoverable by sending an activity.
+ */
+
+import type { EventBus, Plugin } from "../types.ts";
+
+const GRAPHQL_URL = "https://api.linear.app/graphql";
+const POLL_INTERVAL_MS = 20_000;
+/** Drop handled keys older than this so re-stale of a fresh prompt re-fires. */
+const HANDLED_TTL_MS = 10 * 60 * 1000;
+
+interface StaleSession {
+  id: string;
+  updatedAt: string;
+  issueId?: string;
+  issueIdentifier?: string;
+}
+
+const QUERY =
+  "{ agentSessions(first: 25) { nodes { id status updatedAt issue { id identifier } } } }";
+
+/** Pull `stale` sessions from Linear — pure transport, exported for testing. */
+export async function fetchStaleSessions(apiKey: string, fetchImpl: typeof fetch): Promise<StaleSession[]> {
+  const res = await fetchImpl(GRAPHQL_URL, {
+    method: "POST",
+    headers: { Authorization: apiKey, "Content-Type": "application/json" },
+    body: JSON.stringify({ query: QUERY }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) throw new Error(`agentSessions query HTTP ${res.status}`);
+  const json = (await res.json()) as {
+    data?: { agentSessions?: { nodes?: Array<{ id: string; status: string; updatedAt: string; issue?: { id?: string; identifier?: string } }> } };
+    errors?: Array<{ message?: string }>;
+  };
+  if (json.errors?.length) throw new Error(`agentSessions query error: ${json.errors.map(e => e.message).join("; ")}`);
+  return (json.data?.agentSessions?.nodes ?? [])
+    .filter(n => n.status === "stale")
+    .map(n => ({ id: n.id, updatedAt: n.updatedAt, issueId: n.issue?.id, issueIdentifier: n.issue?.identifier }));
+}
+
+export class LinearAgentSessionPoller implements Plugin {
+  readonly name = "linear-agent-session-poller";
+  readonly description = "Recovers stale Linear agent sessions the webhook never delivered";
+  readonly capabilities = ["linear-agent-session-recovery"];
+  readonly publishes = ["message.inbound.linear.agent_session.created"];
+
+  private readonly apiKey?: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly intervalMs: number;
+  private timer?: ReturnType<typeof setInterval>;
+  /** key = `${sessionId}:${updatedAt}` → handled-at ms. */
+  private handled = new Map<string, number>();
+
+  constructor(opts: { apiKey?: string; fetchImpl?: typeof fetch; intervalMs?: number } = {}) {
+    this.apiKey = opts.apiKey ?? process.env.LINEAR_API_KEY;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.intervalMs = opts.intervalMs ?? POLL_INTERVAL_MS;
+  }
+
+  install(bus: EventBus): void {
+    if (!this.apiKey) {
+      console.warn("[linear-session-poller] LINEAR_API_KEY not set — stale-session recovery disabled");
+      return;
+    }
+    this.timer = setInterval(() => void this._poll(bus), this.intervalMs);
+    this.timer.unref?.();
+    void this._poll(bus); // immediate first sweep
+    console.log(`[linear-session-poller] recovering stale agent sessions every ${this.intervalMs / 1000}s`);
+  }
+
+  uninstall(): void {
+    if (this.timer) clearInterval(this.timer);
+  }
+
+  /** One sweep — exported semantics tested via _poll with injected bus/fetch. */
+  async _poll(bus: EventBus): Promise<void> {
+    let sessions: StaleSession[];
+    try {
+      sessions = await fetchStaleSessions(this.apiKey!, this.fetchImpl);
+    } catch (err) {
+      console.error(`[linear-session-poller] poll failed: ${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+    this._prune();
+    for (const s of sessions) {
+      const key = `${s.id}:${s.updatedAt}`;
+      if (this.handled.has(key)) continue;
+      this.handled.set(key, Date.now());
+      bus.publish("message.inbound.linear.agent_session.created", {
+        id: crypto.randomUUID(),
+        correlationId: s.id,
+        topic: "message.inbound.linear.agent_session.created",
+        timestamp: Date.now(),
+        payload: {
+          // Same shape the webhook publishes — routes to Ava's Linear handler.
+          skillHint: "linear_agent_respond",
+          action: "created",
+          sessionId: s.id,
+          issueId: s.issueId,
+          agentSession: { id: s.id, issueId: s.issueId },
+          agentActivity: {},
+          recoveredViaPoll: true,
+        },
+        reply: { topic: `linear.agent_activity.${s.id}`, format: "markdown" as const },
+      });
+      console.log(`[linear-session-poller] recovered stale session ${s.id}${s.issueIdentifier ? ` (${s.issueIdentifier})` : ""} → dispatched to Ava`);
+    }
+  }
+
+  private _prune(): void {
+    const cutoff = Date.now() - HANDLED_TTL_MS;
+    for (const [k, t] of this.handled) if (t < cutoff) this.handled.delete(k);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,6 +197,17 @@ const pluginRegistry: PluginRegistryEntry[] = [
     },
   },
   {
+    // Recovers Linear agent sessions Linear failed to deliver a webhook for
+    // (their delivery is intermittent). Polls for `stale` sessions and re-drives
+    // them through the same agent-session pipeline. Safety net for the webhook.
+    name: "linear-agent-session-poller",
+    condition: () => Boolean(process.env.LINEAR_API_KEY),
+    factory: async () => {
+      const { LinearAgentSessionPoller } = await import("../lib/plugins/linear-agent-session-poller");
+      return new LinearAgentSessionPoller();
+    },
+  },
+  {
     // GitHub issue → protoMaker board bridge. workstacean receives every
     // project repo's webhook + owns the registry, so it resolves the project
     // and POSTs to protoMaker's HTTP board intake (ADR-0001/0002). No-op for


### PR DESCRIPTION
## Summary
Linear's agent-session **webhook delivery is intermittent** — it creates the session (queryable via API) but often never POSTs `agent_session.created/.prompted`, so the session times out to `stale` → "Ava did not respond." Verified repeatedly: issue webhooks deliver to the same endpoint while agent-session ones drop; sessions sit `stale` with zero receipts on our side; secret + URL + receiver + subscription all proven correct. We can't make their webhook reliable, so stop depending on it.

**`LinearAgentSessionPoller`** polls `agentSessions` every 20s and re-drives any **`stale`** session through the existing pipeline (same `agent_session.created` event the webhook would publish, `reply.topic` set → router → `linear_agent_respond` → thought-ack + response activity).

**Why `stale`-only is race-free:** a working webhook never leaves a session stale (the agent responds → active/complete), so the poller can't double-post against a working delivery — it only recovers the dropped ones. Dedup by `id+updatedAt` so a re-staled fresh prompt gets re-picked.

The webhook stays the fast path when it works; this is the safety net (~≤30s recovery: 10s to stale + ≤20s poll).

## Test plan
- [x] `bunx tsc --noEmit` clean; `bun test` — 845 pass (6 new: stale filter, dispatch shape, dedup, re-dispatch on updatedAt, ignore non-stale)
- [ ] Post-deploy: comment on a session → if the webhook drops it, within ~30s Ava recovers it and responds (as Ava); no permanent "did not respond."

🤖 Generated with [Claude Code](https://claude.com/claude-code)