### PR TITLE
feat(ava): live fleet access — list_agents tool + auto-polled chat, no hardcoded roster

### DIFF
--- a/src/executor/__tests__/deep-agent-fleet-tools.test.ts
+++ b/src/executor/__tests__/deep-agent-fleet-tools.test.ts
@@ -1,0 +1,99 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { createLangChainTools } from "../executors/deep-agent-executor.ts";
+import type { HttpClient } from "../../services/http-client.ts";
+import type { StructuredToolInterface } from "@langchain/core/tools";
+
+function fakeHttp(handlers: {
+  get?: (url: string) => unknown;
+  post?: (url: string, body: unknown) => unknown;
+}): HttpClient {
+  return {
+    get: async (url: string) => handlers.get?.(url),
+    post: async (url: string, body: unknown) => handlers.post?.(url, body),
+  } as unknown as HttpClient;
+}
+
+function byName(tools: StructuredToolInterface[], name: string): StructuredToolInterface {
+  const t = tools.find((x) => x.name === name);
+  if (!t) throw new Error(`tool ${name} not built`);
+  return t;
+}
+
+describe("deep-agent fleet tools", () => {
+  beforeAll(() => { process.env.DEEP_AGENT_CHAT_POLL_INTERVAL_MS = "5"; });
+  afterAll(() => { delete process.env.DEEP_AGENT_CHAT_POLL_INTERVAL_MS; });
+
+  test("list_agents returns the live fleet, excluding self and the function cluster", async () => {
+    const http = fakeHttp({
+      get: (url) => {
+        expect(url).toBe("/api/agents/runtime");
+        return {
+          success: true,
+          data: {
+            agents: [
+              { name: "ava", type: "deep-agent", skills: ["chat"] },
+              { name: "function", type: "function", skills: ["alert.fire", "ceremony.run"] },
+              { name: "protopen", type: "a2a", skills: ["threat_intel", "passive_recon"] },
+              { name: "quinn", type: "deep-agent", skills: ["pr_review"] },
+            ],
+          },
+        };
+      },
+    });
+    const tools = createLangChainTools(["list_agents"], http, undefined, "ava");
+    const out = JSON.parse(await byName(tools, "list_agents").invoke({}) as string) as {
+      agents: Array<{ name: string }>;
+    };
+    const names = out.agents.map((a) => a.name);
+
+    expect(names).toContain("protopen");
+    expect(names).toContain("quinn");
+    expect(names).not.toContain("ava"); // self excluded
+    expect(names).not.toContain("function"); // plugin infra excluded
+  });
+
+  test("chat_with_agent auto-polls a pending A2A task and returns the real output", async () => {
+    let polls = 0;
+    const http = fakeHttp({
+      post: (url) => {
+        expect(url).toBe("/api/a2a/chat");
+        return {
+          success: true,
+          data: { pending: true, response: null, taskState: "working", correlationId: "c1", pollUrl: "/api/a2a/task/c1" },
+        };
+      },
+      get: (url) => {
+        expect(url).toBe("/api/a2a/task/c1");
+        polls += 1;
+        return polls < 2
+          ? { success: true, data: { pending: true, taskState: "working", correlationId: "c1" } }
+          : {
+              success: true,
+              data: { done: true, response: "ProtoPen is online and ready.", taskState: "completed", correlationId: "c1", taskId: "t9", contextId: "ctx" },
+            };
+      },
+    });
+    const tools = createLangChainTools(["chat_with_agent"], http, undefined, "ava");
+    const out = JSON.parse(
+      await byName(tools, "chat_with_agent").invoke({ agent: "protopen", message: "ping", skill: "threat_intel" }) as string,
+    ) as { success: boolean; data: Record<string, unknown> };
+
+    expect(out.success).toBe(true);
+    expect(out.data.response).toBe("ProtoPen is online and ready.");
+    expect(out.data.taskState).toBe("completed");
+    expect(out.data.taskId).toBe("t9");
+    expect(polls).toBe(2);
+  });
+
+  test("chat_with_agent returns inline results unchanged (no polling)", async () => {
+    const http = fakeHttp({
+      post: () => ({ success: true, data: { response: "fast answer", taskState: "completed", correlationId: "c2" } }),
+      get: () => { throw new Error("should not poll an inline result"); },
+    });
+    const tools = createLangChainTools(["chat_with_agent"], http, undefined, "ava");
+    const out = JSON.parse(
+      await byName(tools, "chat_with_agent").invoke({ agent: "quinn", message: "hi" }) as string,
+    ) as { data: Record<string, unknown> };
+    expect(out.data.response).toBe("fast answer");
+  });
+});

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -18,6 +18,17 @@ import type { IExecutor, SkillRequest, SkillResult } from "../types.ts";
 
 const LANGFUSE_ENABLED = !!(process.env.LANGFUSE_PUBLIC_KEY && process.env.LANGFUSE_SECRET_KEY);
 
