### PR TITLE
fix(ci): ship-notification must not gate main (#669)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # Best-effort ship notification — must NEVER gate main CI. The image is
+      # already built + pushed by this point; a bad/expired webhook is not a
+      # build failure. Fails loud in the logs but exits 0, and continue-on-error
+      # is a backstop for any unexpected throw (e.g. network error). (#669)
       - name: Notify Discord — what shipped
+        continue-on-error: true
         env:
           WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_PROTOWORKSTACEAN_DEV }}
           COMMIT_SUBJECT: ${{ github.event.head_commit.message }}
@@ -129,11 +134,15 @@ jobs:
           const sha     = (process.env.SHORT_SHA ?? '').slice(0, 7);
           const url     = process.env.COMMIT_URL ?? '';
 
-          const resp = await fetch(webhook, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ embeds: [{ title: \`Shipped — \${sha}\`, description: subject, url, color: 5763719, footer: { text: 'protoWorkstacean' } }] }),
-          });
-          if (!resp.ok) { console.error('Discord post failed:', resp.status); process.exit(1); }
-          console.log('Posted to dev-channel webhook.');
+          try {
+            const resp = await fetch(webhook, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ embeds: [{ title: \`Shipped — \${sha}\`, description: subject, url, color: 5763719, footer: { text: 'protoWorkstacean' } }] }),
+            });
+            if (!resp.ok) { console.error('Discord post failed (non-blocking):', resp.status, await resp.text().catch(() => '')); process.exit(0); }
+            console.log('Posted to dev-channel webhook.');
+          } catch (e) {
+            console.error('Discord post errored (non-blocking):', e?.message ?? e);
+          }
           " --input-type=module


### PR DESCRIPTION
Closes #669.

**Root cause:** main's `CI` workflow went red on *every* push while `build`/`test`/`dashboard` all passed — because the final **"Notify Discord — what shipped"** step did `process.exit(1)` on a non-2xx from the `DISCORD_WEBHOOK_PROTOWORKSTACEAN_DEV` webhook. The image was already built + pushed by that point (deploys worked all session), so the build wasn't broken — a **non-critical notification** was reddening the workflow and making `mainBranchLastPushGreen=false`.

**Fix:** a ship ping is not a build gate. The step now logs loudly but **exits 0** on a failed/errored post (try/catch), with **`continue-on-error: true`** as a backstop. `build`/`test`/`dashboard` still gate main; only the notification is downgraded to non-blocking.

> The webhook secret itself is returning non-2xx — refresh `DISCORD_WEBHOOK_PROTOWORKSTACEAN_DEV` to restore the actual pings. CI is green either way now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment process resilience by making notification delivery non-blocking, ensuring builds continue uninterrupted even if external notification services fail.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->