### PR TITLE
fix(a2a): chat/delegate dispatch over the bus and await the real terminal result

### DIFF
--- a/src/api/__tests__/ava-tools.test.ts
+++ b/src/api/__tests__/ava-tools.test.ts
@@ -1,0 +1,156 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { createRoutes } from "../ava-tools.ts";
+import type { ApiContext } from "../types.ts";
+import type { AgentSkillRequestPayload } from "../../event-bus/payloads.ts";
+
+type Handler = (req: Request, params: Record<string, string>) => Promise<Response> | Response;
+
+function routesFor(ctx: Partial<ApiContext> & { bus: InMemoryEventBus }) {
+  const routes = createRoutes(ctx as unknown as ApiContext);
+  const chat = routes.find((r) => r.path === "/api/a2a/chat")!.handler as Handler;
+  const poll = routes.find((r) => r.path === "/api/a2a/task/:correlationId")!.handler as Handler;
+  const delegate = routes.find((r) => r.path === "/api/a2a/delegate")!.handler as Handler;
+  return { chat, poll, delegate };
+}
+
+/** Registry that resolves an executor for `agent` (or nothing if unknown). */
+function fakeRegistry(knownAgents: string[]) {
+  return {
+    resolve: (_skill: string, targets: string[]) =>
+      targets.some((t) => knownAgents.includes(t)) ? ({ type: "a2a" } as unknown) : undefined,
+  } as unknown as ApiContext["executorRegistry"];
+}
+
+/** A stand-in dispatcher: on each agent.skill.request, publish a terminal reply. */
+function autoReply(
+  bus: InMemoryEventBus,
+  build: (req: AgentSkillRequestPayload, correlationId: string) => Record<string, unknown>,
+) {
+  bus.subscribe("agent.skill.request", "test-dispatcher", (msg) => {
+    const payload = (msg.payload ?? {}) as AgentSkillRequestPayload;
+    const correlationId = msg.correlationId;
+    const replyPayload = build(payload, correlationId);
+    bus.publish(`agent.skill.response.${correlationId}`, {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic: `agent.skill.response.${correlationId}`,
+      timestamp: Date.now(),
+      payload: { correlationId, ...replyPayload },
+    });
+  });
+}
+
+describe("/api/a2a/chat (bus round-trip)", () => {
+  let bus: InMemoryEventBus;
+
+  beforeEach(() => {
+    bus = new InMemoryEventBus();
+    delete process.env.A2A_CHAT_REPLY_TIMEOUT_MS;
+  });
+  afterEach(() => {
+    delete process.env.A2A_CHAT_REPLY_TIMEOUT_MS;
+  });
+
+  test("returns the agent's real terminal output, not a submit-ack stub", async () => {
+    let seen: AgentSkillRequestPayload | undefined;
+    autoReply(bus, (req) => {
+      seen = req;
+      return { content: "the genuine answer", taskState: "completed", taskId: "task-123" };
+    });
+    const { chat } = routesFor({ bus, executorRegistry: fakeRegistry(["protopen"]) });
+
+    const resp = await chat(
+      new Request("http://x/api/a2a/chat", {
+        method: "POST",
+        body: JSON.stringify({ agent: "protopen", skill: "threat_intel", message: "ping", contextId: "conv-1" }),
+      }),
+      {},
+    );
+    const json = (await resp.json()) as { success: boolean; data: Record<string, unknown> };
+
+    expect(resp.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.response).toBe("the genuine answer");
+    expect(json.data.taskState).toBe("completed");
+    expect(json.data.taskId).toBe("task-123");
+    // contextId continuity: the dispatched request carried our contextId, and
+    // the response echoes it.
+    expect(seen?.contextId).toBe("conv-1");
+    expect(json.data.contextId).toBe("conv-1");
+  });
+
+  test("maps an error reply to a non-200 with the error text", async () => {
+    autoReply(bus, () => ({ error: "boom on the agent side", taskState: "failed" }));
+    const { chat } = routesFor({ bus, executorRegistry: fakeRegistry(["protopen"]) });
+
+    const resp = await chat(
+      new Request("http://x/api/a2a/chat", {
+        method: "POST",
+        body: JSON.stringify({ agent: "protopen", message: "ping" }),
+      }),
+      {},
+    );
+    const json = (await resp.json()) as { success: boolean; error: string };
+    expect(resp.status).toBe(502);
+    expect(json.success).toBe(false);
+    expect(json.error).toBe("boom on the agent side");
+  });
+
+  test("returns pending + pollUrl when the terminal result doesn't arrive in time", async () => {
+    process.env.A2A_CHAT_REPLY_TIMEOUT_MS = "40"; // no autoReply → guaranteed timeout
+    const { chat } = routesFor({ bus, executorRegistry: fakeRegistry(["protopen"]) });
+
+    const resp = await chat(
+      new Request("http://x/api/a2a/chat", {
+        method: "POST",
+        body: JSON.stringify({ agent: "protopen", skill: "active_pentest", message: "long task" }),
+      }),
+      {},
+    );
+    const json = (await resp.json()) as { success: boolean; data: Record<string, unknown> };
+    expect(resp.status).toBe(200);
+    expect(json.data.pending).toBe(true);
+    expect(json.data.response).toBeNull();
+    expect(json.data.taskState).toBe("working");
+    expect(json.data.pollUrl).toBe(`/api/a2a/task/${json.data.correlationId}`);
+  });
+
+  test("404 when no executor is registered for the agent", async () => {
+    const { chat } = routesFor({ bus, executorRegistry: fakeRegistry([]) });
+    const resp = await chat(
+      new Request("http://x/api/a2a/chat", {
+        method: "POST",
+        body: JSON.stringify({ agent: "ghost", message: "ping" }),
+      }),
+      {},
+    );
+    expect(resp.status).toBe(404);
+  });
+});
+
+describe("/api/a2a/task/:correlationId (poll)", () => {
+  test("returns the cached terminal result when present", async () => {
+    const bus = new InMemoryEventBus();
+    const taskTracker = {
+      getResult: (id: string) =>
+        id === "c-done" ? { content: "finished output", taskState: "completed", correlationId: id, taskId: "t9" } : undefined,
+      getAll: () => [{ correlationId: "c-working", taskId: "t1", agentName: "protopen" }],
+    } as unknown as ApiContext["taskTracker"];
+    const { poll } = routesFor({ bus, executorRegistry: fakeRegistry(["protopen"]), taskTracker });
+
+    const done = await poll(new Request("http://x/api/a2a/task/c-done"), { correlationId: "c-done" });
+    const dj = (await done.json()) as { data: Record<string, unknown> };
+    expect(dj.data.done).toBe(true);
+    expect(dj.data.response).toBe("finished output");
+
+    const working = await poll(new Request("http://x/api/a2a/task/c-working"), { correlationId: "c-working" });
+    const wj = (await working.json()) as { data: Record<string, unknown> };
+    expect(wj.data.pending).toBe(true);
+    expect(wj.data.taskState).toBe("working");
+
+    const unknown = await poll(new Request("http://x/api/a2a/task/c-nope"), { correlationId: "c-nope" });
+    const uj = (await unknown.json()) as { data: Record<string, unknown> };
+    expect(uj.data.taskState).toBe("unknown");
+  });
+});

