### PR TITLE
fix(ceremony): read skill reply from payload.content, not payload.result

### DIFF
--- a/src/plugins/CeremonyPlugin.ts
+++ b/src/plugins/CeremonyPlugin.ts
@@ -372,14 +372,19 @@ export class CeremonyPlugin implements Plugin {
         const subId = this.bus!.subscribe(replyTopic, this.name, (msg: BusMessage) => {
           if (timeoutTimer !== undefined) clearTimeout(timeoutTimer);
           this.bus?.unsubscribe(subId);
-          const payload = msg.payload as { result?: string; error?: string };
+          // The SkillDispatcher publishes the skill output under `content`
+          // (see _publishResponse) — the same field a2a-server / openai-compat /
+          // linear read. Reading `result` here silently dropped every ceremony
+          // skill result: with timeoutMs set the null read mislabels as
+          // "timeout"; without it, the outcome records "success" but empty.
+          const payload = msg.payload as { content?: string; error?: string };
           if (payload?.error) {
             error = payload.error;
             status = "failure";
           } else {
-            result = payload?.result;
+            result = payload?.content;
           }
-          resolve(payload?.result ?? null);
+          resolve(payload?.content ?? null);
         });
 
         // Set up per-ceremony timeout only if configured

--- a/src/plugins/__tests__/CeremonyPlugin.test.ts
+++ b/src/plugins/__tests__/CeremonyPlugin.test.ts
@@ -301,61 +301,50 @@ describe("ceremony execute EventBus", () => {
     expect(payload.context.runId).toBeTruthy();
   });
 
-  test("ceremony completed EventBus: publishes ceremony.{id}.completed after execution", async () => {
-    const completedMessages: BusMessage[] = [];
+  test("ceremony reply: skill result on payload.content lands in the outcome (regression — CeremonyPlugin read .result, dispatcher publishes .content)", async () => {
+    const completed: BusMessage[] = [];
+    bus.subscribe("ceremony.#", "test-completed", (msg: BusMessage) => {
+      if (msg.topic.endsWith(".completed")) completed.push(msg);
+    });
 
-    bus.subscribe("ceremony.#", "test", (msg: BusMessage) => {
-      if (msg.topic.endsWith(".completed")) {
-        completedMessages.push(msg);
-      }
+    // Reply the way SkillDispatcher._publishResponse actually does: the skill
+    // output is on payload.content (the field a2a-server / openai-compat /
+    // linear all read). If CeremonyPlugin reads payload.result it sees nothing.
+    bus.subscribe("agent.skill.request", "test-agent", (msg: BusMessage) => {
+      const replyTopic = msg.reply?.topic;
+      if (!replyTopic) return;
+      bus.publish(replyTopic, {
+        id: crypto.randomUUID(),
+        correlationId: msg.correlationId,
+        topic: replyTopic,
+        timestamp: Date.now(),
+        payload: { content: "DIGEST: 2 blocked, 1 needs attention", correlationId: msg.correlationId },
+      });
     });
 
     const pluginAny = plugin as unknown as {
       _fireCeremony(ceremony: {
-        id: string;
-        name: string;
-        schedule: string;
-        skill: string;
-        targets: string[];
-        enabled: boolean;
+        id: string; name: string; schedule: string; skill: string;
+        targets: string[]; enabled: boolean; timeoutMs?: number;
       }): void;
     };
 
-    // Fire the ceremony
     pluginAny._fireCeremony({
-      id: "board.test",
-      name: "Test Ceremony",
+      id: "board.reply",
+      name: "Reply Contract Test",
       schedule: "*/30 * * * *",
-      skill: "board_health",
-      targets: ["all"],
+      skill: "portfolio_check_in",
+      targets: ["ava"],
       enabled: true,
+      timeoutMs: 5_000, // defined so the old bug would have mislabeled this "timeout"
     });
 
-    // Publish a mock skill response to simulate agent completing
-    await new Promise((r) => setTimeout(r, 20));
+    await new Promise((r) => setTimeout(r, 30));
 
-    // Find the runId from execute message
-    const executeMsg: BusMessage[] = [];
-    bus.subscribe("ceremony.#", "test-exec", (msg: BusMessage) => {
-      if (msg.topic.endsWith(".execute")) executeMsg.push(msg);
-    });
-
-    // Fire again to capture execute
-    pluginAny._fireCeremony({
-      id: "board.test2",
-      name: "Test Ceremony 2",
-      schedule: "*/30 * * * *",
-      skill: "board_health",
-      targets: ["all"],
-      enabled: true,
-    });
-
-    await new Promise((r) => setTimeout(r, 10));
-
-    // completed will be fired after timeout (120s) unless we simulate agent response
-    // For this test, verify completed is eventually published (will timeout)
-    // Just verify the flow starts correctly
-    expect(true).toBe(true);
+    expect(completed.length).toBeGreaterThan(0);
+    const { outcome } = completed[0]!.payload as { outcome: { status: string; result?: string } };
+    expect(outcome.status).toBe("success");
+    expect(outcome.result).toBe("DIGEST: 2 blocked, 1 needs attention");
   });
 });
 


### PR DESCRIPTION
## The bug (surfaced by smoke-testing the portfolio check-in, #666)

`CeremonyPlugin` waits for the skill reply on **`payload.result`**, but `SkillDispatcher._publishResponse` publishes the skill output under **`payload.content`** — the same field `a2a-server`, `openai-compat`, and `linear` all read. `CeremonyPlugin` was the lone outlier, so it **never captured any ceremony skill result**:

- With `timeoutMs` **set** (the new `portfolio-checkin`), the `null` read hit the `skillResult === null` branch and was mislabeled **"timeout"** — the ceremony reported TIMEOUT at ~52s even though Ava had completed with a correct 882-char per-project digest.
- With `timeoutMs` **unset** (`daily-standup` / `board_audit`), the outcome recorded **"success" but with an empty result** — the standup's Discord digest has silently been blank.

## Fix

Read `payload.content` (one-line field-name correction). Also replaces the prior completion test — a stub that asserted `expect(true).toBe(true)` and never simulated a reply (which is how this slipped through) — with a real reply-contract regression test that **fails on the old `payload.result`**.

## Verification

- `bun test` — **845 pass / 0 fail**; new test passes with the fix, fails when reverted to `.result`
- `bun run typecheck` — clean
- Confirmed against the live system: the `portfolio_check_in` skill itself works end-to-end (Ava produced a grounded per-project digest + escalated blockers via `msg_operator`); this fix makes the ceremony actually capture and post that digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ceremony completion handling to properly capture and report skill workflow outcomes and error information. Ceremony results are now accurately recorded with proper status propagation, improving the reliability and transparency of workflow execution and ensuring comprehensive tracking of completion states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->