### PR TITLE
fix(ceremony): give security-triage non-empty targets (stop loader spam)

### DIFF
--- a/workspace/ceremonies/security-triage.yaml
+++ b/workspace/ceremonies/security-triage.yaml
@@ -1,7 +1,12 @@
 id: security-triage
 name: "Security Incident Triage"
+description: "On-demand: triggered by the ceremony.security_triage action when an open security incident is detected. Disabled as a scheduled cron — fired via the action, not the hourly schedule."
 schedule: "0 * * * *"
 skill: bug_triage
-targets: []
+# bug_triage is Quinn's deep-agent skill (same target shape as daily-standup's
+# board_audit → quinn). A non-empty targets array is required by the loader;
+# an empty one was rejected on every scan, spamming the log.
+targets:
+  - quinn
 notifyChannel: ""
 enabled: false


### PR DESCRIPTION
`security-triage.yaml` had `targets: []`, which `ceremonyYamlLoader` rejects with *'targets must be a non-empty array'* on every scan — spamming the log on each startup + hot-reload poll.

Fix: `targets: [quinn]` (`bug_triage` is Quinn's deep-agent skill — same shape as daily-standup's `board_audit → quinn`). Kept `enabled: false`; it's fired on-demand via the `ceremony.security_triage` action, not the hourly schedule. Added a description noting that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification that security triage ceremony is triggered on-demand by security incident detection, not scheduled

* **Configuration**
  * Updated ceremony targets configuration for proper task routing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->