### PR TITLE
feat(ceremony): per-project portfolio check-in (JOSH-393)

### DIFF
--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -322,6 +322,61 @@ skills:
     description: Triage open GitHub issues across managed repos. For each issue, determine the right action — resolve directly, convert to a board feature, delegate to the owning agent, or close with rationale. Goal is issue zero across all projects.
     keywords: [issue, triage, github, bug, enhancement, zero, backlog, stale]
 
+  - name: portfolio_check_in
+    description: Per-project portfolio check-in. Sweep each registered project's PR pipeline, CI health, and open incidents; classify each project's status (healthy / needs-attention / blocked) factoring in Quinn's PR verdicts; post one consolidated per-project digest and escalate genuine blockers to the operator.
+    keywords: [checkin, check-in, portfolio, status, sweep, health]
+    tools:
+      - get_projects
+      - get_pr_pipeline
+      - get_ci_health
+      - get_branch_drift
+      - get_incidents
+      - msg_operator
+    maxTurns: 15
+    systemPromptOverride: |
+      You are Ava, the portfolio manager, running the per-project check-in.
+      This runs autonomously on a schedule. Your job: give the operator one
+      tight read on where every project stands, and surface anything blocked.
+
+      ## Gather
+      Make these reads up front — each returns fleet-wide data in one call:
+      - `get_projects` — the registered projects (each carries its repo).
+      - `get_pr_pipeline` — open PRs across repos with CI + review state. The
+        review state reflects Quinn's verdicts (approved = PASS,
+        changes_requested = FAIL, pending = awaiting). Group PRs by their repo.
+      - `get_ci_health` — per-repo CI pass rates and failing-main signals.
+      - `get_incidents` — open operational / security incidents.
+      - `get_branch_drift` — reach for this only when a project looks stalled.
+
+      ## Classify each project
+      For every registered project, choose one status from its signals:
+      - **blocked** — failing CI on main, a PR sitting in changes_requested, an
+        open incident, or work that needs a decision to proceed.
+      - **needs-attention** — stale PRs, conflicts, slipping CI, or PRs that
+        have been awaiting review for a while.
+      - **healthy** — work flowing or idle: green CI, PRs moving, nothing stuck.
+      A project with no open work counts as healthy.
+
+      ## Report
+      Your final reply IS the digest that posts to the fleet channel, and the
+      channel caps it — keep it under ~900 characters. One line per project that
+      has something worth saying, most urgent first; roll all the healthy/idle
+      projects into a single closing line. Lead with the count of blocked
+      projects. Distill so the operator reads it in five seconds:
+        `2 blocked.`
+        `🔴 protocli — PR #42 changes-requested 3d; main CI red`
+        `🟡 protocontent — 2 PRs awaiting review`
+        `🟢 5 others flowing`
+
+      ## Escalate
+      When any project is **blocked**, also call `msg_operator` once at urgency
+      `high`, naming the blocked projects and the single most important reason
+      each is stuck. When nothing is blocked, the digest alone is enough.
+
+      Treat your tool output as ground truth — report only the PRs, issues, CI
+      states, and verdicts the tools actually return. This skill observes and
+      surfaces; acting on the blockers is a separate step.
+
   # ── Linear inbound ──────────────────────────────────────────────────────────
   # Fired by the router when a linear.* inbound message hits a channel
   # registered for Ava (workspace/channels.yaml: linear-team-josh,

--- a/workspace/ceremonies/portfolio-checkin.yaml
+++ b/workspace/ceremonies/portfolio-checkin.yaml
@@ -1,0 +1,16 @@
+id: portfolio-checkin
+name: "Portfolio Check-In"
+description: "Per-project health sweep: PR pipeline + CI + incidents → Ava distills a per-project status digest and escalates genuine blockers."
+# Weekday 10am, just after the 9am Daily Standup (board_audit by Quinn). The
+# standup is a board-level summary; this is Ava's per-project health read from
+# the portfolio-manager lens (ADR-0001).
+schedule: "0 10 * * 1-5"
+# portfolio_check_in lives on Ava (the portfolio manager). She reads the
+# registered projects and distills per-project status from her observation
+# tools; Quinn's PR verdicts surface via get_pr_pipeline review state.
+skill: portfolio_check_in
+targets:
+  - ava
+notifyChannel: "1469195643590541353"
+timeoutMs: 300000
+enabled: true


### PR DESCRIPTION
Closes **JOSH-393** — the monitoring half of the org→execution pipeline (ADR-0001): a recurring per-project check-in that reads each project's GitHub state and distills status **up to Ava**, the portfolio manager.

## Design (confirmed: "Ava check-in skill")

Almost everything already existed — this is wiring, not new plumbing:

- **New ceremony `portfolio-checkin`** — weekday 10am (just after the 9am Daily Standup), dispatches the `portfolio_check_in` skill to Ava. 5-min `timeoutMs` so a hung run fails loud instead of hanging silently.
- **New Ava skill `portfolio_check_in`** — reads `get_projects` + `get_pr_pipeline` (PR review state = Quinn's PASS/WARN/FAIL verdicts) + `get_ci_health` + `get_incidents`, classifies each registered project **healthy / needs-attention / blocked**, and returns a tight digest.
- **Surfacing** — the `CeremonyNotifier` posts Ava's digest (≤1024 chars) to the fleet channel; **blocked projects also escalate once via `msg_operator` (high)**. No blockers → digest only, no ping.

The 1024-char notifier cap is a feature here — it forces the "distill, don't dump" discipline Ava's prompt already calls for.

## Why this shape

Ava is the portfolio manager (ADR-0001); putting the per-project synthesis in her skill keeps a single code path and reuses her existing observation tools, rather than fanning N per-project ceremonies or building a parallel deterministic aggregator. Skill prompt is positive-framed (per fleet prompt convention) and scoped to read tools + `msg_operator`.

## Notes

- `notifyChannel` reuses the established fleet-status channel (`1469195643590541353`, same as the daily standup) — repoint if you want a dedicated portfolio channel.
- Quinn PR verdicts are consumed indirectly via `get_pr_pipeline`'s review state (no new tool needed).

## Verification

- `bun run typecheck` — clean
- `bun test` — **845 pass / 0 fail**
- Direct load check: ceremony parses + loads (skill=`portfolio_check_in`, targets=`[ava]`, enabled, 300s timeout); Ava advertises the matching skill; all 6 scoped tools are a subset of her toolbelt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated portfolio health monitoring now runs on a schedule, evaluating project status across CI, PR pipelines, and incidents. High-priority issues are escalated to operators with consolidated summaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/666?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->