--- a/src/api/ava-tools.ts
+++ b/src/api/ava-tools.ts
@@ -2,23 +2,71 @@
  * Ava operational tools — chat with agent (multi-turn A2A) + delegate task.
  *
  * These endpoints back Ava's chat_with_agent and delegate_task bus tools.
- * chat_with_agent calls A2AExecutor directly (synchronous, bypasses the bus)
- * for multi-turn conversation with contextId continuity.
+ * BOTH go through the bus (agent.skill.request → SkillDispatcher → executor),
+ * the same path every other trigger uses. chat awaits the real terminal result
+ * on the reply topic (agent.skill.response.{correlationId}) with a timeout;
+ * TaskTracker drives long-running A2A tasks to a terminal state and publishes
+ * the actual artifact there. No executor is called directly — so the chokepoint
+ * invariants (cooldown, target guard, …) and task lifecycle apply uniformly,
+ * and chat returns the agent's genuine output rather than a submit-ack.
  */
 
 import type { Route, ApiContext } from "./types.ts";
-import type { SkillRequest } from "../executor/types.ts";
+import type { EventBus } from "../../lib/types.ts";
+import type { AgentSkillResponsePayload } from "../event-bus/payloads.ts";
 
 const AGENT_OPS_CHANNEL = process.env.DISCORD_AGENT_OPS_CHANNEL ?? "";
 
