### PR TITLE
fix(linear): Ava responds only when assigned or @mentioned; triage stays on GitHub

### DIFF
--- a/lib/linear/__tests__/agent-activity-client.test.ts
+++ b/lib/linear/__tests__/agent-activity-client.test.ts
@@ -102,4 +102,27 @@ describe("LinearAgentActivityClient", () => {
     await expect(c.thought("s", "x")).rejects.toThrow(/not authorized/);
     expect(calls).toHaveLength(0); // never hit the network
   });
+
+  test("getViewerId queries viewer { id } and caches the result", async () => {
+    nextResponse = () => new Response(JSON.stringify({ data: { viewer: { id: "ava-123" } } }), { status: 200 });
+    const c = new LinearAgentActivityClient(fakeTokens("t"), mockFetch());
+    expect(await c.getViewerId()).toBe("ava-123");
+    expect(await c.getViewerId()).toBe("ava-123");
+    expect(calls).toHaveLength(1); // second call served from cache
+  });
+
+  test("isAssignedToAva is true only when the issue's assignee is Ava", async () => {
+    // mockFetch returns the same combined body to both the viewer + issue queries.
+    nextResponse = () => new Response(JSON.stringify({ data: { viewer: { id: "ava-123" }, issue: { assignee: { id: "ava-123" } } } }), { status: 200 });
+    const c = new LinearAgentActivityClient(fakeTokens("t"), mockFetch());
+    expect(await c.isAssignedToAva("issue-1")).toBe(true);
+  });
+
+  test("isAssignedToAva is false when assignee differs or is unset", async () => {
+    nextResponse = () => new Response(JSON.stringify({ data: { viewer: { id: "ava-123" }, issue: { assignee: { id: "someone-else" } } } }), { status: 200 });
+    expect(await new LinearAgentActivityClient(fakeTokens("t"), mockFetch()).isAssignedToAva("i")).toBe(false);
+
+    nextResponse = () => new Response(JSON.stringify({ data: { viewer: { id: "ava-123" }, issue: { assignee: null } } }), { status: 200 });
+    expect(await new LinearAgentActivityClient(fakeTokens("t"), mockFetch()).isAssignedToAva("i")).toBe(false);
+  });
 });

--- a/lib/linear/agent-activity-client.ts
+++ b/lib/linear/agent-activity-client.ts
@@ -93,6 +93,31 @@ export class LinearAgentActivityClient {
     if (!ok) throw new Error("commentCreate returned success=false");
   }
 
+  /** Ava's own Linear user id (the actor=app identity), cached. */
+  private _viewerId?: string;
+  async getViewerId(): Promise<string> {
+    if (this._viewerId) return this._viewerId;
+    const data = await this._gql("viewer", "{ viewer { id } }", {});
+    const id = (data.viewer as { id?: string } | undefined)?.id;
+    if (!id) throw new Error("viewer query returned no id");
+    this._viewerId = id;
+    return id;
+  }
+
+  /**
+   * True iff the issue is currently assigned to Ava (this app's actor). Used to
+   * gate linear_agent_respond so Ava only acts on Linear issues that are hers —
+   * not ambient activity or stale sessions on issues she was never assigned.
+   */
+  async isAssignedToAva(issueId: string): Promise<boolean> {
+    const [viewerId, data] = await Promise.all([
+      this.getViewerId(),
+      this._gql("issueAssignee", "query($id:String!){ issue(id:$id){ assignee{ id } } }", { id: issueId }),
+    ]);
+    const assigneeId = ((data.issue as { assignee?: { id?: string } } | undefined)?.assignee)?.id;
+    return !!assigneeId && assigneeId === viewerId;
+  }
+
   thought(sessionId: string, body: string): Promise<void> {
     return this.createActivity(sessionId, { type: "thought", body });
   }

--- a/lib/plugins/__tests__/linear-agent-session-poller.test.ts
+++ b/lib/plugins/__tests__/linear-agent-session-poller.test.ts
@@ -81,4 +81,44 @@ describe("LinearAgentSessionPoller._poll", () => {
     await p._poll(bus); await Bun.sleep(5);
     expect(got).toHaveLength(0);
   });
