### PR TITLE
feat(a2a): unified SkillResponseCache — poll endpoint covers in-process results too

### DIFF
--- a/src/api/__tests__/ava-tools.test.ts
+++ b/src/api/__tests__/ava-tools.test.ts
@@ -132,12 +132,16 @@ describe("/api/a2a/chat (bus round-trip)", () => {
 describe("/api/a2a/task/:correlationId (poll)", () => {
   test("returns the cached terminal result when present", async () => {
     const bus = new InMemoryEventBus();
-    const taskTracker = {
-      getResult: (id: string) =>
+    // Terminal results now come from the SkillResponseCache (covers in-process
+    // + A2A); TaskTracker only reports the live "still working" state.
+    const skillResponseCache = {
+      get: (id: string) =>
         id === "c-done" ? { content: "finished output", taskState: "completed", correlationId: id, taskId: "t9" } : undefined,
+    } as unknown as ApiContext["skillResponseCache"];
+    const taskTracker = {
       getAll: () => [{ correlationId: "c-working", taskId: "t1", agentName: "protopen" }],
     } as unknown as ApiContext["taskTracker"];
-    const { poll } = routesFor({ bus, executorRegistry: fakeRegistry(["protopen"]), taskTracker });
+    const { poll } = routesFor({ bus, executorRegistry: fakeRegistry(["protopen"]), taskTracker, skillResponseCache });
 
     const done = await poll(new Request("http://x/api/a2a/task/c-done"), { correlationId: "c-done" });
     const dj = (await done.json()) as { data: Record<string, unknown> };

--- a/src/api/ava-tools.ts
+++ b/src/api/ava-tools.ts
@@ -218,13 +218,14 @@ export function createRoutes(ctx: ApiContext): Route[] {
 
   /**
    * GET /api/a2a/task/:correlationId — fetch the result of a dispatch that a
-   * chat caller stopped awaiting (timed out). Reads TaskTracker's terminal-result
-   * cache, falling back to the live tracked state.
+   * chat caller stopped awaiting (timed out). Reads the SkillResponseCache
+   * (covers both in-process and A2A results), falling back to TaskTracker's
+   * live tracked state for "still working".
    *
    * Returns one of:
    *   { done: true, response, error?, taskState, … }   — terminal result available
    *   { pending: true, taskState: "working", taskId }  — still running
-   *   { pending: false, taskState: "unknown" }         — never tracked / aged out
+   *   { pending: false, taskState: "unknown" }         — never seen / aged out
    */
   function handleTaskPoll(req: Request, params: Record<string, string>): Response {
     if (ctx.apiKey && req.headers.get("X-API-Key") !== ctx.apiKey) {
@@ -235,7 +236,7 @@ export function createRoutes(ctx: ApiContext): Route[] {
       return Response.json({ success: false, error: "correlationId required" }, { status: 400 });
     }
 
-    const result = ctx.taskTracker?.getResult(correlationId);
+    const result = ctx.skillResponseCache?.get(correlationId);
     if (result) {
       return Response.json({
         success: true,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -15,6 +15,7 @@ import type { ContextMailbox } from "../../lib/dm/context-mailbox.ts";
 import type { TaskTracker } from "../executor/task-tracker.ts";
 import type { AgentKeyRegistry } from "../../lib/auth/agent-keys.ts";
 import type { BusHistoryRecorder } from "../event-bus/history-recorder.ts";
+import type { SkillResponseCache } from "../event-bus/skill-response-cache.ts";
 import type { ChannelRegistry } from "../../lib/channels/channel-registry.ts";
 import type { ProjectRegistry } from "../plugins/project-registry.ts";
 
@@ -54,6 +55,13 @@ export interface ApiContext {
    * when the bus-history-recorder plugin is installed.
    */
   busHistory?: BusHistoryRecorder;
+  /**
+   * Terminal skill-response cache keyed by correlationId. Backs
+   * GET /api/a2a/task/:correlationId so a caller that stopped awaiting a
+   * dispatch can still fetch the final outcome — covers both in-process
+   * (dispatcher inline) and A2A (TaskTracker) results. Wired in src/index.ts.
+   */
+  skillResponseCache?: SkillResponseCache;
   /** Source of truth for project metadata (slug, path, github coordinates). */
   projectRegistry?: ProjectRegistry;
   /** Channels registry — used by routes that need per-project channel lookups. */

--- a/src/event-bus/__tests__/skill-response-cache.test.ts
+++ b/src/event-bus/__tests__/skill-response-cache.test.ts
@@ -1,0 +1,87 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { SkillResponseCache, SkillResponseCachePlugin } from "../skill-response-cache.ts";
+import type { AgentSkillResponsePayload } from "../payloads.ts";
+
+function publishResponse(bus: InMemoryEventBus, correlationId: string, payload: Partial<AgentSkillResponsePayload>) {
+  const topic = `agent.skill.response.${correlationId}`;
+  bus.publish(topic, {
+    id: crypto.randomUUID(),
+    correlationId,
+    topic,
+    timestamp: Date.now(),
+    payload: { correlationId, ...payload },
+  });
+}
+
+describe("SkillResponseCache", () => {
+  let plugin: SkillResponseCachePlugin | undefined;
+  afterEach(() => { plugin?.uninstall(); plugin = undefined; });
+
+  function install(bus: InMemoryEventBus, opts?: { ttlMs?: number; maxEntries?: number }) {
+    const cache = new SkillResponseCache(opts);
+    plugin = new SkillResponseCachePlugin(cache);
+    plugin.install(bus);
+    return cache;
+  }
+
+  test("captures dispatcher-inline-shaped terminal responses", async () => {
+    const bus = new InMemoryEventBus();
+    const cache = install(bus);
+    publishResponse(bus, "c1", { content: "in-process answer", taskState: "completed" });
+    const got = cache.get("c1");
+    expect(got?.content).toBe("in-process answer");
+    expect(got?.taskState).toBe("completed");
+  });
+
+  test("captures TaskTracker-shaped terminal responses (same subscriber, both paths)", async () => {
+    const bus = new InMemoryEventBus();
+    const cache = install(bus);
+    publishResponse(bus, "c2", { content: "a2a answer", taskState: "completed", taskId: "t9", contextId: "ctx" });
+    const got = cache.get("c2");
+    expect(got?.content).toBe("a2a answer");
+    expect(got?.taskId).toBe("t9");
+  });
+
+  test("preserves error payloads", async () => {
+    const bus = new InMemoryEventBus();
+    const cache = install(bus);
+    publishResponse(bus, "c3", { error: "boom", taskState: "failed" });
+    expect(cache.get("c3")?.error).toBe("boom");
+  });
+
+  test("expires entries past the TTL", async () => {
+    const bus = new InMemoryEventBus();
+    const cache = install(bus, { ttlMs: 10 });
+    publishResponse(bus, "c4", { content: "ephemeral" });
+    expect(cache.get("c4")?.content).toBe("ephemeral");
+    await new Promise((r) => setTimeout(r, 25));
+    expect(cache.get("c4")).toBeUndefined();
+  });
+
+  test("evicts the oldest entry past the size cap", async () => {
+    const bus = new InMemoryEventBus();
+    const cache = install(bus, { maxEntries: 2 });
+    publishResponse(bus, "a", { content: "1" });
+    publishResponse(bus, "b", { content: "2" });
+    publishResponse(bus, "c", { content: "3" }); // pushes "a" out
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.get("b")?.content).toBe("2");
+    expect(cache.get("c")?.content).toBe("3");
+  });
+
+  test("returns undefined for an unseen correlationId", () => {
+    const bus = new InMemoryEventBus();
+    const cache = install(bus);
+    expect(cache.get("never")).toBeUndefined();
+  });
+
+  test("stops recording after uninstall", () => {
+    const bus = new InMemoryEventBus();
+    const cache = install(bus);
+    plugin?.uninstall();
+    plugin = undefined;
+    publishResponse(bus, "c5", { content: "after teardown" });
+    expect(cache.get("c5")).toBeUndefined();
+  });
+});

--- a/src/event-bus/skill-response-cache.ts
+++ b/src/event-bus/skill-response-cache.ts
@@ -1,0 +1,131 @@
+/**
+ * SkillResponseCache — in-memory, correlationId-keyed cache of terminal skill
+ * responses. Backs GET /api/a2a/task/:correlationId so a caller that stopped
+ * awaiting a dispatch (e.g. a chat request that hit its reply timeout, or a
+ * fire-and-forget delegate) can still fetch the final outcome.
+ *
+ * Why a bus subscriber: every terminal response — whether from the dispatcher's
+ * inline-complete path (in-process DeepAgents) or TaskTracker's terminal path
+ * (long-running A2A tasks) — is published to `agent.skill.response.{correlationId}`.
+ * Subscribing to that one topic captures BOTH uniformly with zero producer
+ * changes, instead of bolting a cache onto each producer. This is the single
+ * code path the prior per-component cache (TaskTracker.recentResults) couldn't
+ * provide: in-process executors never reach TaskTracker, so their results were
+ * never cacheable.
+ *
+ * Bounded by TTL + a hard entry cap. Not durable — process restart wipes it,
+ * which is fine: the cache only needs to survive the minutes between a dispatch
+ * timing out and the caller polling.
+ */
+
+import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
+import type { AgentSkillResponsePayload } from "./payloads.ts";
+
+const DEFAULT_TTL_MS = 15 * 60 * 1000;
+const DEFAULT_MAX_ENTRIES = 5_000;
+const PRUNE_INTERVAL_MS = 60_000;
+const RESPONSE_TOPIC_WILDCARD = "agent.skill.response.#";
+
+export interface SkillResponseCacheConfig {
+  ttlMs?: number;
+  maxEntries?: number;
+}
+
+export class SkillResponseCache {
+  /** Insertion-ordered (Map preserves it) so the oldest entry is evictable. */
+  private readonly store = new Map<string, { payload: AgentSkillResponsePayload; at: number }>();
+  private readonly ttlMs: number;
+  private readonly maxEntries: number;
+
+  constructor(config: SkillResponseCacheConfig = {}) {
+    this.ttlMs = config.ttlMs ?? DEFAULT_TTL_MS;
+    this.maxEntries = config.maxEntries ?? DEFAULT_MAX_ENTRIES;
+  }
+
+  /**
+   * Cache a terminal skill response. Keyed on the message's correlationId
+   * (always set on a BusMessage), falling back to the payload's. Skips entries
+   * with no resolvable correlationId.
+   */
+  record(msg: BusMessage): void {
+    const payload = (msg.payload ?? {}) as AgentSkillResponsePayload;
+    const correlationId = msg.correlationId ?? payload.correlationId;
+    if (!correlationId) return;
+
+    this.store.set(correlationId, { payload, at: Date.now() });
+
+    // Hard cap backstop against a burst between prune cycles — evict oldest.
+    if (this.store.size > this.maxEntries) {
+      const oldest = this.store.keys().next().value;
+      if (oldest !== undefined) this.store.delete(oldest);
+    }
+  }
+
+  /**
+   * The cached response for a correlationId, or undefined if never seen or aged
+   * past the TTL (expired entries are dropped on read).
+   */
+  get(correlationId: string): AgentSkillResponsePayload | undefined {
+    const entry = this.store.get(correlationId);
+    if (!entry) return undefined;
+    if (Date.now() - entry.at > this.ttlMs) {
+      this.store.delete(correlationId);
+      return undefined;
+    }
+    return entry.payload;
+  }
+
+  stats(): { size: number; maxEntries: number; ttlMs: number } {
+    return { size: this.store.size, maxEntries: this.maxEntries, ttlMs: this.ttlMs };
+  }
+
+  /** Drop entries past the TTL so payloads become GC-eligible between reads. */
+  prune(): void {
+    const cutoff = Date.now() - this.ttlMs;
+    for (const [correlationId, entry] of this.store) {
+      if (entry.at < cutoff) this.store.delete(correlationId);
+    }
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+/**
+ * Plugin that subscribes to `agent.skill.response.#` and writes every terminal
+ * response into a shared SkillResponseCache. The cache is the contract surface
+ * (injected into ApiContext); the plugin is just the wiring.
+ */
+export class SkillResponseCachePlugin implements Plugin {
+  readonly name = "skill-response-cache";
+  readonly description =
+    "Caches terminal skill responses by correlationId for GET /api/a2a/task/:correlationId";
+  readonly capabilities = ["skill-response-cache"];
+
+  private bus: EventBus | null = null;
+  private subscriptionId: string | null = null;
+  private pruneTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(public readonly cache: SkillResponseCache) {}
+
+  install(bus: EventBus): void {
+    this.bus = bus;
+    this.subscriptionId = bus.subscribe(RESPONSE_TOPIC_WILDCARD, this.name, (msg) => this.cache.record(msg));
+    this.pruneTimer = setInterval(() => this.cache.prune(), PRUNE_INTERVAL_MS);
+    if (typeof this.pruneTimer.unref === "function") this.pruneTimer.unref();
+    console.log(
+      `[skill-response-cache] installed (maxEntries=${this.cache.stats().maxEntries}, ttlMs=${this.cache.stats().ttlMs})`,
+    );
+  }
+
+  uninstall(): void {
+    if (this.pruneTimer) {
+      clearInterval(this.pruneTimer);
+      this.pruneTimer = null;
+    }
+    if (this.bus && this.subscriptionId) this.bus.unsubscribe(this.subscriptionId);
+    this.subscriptionId = null;
+    this.bus = null;
+  }
+}

--- a/src/executor/task-tracker.ts
+++ b/src/executor/task-tracker.ts
@@ -58,8 +58,6 @@ export interface TaskTrackerOptions {
   defaultPollIntervalMs?: number;
   /** Max time to track a task before giving up (ms). Default: 1hr. */
   maxTrackingMs?: number;
-  /** How long a terminal result stays retrievable via getResult (ms). Default: 5min. */
-  resultTtlMs?: number;
 }
 
 export class TaskTracker {
@@ -68,21 +66,15 @@ export class TaskTracker {
   private readonly sweepIntervalMs: number;
   private readonly defaultPollIntervalMs: number;
   private readonly maxTrackingMs: number;
-  private readonly resultTtlMs: number;
   private readonly sweepTimer: ReturnType<typeof setInterval>;
   /** Tracks task IDs for which world.state.delta events have already been published. */
   private readonly publishedDeltaTaskIds = new Set<string>();
-  /** Terminal results retained briefly so a caller that stopped awaiting the
-   *  reply topic (e.g. a chat request that hit its timeout) can still fetch the
-   *  final outcome by correlationId. TTL-evicted in the sweep. */
-  private readonly recentResults = new Map<string, { payload: AgentSkillResponsePayload; at: number }>();
 
   constructor(opts: TaskTrackerOptions) {
     this.bus = opts.bus;
     this.sweepIntervalMs = opts.sweepIntervalMs ?? 10_000;
     this.defaultPollIntervalMs = opts.defaultPollIntervalMs ?? 30_000;
     this.maxTrackingMs = opts.maxTrackingMs ?? 60 * 60_000;
-    this.resultTtlMs = opts.resultTtlMs ?? 5 * 60_000;
     this.sweepTimer = setInterval(() => { void this._sweep(); }, this.sweepIntervalMs);
     this.sweepTimer.unref?.();
   }
@@ -208,7 +200,6 @@ export class TaskTracker {
   destroy(): void {
     clearInterval(this.sweepTimer);
     this.tasks.clear();
-    this.recentResults.clear();
   }
 
   /**
@@ -218,11 +209,6 @@ export class TaskTracker {
    */
   private async _sweep(): Promise<void> {
     const now = Date.now();
-
-    // Evict aged-out terminal results.
-    for (const [correlationId, entry] of this.recentResults) {
-      if (now - entry.at > this.resultTtlMs) this.recentResults.delete(correlationId);
-    }
 
     for (const task of this.tasks.values()) {
       // Age-out: task has been working for too long
@@ -338,7 +324,9 @@ export class TaskTracker {
       ...(typeof data?.confidenceExplanation === "string"
         ? { confidenceExplanation: data.confidenceExplanation } : {}),
     };
-    this.recentResults.set(task.correlationId, { payload, at: Date.now() });
+    // Terminal result is cached downstream by SkillResponseCache, which
+    // subscribes to agent.skill.response.# (covers both this A2A path and the
+    // dispatcher's inline-complete path uniformly). We just publish.
     this.bus.publish(task.replyTopic, {
       id: crypto.randomUUID(),
       correlationId: task.correlationId,
@@ -346,21 +334,5 @@ export class TaskTracker {
       timestamp: Date.now(),
       payload,
     });
-  }
-
-  /**
-   * Fetch a recently-terminal task's result by correlationId. Returns undefined
-   * if the task is still running, never existed, or its result has aged past
-   * resultTtlMs. Backs GET /api/a2a/task/:correlationId so a chat caller that
-   * timed out can still retrieve the final outcome.
-   */
-  getResult(correlationId: string): AgentSkillResponsePayload | undefined {
-    const entry = this.recentResults.get(correlationId);
-    if (!entry) return undefined;
-    if (Date.now() - entry.at > this.resultTtlMs) {
-      this.recentResults.delete(correlationId);
-      return undefined;
-    }
-    return entry.payload;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,12 @@ const busHistoryRecorder = new BusHistoryRecorder();
 const busHistoryRecorderPlugin = new BusHistoryRecorderPlugin(busHistoryRecorder);
 busHistoryRecorderPlugin.install(bus);
 
+// --- Skill-response cache — terminal results by correlationId for /api/a2a/task ---
+import { SkillResponseCache, SkillResponseCachePlugin } from "./event-bus/skill-response-cache.ts";
+const skillResponseCache = new SkillResponseCache();
+const skillResponseCachePlugin = new SkillResponseCachePlugin(skillResponseCache);
+skillResponseCachePlugin.install(bus);
+
 // --- Context mailbox — mid-execution DM queue for debounced message injection ---
 import { ContextMailbox } from "../lib/dm/context-mailbox.ts";
 const contextMailbox = new ContextMailbox();
@@ -582,6 +588,7 @@ const apiContext: ApiContext = {
   mailbox: contextMailbox,
   taskTracker,
   busHistory: busHistoryRecorder,
+  skillResponseCache,
   projectRegistry,
   channelRegistry,
 };


### PR DESCRIPTION
## Why

The terminal-result cache from #673 lived inside `TaskTracker`, which only sees long-running **A2A** tasks. In-process DeepAgents (ava, quinn, proto, protobot) complete on the dispatcher's inline path and were never cached — so a slow in-process dispatch (e.g. **Ava routing a sub-task and blocking on it past the 30s reply window**) returned `pending`, and `GET /api/a2a/task/:correlationId` then returned `"unknown"`. Her result was lost to the HTTP caller. That's the exact gap that stopped us from routing the protopen pentest *through Ava*.

## Fix — one cache on the bus

A single **`SkillResponseCache`** that subscribes to `agent.skill.response.#` — the one topic where **all** terminal responses land, from both the dispatcher's inline-complete path **and** `TaskTracker`'s terminal path. Subscribing once downstream captures both uniformly with **zero producer changes**, instead of bolting a cache onto each producer. Modeled on the repo's existing `BusHistoryRecorder` (service + thin `Plugin`), injected into `ApiContext`.

- **New** `src/event-bus/skill-response-cache.ts` — correlationId-keyed, 15-min TTL, 5k-entry cap (oldest-evicted), 60s pruner.
- Poll endpoint reads `ctx.skillResponseCache.get()` instead of `taskTracker.getResult()`.
- **Removed** `TaskTracker`'s `recentResults`/`getResult`/`resultTtlMs` (now redundant — greenfield: deleted, not shimmed). It just publishes; the cache picks it up off the bus.
- Wired in `src/index.ts`; added `skillResponseCache` to `ApiContext`.

Net: routing a long task through **any** agent (in-process or A2A) is now pollable to completion via the same `/api/a2a/task` endpoint.

## Tests

New `skill-response-cache.test.ts` — both producer shapes captured by the one subscriber, TTL expiry, size-cap eviction, error payloads, uninstall teardown. Updated the `ava-tools` poll test to stub the cache. Full suite **860 pass**, tsc clean. (Lone biome warning is pre-existing at `index.ts:178`, not from this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented a response caching system with time-based expiration (default 15 minutes) and maximum entry limits to improve task result retrieval performance.

* **Bug Fixes**
  * Enhanced task status polling by consolidating response cache logic, ensuring consistent and reliable result delivery for asynchronous tasks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->