+/** How long a synchronous chat blocks for the terminal result before returning
+ *  `pending`. Passive skills finish well within this; long-running ones (e.g.
+ *  active pentests) return pending + a pollUrl. Override with
+ *  A2A_CHAT_REPLY_TIMEOUT_MS. */
+const REPLY_TIMEOUT_MS = 30_000;
+
+function replyTimeoutMs(): number {
+  return Number(process.env.A2A_CHAT_REPLY_TIMEOUT_MS) || REPLY_TIMEOUT_MS;
+}
+
+/**
+ * Subscribe to a skill request's reply topic and resolve with the response
+ * payload when it arrives, or `null` on timeout. Subscribes immediately so the
+ * caller can publish the request right after and not miss a fast completion.
+ */
+function awaitSkillResponse(
+  bus: EventBus,
+  correlationId: string,
+  timeoutMs: number,
+): Promise<AgentSkillResponsePayload | null> {
+  return new Promise((resolve) => {
+    let settled = false;
+    let subId = "";
+    const timer = setTimeout(() => finish(null), timeoutMs);
+    function finish(val: AgentSkillResponsePayload | null): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (subId) bus.unsubscribe(subId);
+      resolve(val);
+    }
+    subId = bus.subscribe(
+      `agent.skill.response.${correlationId}`,
+      "a2a-chat-await",
+      (msg) => finish((msg.payload ?? null) as AgentSkillResponsePayload | null),
+    );
+  });
+}
+
 export function createRoutes(ctx: ApiContext): Route[] {
   /**
-   * POST /api/a2a/chat — synchronous multi-turn conversation with an agent.
+   * POST /api/a2a/chat — multi-turn conversation with an agent over the bus.
    *
-   * Body: { agent, message, contextId?, skill?, done? }
-   * Returns: { success, data: { response, contextId?, correlationId } }
+   * Body: { agent, message, contextId?, skill?, done?, dispatcherAgent? }
+   * Returns on completion: { success, data: { response, contextId?, taskId?,
+   *   taskState, correlationId, agent, usage?, costUsd?, confidence?, durationMs? } }
+   * Returns on timeout: { success, data: { pending: true, response: null,
+   *   taskState: "working", correlationId, contextId?, agent, pollUrl } }
    *
-   * When done=true, the response omits contextId to signal conversation end.
+   * When done=true, the response omits contextId/taskId to signal conversation end.
    */
   async function handleChat(req: Request): Promise<Response> {
     if (ctx.apiKey && req.headers.get("X-API-Key") !== ctx.apiKey) {
@@ -46,9 +94,8 @@ export function createRoutes(ctx: ApiContext): Route[] {
       );
     }
 
-    // Resolve the agent's executor by name
-    const executor = ctx.executorRegistry.resolve(skill, [agent]);
-    if (!executor) {
+    // Fast guard: no executor for this agent → 404 without dispatching.
+    if (!ctx.executorRegistry.resolve(skill, [agent])) {
       return Response.json(
         { success: false, error: `No executor found for agent "${agent}"` },
         { status: 404 },
@@ -58,132 +105,180 @@ export function createRoutes(ctx: ApiContext): Route[] {
     const correlationId = crypto.randomUUID();
     const conversationId = contextId ?? crypto.randomUUID();
 
-    const skillReq: SkillRequest = {
-      skill,
-      content: message,
+    // Ava's outbound message for o11y (agent-ops channel + Discord mirror).
+    ctx.bus.publish("agent.chat.outbound", {
+      id: crypto.randomUUID(),
       correlationId,
-      contextId: conversationId,
-      replyTopic: `agent.skill.response.${correlationId}`,
+      topic: "agent.chat.outbound",
+      timestamp: Date.now(),
+      payload: { from: "ava", to: agent, contextId: conversationId, message, skill },
+    });
+    if (AGENT_OPS_CHANNEL) {
+      ctx.bus.publish(`message.outbound.discord.push.${AGENT_OPS_CHANNEL}`, {
+        id: crypto.randomUUID(),
+        correlationId,
+        topic: `message.outbound.discord.push.${AGENT_OPS_CHANNEL}`,
+        timestamp: Date.now(),
+        payload: {
+          content: `**ava → ${agent}** (${skill})\n${message.length > 300 ? message.slice(0, 300) + "…" : message}`,
+        },
+      });
+    }
+
+    // Listen for the terminal result BEFORE dispatching so a fast inline
+    // completion can't fire before we're subscribed.
+    const replyPromise = awaitSkillResponse(ctx.bus, correlationId, replyTimeoutMs());
+
+    ctx.bus.publish("agent.skill.request", {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic: "agent.skill.request",
+      timestamp: Date.now(),
       payload: {
         skill,
         content: message,
         targets: [agent],
+        contextId: conversationId,
         ...(dispatcherAgent ? { meta: { dispatcherAgent } } : {}),
       },
-    };
+    });
 
-    try {
-      // Publish Ava's outbound message for o11y (agent-ops channel)
-      ctx.bus.publish("agent.chat.outbound", {
-        id: crypto.randomUUID(),
-        correlationId,
-        topic: "agent.chat.outbound",
-        timestamp: Date.now(),
-        payload: {
-          from: "ava",
-          to: agent,
-          contextId: conversationId,
-          message,
-          skill,
-        },
-      });
+    const reply = await replyPromise;
 
-      // Post to Discord agent-ops channel so agent conversations are visible
-      if (AGENT_OPS_CHANNEL) {
-        ctx.bus.publish(`message.outbound.discord.push.${AGENT_OPS_CHANNEL}`, {
-          id: crypto.randomUUID(),
-          correlationId,
-          topic: `message.outbound.discord.push.${AGENT_OPS_CHANNEL}`,
-          timestamp: Date.now(),
-          payload: {
-            content: `**ava → ${agent}** (${skill})\n${message.length > 300 ? message.slice(0, 300) + "…" : message}`,
-          },
-        });
-      }
-
-      const result = await executor.execute(skillReq);
-
-      // Publish agent's response for o11y
-      ctx.bus.publish("agent.chat.inbound", {
-        id: crypto.randomUUID(),
-        correlationId,
-        topic: "agent.chat.inbound",
-        timestamp: Date.now(),
-        payload: {
-          from: agent,
-          to: "ava",
-          contextId: conversationId,
-          message: result.text,
-          skill,
-          done,
-        },
-      });
-
-      // Post agent response to Discord
-      if (AGENT_OPS_CHANNEL) {
-        const responsePreview = result.text.length > 500
-          ? result.text.slice(0, 500) + "…"
-          : result.text;
-        ctx.bus.publish(`message.outbound.discord.push.${AGENT_OPS_CHANNEL}`, {
-          id: crypto.randomUUID(),
-          correlationId,
-          topic: `message.outbound.discord.push.${AGENT_OPS_CHANNEL}`,
-          timestamp: Date.now(),
-          payload: {
-            content: `**${agent} → ava** (${result.data?.taskState ?? "completed"})\n${responsePreview}`,
-          },
-        });
-      }
-
-      const remoteTaskId = result.data?.taskId;
-      const remoteContextId = result.data?.contextId ?? conversationId;
-      const taskState = result.data?.taskState ?? "completed";
-      // Surface observability fields (cost-v1, confidence-v1, duration) so the
-      // caller agent sees what its delegation cost and how confident the
-      // sub-agent was. Fields are only present when the sub-agent opted in to
-      // the respective extension and emitted the DataPart — undefined otherwise.
-      const usage = result.data?.usage;
-      const durationMs = typeof result.data?.durationMs === "number" ? result.data.durationMs : undefined;
-      const costUsd = typeof result.data?.costUsd === "number" ? result.data.costUsd : undefined;
-      const confidence = typeof result.data?.confidence === "number" ? result.data.confidence : undefined;
-      const confidenceExplanation = typeof result.data?.confidenceExplanation === "string"
-        ? result.data.confidenceExplanation : undefined;
-
+    // Timed out — task is still running. TaskTracker will deliver the result to
+    // the reply topic + an autonomous.outcome event when it finishes; the caller
+    // can poll GET /api/a2a/task/{correlationId} to retrieve it.
+    if (!reply) {
       return Response.json({
         success: true,
         data: {
-          response: result.text,
-          // Omit contextId/taskId when done — signals conversation end
-          ...(done ? {} : {
-            contextId: remoteContextId,
-            ...(remoteTaskId ? { taskId: remoteTaskId } : {}),
-          }),
-          taskState,
+          pending: true,
+          response: null,
+          taskState: "working",
           correlationId,
+          ...(done ? {} : { contextId: conversationId }),
           agent,
-          ...(usage ? { usage } : {}),
-          ...(durationMs !== undefined ? { durationMs } : {}),
-          ...(costUsd !== undefined ? { costUsd } : {}),
-          ...(confidence !== undefined ? { confidence } : {}),
-          ...(confidenceExplanation ? { confidenceExplanation } : {}),
+          pollUrl: `/api/a2a/task/${correlationId}`,
         },
       });
-    } catch (e) {
+    }
+
+    // Mirror the agent's response (or error) for o11y.
+    const responseText = reply.content ?? "";
+    ctx.bus.publish("agent.chat.inbound", {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic: "agent.chat.inbound",
+      timestamp: Date.now(),
+      payload: {
+        from: agent, to: "ava", contextId: conversationId,
+        message: reply.error ? `(error) ${reply.error}` : responseText, skill, done,
+      },
+    });
+    if (AGENT_OPS_CHANNEL) {
+      const shown = reply.error ?? responseText;
+      const preview = shown.length > 500 ? shown.slice(0, 500) + "…" : shown;
+      ctx.bus.publish(`message.outbound.discord.push.${AGENT_OPS_CHANNEL}`, {
+        id: crypto.randomUUID(),
+        correlationId,
+        topic: `message.outbound.discord.push.${AGENT_OPS_CHANNEL}`,
+        timestamp: Date.now(),
+        payload: { content: `**${agent} → ava** (${reply.taskState ?? (reply.error ? "failed" : "completed")})\n${preview}` },
+      });
+    }
+
+    if (reply.error) {
+      const status = reply.error.startsWith("No executor registered") ? 404 : 502;
       return Response.json(
-        {
-          success: false,
-          error: e instanceof Error ? e.message : String(e),
-        },
-        { status: 502 },
+        { success: false, error: reply.error, data: { correlationId, agent, taskState: reply.taskState ?? "failed" } },
+        { status },
       );
     }
+
+    return Response.json({
+      success: true,
+      data: {
+        response: responseText,
+        // Omit contextId/taskId when done — signals conversation end.
+        ...(done ? {} : {
+          contextId: reply.contextId ?? conversationId,
+          ...(reply.taskId ? { taskId: reply.taskId } : {}),
+        }),
+        taskState: reply.taskState ?? "completed",
+        correlationId,
+        agent,
+        ...(reply.usage ? { usage: reply.usage } : {}),
+        ...(reply.durationMs !== undefined ? { durationMs: reply.durationMs } : {}),
+        ...(reply.costUsd !== undefined ? { costUsd: reply.costUsd } : {}),
+        ...(reply.confidence !== undefined ? { confidence: reply.confidence } : {}),
+        ...(reply.confidenceExplanation ? { confidenceExplanation: reply.confidenceExplanation } : {}),
+      },
+    });
+  }
+
+  /**
+   * GET /api/a2a/task/:correlationId — fetch the result of a dispatch that a
+   * chat caller stopped awaiting (timed out). Reads TaskTracker's terminal-result
+   * cache, falling back to the live tracked state.
+   *
+   * Returns one of:
+   *   { done: true, response, error?, taskState, … }   — terminal result available
+   *   { pending: true, taskState: "working", taskId }  — still running
+   *   { pending: false, taskState: "unknown" }         — never tracked / aged out
+   */
+  function handleTaskPoll(req: Request, params: Record<string, string>): Response {
+    if (ctx.apiKey && req.headers.get("X-API-Key") !== ctx.apiKey) {
+      return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+    }
+    const correlationId = params.correlationId;
+    if (!correlationId) {
+      return Response.json({ success: false, error: "correlationId required" }, { status: 400 });
+    }
+
+    const result = ctx.taskTracker?.getResult(correlationId);
+    if (result) {
+      return Response.json({
+        success: true,
+        data: {
+          done: true,
+          response: result.content ?? null,
+          ...(result.error ? { error: result.error } : {}),
+          taskState: result.taskState ?? (result.error ? "failed" : "completed"),
+          correlationId,
+          ...(result.taskId ? { taskId: result.taskId } : {}),
+          ...(result.contextId ? { contextId: result.contextId } : {}),
+          ...(result.usage ? { usage: result.usage } : {}),
+          ...(result.durationMs !== undefined ? { durationMs: result.durationMs } : {}),
+          ...(result.costUsd !== undefined ? { costUsd: result.costUsd } : {}),
+          ...(result.confidence !== undefined ? { confidence: result.confidence } : {}),
+        },
+      });
+    }
+
+    const tracked = ctx.taskTracker?.getAll().find((t) => t.correlationId === correlationId);
+    if (tracked) {
+      return Response.json({
+        success: true,
+        data: { pending: true, taskState: "working", correlationId, taskId: tracked.taskId, agent: tracked.agentName },
+      });
+    }
+
+    return Response.json({
+      success: true,
+      data: {
+        pending: false,
+        taskState: "unknown",
+        correlationId,
+        note: "No tracked task and no cached result — it may never have been dispatched, or its result aged out.",
+      },
+    });
   }
 
   /**
    * POST /api/a2a/delegate — fire-and-forget task dispatch to an agent.
    *
-   * Body: { agent, skill, message, projectSlug? }
-   * Returns: { success, data: { correlationId, message } }
+   * Body: { agent, skill, message, projectSlug?, dispatcherAgent? }
+   * Returns: { success, data: { correlationId, message, pollUrl } }
    */
   async function handleDelegate(req: Request): Promise<Response> {
     if (ctx.apiKey && req.headers.get("X-API-Key") !== ctx.apiKey) {
@@ -211,12 +306,11 @@ export function createRoutes(ctx: ApiContext): Route[] {
     }
 
     const correlationId = crypto.randomUUID();
-    const topic = "agent.skill.request";
 
-    ctx.bus.publish(topic, {
+    ctx.bus.publish("agent.skill.request", {
       id: crypto.randomUUID(),
       correlationId,
-      topic,
+      topic: "agent.skill.request",
       timestamp: Date.now(),
       payload: {
         skill,
@@ -232,6 +326,7 @@ export function createRoutes(ctx: ApiContext): Route[] {
       data: {
         correlationId,
         message: `Task delegated to ${agent} (skill: ${skill})`,
+        pollUrl: `/api/a2a/task/${correlationId}`,
       },
     });
   }
@@ -239,5 +334,6 @@ export function createRoutes(ctx: ApiContext): Route[] {
   return [
     { method: "POST", path: "/api/a2a/chat", handler: (req) => handleChat(req) },
     { method: "POST", path: "/api/a2a/delegate", handler: (req) => handleDelegate(req) },
+    { method: "GET", path: "/api/a2a/task/:correlationId", handler: (req, params) => handleTaskPoll(req, params) },
   ];
 }

--- a/src/event-bus/payloads.ts
+++ b/src/event-bus/payloads.ts
@@ -29,6 +29,10 @@ export interface AgentSkillRequestPayload {
   runId?: string;
   /** Project slug for multi-project routing. */
   projectSlug?: string;
+  /** Conversation/context id for multi-turn continuity. The dispatcher
+   *  propagates this onto SkillRequest.contextId so executors keep one
+   *  conversation across turns instead of starting fresh each correlationId. */
+  contextId?: string;
   /** Explicit skill hint set by surface plugins before inbound routing. */
   skillHint?: string;
   /** Whether this message originated from a direct message conversation. */
@@ -55,7 +59,10 @@ export interface AgentSkillRequestPayload {
 
 // ── agent.skill.response.* ───────────────────────────────────────────────────
 
-/** Payload for `agent.skill.response.*` — published by SkillDispatcherPlugin. */
+/** Payload for `agent.skill.response.*` — published by SkillDispatcherPlugin
+ * (inline-complete executors) and TaskTracker (long-running A2A tasks). Both
+ * sites populate the same shape so a reply-topic subscriber sees the full
+ * executor result regardless of which path produced it. */
 export interface AgentSkillResponsePayload {
   /** Successful result text (undefined on error). */
   content?: string;
@@ -63,6 +70,23 @@ export interface AgentSkillResponsePayload {
   error?: string;
   /** Propagated trace ID. */
   correlationId: string;
+  /** Terminal A2A task state ("completed" | "failed" | "canceled" | "rejected"),
+   *  or "completed"/"failed" inferred for non-task executors. */
+  taskState?: string;
+  /** Remote A2A task id, when the executor created one. */
+  taskId?: string;
+  /** Conversation/context id for multi-turn continuity. */
+  contextId?: string;
+  /** Token usage, when the sub-agent emitted it. */
+  usage?: { input_tokens?: number; output_tokens?: number; [k: string]: unknown };
+  /** Delegation cost in USD (cost-v1 extension), when emitted. */
+  costUsd?: number;
+  /** Sub-agent self-reported confidence 0..1 (confidence-v1 extension), when emitted. */
+  confidence?: number;
+  /** Free-text rationale for the confidence score, when emitted. */
+  confidenceExplanation?: string;
+  /** Wall-clock execution time in ms, when known. */
+  durationMs?: number;
 }
 
 // ── agent.skill.progress.* ───────────────────────────────────────────────────

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -18,6 +18,7 @@ import type { ExecutorRegistry } from "./executor-registry.ts";
 import type { SkillRequest } from "./types.ts";
 import type {
   AgentSkillRequestPayload,
+  AgentSkillResponsePayload,
   AutonomousOutcomePayload,
   FlowItemPayload,
   AgentActivityPayload,
@@ -318,6 +319,10 @@ export class SkillDispatcherPlugin implements Plugin {
       prompt: typeof payload.prompt === "string" ? payload.prompt : undefined,
       correlationId,
       parentId,
+      // Conversation continuity: when the caller supplies a contextId (chat
+      // turns), thread it through so the executor keeps one conversation
+      // instead of starting fresh on every correlationId.
+      contextId: typeof payload.contextId === "string" ? payload.contextId : undefined,
       replyTopic,
       payload,
     };
@@ -582,6 +587,19 @@ export class SkillDispatcherPlugin implements Plugin {
         correlationId,
         result.isError ? undefined : result.text,
         result.isError ? result.text || "Executor error" : undefined,
+        {
+          taskState: (typeof result.data?.taskState === "string"
+            ? result.data.taskState
+            : (result.isError ? "failed" : "completed")),
+          ...(typeof result.data?.taskId === "string" ? { taskId: result.data.taskId } : {}),
+          ...(typeof result.data?.contextId === "string" ? { contextId: result.data.contextId } : {}),
+          ...(result.data?.usage ? { usage: result.data.usage as AgentSkillResponsePayload["usage"] } : {}),
+          ...(typeof result.data?.costUsd === "number" ? { costUsd: result.data.costUsd } : {}),
+          ...(typeof result.data?.confidence === "number" ? { confidence: result.data.confidence } : {}),
+          ...(typeof result.data?.confidenceExplanation === "string"
+            ? { confidenceExplanation: result.data.confidenceExplanation } : {}),
+          durationMs: Date.now() - dispatchedAt,
+        },
       );
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
@@ -808,6 +826,7 @@ export class SkillDispatcherPlugin implements Plugin {
     correlationId: string,
     result: string | undefined,
     error: string | undefined,
+    extra?: Omit<Partial<AgentSkillResponsePayload>, "content" | "error" | "correlationId">,
   ): void {
     if (!this.bus) return;
     this.bus.publish(replyTopic, {
@@ -815,7 +834,7 @@ export class SkillDispatcherPlugin implements Plugin {
       correlationId,
       topic: replyTopic,
       timestamp: Date.now(),
-      payload: { content: result, error, correlationId },
+      payload: { content: result, error, correlationId, ...extra },
     });
   }
 

--- a/src/executor/task-tracker.ts
+++ b/src/executor/task-tracker.ts
@@ -58,6 +58,8 @@ export interface TaskTrackerOptions {
   defaultPollIntervalMs?: number;
   /** Max time to track a task before giving up (ms). Default: 1hr. */
   maxTrackingMs?: number;
+  /** How long a terminal result stays retrievable via getResult (ms). Default: 5min. */
+  resultTtlMs?: number;
 }
 
 export class TaskTracker {
@@ -66,15 +68,21 @@ export class TaskTracker {
   private readonly sweepIntervalMs: number;
   private readonly defaultPollIntervalMs: number;
   private readonly maxTrackingMs: number;
+  private readonly resultTtlMs: number;
   private readonly sweepTimer: ReturnType<typeof setInterval>;
   /** Tracks task IDs for which world.state.delta events have already been published. */
   private readonly publishedDeltaTaskIds = new Set<string>();
+  /** Terminal results retained briefly so a caller that stopped awaiting the
+   *  reply topic (e.g. a chat request that hit its timeout) can still fetch the
+   *  final outcome by correlationId. TTL-evicted in the sweep. */
+  private readonly recentResults = new Map<string, { payload: AgentSkillResponsePayload; at: number }>();
 
   constructor(opts: TaskTrackerOptions) {
     this.bus = opts.bus;
     this.sweepIntervalMs = opts.sweepIntervalMs ?? 10_000;
     this.defaultPollIntervalMs = opts.defaultPollIntervalMs ?? 30_000;
     this.maxTrackingMs = opts.maxTrackingMs ?? 60 * 60_000;
+    this.resultTtlMs = opts.resultTtlMs ?? 5 * 60_000;
     this.sweepTimer = setInterval(() => { void this._sweep(); }, this.sweepIntervalMs);
     this.sweepTimer.unref?.();
   }
@@ -200,6 +208,7 @@ export class TaskTracker {
   destroy(): void {
     clearInterval(this.sweepTimer);
     this.tasks.clear();
+    this.recentResults.clear();
   }
 
   /**
@@ -209,6 +218,11 @@ export class TaskTracker {
    */
   private async _sweep(): Promise<void> {
     const now = Date.now();
+
+    // Evict aged-out terminal results.
+    for (const [correlationId, entry] of this.recentResults) {
+      if (now - entry.at > this.resultTtlMs) this.recentResults.delete(correlationId);
+    }
 
     for (const task of this.tasks.values()) {
       // Age-out: task has been working for too long
@@ -240,7 +254,7 @@ export class TaskTracker {
         if (state && TERMINAL_STATES.has(state)) {
           const rawArtifacts = (result.data?.artifacts ?? []) as Array<{ extensions?: string[]; parts?: Array<{ kind?: string; text?: string; data?: Record<string, unknown> }> }>;
           this._extractAndPublishDeltas(task.taskId, task.agentName, rawArtifacts);
-          this._publishResponse(task, result.text, result.isError ? result.text : undefined, state);
+          this._publishResponse(task, result.text, result.isError ? result.text : undefined, state, result.data);
           this.tasks.delete(task.correlationId);
           console.log(
             `[task-tracker] Task ${task.taskId.slice(0, 8)}… reached terminal state "${state}" after ${Math.round((now - task.registeredAt) / 1000)}s`,
@@ -305,6 +319,7 @@ export class TaskTracker {
     content: string | undefined,
     error: string | undefined,
     taskState?: string,
+    data?: Record<string, unknown>,
   ): void {
     const isError = error !== undefined;
     const resolvedState = taskState ?? (isError ? "failed" : "completed");
@@ -314,7 +329,16 @@ export class TaskTracker {
       content,
       error,
       correlationId: task.correlationId,
+      taskState: resolvedState,
+      taskId: task.taskId,
+      ...(typeof data?.contextId === "string" ? { contextId: data.contextId } : {}),
+      ...(data?.usage ? { usage: data.usage as AgentSkillResponsePayload["usage"] } : {}),
+      ...(typeof data?.costUsd === "number" ? { costUsd: data.costUsd } : {}),
+      ...(typeof data?.confidence === "number" ? { confidence: data.confidence } : {}),
+      ...(typeof data?.confidenceExplanation === "string"
+        ? { confidenceExplanation: data.confidenceExplanation } : {}),
     };
+    this.recentResults.set(task.correlationId, { payload, at: Date.now() });
     this.bus.publish(task.replyTopic, {
       id: crypto.randomUUID(),
       correlationId: task.correlationId,
@@ -322,5 +346,21 @@ export class TaskTracker {
       timestamp: Date.now(),
       payload,
     });
+  }
+
+  /**
+   * Fetch a recently-terminal task's result by correlationId. Returns undefined
+   * if the task is still running, never existed, or its result has aged past
+   * resultTtlMs. Backs GET /api/a2a/task/:correlationId so a chat caller that
+   * timed out can still retrieve the final outcome.
+   */
+  getResult(correlationId: string): AgentSkillResponsePayload | undefined {
+    const entry = this.recentResults.get(correlationId);
+    if (!entry) return undefined;
+    if (Date.now() - entry.at > this.resultTtlMs) {
+      this.recentResults.delete(correlationId);
+      return undefined;
+    }
+    return entry.payload;
   }
 }


### PR DESCRIPTION
## The gotcha

`POST /api/a2a/chat` **bypassed the bus** (its own comment said so) and called the executor directly, returning the executor's *first* response. For A2A agents that's a non-terminal **submit-ack** — the literal `Skill "X" completed by <agent>` placeholder — not the agent's actual output. And because it bypassed the dispatcher, it **never registered the task with `TaskTracker`**, so the task was never driven to completion: workstacean just forgot about it.

Discovered while testing protopen — `threat_intel` came back as `Skill "threat_intel" completed by protopen` (`taskState: submitted`), which looks like an answer but isn't.

## The fix — one dispatch path

chat and delegate now publish `agent.skill.request` → `SkillDispatcher` → executor, the same path every trigger uses. So the chokepoint invariants (cooldown, target guard, …) and the **A2A task lifecycle** (TaskTracker polling / push-callback → terminal state) apply uniformly. chat then **awaits the genuine terminal result** on `agent.skill.response.{correlationId}`:

- result within **30s** (override `A2A_CHAT_REPLY_TIMEOUT_MS`) → returns the real `response` + `taskState`/`taskId`/usage/cost/confidence
- past 30s → `{ pending: true, pollUrl: /api/a2a/task/{correlationId} }`; the caller fetches the outcome from the new poll endpoint, backed by a **race-free 5-min terminal-result cache** in TaskTracker

## Parity + correctness

- Enriched `AgentSkillResponsePayload` to carry the full executor result (`taskState`, `taskId`, `contextId`, `usage`, `costUsd`, `confidence`, `durationMs`), populated **identically** by the dispatcher's inline-complete path and TaskTracker's terminal path — so a reply-topic subscriber sees the same shape regardless of which path produced it.
- Fixed **multi-turn continuity over the bus**: the dispatcher now propagates `payload.contextId` → `SkillRequest.contextId` (it previously fell back to `correlationId`, starting a fresh conversation every turn).

## Tests

New `src/api/__tests__/ava-tools.test.ts`: real-output round-trip, contextId continuity, error→non-200 mapping, pending/timeout + pollUrl, 404, and the poll endpoint (done / working / unknown). Full suite **850 pass**, `tsc` clean, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added task polling endpoint to retrieve asynchronous operation results.
  * Implemented timeout-based responses returning `pending` status with polling URLs for long-running operations.
  * Enriched responses with execution metadata including token usage, costs, confidence scores, and processing duration.
  * Added support for multi-turn conversations with context preservation across requests.

* **Tests**
  * Added comprehensive test suite for agent skill request/response handling and task polling workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/673?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->