+
+  describe("assignee gating", () => {
+    function gatedPoller(
+      nodes: Array<{ id: string; status: string; updatedAt: string; issue?: { id: string; identifier: string } }>,
+      assignedToAva: (issueId: string) => Promise<boolean>,
+    ) {
+      const fetchImpl = (async () => sessionsResponse(nodes)) as unknown as typeof fetch;
+      return new LinearAgentSessionPoller({ apiKey: "k", fetchImpl, assignedToAva });
+    }
+
+    test("recovers a stale session when the issue is assigned to Ava", async () => {
+      const p = gatedPoller(
+        [{ id: "s1", status: "stale", updatedAt: "t1", issue: { id: "i1", identifier: "JOSH-9" } }],
+        async () => true,
+      );
+      await p._poll(bus); await Bun.sleep(5);
+      expect(got).toHaveLength(1);
+    });
+
+    test("skips a stale session when the issue is NOT assigned to Ava", async () => {
+      const p = gatedPoller(
+        [{ id: "s1", status: "stale", updatedAt: "t1", issue: { id: "i1", identifier: "JOSH-403" } }],
+        async () => false,
+      );
+      await p._poll(bus); await Bun.sleep(5);
+      expect(got).toHaveLength(0);
+    });
+
+    test("does not recover or mark-handled on a check error — retries next sweep", async () => {
+      let calls = 0;
+      const p = gatedPoller(
+        [{ id: "s1", status: "stale", updatedAt: "t1", issue: { id: "i1", identifier: "JOSH-9" } }],
+        async () => { calls += 1; if (calls === 1) throw new Error("transient"); return true; },
+      );
+      await p._poll(bus); await Bun.sleep(5);
+      expect(got).toHaveLength(0); // first sweep errored → skipped, not handled
+      await p._poll(bus); await Bun.sleep(5);
+      expect(got).toHaveLength(1); // retried, now assigned → recovered
+    });
+  });
 });

--- a/lib/plugins/linear-agent-session-poller.ts
+++ b/lib/plugins/linear-agent-session-poller.ts
@@ -20,7 +20,10 @@
  *     docs, a stale session is recoverable by sending an activity.
  */
 
+import { join } from "node:path";
 import type { EventBus, Plugin } from "../types.ts";
+import { LinearAgentActivityClient } from "../linear/agent-activity-client.ts";
+import { getLinearAvaTokenManager } from "../linear/ava-oauth-token-manager.ts";
 
 const GRAPHQL_URL = "https://api.linear.app/graphql";
 const POLL_INTERVAL_MS = 20_000;
