### PR TITLE
fix(router): Linear events dispatch only via explicit skillHint — never keyword-routed (the real Quinn-on-Linear bug)

### DIFF
--- a/src/router/__tests__/router-plugin.test.ts
+++ b/src/router/__tests__/router-plugin.test.ts
@@ -64,6 +64,7 @@ const avaAgent = {
   tools: [],
   skills: [
     { name: "sitrep", keywords: ["status", "sitrep", "/sitrep"] },
+    { name: "linear_agent_respond", keywords: ["linear", "issue", "ticket", "mention", "assigned", "comment"] },
   ],
 };
 
@@ -438,17 +439,63 @@ describe("RouterPlugin", () => {
             "message.inbound.linear.agent.issueCommentMention",
             makeInbound("message.inbound.linear.agent.issueCommentMention", {
               content: "this is a bug in the auth flow",
+              // LinearPlugin stamps this on genuine @mentions; it's the ONLY way
+              // a Linear event dispatches — via the explicit hint to Ava's
+              // handler, never keyword-matched to another agent's skill.
+              skillHint: "linear_agent_respond",
             }),
           );
-          await requestPromise;
+          const req = await requestPromise;
+          // Dispatches the hinted skill; the executor registry resolves it to
+          // Ava (no agent attached at the router for hint matches).
+          expect((req!.payload as Record<string, unknown>).skill).toBe("linear_agent_respond");
         } finally {
           console.log = origLog;
         }
 
         const linearLine = logs.find(l => l.includes("[linear] event=agent.issueCommentMention"));
         expect(linearLine).toBeDefined();
-        expect(linearLine).toContain("delivered to quinn");
-        expect(linearLine).toContain("skill=bug_triage");
+        expect(linearLine).toContain("skill=linear_agent_respond");
+
+        plugin.uninstall();
+      } finally { cleanup(); }
+    });
+
+    test("does NOT keyword-route a Linear event without a skillHint (Quinn stays off Linear)", async () => {
+      // Regression: a Linear comment whose text matches a GitHub-domain skill's
+      // keywords (e.g. "PR review", "code reviewer" → pr_review) must NOT pull
+      // that skill onto Linear. Without an explicit skillHint, a Linear event is
+      // dropped — preventing the deletion→comment.removed→pr_review→re-comment loop.
+      const { workspaceDir, cleanup } = makeWorkspace({
+        agents: { "quinn.yaml": quinnAgent, "ava.yaml": avaAgent },
+      });
+      try {
+        const bus = new InMemoryEventBus();
+        const plugin = new RouterPlugin({ workspaceDir });
+        plugin.install(bus);
+
+        const dispatched: BusMessage[] = [];
+        bus.subscribe("agent.skill.request", "spy", (m) => { dispatched.push(m); });
+
+        const logs: string[] = [];
+        const origLog = console.log;
+        console.log = (...args: unknown[]) => { logs.push(args.map(String).join(" ")); };
+        try {
+          bus.publish(
+            "message.inbound.linear.comment.removed",
+            makeInbound("message.inbound.linear.comment.removed", {
+              content: "not a GitHub PR. I'm Quinn, a code reviewer.",
+            }),
+          );
+          await new Promise(r => setTimeout(r, 20));
+        } finally {
+          console.log = origLog;
+        }
+
+        expect(dispatched).toHaveLength(0); // nothing dispatched
+        const linearLine = logs.find(l => l.includes("[linear] event=comment.removed"));
+        expect(linearLine).toBeDefined();
+        expect(linearLine).toContain("delivered to none");
 
         plugin.uninstall();
       } finally { cleanup(); }

--- a/src/router/router-plugin.ts
+++ b/src/router/router-plugin.ts
@@ -203,7 +203,16 @@ export class RouterPlugin implements Plugin {
     const conversationId = workingMsg.correlationId;
     const storedSession = isDM ? this.dmSessions.get(conversationId) : undefined;
 
-    let match = this.resolver.resolve(skillHint, content);
+    // Linear is Ava's surface: Linear inbound events dispatch ONLY via an
+    // explicit skillHint (set by LinearPlugin's gated agent-session / mention
+    // paths → linear_agent_respond). Never keyword-match Linear content — that
+    // pulls GitHub-domain skills onto Linear (e.g. a comment mentioning "code
+    // reviewer" matching pr_review → Quinn replying on a Linear ticket, and a
+    // delete→re-comment loop). No hint on a Linear event → drop.
+    const isLinearEvent = extractLinearEvent(msg.topic) !== undefined;
+    let match = (isLinearEvent && !skillHint)
+      ? null
+      : this.resolver.resolve(skillHint, content);
 
     if (isDM && !match && !storedSession) {
       // No keyword match and no active session — check DM default fallback.


### PR DESCRIPTION
## Root cause (found via the live incident)

The JOSH-403 "I'm Quinn" comment reappeared **after** #676 deployed. Timestamped logs showed why:

```
[router] message.inbound.linear.comment.removed → skill "pr_review" (via keyword) [quinn] → linear.reply.JOSH-403
[linear] Comment posted AS Ava on issue JOSH-403
```

**RouterPlugin keyword-matches inbound Linear event *content* to any skill.** A comment whose body says *"…not a GitHub PR. I'm Quinn, a code reviewer…"* keyword-matches `pr_review` → the router dispatched a **Linear** event to **Quinn**, whose reply landed on the Linear ticket (as Ava, via the reply topic). And deleting that comment fired `comment.removed`, whose body re-matched `pr_review` → Quinn re-commented → **loop**.

This is the actual `ava ↔ Linear, quinn ↔ GitHub` violation. #676 gated the agent-session/poller path (still valid); this closes the **keyword-routing** path that actually produced the comments.

## Fix

In `RouterPlugin._handleInbound`, a Linear inbound event resolves a skill **only from an explicit `skillHint`** (set by LinearPlugin's gated agent-session / @mention paths → `linear_agent_respond`). Linear content is **never keyword-matched**, so GitHub-domain skills (`pr_review`, `bug_triage`) can't be pulled onto Linear. No hint on a Linear event → dropped.

```ts
const isLinearEvent = extractLinearEvent(msg.topic) !== undefined;
let match = (isLinearEvent && !skillHint) ? null : this.resolver.resolve(skillHint, content);
```

## Tests
Updated the linear-delivery test to dispatch via `skillHint` (the only valid path now), and added a **regression test**: a `comment.removed` whose text matches `pr_review` keywords dispatches **nothing** and logs "delivered to none". Full suite **867 pass**, tsc + lint clean.

## Note
Confirmed live: JOSH-403 now has **0 comments** and no loop. Combined with #676, Linear is fully Ava's surface — Quinn cannot be pulled onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linear message routing to require explicit routing hints before processing, eliminating unintended keyword-based routing matches that could cause incorrect message dispatch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->