### PR TITLE
feat(ceremony): route check-in + standup to the updates webhook

### DIFF
--- a/workspace/ceremonies/daily-standup.yaml
+++ b/workspace/ceremonies/daily-standup.yaml
@@ -9,5 +9,8 @@ schedule: "0 9 * * 1-5"
 skill: board_audit
 targets:
   - quinn
-notifyChannel: "1469195643590541353"
+# Routes to the Discord webhook in env DISCORD_WEBHOOK_UPDATES (the slug maps
+# to DISCORD_WEBHOOK_<SLUG>). The prior numeric channel id resolved to no
+# webhook env var, so the standup digest fell through to console.
+notifyChannel: "updates"
 enabled: true

--- a/workspace/ceremonies/portfolio-checkin.yaml
+++ b/workspace/ceremonies/portfolio-checkin.yaml
@@ -11,6 +11,8 @@ schedule: "0 10 * * 1-5"
 skill: portfolio_check_in
 targets:
   - ava
-notifyChannel: "1469195643590541353"
+# Routes to the Discord webhook in env DISCORD_WEBHOOK_UPDATES (a "fleet
+# updates" channel). The CeremonyNotifier maps the slug → DISCORD_WEBHOOK_<SLUG>.
+notifyChannel: "updates"
 timeoutMs: 300000
 enabled: true


### PR DESCRIPTION
Routes the portfolio check-in and daily standup digests to a dedicated Discord webhook (env `DISCORD_WEBHOOK_UPDATES`) via the `updates` notifyChannel slug.

- Both previously used a numeric channel id that matched no `DISCORD_WEBHOOK_<slug>` var → digests fell through to console.
- **Scoped, not global:** the global `DISCORD_CEREMONY_WEBHOOK_URL` stays unset so high-frequency ceremonies (`fleet_alerts` runs every minute) don't spam the channel.
- Pairs with: `DISCORD_WEBHOOK_UPDATES` added to Infisical (ai/prod) + referenced in the homelab-iac ai-stack compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)