### PR TITLE
chore(beads): track br (Beads Rust) workspace config

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -1,0 +1,14 @@
+# Database
+*.db
+*.db-shm
+*.db-wal
+
+# Lock files
+*.lock
+
+# Temporary
+last-touched
+*.tmp
+
+# Local history backups (machine-specific)
+.br_history/

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,0 +1,4 @@
+# Beads Project Configuration
+# issue_prefix: ws
+# default_priority: 2
+# default_type: task

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,0 +1,4 @@
+{
+  "database": "beads.db",
+  "jsonl_export": "issues.jsonl"
+}


### PR DESCRIPTION
## What

This repo's issue tracker is **`br` (Beads Rust)** — [Dicklesworthstone/beads_rust](https://github.com/Dicklesworthstone/beads_rust), `~/.cargo/bin/br` — **not** the node `@beads/bd`. The two share the SQLite+JSONL concept but have incompatible schemas.

The `.beads/` workspace was an empty/legacy br DB whose daemon appeared to "crash-loop with a corrupt DB." Root cause: node `bd` was being invoked against a `br`-format DB → `sqlite3: SQL logic error: no such column: spec_id`. (`br` runs in direct mode with no daemon, so a crash-looping beads daemon is itself the tell that the wrong tool is in use.)

Re-initialized cleanly with `br init`. No data lost — the tracker was empty (0 issues, empty JSONL across all history, no `br history` backups).

## Changes

- Track the `br` workspace config (`config.yaml`, `metadata.json`) + its `.gitignore` so clones share the same workspace.
- **Prefix is now `ws`** (`ws-<hash>` IDs), reset from the old `pro` which collided with protoMaker's tracker.
- Ignore `.br_history/` (machine-specific local backup snapshots).
- `issues.jsonl` stays tracked + empty; SQLite `*.db*` files stay gitignored.

## Verification

`br doctor` → all OK (schema, integrity, `counts.db_vs_jsonl: Both have 0 records`, DB/JSONL in sync). create→list→delete roundtrip confirmed, then reset to pristine empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Initialized project configuration files for database and export settings.
  * Added local environment exclusions to manage build artifacts and temporary files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/664?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->