+/** Sleep used by chat_with_agent's pending-result poller. */
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+/** chat_with_agent polls a pending A2A result this often, up to this budget,
+ *  before handing back the pending marker. Slow skills (recon, pentest) finish
+ *  well inside this; it just bounds the wait so a stuck task can't pin the tool.
+ *  Interval is env-overridable (DEEP_AGENT_CHAT_POLL_INTERVAL_MS). */
+const CHAT_POLL_BUDGET_MS = 240_000;
+function chatPollIntervalMs(): number {
+  return Number(process.env.DEEP_AGENT_CHAT_POLL_INTERVAL_MS) || 5_000;
+}
+
 /**
  * Extract the assistant's text output from a LangChain AIMessage's `content`.
  * Reasoning-style models (e.g. protolabs/reasoning, o3, claude with extended
@@ -95,7 +106,7 @@ export interface DeepAgentConfig {
 // These are all StructuredToolInterface at runtime, but TS can't unify them into a single
 // Record type because tool()'s zod v3/v4 interop overloads produce SchemaOutputT params
 // that don't widen back to the base interface defaults. Record stays loose; return is typed.
-function createLangChainTools(toolNames: string[], http: HttpClient, correlationId?: string, agentName?: string): StructuredToolInterface[] {
+export function createLangChainTools(toolNames: string[], http: HttpClient, correlationId?: string, agentName?: string): StructuredToolInterface[] {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const all: Record<string, any> = {
     chat_with_agent: tool(
@@ -103,7 +114,44 @@ function createLangChainTools(toolNames: string[], http: HttpClient, correlation
         console.log(`[deep-agent:tool] chat_with_agent called: agent=${input.agent}, skill=${input.skill ?? "auto"}, msg="${input.message.slice(0, 80)}"`);
         try {
           const body = agentName ? { ...input, dispatcherAgent: agentName } : input;
-          const result = await http.post("/api/a2a/chat", body);
+          const result = await http.post("/api/a2a/chat", body) as { success?: boolean; data?: Record<string, unknown> };
+
+          // Slow A2A skills return { pending: true, pollUrl } after the chat
+          // endpoint's wait window. Poll it to completion so chat_with_agent
+          // presents a synchronous result instead of leaking the pending stub.
+          const data = result?.data;
+          if (data?.pending === true && typeof data.pollUrl === "string") {
+            const deadline = Date.now() + CHAT_POLL_BUDGET_MS;
+            while (Date.now() < deadline) {
+              await sleep(chatPollIntervalMs());
+              const polled = await http.get(data.pollUrl) as { data?: Record<string, unknown> };
+              const pd = polled?.data;
+              if (!pd) continue;
+              if (pd.done === true) {
+                const merged = {
+                  success: !pd.error,
+                  data: {
+                    response: pd.response ?? null,
+                    taskState: pd.taskState,
+                    correlationId: pd.correlationId,
+                    agent: input.agent,
+                    ...(pd.taskId ? { taskId: pd.taskId } : {}),
+                    ...(pd.contextId ? { contextId: pd.contextId } : {}),
+                    ...(pd.error ? { error: pd.error } : {}),
+                    ...(pd.usage ? { usage: pd.usage } : {}),
+                    ...(pd.costUsd !== undefined ? { costUsd: pd.costUsd } : {}),
+                    ...(pd.confidence !== undefined ? { confidence: pd.confidence } : {}),
+                  },
+                };
+                console.log(`[deep-agent:tool] chat_with_agent resolved pending ${input.agent} task: taskState=${pd.taskState}`);
+                return JSON.stringify(merged);
+              }
+              if (pd.taskState === "unknown") break; // never tracked / aged out
+            }
+            console.log(`[deep-agent:tool] chat_with_agent ${input.agent} still pending after budget`);
+            return JSON.stringify(result);
+          }
+
           console.log(`[deep-agent:tool] chat_with_agent returned: ${JSON.stringify(result).slice(0, 200)}`);
           return JSON.stringify(result);
         } catch (e) {
@@ -114,9 +162,11 @@ function createLangChainTools(toolNames: string[], http: HttpClient, correlation
       {
         name: "chat_with_agent",
         description:
-          "Multi-turn conversation with another agent. " +
-          "Pass contextId+taskId from prior response to continue. " +
-          "Set done=true on final message. Response includes taskState.",
+          "Multi-turn conversation with another agent. Reaches ANY registered agent — " +
+          "call list_agents to see the live fleet. Pass contextId+taskId from a prior " +
+          "response to continue; set done=true on your final message. Long-running skills " +
+          "are polled to completion automatically, so the response carries the agent's real " +
+          "output plus taskState.",
         schema: z.object({
           agent: z.string(),
           message: z.string(),
@@ -134,13 +184,36 @@ function createLangChainTools(toolNames: string[], http: HttpClient, correlation
       },
       {
         name: "delegate_task",
-        description: "Fire-and-forget: dispatch work to an agent.",
+        description:
+          "Fire-and-forget: dispatch work to an agent without waiting. Reaches ANY " +
+          "registered agent (see list_agents). Returns a correlationId + pollUrl.",
         schema: z.object({
           agent: z.string(),
           skill: z.string(),
           message: z.string(),
           projectSlug: z.string().optional(),
         }),
+      },
+    ),
+    list_agents: tool(
+      async () => {
+        const res = await http.get("/api/agents/runtime") as {
+          data?: { agents?: Array<{ name: string; type: string; skills: string[]; pendingDiscovery?: boolean }> };
+        };
+        // Exclude self and the synthetic function-executor cluster (alert.*,
+        // ceremony.*, pr.* — plugin infra, not a conversational delegate target).
+        const agents = (res?.data?.agents ?? []).filter((a) => a.name !== agentName && a.type !== "function");
+        return JSON.stringify({ success: true, agents });
+      },
+      {
+        name: "list_agents",
+        description:
+          "List the live agent fleet you can reach via chat_with_agent / delegate_task — " +
+          "each registered agent with its type (deep-agent | a2a) and the skills it serves. " +
+          "This registry is the source of truth; call it to discover who's available rather " +
+          "than assuming a fixed roster. Agents with pendingDiscovery=true are configured but " +
+          "not currently reachable (e.g. an A2A host that's offline).",
+        schema: z.object({}),
       },
     ),
     manage_board: tool(

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -79,9 +79,14 @@ systemPrompt: |
   Use them, don't narrate them.
 
   ### Orchestration
-  - **chat_with_agent** — Multi-turn conversation with another agent.
-    Pass contextId from a prior response to continue. Set done=true on
-    your final message to close the conversation cleanly.
+  - **list_agents** — The live fleet: every registered agent, its type, and the
+    skills it serves. This is your roster — read it to see who's available
+    instead of assuming a fixed set. New agents appear here the moment they
+    register; offline ones show pendingDiscovery.
+  - **chat_with_agent** — Multi-turn conversation with another agent. Reaches
+    ANY agent from list_agents. Pass contextId from a prior response to continue.
+    Set done=true on your final message to close the conversation cleanly.
+    Long-running skills are awaited for you — the response carries real output.
   - **delegate_task** — Fire-and-forget: dispatch work without waiting.
   - **publish_event** — Inject a bus event to signal other plugins/agents.
   - **manage_cron** — CRUD scheduled ceremonies (cron jobs).
@@ -142,14 +147,18 @@ systemPrompt: |
   - **A project's engineering work** → file a GitHub issue on that project's
     repo with `create_github_issue`. It lands on the project's board and gets
     decomposed + executed there. This is your main routing action.
-  - **proto** — your in-process hands for a one-shot research or code task you
-    want done directly. `chat_with_agent(agent="proto", skill="research.codebase" | "code.execute")`.
-  - **protoBot** — Discord server infrastructure. `chat_with_agent(agent="protobot", …)`.
-  - **Quinn** — the QA gate; she auto-reviews PRs. Watch her verdicts via
-    `quinn.review.submitted` / `get_pr_pipeline`.
+  - **The fleet** → for anything an agent does directly, `chat_with_agent` /
+    `delegate_task` reach **any** agent in `list_agents`. Don't assume a fixed
+    set — read the roster and match the work to whatever skills are available
+    (e.g. research/code, Discord infra, QA review, security/recon, …). The live
+    registry is the source of truth for who exists and what each can do.
 
-  The agents you can talk to are listed above; `chat_with_agent` reaches them,
-  and the live agent registry is the source of truth for what each does.
+  A few you'll lean on often (but always confirm against `list_agents`):
+  - **proto** — your in-process hands for a one-shot research or code task,
+    `chat_with_agent(agent="proto", skill="research.codebase" | "code.execute")`.
+  - **Quinn** — the QA gate; she auto-reviews PRs. Watch verdicts via
+    `quinn.review.submitted` / `get_pr_pipeline`.
+  - **protoBot** — Discord server infrastructure.
 
   ## Cron-dispatched and ceremony-dispatched work
 
@@ -218,6 +227,7 @@ systemPrompt: |
 
 tools:
   # ── Orchestration ──────────────────────────────────────────────────
+  - list_agents
   - chat_with_agent
   - delegate_task
   - publish_event


### PR DESCRIPTION
## Why

Ava is the control interface — her roster should **be** the live registry, not a hand-maintained list in her prompt. Today she can't actually use protopen: it's not in her prompt roster, she has no way to *discover* it, and even if she named it, protopen's slow A2A skills return only a `pending` marker she can't resolve.

"She should just auto-search like her roster… Ava should have access to all of the agents. That's her whole purpose." — so:

## Changes

- **New `list_agents` tool** — reads `/api/agents/runtime` (the live `ExecutorRegistry` grouped by agent → type + skills, plus yaml-declared A2A agents), excluding herself and the synthetic function-executor cluster. New agents appear the moment they register; offline ones surface `pendingDiscovery`. This is her roster now.
- **`chat_with_agent` auto-polls** a pending A2A result to completion via `/api/a2a/task/{correlationId}` (from #673), so it returns the agent's **real output synchronously** instead of leaking the pending stub. Reaches any registered agent. (Poll interval env-overridable for fast tests.)
- **`ava.yaml`**: added `list_agents` to her tools and **de-hardcoded the roster** — prose now points at `list_agents` as the live roster and says `chat_with_agent`/`delegate_task` reach **any** agent (research/code, Discord, QA, security/recon, …), keeping proto/Quinn/protoBot only as common examples to confirm against the registry.

Net effect: register an agent → Ava knows about it and can use it, protopen included. No prompt edits per agent.

## Tests

New `deep-agent-fleet-tools.test.ts`: `list_agents` filtering (self + function excluded), the auto-poll round-trip (pending → polled → real output), and inline results passing through without polling. Full suite **853 pass**, tsc clean.

## Deploy note

Code (the two `.ts` files) ships via the `:main` image. `workspace/agents/ava.yaml` is a host bind-mount — needs a `git pull` on the host + a container restart to load (agent YAMLs don't hot-reload). I'll pull it on the host after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `list_agents` tool enabling agents to discover available fleet members and their capabilities
  * Enhanced `chat_with_agent` with automatic polling for long-running operations, handling pending responses seamlessly
  * Updated agent configurations to reflect new orchestration capabilities

* **Tests**
  * Added comprehensive test suite for deep-agent fleet tools and polling behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/674?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->