### PR TITLE
docs: retire workspace/projects.yaml references (#683 theme 2)

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -237,8 +237,8 @@ workspace/
   agents.yaml                  # A2A remote agents
   agents/                      # In-process agent YAMLs
   ceremonies/                  # Scheduled rituals
-  crons/                       # Plain cron entries
-  projects.yaml
+  crons/                       # Plain cron entries (created by SchedulerPlugin)
+  channels.yaml                # Channel→agent + per-project channel bindings
 test/
   integration/
 tests/

--- a/docs/how-to/configure-discord.md
+++ b/docs/how-to/configure-discord.md
@@ -144,14 +144,14 @@ commands:
     skillHint: bug_triage
 ```
 
-When `project` is an autocomplete option, the plugin loads `projects.yaml` at interaction time and returns matching projects (filtered by slug or title) as Discord choices.
+When `project` is an autocomplete option, the plugin reads the in-process project registry (`ctx.projectRegistry.getProjects()`, sourced from protoMaker) at interaction time and returns matching projects (filtered by slug or name) as Discord choices.
 
-On submission, the project slug is resolved to `devChannelId` and `projectRepo` which are added to the inbound bus payload:
+On submission, the project slug is resolved against the registry; its dev channel is looked up in the `ChannelRegistry` (`getProjectChannel(slug, "dev")`, backed by `workspace/channels.yaml`) and its repo from the registry entry's `github`. Both are added to the inbound bus payload:
 
 ```typescript
 {
-  devChannelId?: string;   // discord.dev channel ID from projects.yaml
-  projectRepo?: string;    // GitHub full name, e.g. "protoLabsAI/protoUI"
+  devChannelId?: string;   // dev channel from ChannelRegistry.getProjectChannel(slug, "dev")
+  projectRepo?: string;    // GitHub full name from the registry, e.g. "protoLabsAI/protoUI"
 }
 ```
 

--- a/docs/how-to/onboard-a-project.md
+++ b/docs/how-to/onboard-a-project.md
@@ -3,7 +3,7 @@ title: How to Onboard a Project
 ---
 
 
-_This is a how-to guide. It assumes the workstacean container is running and you have Ava configured in `workspace/agents.yaml`._
+_This is a how-to guide. It assumes the workstacean container is running and you have Ava configured in `workspace/agents/ava.yaml` (the in-process agent definition)._
 
 ---
 
@@ -55,7 +55,17 @@ Ava's `onboard_project` skill runs these steps in sequence:
 2. **`.automaker/` scaffold** — writes `project.json` and `settings.json` into the target repo, commits and pushes
 3. **`.gitignore` + worktree init** — adds worktree paths to `.gitignore` in the target repo
 4. **Discord provisioning** — calls Quinn's `provision_discord` skill (via chain), which creates a Discord category with three channels: `dev`, `alerts`, `releases`
-5. **Write-back** — stores Discord channel IDs in both `.automaker/settings.json` (in the target repo) and `workspace/projects.yaml` (in this repo)
+5. **Write-back** — stores Discord channel IDs in `.automaker/settings.json` (in the target repo)
+
+Project metadata itself lives in the **protoMaker registry** (the source of truth), and the workstacean-side channel→agent bindings live in `workspace/channels.yaml` via the `ChannelRegistry` — onboarding does **not** write a `workspace/projects.yaml` (that file no longer exists). To make feature-notifier and slash-commands resolve "the dev channel for this project", add a per-project binding to `workspace/channels.yaml`:
+
+```yaml
+- id: project-my-new-repo-dev
+  platform: discord
+  project: my-new-repo        # project slug
+  kind: dev
+  channelId: "<channel-id>"
+```
 
 On completion, a summary message is sent to the originating interface (Discord channel or the bus outbound topic).
 
@@ -63,14 +73,10 @@ On completion, a summary message is sent to the originating interface (Discord c
 
 ## Verifying the onboard completed
 
-Check `workspace/projects.yaml` for a new entry:
+Confirm the project shows up in workstacean's registry (sourced from protoMaker):
 
-```yaml
-- repo: protoLabsAI/my-new-repo
-  discord:
-    dev: "<channel-id>"
-    alerts: "<channel-id>"
-    releases: "<channel-id>"
+```bash
+curl -s http://workstacean:3000/api/projects | jq '.data[] | select(.github.repo == "my-new-repo")'
 ```
 
 Check the target repo for a `.automaker/` directory:
@@ -78,6 +84,10 @@ Check the target repo for a `.automaker/` directory:
 ```bash
 gh api repos/protoLabsAI/my-new-repo/contents/.automaker/project.json
 ```
+
+If you added a per-project Discord binding, confirm it resolves via the
+`ChannelRegistry` — the dev channel is keyed by `(slug, "dev")` in
+`workspace/channels.yaml`.
 
 ---
 
@@ -105,5 +115,5 @@ curl -s -X POST http://workstacean:3000/publish \
 ## Related docs
 
 - [reference/agent-skills.md](../reference/agent-skills) — full skill registry including `onboard_project` parameters
-- [reference/config-files.md](../reference/config-files) — `projects.yaml` schema
+- [reference/config-files.md](../reference/config-files) — workspace config + protoMaker project registry
 - [explanation/agent-identity.md](../explanation/agent-identity) — why Quinn handles Discord provisioning (not Ava)

--- a/docs/reference/config-files.md
+++ b/docs/reference/config-files.md
@@ -86,7 +86,6 @@ Each has a `.example` counterpart — copy it to bootstrap a new deployment:
 |------|-----------|
 | `workspace/agents/<name>.yaml` | `workspace/agents/<name>.yaml.example` — one file per in-process agent |
 | `workspace/agents.yaml` | `workspace/agents.yaml.example` — external A2A agent registry |
-| `workspace/projects.yaml` | `workspace/projects.yaml.example` |
 | `workspace/discord.yaml` | `workspace/discord.yaml.example` |
 | `workspace/google.yaml` | `workspace/google.yaml.example` |
 | `workspace/a2a.yaml` | `workspace/a2a.yaml.example` — outbound A2A delivery targets for the scheduler |
@@ -194,28 +193,13 @@ agents:
 
 ---
 
-## workspace/projects.yaml
+## Project metadata (no workspace file)
 
-Source of truth for the project registry. Consumed by Quinn and protoMaker via `GET /api/projects`. Written to during `onboard_project`.
+There is no `workspace/projects.yaml`. The **protoMaker registry is the source of truth** for project metadata. workstacean pulls the canonical project list from protoMaker (`GET /api/settings/global`) via `ProjectRegistry` ([`src/plugins/project-registry.ts`](../../src/plugins/project-registry.ts)) and re-serves it at `GET /api/projects`. Each entry exposes `id`, `name`, derived `slug`, filesystem `path`, derived `github` (`{ owner, repo }`), and `defaultBranch`.
 
-Webhook URLs are never stored here — use `webhookEnv` to point at an env var holding the URL.
+Discord channel bindings are **not** part of project metadata — they live in `workspace/channels.yaml` via the [ChannelRegistry](workspace-files), keyed by `(projectSlug, kind)` and resolved with `ChannelRegistry.getProjectChannel(slug, kind)`.
 
-```yaml
-projects:
-  - slug: your-org-your-repo
-    title: Your Project
-    github: your-org/your-repo
-    defaultBranch: main
-    status: active
-    agents: [protomaker, quinn]
-    discord:
-      dev:
-        channelId: ""
-        webhookEnv: DISCORD_WEBHOOK_YOURPROJECT_DEV      # env var name, not the URL
-      release:
-        channelId: ""
-        webhookEnv: DISCORD_WEBHOOK_YOURPROJECT_RELEASE
-```
+To add a project, register it in protoMaker's UI; workstacean picks it up on the next registry refresh (5-min interval, or immediately on restart).
 
 ---
 
@@ -248,7 +232,7 @@ commands:
             description: "Option description"
             type: string               # string | integer | boolean
             required: false
-            autocomplete: false        # true enables live Discord filtering; project options load from projects.yaml
+            autocomplete: false        # true enables live Discord filtering; project options resolve via the in-process project registry
 ```
 
 ---

--- a/docs/reference/onboarding-plugin.md
+++ b/docs/reference/onboarding-plugin.md
@@ -2,33 +2,31 @@
 title: OnboardingPlugin Reference
 ---
 
-_This is a reference doc. It covers the OnboardingPlugin pipeline, request schema, idempotency guarantees, trigger sources, and related tooling._
-
----
+_This is a reference doc. It covers the OnboardingPlugin pipeline, request schema, idempotency guarantees, and trigger sources._
 
 ---
 
 ## Overview
 
-`OnboardingPlugin` (`lib/plugins/onboarding.ts`) implements a deterministic, idempotent 7-step project provisioning pipeline. When triggered, it registers a project across GitHub and Google Drive, then writes the project's metadata to `workspace/projects.yaml` and notifies downstream consumers.
+`OnboardingPlugin` (`lib/plugins/onboarding.ts`) runs the deterministic, idempotent side-effects of bringing a project online: registering its GitHub webhook, creating its Google Drive folder, and notifying downstream consumers.
+
+**Project registration itself is owned by protoMaker** — protoMaker's project registry is the source of truth for project metadata (see [config-files](config-files) and [`src/plugins/project-registry.ts`](../../src/plugins/project-registry.ts)). Operators register the project in protoMaker's UI _before_ triggering onboarding here; this plugin does not create or persist a project record of its own. workstacean reads the canonical project list from protoMaker via the `ProjectRegistry` (exposed at `GET /api/projects`).
 
 ---
 
-## The 7-step pipeline
+## The pipeline
 
 Steps run in sequence. Each step is individually idempotent — re-running the full pipeline for the same slug is safe.
 
 | # | Step | What it does | Skip condition |
 |---|------|-------------|----------------|
-| 1 | **validate** | Checks `slug`, `title`, and `github` are present; validates `github` is `owner/repo` format; rejects duplicate in-flight runs | Missing required fields or invalid format |
-| 2 | **idempotency** | Reads `workspace/projects.yaml` and exits early (success) if the slug is already registered | Slug already in `projects.yaml` |
-| 3 | **github_webhook** | Registers a GitHub repo webhook for `issues`, `issue_comment`, `pull_request`, `pull_request_review_comment` events; skips if webhook URL already registered | No GitHub auth (`QUINN_APP_ID` or `GITHUB_TOKEN`), or `WORKSTACEAN_PUBLIC_URL` not set, or webhook already exists |
-| 4 | **drive_folder** | Creates a Google Drive folder under the org root folder (`drive.orgFolderId` in `workspace/google.yaml`) | Google credentials not set, `google.yaml` missing, or `drive.orgFolderId` empty |
-| 5 | **projects_yaml** | Upserts the project entry into `workspace/projects.yaml` under a write lock; validates entry against `ProjectEntrySchema` before writing; preserves file header comments | Slug already present (double-checked under lock) |
-| 6 | **bus_notify** | Publishes `message.inbound.onboard.complete` with project metadata and step outcomes | Never skipped |
-| 7 | **reply** | Sends a confirmation message (or error) to the reply topic | No reply topic in the inbound message |
+| 1 | **validate** | Checks `slug`, `title`, and `github` are present; validates `github` is `owner/repo` format; rejects duplicate in-flight runs for the same slug | Missing required fields or invalid format |
+| 2 | **github_webhook** | Registers a GitHub repo webhook for `issues`, `issue_comment`, `pull_request`, `pull_request_review_comment` events; lists existing webhooks first and skips if the target URL is already registered | No GitHub auth (`QUINN_APP_ID` or `GITHUB_TOKEN`), or `WORKSTACEAN_PUBLIC_URL` not set, or webhook already exists |
+| 3 | **drive_folder** | Creates a Google Drive folder named after the project title, under the org root folder (`drive.orgFolderId` in `workspace/google.yaml`) | Google credentials not set, `google.yaml` missing, or `drive.orgFolderId` empty |
+| 4 | **bus_notify** | Publishes `message.inbound.onboard.complete` with project metadata and per-step outcomes for downstream consumers | Never skipped |
+| 5 | **reply** | Sends a confirmation message (or error) to the inbound message's reply topic | No reply topic in the inbound message |
 
-Steps 3–4 are non-fatal: an error in one step is logged, and the pipeline continues to `projects_yaml`. The pipeline aborts only if `projects_yaml` (step 5) fails.
+Steps 2–3 are non-fatal: an error in one step is recorded in the step result and the pipeline continues. The plugin does not write any project file — it only performs the external side-effects and publishes the completion event.
 
 ---
 
@@ -46,42 +44,7 @@ Sent as the `payload` of a `message.inbound.onboard` bus message (or the JSON bo
 | `agents` | `string[]` | | `["protomaker", "quinn"]` | Agent identifiers to associate |
 | `discord` | `object` | | `{}` | Discord channel IDs (`general`, `updates`, `dev`, `alerts`, `releases`) |
 
----
-
-## `lib/project-schema.ts` — Zod schema
-
-`lib/project-schema.ts` defines the Zod schema for `workspace/projects.yaml` entries. It is used by:
-
-- `lib/plugins/onboarding.ts` — validates each new entry before writing (step 7 fails if validation fails)
-- `lib/plugins/a2a.ts` — validates on load (warns and skips invalid entries)
-
-### `ProjectEntrySchema` fields
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| `slug` | ✅ | Unique project slug |
-| `github` | ✅ | `"owner/repo"` format |
-| `status` | ✅ | Project status string |
-| `discord.dev` | ✅ | Dev channel ID (may be empty string until channel is created) |
-| `title` | | Human-readable name |
-| `defaultBranch` | | Git default branch |
-| `team` | | Team assignment |
-| `agents` | | List of agent identifiers |
-| `onboardedAt` | | ISO 8601 timestamp of onboarding |
-| `onboardingState` | | Per-step status tracking (`ok` \| `skip` \| `error`) |
-| `googleWorkspace.driveFolderId` | | Google Drive folder ID created during onboarding |
-| `googleWorkspace.sharedDocId` | | Project spec/brief Google Doc ID |
-| `googleWorkspace.calendarId` | | Project-scoped calendar ID |
-
-### Validation helpers
-
-```typescript
-// Validate a single raw entry
-validateProjectEntry(raw: unknown): { ok: true; entry: ProjectEntry } | { ok: false; errors: string[] }
-
-// Parse and validate the full projects.yaml structure (throws on invalid)
-parseProjectsYaml(raw: unknown): ProjectsYaml
-```
+These fields are echoed back on `message.inbound.onboard.complete`; the plugin does not persist them. Channel→agent bindings live in `workspace/channels.yaml` ([ChannelRegistry](workspace-files)), and project metadata lives in the protoMaker registry — neither is written by this plugin.
 
 ---
 
@@ -89,10 +52,9 @@ parseProjectsYaml(raw: unknown): ProjectsYaml
 
 The pipeline is safe to re-run for the same project slug:
 
-1. **Step 2 (idempotency check)** exits early with `status: "already_onboarded"` if the slug is already in `projects.yaml`. No external API calls are made.
-2. **Step 3 (github_webhook)** lists existing webhooks before creating; skips if the target URL is already registered.
-3. **Step 5 (projects_yaml)** double-checks for the slug under a write lock before appending.
-4. **In-flight guard** — concurrent requests for the same slug are rejected with an error while the first run is in progress.
+1. **Step 2 (github_webhook)** lists existing webhooks before creating; skips if the target URL is already registered.
+2. **Step 3 (drive_folder)** is skipped entirely when Google credentials or the org folder ID are absent.
+3. **In-flight guard** — concurrent requests for the same slug are rejected with an error while the first run is in progress.
 
 ---
 
@@ -119,13 +81,13 @@ Content-Type: application/json
 }
 ```
 
-The HTTP handler waits up to 30 seconds for the pipeline to complete and returns the result synchronously. If the pipeline takes longer than 30s, it returns `{ success: true, status: "accepted" }` immediately and the pipeline continues in the background.
+The HTTP handler publishes to `message.inbound.onboard` and waits for the pipeline result on the reply topic.
 
-### Discord `/onboard` slash command (M2)
+### Discord `/onboard` slash command
 
-The Discord plugin routes slash commands to `message.inbound.discord.slash.{interactionId}` via the command config in `workspace/discord.yaml`. An `/onboard` command configured in `discord.yaml` can pass the project fields as options and publish to `message.inbound.onboard`. Autocomplete for project fields can be configured via the `choices` option in the command spec.
+The Discord plugin routes slash commands to `message.inbound.discord.slash.{interactionId}` via the command config in `workspace/discord.yaml`. An `/onboard` command configured in `discord.yaml` can pass the project fields as options and publish to `message.inbound.onboard`.
 
-### GitHub org webhook: `repository.created` (M2)
+### GitHub org webhook: `repository.created`
 
 When the GitHub org webhook is registered and a new repository is created under the org, `lib/plugins/github.ts` catches the `repository` + `action: created` event and publishes to `message.inbound.onboard` automatically. The payload uses the repository's `full_name`, `name`, `owner.login`, `description`, and visibility.
 
@@ -135,7 +97,7 @@ When the GitHub org webhook is registered and a new repository is created under 
 
 | Topic | When published | Payload highlights |
 |-------|---------------|-------------------|
-| `message.inbound.onboard.complete` | After `projects_yaml` step succeeds | `slug`, `github`, `driveFolderId`, per-step `status` |
+| `message.inbound.onboard.complete` | After the pipeline runs | `slug`, `title`, `github`, `defaultBranch`, `team`, `agents`, `discord`, `driveFolderId`, per-step `status` |
 | `{msg.reply.topic}` | After pipeline finishes (success or error) | Full result with `success`, `step`, human-readable `content` |
 
 ---
@@ -144,33 +106,20 @@ When the GitHub org webhook is registered and a new repository is created under 
 
 | Variable | Required by | Default | Purpose |
 |----------|-------------|---------|---------|
-| `WORKSTACEAN_PUBLIC_URL` | Step 3 | — | Base URL for webhook registration (e.g. `https://ws.example.com`) |
-| `QUINN_APP_ID` | Step 3 | — | GitHub App ID for auth (used by `makeGitHubAuth`) |
-| `QUINN_APP_PRIVATE_KEY` | Step 3 | — | GitHub App private key |
-| `GITHUB_TOKEN` | Step 3 | — | Alternative GitHub PAT for webhook registration |
-| `GITHUB_WEBHOOK_SECRET` | Step 3 | — | Optional HMAC secret for GitHub webhooks |
-| `GOOGLE_CLIENT_ID` | Step 4 | — | Google OAuth client ID |
-| `GOOGLE_CLIENT_SECRET` | Step 4 | — | Google OAuth client secret |
-| `GOOGLE_REFRESH_TOKEN` | Step 4 | — | Google OAuth refresh token |
-
----
-
-## Config hot-reload
-
-The following workspace config files are watched at runtime (polled every 5 seconds by Node's `watchFile`). Changes take effect without a container restart:
-
-| File | Watched by | What reloads |
-|------|-----------|-------------|
-| `workspace/github.yaml` | `GithubPlugin` | Mention handle, admins, per-event skill hints |
-| `workspace/projects.yaml` | `GithubPlugin`, `A2aPlugin` | Monitored repo list (GithubPlugin), project routing table (A2aPlugin) |
-| `workspace/discord.yaml` | `DiscordPlugin` | Channel config, slash command list (re-registers commands on change) |
-| `workspace/agents.yaml` | `DiscordPlugin` | Agent identity list (bot → agent mapping) |
+| `WORKSTACEAN_PUBLIC_URL` | github_webhook | — | Base URL for webhook registration (e.g. `https://ws.example.com`) |
+| `QUINN_APP_ID` | github_webhook | — | GitHub App ID for auth (used by `makeGitHubAuth`) |
+| `QUINN_APP_PRIVATE_KEY` | github_webhook | — | GitHub App private key |
+| `GITHUB_TOKEN` | github_webhook | — | Alternative GitHub PAT for webhook registration |
+| `GITHUB_WEBHOOK_SECRET` | github_webhook | — | Optional HMAC secret for GitHub webhooks |
+| `GOOGLE_CLIENT_ID` | drive_folder | — | Google OAuth client ID |
+| `GOOGLE_CLIENT_SECRET` | drive_folder | — | Google OAuth client secret |
+| `GOOGLE_REFRESH_TOKEN` | drive_folder | — | Google OAuth refresh token |
 
 ---
 
 ## References
 
 - [`lib/plugins/onboarding.ts`](../../lib/plugins/onboarding.ts) — plugin implementation
-- [`lib/project-schema.ts`](../../lib/project-schema.ts) — Zod schema for `projects.yaml` entries
+- [`src/plugins/project-registry.ts`](../../src/plugins/project-registry.ts) — protoMaker-backed project registry (source of truth)
 - [`reference/bus-topics.md`](bus-topics) — full bus topic registry
 - [`reference/config-files.md`](config-files) — workspace config file reference

--- a/docs/reference/workspace-files.md
+++ b/docs/reference/workspace-files.md
@@ -112,18 +112,27 @@ skills:
 
 ---
 
-## workspace/projects.yaml
+## Project metadata
 
-Project registry. Read by `RouterPlugin` for GitHub-message enrichment (resolving an inbound `owner/repo` to a project slug + Discord channel set).
+There is no `workspace/projects.yaml`. Project metadata comes from the **protoMaker registry** — workstacean pulls the canonical list via `ProjectRegistry` ([`src/plugins/project-registry.ts`](../../src/plugins/project-registry.ts)) and serves it at `GET /api/projects`. `RouterPlugin` resolves an inbound `owner/repo` to a project (`ProjectRegistry.getByGithub`) and then looks up its Discord channels in `workspace/channels.yaml` via `ChannelRegistry.getProjectChannel(slug, kind)`.
+
+## workspace/channels.yaml
+
+Channel→agent and per-project channel bindings. Read by `ChannelRegistry`. Each entry maps a `(platform, channelId)` to an agent, or binds a `(project, kind)` pair to a Discord channel.
 
 ```yaml
-projects:
-  - slug: string           # Unique project identifier
-    owner: string          # GitHub org or user
-    repo: string           # GitHub repository name
-    workspace?: string     # Path to per-project config dir (relative to WORKSPACE_DIR)
-    discordChannels?:      # Discord channel IDs associated with this project
-      - string
+channels:
+  - id: string             # Unique entry id
+    platform: string       # discord | linear | google
+    channelId: string      # Platform channel/team/issue id
+    agent?: string         # Agent that handles this channel (channel→agent route)
+    project?: string       # Project slug — for per-project channel bindings
+    kind?: string          # Binding kind (e.g. "dev") for getProjectChannel(slug, kind)
+    description?: string
+    conversation?:          # Optional multi-turn conversation settings
+      enabled: boolean
+      timeoutMs: number
+      requireMentionAfterFirst?: boolean
 ```
 
 ---

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -66,10 +66,9 @@ cp workspace/agents/frank.yaml.example workspace/agents/frank.yaml
 
 # External A2A agent registry — list the protoMaker team, quinn, etc.
 cp workspace/agents.yaml.example workspace/agents.yaml
-
-# Project registry
-cp workspace/projects.yaml.example workspace/projects.yaml
 ```
+
+There is no project file to copy — projects come from the **protoMaker registry**, not a workspace file. workstacean pulls the canonical project list from protoMaker at startup (and refreshes it periodically) and serves it at `GET /api/projects`.
 
 Edit `workspace/agents/ava.yaml` and set your `systemPrompt`. For a minimal
 chat-only Ava:


### PR DESCRIPTION
## What

Theme 2 of #683 — sweep retired `workspace/projects.yaml` references out of the docs. The file was retired; the **protoMaker registry** (`src/plugins/project-registry.ts`, served at `GET /api/projects` from `ctx.projectRegistry`) is now the source of truth, and per-project Discord channel bindings live in `workspace/channels.yaml` via `ChannelRegistry`.

## Per-file changes

- **`reference/onboarding-plugin.md`** — was largely fiction (a 7-step pipeline that read/wrote `projects.yaml`, plus `lib/project-schema.ts`/`ProjectEntrySchema` and `lib/plugins/a2a.ts`/`A2aPlugin`, none of which exist). Rewritten to the real side-effects-only pipeline from `lib/plugins/onboarding.ts`: `validate → github_webhook → drive_folder → bus_notify → reply`. Deleted the schema/projects.yaml/A2aPlugin sections; states registration is owned by protoMaker.
- **`reference/config-files.md`** — deleted the `projects.yaml` schema section + its gitignored-files entry; replaced with a "project metadata comes from the protoMaker registry" note; fixed the discord autocomplete comment.
- **`reference/workspace-files.md`** — deleted the stale `projects.yaml` section (`owner`/`repo`/`discordChannels`, "read by RouterPlugin"); documented `workspace/channels.yaml` + the registry instead.
- **`tutorials/getting-started.md`** — dropped the `cp workspace/projects.yaml.example …` bootstrap step; noted projects come from the protoMaker registry.
- **`how-to/onboard-a-project.md`** — channels live in `channels.yaml` (ChannelRegistry), project metadata in the protoMaker registry; fixed write-back/verify steps; fixed the Ava config path to `workspace/agents/ava.yaml`.
- **`how-to/configure-discord.md`** — project autocomplete resolves via the in-process project registry + `ChannelRegistry.getProjectChannel(slug, "dev")` (verified against `lib/plugins/discord/slash-commands.ts`).
- **`contributing/development.md`** — removed `projects.yaml` from the workspace layout.

## Notes / divergences from the brief

- **`workspace/crons/` was kept**, not removed. The brief said the dir doesn't exist, but `lib/plugins/scheduler.ts` actively creates (`mkdirSync`) and reads `<dataDir>/crons`, and `src/scheduler.test.ts` exercises it. The layout entry in `development.md` and the `contributing/index.md` reference are accurate, so leaving them in.
- `reference/http-api.md` left untouched (auto-generated, already correct).
- ADR/decisions references left untouched (correctly historical).

## Verify

`bunx vitepress build` passes.

Refs #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)