@@ -68,11 +71,24 @@ export class LinearAgentSessionPoller implements Plugin {
   private timer?: ReturnType<typeof setInterval>;
   /** key = `${sessionId}:${updatedAt}` → handled-at ms. */
   private handled = new Map<string, number>();
+  /** Gate: only recover a stale session if its issue is assigned to Ava. When
+   *  undefined (Ava OAuth not configured), gating is disabled — recover all. */
+  private readonly assignedToAva?: (issueId: string) => Promise<boolean>;
 
-  constructor(opts: { apiKey?: string; fetchImpl?: typeof fetch; intervalMs?: number } = {}) {
+  constructor(opts: { apiKey?: string; fetchImpl?: typeof fetch; intervalMs?: number; assignedToAva?: (issueId: string) => Promise<boolean> } = {}) {
     this.apiKey = opts.apiKey ?? process.env.LINEAR_API_KEY;
     this.fetchImpl = opts.fetchImpl ?? fetch;
     this.intervalMs = opts.intervalMs ?? POLL_INTERVAL_MS;
+    if (opts.assignedToAva) {
+      this.assignedToAva = opts.assignedToAva;
+    } else {
+      const dataDir = process.env.DATA_DIR || join(process.cwd(), "data");
+      const tokenManager = getLinearAvaTokenManager(dataDir);
+      if (tokenManager.isConfigured()) {
+        const client = new LinearAgentActivityClient(tokenManager);
+        this.assignedToAva = (issueId) => client.isAssignedToAva(issueId);
+      }
+    }
   }
 
   install(bus: EventBus): void {
@@ -103,6 +119,26 @@ export class LinearAgentSessionPoller implements Plugin {
     for (const s of sessions) {
       const key = `${s.id}:${s.updatedAt}`;
       if (this.handled.has(key)) continue;
+
+      // Only recover sessions for issues assigned to Ava — a stale session on
+      // an unassigned/abandoned issue is noise, not a missed assignment.
+      if (this.assignedToAva) {
+        if (!s.issueId) continue; // no issue → nothing to verify; leave it
+        let assigned: boolean;
+        try {
+          assigned = await this.assignedToAva(s.issueId);
+        } catch (err) {
+          // Transient/auth error — don't mark handled, retry next sweep.
+          console.warn(`[linear-session-poller] assignee check failed for session ${s.id} — retry next sweep: ${err instanceof Error ? err.message : String(err)}`);
+          continue;
+        }
+        if (!assigned) {
+          this.handled.set(key, Date.now()); // mark so we don't re-check this stale state every sweep
+          console.log(`[linear-session-poller] stale session ${s.id}${s.issueIdentifier ? ` (${s.issueIdentifier})` : ""} not assigned to Ava — skipping recovery`);
+          continue;
+        }
+      }
+
       this.handled.set(key, Date.now());
       bus.publish("message.inbound.linear.agent_session.created", {
         id: crypto.randomUUID(),

--- a/lib/plugins/linear.ts
+++ b/lib/plugins/linear.ts
@@ -211,6 +211,8 @@ export class LinearPlugin implements Plugin {
   readonly capabilities = ["linear-inbound", "linear-outbound"];
 
   private server: ReturnType<typeof Bun.serve> | null = null;
+  /** Ava's actor=app client — also used to gate responses on assignee==Ava. */
+  private _avaClient: LinearAgentActivityClient | null = null;
 
   install(bus: EventBus): void {
     const webhookSecret = process.env.LINEAR_WEBHOOK_SECRET ?? "";
@@ -240,6 +242,7 @@ export class LinearPlugin implements Plugin {
     const dataDir = process.env.DATA_DIR || join(process.cwd(), "data");
     const tokenManager = getLinearAvaTokenManager(dataDir);
     const avaClient = tokenManager.isConfigured() ? new LinearAgentActivityClient(tokenManager) : null;
+    this._avaClient = avaClient;
     if (!avaClient) console.warn("[linear] LINEAR_AVA_CLIENT_ID/_SECRET not set — post-as-Ava disabled (replies fall back to personal key)");
 
     // Outbound comments prefer Ava's identity; create/update still use the
@@ -401,7 +404,7 @@ export class LinearPlugin implements Plugin {
     if (payload.type === "AgentSessionEvent") {
       // Linear's newer Agent Session API. Body is in `agentSession` plus
       // optionally `agentActivity` (for prompted events).
-      this._publishAgentSession(payload.action, payload.agentSession ?? {}, payload.agentActivity, bus);
+      void this._publishAgentSession(payload.action, payload.agentSession ?? {}, payload.agentActivity, bus);
       return;
     }
     // Unknown envelope type — log loudly + drop. Linear adds new resource
@@ -416,32 +419,61 @@ export class LinearPlugin implements Plugin {
     const commentId = (notification.commentId as string | undefined)
       ?? ((notification.comment as { id?: string } | undefined)?.id);
     const correlationId = issueId ? `linear-${issueId}` : crypto.randomUUID();
+
+    // A direct @mention of Ava is the OTHER way (besides assignment) she may act
+    // on Linear. Route only mention actions to her handler; assignment is
+    // handled via the agent-session path, and ambient verbs (issueNewComment,
+    // issueAssignedToYou, …) intentionally have no skill hint so the router
+    // drops them — Ava doesn't chase activity she wasn't pulled into.
+    const isMention = action === "issueMention" || action === "issueCommentMention";
+
     bus.publish(topic, {
       id: crypto.randomUUID(),
       correlationId,
       topic,
       timestamp: Date.now(),
       payload: {
+        ...(isMention ? { skillHint: "linear_agent_respond" } : {}),
         action,
         notification,
         issueId,
         commentId,
       },
     });
-    console.log(`[linear] agent.${action}${issueId ? ` on issue ${issueId}` : ""}`);
+    console.log(`[linear] agent.${action}${issueId ? ` on issue ${issueId}` : ""}${isMention ? " → Ava (mention)" : ""}`);
   }
 
-  private _publishAgentSession(
+  private async _publishAgentSession(
     action: string,
     agentSession: Record<string, unknown>,
     agentActivity: Record<string, unknown> | undefined,
     bus: EventBus,
-  ): void {
+  ): Promise<void> {
     const topic = `message.inbound.linear.agent_session.${action}`;
     const sessionId = agentSession.id as string | undefined;
     const issueId = (agentSession.issueId as string | undefined)
       ?? ((agentSession.issue as { id?: string } | undefined)?.id);
     const correlationId = sessionId ?? (issueId ? `linear-${issueId}` : crypto.randomUUID());
+
+    // Ava acts on Linear only for issues assigned to her. Linear creates a
+    // session on assignment; @mentions arrive separately as
+    // issue{,Comment}Mention notifications (wired in _publishAgentNotification).
+    // Gating here drops ambient/stale sessions on issues that aren't hers.
+    // Fail OPEN on a check error — a transient Linear API hiccup must not
+    // silently mute a legitimate assignment.
+    if (issueId && this._avaClient) {
+      let assigned = true;
+      try {
+        assigned = await this._avaClient.isAssignedToAva(issueId);
+      } catch (err) {
+        console.warn(`[linear] assignee check failed for issue ${issueId} — allowing (fail-open): ${err instanceof Error ? err.message : String(err)}`);
+      }
+      if (!assigned) {
+        console.log(`[linear] agent_session.${action} on issue ${issueId} — not assigned to Ava, dropping (no response)`);
+        return;
+      }
+    }
+
     bus.publish(topic, {
       id: crypto.randomUUID(),
       correlationId,

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -406,8 +406,8 @@ skills:
   # Scoped tools: enough to read context, reply, look up the project, and file
   # the routing issue. Not the full toolbelt — no cron / incidents / board here.
   - name: linear_agent_respond
-    description: Handle a Linear @mention, comment, assignment, or notification routed to Ava. Read the issue context, decide on action, reply via linear_add_comment, and route engineering work onto the right project board by filing a GitHub issue.
-    keywords: [linear, issue, ticket, mention, assigned, comment, triage]
+    description: Handle a Linear event that is ABOUT YOU — an issue assigned to you or a comment/issue that @mentions you. Read the issue, decide where the work goes, and route engineering work onto the right project's board by filing a GitHub issue. You only see this when assigned or mentioned; you do not chase ambient Linear activity.
+    keywords: [linear, issue, ticket, mention, assigned, comment]
     tools:
       - linear_get_issue
       - linear_list_issues
@@ -416,26 +416,32 @@ skills:
       - linear_create_issue
       - get_projects
       - create_github_issue
-      - chat_with_agent
       - send_update
     maxTurns: 15
     systemPromptOverride: |
-      You are Ava, handling a Linear event. The payload tells you what
-      happened — branch on the event type and act accordingly. Keep
-      replies tight; Linear isn't a chat surface, it's a tracker.
+      You are Ava, handling a Linear event that was routed to you because the
+      issue is assigned to you or @mentions you. The payload tells you what
+      happened — branch on it and act. Keep replies tight; Linear isn't a chat
+      surface, it's a tracker.
 
-      ## Your job here (read this first)
+      ## Linear is your surface (read this first)
 
-      You are the PORTFOLIO MANAGER — a router. When a ticket is assigned to
-      you, route it to the right project's board. A ticket that says "search
-      this path", "add capability X", or "fix this bug" is work to ROUTE, and
-      your final reply is where you sent it.
+      You own Linear; Quinn owns GitHub. You are the PORTFOLIO MANAGER — a
+      router. Route the work to the right project's board by filing a GitHub
+      issue with `create_github_issue` (that hands it to GitHub, Quinn's
+      surface, where triage/review/decomposition happen). A ticket that says
+      "search this path", "add capability X", or "fix this bug" is work to
+      ROUTE, and your final reply is where you sent it.
 
       Routing is your whole job, so your toolkit (`get_projects` +
       `create_github_issue`) is exactly enough. A ticket that would need a tool
       you don't carry is still a routing case: that tool belongs to an executor,
-      so route the ticket to the project that owns the work. Reviews and QA are
-      Quinn's; she handles those.
+      so route it to the project that owns the work.
+
+      Reviews/QA/triage are Quinn's, and they happen on GitHub — never pull her
+      onto Linear or speak for her here. If review or triage is needed, the
+      GitHub issue you file is the handoff; do not relay another agent's words
+      as a Linear comment.
 
       A ticket proposing a new capability for Ava or the fleet itself is a
       decision for Josh — surface it to his JOSH review queue with


### PR DESCRIPTION
## The model

**Ava ↔ Linear, Quinn ↔ GitHub** — they hand off across surfaces (Ava files a GitHub issue → Quinn's domain; results surface back via Linear) or via native GH Actions / Linear automations. Triage is a **GitHub** concern.

## The bug (observed: JOSH-403)

`JOSH-403` had **assignee: None**, yet a comment was posted **as Ava**: *"…manual operational task — not a GitHub PR. I'm Quinn, a code reviewer; I don't have access to Cloudflare…"* — an unassigned **Linear** issue pulled into a code-review/triage mindset, with another agent's voice on the wrong surface. Two roots:

### 1. No assignment gate
`linear_agent_respond` fired off any agent-session event **plus** a stale-session **poller** that resurrects sessions indiscriminately (the likely JOSH-403 trigger). Now:
- **LinearPlugin** gates the agent-session dispatch on `issue.assignee == Ava` (resolved via her OAuth `viewer` id). **Fail-open** on a check error so a transient API hiccup never mutes a real assignment.
- **@mentions** are honored via Linear's explicit `issueMention`/`issueCommentMention` notifications — the only `AppUserNotification` verbs that now carry a skill hint; ambient verbs (`issueNewComment`, `issueAssignedToYou`, …) stay unrouted.
- The **stale-session poller** only recovers sessions whose issue is assigned to Ava (skips + retries on check error; gating disabled when OAuth unconfigured → current behavior preserved, so existing tests pass).
- New: `LinearAgentActivityClient.getViewerId()` + `isAssignedToAva()`.

### 2. Persona / surface leak
`ava.yaml` `linear_agent_respond` dropped `chat_with_agent` and the `triage` keyword; the prompt now states **Linear is Ava's surface**, engineering/review routes to **GitHub** via `create_github_issue` (Quinn's surface, where triage happens), and she **never relays another agent's words as a Linear comment.**

## Tests
Poller assignee-gating (recover / skip / retry-on-error), client `getViewerId` + `isAssignedToAva` (assigned / differs / unset). Full suite **866 pass**, tsc + lint clean.

## Deploy note
Code ships via the `:main` image. `workspace/agents/ava.yaml` is a host bind-mount — needs a `git pull` on the host + container restart to load (I'll pull it post-merge). The already-posted JOSH-403 comment is a one-off; say the word and I'll delete it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added assignee-based gating for Linear agent session handling—the agent now verifies issue assignments before responding to ensure relevance.

* **Refactor**
  * Refined Linear skill to focus on personally relevant events (assigned to you or `@mentions` you).
  * Removed chat capability from Linear skill; messaging now limited to updates.
  * Strengthened routing guidance to prioritize GitHub issue-based handoffs over Linear comments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->