### PR TITLE
docs: agents are in-process; fix Linear bridge + gating (#683 theme 3)

### DIFF
--- a/docs/architecture/flow-inbound-message.md
+++ b/docs/architecture/flow-inbound-message.md
@@ -12,6 +12,8 @@ Discord/GitHub/Linear/Google webhooks land as `message.inbound.*` topics. [Route
 
 No LLM in the routing layer. Routing is keyword/channel YAML; LLM-driven decisions happen *inside* executors.
 
+**Linear inbound is a special case.** RouterPlugin dispatches a Linear event **only via an explicit `skillHint`** — Linear content is never keyword-matched. `LinearPlugin` stamps `skillHint: linear_agent_respond` on @mention notifications (`issueMention`/`issueCommentMention`) and on agent-session events for issues **assigned to Ava** (`isAssignedToAva`, fail-open). Everything else on Linear is un-hinted and dropped. So Ava responds on Linear only when @mentioned or assigned. The `proto-task` label path is handled separately by `linear-proto-bridge` (see [flow-linear-bridges](flow-linear-bridges.md)).
+
 ---
 
 ## ASCII spine
@@ -47,10 +49,10 @@ No LLM in the routing layer. Routing is keyword/channel YAML; LLM-driven decisio
                   │
         ┌─────────┼─────────┐
         ▼         ▼         ▼
-    DeepAgent  ProtoSdk   A2A   FunctionExecutor
-    Executor   Executor   Exec  (alert/ceremony/pr-r)
-        │         │         │         │
-        └─────────┴─────────┴─────────┘
+    DeepAgent    A2A    FunctionExecutor
+    Executor     Exec   (alert/ceremony/pr-r)
+        │         │         │
+        └─────────┴─────────┘
                   │
                   ▼
    ┌──────────────────────────┐
@@ -118,8 +120,8 @@ sequenceDiagram
 |---|---|---|---|
 | `message.inbound.discord.{channelId}` | DiscordPlugin | RouterPlugin | `lib/plugins/discord/inbound.ts:130,247,283` |
 | `message.inbound.github.{owner}.{repo}.{event}.{n}` | GitHubPlugin | RouterPlugin, PR-review handler | `lib/plugins/github.ts:635,700,795,939` |
-| `message.inbound.linear.{event}` | LinearPlugin | RouterPlugin, linear-protomaker-bridge, linear-proto-bridge | `lib/plugins/linear.ts` |
-| `agent.skill.request` | RouterPlugin, bridges, ActionDispatcher, SkillDispatcher (drain) | **SkillDispatcherPlugin (sole)** | `src/router/router-plugin.ts:272,322`; `src/executor/skill-dispatcher-plugin.ts:507` |
+| `message.inbound.linear.{event}` | LinearPlugin | RouterPlugin (skillHint-only), linear-proto-bridge | `lib/plugins/linear.ts` |
+| `agent.skill.request` | RouterPlugin, linear-proto-bridge, SkillDispatcher (mailbox drain) | **SkillDispatcherPlugin (sole)** | `src/router/router-plugin.ts:272,322`; `src/executor/skill-dispatcher-plugin.ts:507` |
 | `flow.item.created` | SkillDispatcher | telemetry / dashboard | `src/executor/skill-dispatcher-plugin.ts:275` |
 | `flow.item.updated` | SkillDispatcher (running / error) | telemetry / dashboard | `src/executor/skill-dispatcher-plugin.ts:370,385,457` |
 | `agent.skill.progress.{correlationId}` | executor (opt-in) | dashboard / streaming | `src/event-bus/payloads.ts:86-95` |
@@ -161,7 +163,7 @@ The dispatcher enforces invariants in this order ([skill-dispatcher-plugin.ts:16
 
 ## Related flows
 
-- [flow-linear-bridges](flow-linear-bridges.md) — Linear inbound bypasses RouterPlugin for label-triggered dispatches.
+- [flow-linear-bridges](flow-linear-bridges.md) — the `proto-task` label bridge builds its own `agent.skill.request` instead of routing through RouterPlugin.
 - [flow-pr-review](flow-pr-review.md) — GitHub PR events follow this flow but with a fixed `skillHint=pr_review`.
 - [chokepoint-invariants](chokepoint-invariants.md) — the four invariants that sit inside the dispatcher.
 - [flow-agent-runtime-telemetry](flow-agent-runtime-telemetry.md) — what the dispatcher's outcome topics feed.

--- a/docs/architecture/flow-linear-bridges.md
+++ b/docs/architecture/flow-linear-bridges.md
@@ -1,19 +1,22 @@
 ---
-title: Flow — Linear bridges (protomaker + proto)
+title: Flow — Linear → proto bridge
 ---
 
-_Two near-identical bridges turn label-tagged Linear issues into agent dispatches. They bypass RouterPlugin and use a `reply.topic` contract to round-trip the agent's response back to the Linear issue as a comment, with no bridge-side state._
+_A label-tagged Linear issue becomes a `code.execute` dispatch to the in-process `proto` agent. The bridge bypasses RouterPlugin's keyword/channel resolution and uses a `reply.topic` contract to round-trip the agent's response back to the Linear issue as a comment, with no bridge-side state._
 
 ---
 
 ## What & why
 
-`RouterPlugin` resolves chat messages via channels + keywords — neither concept fits a Linear *label* gate (which inspects the issue payload itself). Two bridges fill the gap:
+`RouterPlugin` resolves messages via channels + `skillHint` — neither concept fits a Linear *label* gate (which inspects the issue payload itself). One bridge fills the gap:
 
-- **`linear-protomaker-bridge`** ([lib/plugins/linear-protomaker-bridge.ts](../../lib/plugins/linear-protomaker-bridge.ts)) — issues with the team's configured trigger label dispatch `manage_feature` to `protomaker`. Configured per-team via `workspace/linear-board-mappings.yaml`.
-- **`linear-proto-bridge`** ([lib/plugins/linear-proto-bridge.ts](../../lib/plugins/linear-proto-bridge.ts)) — issues with the `proto-task` label dispatch `code.execute` to the in-process `proto` agent. Single global label gate; override via `LINEAR_PROTO_BRIDGE_LABEL` env.
+- **`linear-proto-bridge`** ([lib/plugins/linear-proto-bridge.ts](../../lib/plugins/linear-proto-bridge.ts)) — issues with the `proto-task` label dispatch `code.execute` to the in-process `proto` agent. Single global label gate; override via `LINEAR_PROTO_BRIDGE_LABEL` env. No per-team mapping — `proto` is one fleet-wide agent, not per-board.
 
-Both follow the same shape; only the gating logic and the target skill/agent differ.
+> **There is no Linear → protoMaker board bridge.** The path that feeds protoMaker's board is `protomaker-board-bridge.ts`, which forwards **`github.issue.opened`** events (not Linear) to protoMaker's HTTP intake. protoMaker serves no `/a2a` endpoint. See [Related](#related).
+
+### How this differs from the mention/assignment path
+
+A Linear @mention or assigned-issue session is **not** a bridge concern. `LinearPlugin` stamps `skillHint: linear_agent_respond` on those events and `RouterPlugin` dispatches them to Ava. Linear inbound is otherwise **`skillHint`-only**: an un-hinted Linear event is never keyword-matched, so it drops. The `proto-task` label bridge is the one place a Linear event turns into a dispatch *without* a `skillHint` — it builds the `agent.skill.request` itself.
 
 ---
 
@@ -31,22 +34,21 @@ Both follow the same shape; only the gating logic and the target skill/agent dif
    ┌──────────────────────────┐
    │ message.inbound.linear.  │
    │   issue.created          │
-   └──────┬──────────────┬────┘
-          │              │
-          ▼              ▼
-   ┌────────────┐  ┌────────────┐
-   │ protomaker │  │   proto    │   each bridge subscribes
-   │   bridge   │  │   bridge   │   independently
-   │            │  │            │
-   │ label gate │  │ label gate │   (different label per bridge)
-   │ team       │  │ env-       │
-   │ mapping    │  │ overridable│
-   └─────┬──────┘  └─────┬──────┘
-         │               │
-         └───────┬───────┘
-                 ▼
+   └──────────────┬───────────┘
+                  │
+                  ▼
+          ┌────────────────┐
+          │  proto bridge  │   subscribes to issue.created
+          │                │
+          │  label gate    │   default "proto-task"
+          │  (env-         │   override LINEAR_PROTO_BRIDGE_LABEL
+          │   overridable) │
+          └───────┬────────┘
+                  │
+                  ▼
    ┌──────────────────────────┐
-   │  agent.skill.request     │  reply.topic = linear.reply.{issueId}
+   │  agent.skill.request     │  skill=code.execute, targets=[proto]
+   │                          │  reply.topic = linear.reply.{issueId}
    └──────────────┬───────────┘
                   ▼
               SkillDispatcher  (→ [flow-inbound-message](flow-inbound-message.md))
@@ -71,9 +73,9 @@ sequenceDiagram
     participant Ext as Linear (external)
     participant LP as LinearPlugin
     participant Bus as Bus
-    participant B as Bridge<br/>(proto OR protomaker)
+    participant B as linear-proto-bridge
     participant SD as SkillDispatcher
-    participant E as Executor<br/>(proto / protomaker)
+    participant E as proto (DeepAgentExecutor)
 
     Ext->>LP: webhook (Issue.Create)
     LP->>LP: validate + dedupe
@@ -81,10 +83,10 @@ sequenceDiagram
     Bus->>B: deliver
 
     rect rgb(240, 230, 220)
-        Note over B: label gate
+        Note over B: label gate (proto-task)
         alt label matches
             B->>B: build content + meta
-            B->>Bus: agent.skill.request<br/>(reply.topic = linear.reply.{issueId})
+            B->>Bus: agent.skill.request<br/>(code.execute@proto, reply.topic = linear.reply.{issueId})
         else label miss
             Note over B: silent drop
         end
@@ -96,7 +98,7 @@ sequenceDiagram
 
     Bus->>LP: deliver (subscriber: linear.reply.#)
     LP->>LP: extract issueId from topic
-    LP->>Ext: client.createComment(issueId, content)
+    LP->>Ext: createComment(issueId, content)
     LP->>Bus: linear.reply.result.{correlationId}<br/>(record API result)
 ```
 
@@ -106,88 +108,53 @@ sequenceDiagram
 
 | Topic | Published by | Subscribed by | File:line |
 |---|---|---|---|
-| `message.inbound.linear.issue.created` | LinearPlugin (webhook) | RouterPlugin, linear-protomaker-bridge, linear-proto-bridge | `lib/plugins/linear.ts` |
-| `agent.skill.request` (manage_feature, protomaker) | linear-protomaker-bridge | SkillDispatcher | `lib/plugins/linear-protomaker-bridge.ts:178` |
-| `agent.skill.request` (code.execute, proto) | linear-proto-bridge | SkillDispatcher | `lib/plugins/linear-proto-bridge.ts:106` |
-| `linear.reply.{issueId}` | SkillDispatcher / executor (writes payload.content) | LinearPlugin._wireOutbound | `lib/plugins/linear.ts:561` |
-| `linear.reply.result.{correlationId}` | LinearPlugin (after API call) | telemetry | `lib/plugins/linear.ts:567` |
+| `message.inbound.linear.issue.created` | LinearPlugin (webhook) | RouterPlugin (skillHint-only), linear-proto-bridge | `lib/plugins/linear.ts` |
+| `agent.skill.request` (code.execute, proto) | linear-proto-bridge | SkillDispatcher | `lib/plugins/linear-proto-bridge.ts:105` |
+| `linear.reply.{issueId}` | SkillDispatcher / executor (writes payload.content) | LinearPlugin outbound subscriber | `lib/plugins/linear.ts` |
+| `linear.reply.result.{correlationId}` | LinearPlugin (after API call) | telemetry | `lib/plugins/linear.ts` |
 
 ---
 
 ## Gate logic
 
-### linear-protomaker-bridge
-
-Configured by **`workspace/linear-board-mappings.yaml`** ([line 96–100](../../lib/plugins/linear-protomaker-bridge.ts)):
-
-```yaml
-mappings:
-  - linearTeamKey: ENG
-    protoMakerProjectSlug: protoworkstacean
-    triggerLabel: feature
-```
-
-Hot-reload: 5s file watcher. Schema validation is **fail-loud** — one malformed mapping rejects the whole file.
-
-Gate sequence ([line 147–211](../../lib/plugins/linear-protomaker-bridge.ts)):
-1. Drop if `issueId || teamKey || title` missing (line 149)
-2. Look up mapping by `teamKey` — drop if not found (line 151)
-3. Check `issue.labels.includes(mapping.triggerLabel)` — drop if absent (line 155)
-4. Build `agent.skill.request` with skill `manage_feature`, targets `["protomaker"]`, reply.topic `linear.reply.${issueId}`
-
-### linear-proto-bridge
-
 Single global label, env-overridable:
 
 ```
-default: proto-task
+default:  proto-task
 override: LINEAR_PROTO_BRIDGE_LABEL=<custom>
 ```
 
 Gate sequence ([line 81–140](../../lib/plugins/linear-proto-bridge.ts)):
 1. Drop if `issueId || title` missing (line 83)
 2. Check `issue.labels.includes(this.triggerLabel)` — drop if absent (line 86–92)
-3. Build `agent.skill.request` with skill `code.execute`, targets `["proto"]`, reply.topic `linear.reply.${issueId}`
-
-No team mapping — proto is a single fleet-wide agent, not per-board.
+3. Build `agent.skill.request` with skill `code.execute`, targets `["proto"]`, reply.topic `linear.reply.${issueId}` (line 105)
 
 ---
 
 ## Reply round-trip
 
-Both bridges set `reply.topic = linear.reply.{issueId}` on dispatch. SkillDispatcher publishes the executor's response to that topic. LinearPlugin subscribes to `linear.reply.#` (excluding `linear.reply.result.*` to avoid feedback loop) and:
+The bridge sets `reply.topic = linear.reply.{issueId}` on dispatch. SkillDispatcher publishes the executor's response to that topic. LinearPlugin subscribes to `linear.reply.#` (excluding `linear.reply.result.*` to avoid a feedback loop) and:
 
-1. Extracts `issueId` from the topic ([linear.ts:565](../../lib/plugins/linear.ts))
-2. Calls `LinearClient.createComment(issueId, msg.payload.content)`
-3. Publishes `linear.reply.result.{correlationId}` with API result for audit
+1. Extracts `issueId` from the topic
+2. Posts the comment (as Ava via actor=app OAuth when wired, else via `LINEAR_API_KEY`)
+3. Publishes `linear.reply.result.{correlationId}` with the API result for audit
 
-The bridges hold **no state** for round-trip — `reply.topic` is the entire close-the-loop contract.
-
----
-
-## Why two bridges, not one
-
-Greenfield rule: "absence of a default = no behavior". The bridges differ in:
-
-- **Configuration shape** (per-team mappings yaml vs. single env var)
-- **Skill** (`manage_feature` vs. `code.execute`)
-- **Target** (`protomaker` vs. `proto`)
-
-A unified bridge would either need a routing table (over-engineering for two cases) or per-bridge configuration that essentially looks like the current two files. Two small bridges is the simpler shape — and both are no-op when their gate misses, so installing both unconditionally is safe.
+The bridge holds **no state** for round-trip — `reply.topic` is the entire close-the-loop contract, and `code.execute` is one-shot: dispatch, run to completion, reply.
 
 ---
 
 ## Failure modes & gotchas
 
-- **Both bridges silent-drop on non-matching label** — by design. RouterPlugin's chat path still handles the issue via `channels.yaml` if a team's channel routes to a default agent. Bridges and router can coexist on the same inbound event.
-- **No "feature completed" close-the-loop** — when the agent's work eventually merges, no automatic comment lands on the originating Linear issue. The bridge only handles the *first* dispatch reply; if the agent's reply is "I'll work on this and PR shortly", there's no async follow-up. See [protoMaker#3810](https://github.com/protoLabsAI/protoMaker/issues/3810) for the lifecycle event work that would close this.
-- **Mapping yaml hot-reload re-validates everything** — a single bad mapping rejects the whole file. Restart-safe but operator gets one chance to see the warning.
-- **`correlationId` convention** — `linear-bridge-${issueId}` (protomaker) or `linear-proto-${issueId}` (proto). Not used for reply routing (that's `reply.topic`); used for tracing and `linear.reply.result.*` correlation.
+- **Silent-drop on non-matching label** — by design. The mention/assignment path (`linear_agent_respond` to Ava) is independent and handles its own events.
+- **No "task completed" close-the-loop** — when the agent's work eventually merges, no automatic comment lands on the originating Linear issue. The bridge only handles the *first* dispatch reply.
+- **`correlationId` convention** — `linear-proto-${issueId}`. Not used for reply routing (that's `reply.topic`); used for tracing and `linear.reply.result.*` correlation.
 
 ---
 
 ## Related
 
-- [flow-inbound-message](flow-inbound-message.md) — what happens after the bridge publishes `agent.skill.request`
-- [flow-pr-review](flow-pr-review.md) — the analogous label-gated dispatch for GitHub PRs (no separate bridge, lives inside GitHubPlugin)
-- [flow-hitl](flow-hitl.md) — what happens if the dispatched agent escalates (HITL gap applies)
+- [integrations/linear](../integrations/linear) — full Linear plugin contract, the `linear_agent_respond` mention/assignment gate, and actor=app OAuth posting.
+- [flow-inbound-message](flow-inbound-message.md) — what happens after the bridge publishes `agent.skill.request`.
+- [integrations/github](../integrations/github) — the GitHub-issue → protoMaker board forwarder (`protomaker-board-bridge.ts`), the path people sometimes confuse with a Linear bridge.
+- [flow-pr-review](flow-pr-review.md) — the analogous label-gated dispatch for GitHub PRs (no separate bridge, lives inside GitHubPlugin).
+- [flow-hitl](flow-hitl.md) — what happens if the dispatched agent escalates.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -50,8 +50,8 @@ Nine flows + one cross-cut. Each doc has the same shape:
                                                               ▼                                       ▼
                                                   ┌────────────────────┐                  ┌──────────────────┐
                                                   │  DeepAgentExecutor │                  │ FunctionExecutor │
-                                                  │  ProtoSdkExecutor  │                  │  (alert/ceremony │
-                                                  │   A2AExecutor      │                  │   /pr-remediator)│
+                                                  │   A2AExecutor      │                  │  (alert/ceremony │
+                                                  │                    │                  │   /pr-remediator)│
                                                   └─────────┬──────────┘                  └────────┬─────────┘
                                                             │ message.outbound.*                   │
                                                             │ linear.reply.{id}                    │
@@ -73,7 +73,7 @@ Everything else — telemetry, dashboard, HITL, fleet health — observes this s
 | # | Doc | Entry trigger | Terminal topic |
 |---|---|---|---|
 | 1 | [flow-inbound-message](flow-inbound-message.md) | `message.inbound.{platform}.*` | `message.outbound.{platform}.*` |
-| 2 | [flow-linear-bridges](flow-linear-bridges.md) | `message.inbound.linear.issue.created` (label-gated) | `linear.reply.{issueId}` |
+| 2 | [flow-linear-bridges](flow-linear-bridges.md) | `message.inbound.linear.issue.created` (`proto-task` label → `code.execute`@`proto`) | `linear.reply.{issueId}` |
 | 3 | [flow-ceremonies](flow-ceremonies.md) | cron tick / external trigger | `ceremony.{id}.completed` + `autonomous.outcome.ceremony.{id}.{skill}` |
 | 4 | [flow-pr-review](flow-pr-review.md) | `message.inbound.github.{owner}.{repo}.pull_request.{n}` | GitHub review (APPROVED / COMMENTED / CHANGES_REQUESTED) |
 | 5 | [flow-alert-remediator](flow-alert-remediator.md) | fleet-health threshold trip → `action.*` / `pr.remediate.*` | `message.outbound.discord.alert` / GitHub mutation |

--- a/docs/extensions/cost-v1.md
+++ b/docs/extensions/cost-v1.md
@@ -102,10 +102,12 @@ Payload is the raw `CostSample` above. Used for the dashboard fleet-cost view an
 
 | Side | Where | Notes |
 |---|---|---|
-| **Extraction** (consumer) | [`src/executor/executors/a2a-executor.ts`](https://github.com/protoLabsAI/protoWorkstacean/blob/main/src/executor/executors/a2a-executor.ts) — added in #372 | Scans terminal Task artifact parts for `application/vnd.protolabs.cost-v1+json`, flattens onto `result.data` so the cost interceptor records the sample |
-| **Emission** (producer) | [`Quinn/a2a_handler.py::_terminal_artifact_parts`](https://github.com/protoLabsAI/quinn/blob/main/a2a_handler.py) + [`Quinn/server.py::_chat_langgraph_stream`](https://github.com/protoLabsAI/quinn/blob/main/server.py) — added in Quinn #56 | Captures `on_chat_model_end` events from LangGraph for `usage_metadata`, accumulates onto `TaskRecord.usage`, emits the DataPart on COMPLETED |
+| **Extraction** (consumer) | [`src/executor/executors/a2a-executor.ts`](https://github.com/protoLabsAI/protoWorkstacean/blob/main/src/executor/executors/a2a-executor.ts) — added in #372 | Scans terminal Task artifact parts for `application/vnd.protolabs.cost-v1+json`, flattens onto `result.data` so the cost interceptor records the sample. This applies to **remote A2A agents** — the only live one is `protopen`. |
+| **Emission** (producer) | Remote A2A agent's `/a2a` handler | The remote agent surfaces `usage` + `durationMs` (and optionally `costUsd`) on the terminal Task — workstacean's interceptor reads it off `result.data`. |
 
-Quinn currently emits `usage` + `durationMs` only — `costUsd` capture from the LiteLLM gateway response is a follow-up. Consumers tolerate missing `costUsd` and can derive it from per-model rates if needed.
+This extension only fires on the A2A dispatch path. In-process DeepAgents (`ava`, `quinn`, `proto`, `protobot`) run inside the workstacean process — there is no JSON-RPC round-trip and no SQLite layer; their token/wall-time accounting comes from the runtime's own telemetry, not this interceptor. (Quinn was absorbed from a standalone service; its old Python `server.py` / SQLite cost path no longer exists.)
+
+Consumers tolerate a missing `costUsd` and can derive it from per-model rates if needed.
 
 ---
 

--- a/docs/guides/a2a-streaming.md
+++ b/docs/guides/a2a-streaming.md
@@ -133,11 +133,11 @@ async def sse_generator(req):
 
 ```yaml
 agents:
-  - name: researcher
-    url: "http://protoresearcher:7870/a2a"
+  - name: protopen
+    url: "${PROTOPEN_BASE_URL}/a2a"
     streaming: true    # ← enables SSE client
     skills:
-      - name: deep_research
+      - name: passive_recon
 ```
 
 ### 2. Discord o11y (optional)
@@ -149,7 +149,7 @@ The `SkillBrokerPlugin` wires the `onStreamUpdate` callback automatically when t
 ## How it works end-to-end
 
 ```
-Inbound message: "research full-duplex voice AI"
+Inbound message: "run passive recon on example.com"
   → RouterPlugin → agent.skill.request (bus)
     → SkillDispatcherPlugin
       → ExecutorRegistry → A2AExecutor (streaming: true)
@@ -263,4 +263,4 @@ Same task lifecycle, real-time visibility into what the agent is doing.
 
 ## Push-notification configs survive restart
 
-Inbound A2A clients can register a webhook callback via `tasks/pushNotificationConfig/set` so workstacean POSTs them when long-running work terminates. Those configs are persisted to `${DATA_DIR}/push-notifications.db` (SQLite, WAL journal) so they survive container restarts — important on `:dev` where watchtower auto-pulls multiple times per day. Each config carries a 24-hour TTL by default; expired rows are filtered from `load()` and opportunistically purged on subsequent `save()` calls. Falls back to the SDK's in-memory store when `DATA_DIR` is unset (tests + ephemeral setups).
+Inbound A2A clients can register a webhook callback via `tasks/pushNotificationConfig/set` so workstacean POSTs them when long-running work terminates. Those configs are persisted to `${DATA_DIR}/push-notifications.db` (SQLite, WAL journal) so they survive container restarts — important on `:main` where watchtower auto-pulls multiple times per day. Each config carries a 24-hour TTL by default; expired rows are filtered from `load()` and opportunistically purged on subsequent `save()` calls. Falls back to the SDK's in-memory store when `DATA_DIR` is unset (tests + ephemeral setups).

--- a/docs/guides/add-an-agent.md
+++ b/docs/guides/add-an-agent.md
@@ -4,8 +4,8 @@ title: Add an Agent
 
 protoWorkstacean supports two agent patterns:
 
-- **In-process** — the agent runs inside the workstacean process, powered by LangGraph's `createReactAgent`. Skills execute as LangGraph ReAct sessions with a configurable system prompt, model (via the LiteLLM gateway), and tool whitelist. Example today: `ava` (conversational chat + fleet-delegation tools).
-- **External A2A** — the agent runs in a separate service with its own HTTP surface. protoWorkstacean calls it over JSON-RPC 2.0. Right choice for stateful agents with their own infrastructure. Examples today: the **protoMaker team** (at `${AVA_BASE_URL}/a2a`, handles board ops and planning), **Quinn** (PR review, bug triage), **protoContent** (Jon/Cindi content), **Frank** (infra).
+- **In-process** — the agent runs inside the workstacean process, powered by LangGraph's `createReactAgent`. Skills execute as LangGraph ReAct sessions with a configurable system prompt, model (via the LiteLLM gateway), and tool whitelist. Defined in `workspace/agents/<name>.yaml`. Examples today: `ava` (conversational chat + fleet-delegation tools), `quinn` (PR review / bug triage — absorbed from a standalone service; it is **not** an A2A agent), `proto`, `protobot`.
+- **External A2A** — the agent runs in a separate service with its own HTTP surface. protoWorkstacean calls it over JSON-RPC 2.0. Right choice for stateful agents with their own infrastructure. The only live A2A agent today is **protopen** (security / pentest / RF recon, remote on the steamdeck at `${PROTOPEN_BASE_URL}/a2a`). Note: **protoMaker is not an A2A agent** — it serves an agent card but no `/a2a` endpoint, and workstacean integrates with it over plain HTTP / webhooks (e.g. `protomaker-board-bridge.ts` POSTs to its `/api/engine/signal/submit` intake).
 
 Both patterns register into `ExecutorRegistry` and are dispatched by `SkillDispatcherPlugin`. From the bus's perspective they are identical — both consume `agent.skill.request` and reply on `agent.skill.response.<correlationId>`.
 
@@ -231,9 +231,10 @@ Returns:
 
 ```json
 [
-  { "name": "ava",        "type": "deep-agent", "skills": ["chat"] },
-  { "name": "protomaker", "type": "a2a",       "skills": ["sitrep", "board_health", "manage_feature", "bug_triage"] },
-  { "name": "quinn",      "type": "a2a",       "skills": ["pr_review", "bug_triage", "security_triage"] }
+  { "name": "ava",     "type": "deep-agent", "skills": ["chat"] },
+  { "name": "quinn",   "type": "deep-agent", "skills": ["pr_review", "bug_triage", "security_triage"] },
+  { "name": "proto",   "type": "deep-agent", "skills": ["code.execute"] },
+  { "name": "protopen","type": "a2a",        "skills": ["passive_recon", "active_pentest", "security_report", "threat_intel"] }
 ]
 ```
 

--- a/docs/how-to/use-quinn-pr-review.md
+++ b/docs/how-to/use-quinn-pr-review.md
@@ -109,7 +109,7 @@ Quinn responds with a review comment posted as `protoquinn[bot]`.
 /quinn review
 ```
 
-With the `pr_review` skillHint, A2APlugin routes to Quinn's `pr_review` skill.
+With the `pr_review` skillHint, `RouterPlugin` publishes an `agent.skill.request` that `SkillDispatcherPlugin` routes to Quinn's `pr_review` skill on its in-process `DeepAgentExecutor`. Quinn runs inside the workstacean process — there is no A2A hop.
 
 ---
 

--- a/docs/integrations/linear.md
+++ b/docs/integrations/linear.md
@@ -2,15 +2,17 @@
 title: Linear
 ---
 
-Linear is an optional communication interface for users to talk to agents and supply context about projects, issues, and work. A user writes a Linear issue or comments on one, Workstacean's `LinearPlugin` publishes the event to the internal bus, `RouterPlugin` routes it to the agent configured in `workspace/channels.yaml`, and the agent's reply comes back as a Linear comment.
+Linear is an optional communication interface for users to talk to Ava and supply context about projects, issues, and work. Ava acts on Linear **only when she is @mentioned or the issue is assigned to her** — she does not chase ambient activity. When that gate passes, `LinearPlugin` publishes the event with an explicit `skillHint: linear_agent_respond`, `RouterPlugin` dispatches it to Ava, and her reply comes back as a Linear agent-activity or comment (posted **as Ava** when her OAuth token is wired).
 
 The plugin also exposes outbound mutations so agents can file or update Linear tickets as part of their work.
 
 ## Overview
 
-The flow in one sentence: a Linear event hits the webhook → `LinearPlugin` verifies the HMAC signature and publishes `message.inbound.linear.{issue,comment,project}.*` → `RouterPlugin` resolves the channel via `workspace/channels.yaml` and dispatches `agent.skill.request` → the agent's response publishes to `linear.reply.{issueId}` → `LinearPlugin` posts it as a Linear comment.
+The flow in one sentence: a Linear event hits the webhook → `LinearPlugin` verifies the HMAC signature and publishes `message.inbound.linear.{issue,comment,project,agent_session}.*` → for @mentions and assigned sessions it stamps `skillHint: linear_agent_respond` → `RouterPlugin` dispatches `agent.skill.request` to Ava → her response publishes to `linear.reply.{issueId}` (or `linear.agent_activity.{sessionId}`) → `LinearPlugin` posts it back.
 
-No cross-plugin dependencies. A second plugin that wants "Linear issue → protoMaker feature" just subscribes to `message.inbound.linear.issue.created` and fires the appropriate skill — it doesn't touch `LinearPlugin` at all.
+**Linear inbound is `skillHint`-gated, never keyword-routed.** `RouterPlugin` only dispatches a Linear event that carries an explicit `skillHint`; Linear content is never keyword-matched. An un-hinted Linear event is dropped. This prevents GitHub-domain skills (e.g. `pr_review`) from being pulled onto Linear tickets by a stray keyword. `LinearPlugin` sets `skillHint: linear_agent_respond` for `issueMention`/`issueCommentMention` notifications and for agent-session events on issues assigned to Ava — nothing else gets a hint, so nothing else is dispatched.
+
+No cross-plugin dependencies. A second plugin that wants "Linear issue → some agent" just subscribes to `message.inbound.linear.issue.created` and fires the appropriate skill — it doesn't touch `LinearPlugin` at all (see [Linear → proto bridge](#linear--proto-code-execution-bridge) below).
 
 ## Setup
 
@@ -99,84 +101,74 @@ Inbound webhooks are validated against a Zod envelope schema — a malformed Lin
 ## Multi-layer conversation example
 
 ```
-User writes Linear comment:       "Ava, can you plan the migration?"
+User @mentions Ava in a comment:  "@Ava can you plan the migration?"
   ↓
-Linear webhook POST /webhooks/linear
+Linear webhook POST /webhooks/linear  (agent notification: issueCommentMention)
   ↓
-LinearPlugin publishes:           message.inbound.linear.comment.created
-  ↓                               { body, teamKey: "ENG", issueId, ... }
+LinearPlugin publishes:           message.inbound.linear.* with
+  ↓                               { skillHint: "linear_agent_respond", issueId, ... }
+  ↓                               (mention → hinted; un-mentioned ambient events get no hint and drop)
   ↓
-RouterPlugin reads channels.yaml  (linear/ENG → ava)
-  ↓
-RouterPlugin publishes:           agent.skill.request
-  ↓                               { skill: "chat", targets: ["ava"], content: "..." }
+RouterPlugin sees the explicit skillHint and publishes:
+  ↓                               agent.skill.request
+  ↓                               { skill: "linear_agent_respond", targets: ["ava"], content: "..." }
   ↓
 SkillDispatcherPlugin routes to Ava → Ava runs → returns response
   ↓
-Response published on:            linear.reply.{issueId}
+Response published on:            linear.reply.{issueId}  (or linear.agent_activity.{sessionId})
   ↓
-LinearPlugin outbound subscriber  → client.addComment(issueId, text)
+LinearPlugin outbound subscriber  → posts as Ava (actor=app OAuth) or via LINEAR_API_KEY
   ↓
-Comment appears on the Linear issue.
+Comment / agent-activity appears on the Linear issue.
 ```
 
-## Linear → protoMaker board bridge
+For an **assigned** issue, Linear opens an agent session instead of a mention notification. `LinearPlugin` checks `isAssignedToAva(issueId)` (via Ava's OAuth client, fail-open on API error), and only the assigned sessions get `skillHint: linear_agent_respond`. Sessions on issues not assigned to Ava are dropped with no response.
 
-`LinearProtoMakerBridgePlugin` (`lib/plugins/linear-protomaker-bridge.ts`) wires inbound Linear issues into the protoMaker board with no direct dependency on either side — pure bus contract. It's installed unconditionally and is a no-op until `workspace/linear-board-mappings.yaml` exists.
+## Posting as Ava (actor=app OAuth)
+
+Linear distinguishes a *personal* API key (posts as the human who minted it) from an *actor=app* OAuth grant (posts as the application — i.e. "Ava"). When Ava's OAuth token is configured, `LinearPlugin` instantiates an `_avaClient` (built via `getLinearAvaTokenManager`) and uses it for two jobs:
+
+1. **Posting as Ava** — agent activities and plain comments go out under Ava's app identity, not a human's. This is the preferred outbound path.
+2. **Gating responses** — `isAssignedToAva(issueId)` resolves the issue's assignee against Ava's app identity, which is how the assigned-session gate above decides whether to respond.
+
+`LINEAR_API_KEY` is the **fallback**: if no Ava OAuth token is present, outbound mutations fall back to the personal key. With neither set, outbound Linear mutations are disabled (inbound webhooks still work).
+
+The one-time browser authorize that captures Ava's `actor=app` refresh token is driven through the admin `/api/linear/oauth/*` routes (auth = `WORKSTACEAN_API_KEY` as `?apiKey=`).
+
+## Linear → proto code-execution bridge
+
+`LinearProtoBridgePlugin` (`lib/plugins/linear-proto-bridge.ts`) dispatches Linear issues tagged with a trigger label to the **in-process `proto` agent** as a one-shot `code.execute`. Pure bus contract — no direct dependency on `LinearPlugin` or the proto runtime.
 
 ### Configuration
 
-Copy `workspace/linear-board-mappings.yaml.example` to `workspace/linear-board-mappings.yaml` and edit:
-
-```yaml
-mappings:
-  - linearTeamKey: "ENG"
-    protoMakerProjectSlug: "engineering"
-    triggerLabel: "board"
-  - linearTeamKey: "DESIGN"
-    protoMakerProjectSlug: "design-system"
-    triggerLabel: "board"
-```
-
-Each mapping says: when an inbound Linear issue from `linearTeamKey` carries `triggerLabel`, file it as a feature on `protoMakerProjectSlug` via the `manage_feature` skill. Issues without the label drop straight through (RouterPlugin's chat path still handles them per `channels.yaml`).
-
-The mapping file is hot-reloaded at a 5-second interval — add or remove routes without a restart.
+The trigger label defaults to **`proto-task`**. Override it with the `LINEAR_PROTO_BRIDGE_LABEL` env var. There is no config file and no per-team mapping — `proto` is a single fleet-wide agent.
 
 ### Flow
 
 ```
-User creates Linear issue with the "board" label
+User creates / labels a Linear issue with "proto-task"
   ↓
 LinearPlugin publishes:           message.inbound.linear.issue.created
-  ↓                               { teamKey: "ENG", labels: ["board"], ... }
+  ↓                               { issueId, title, labels: ["proto-task"], ... }
   ↓
-LinearProtoMakerBridgePlugin matches the team + label and publishes:
+LinearProtoBridgePlugin matches the label and publishes:
   agent.skill.request {
-    skill:   "manage_feature",
-    targets: ["protomaker"],
-    content: "Create a feature on project 'engineering' ...",
-    meta:    { sourceLinearIssueId, sourceLinearIdentifier, ... },
+    skill:   "code.execute",
+    targets: ["proto"],
+    content: "Execute this scoped coding/research task ...",
+    meta:    { sourceLinearIssueId, sourceLinearIdentifier, triggerLabel, via: "linear-proto-bridge" },
     reply:   { topic: "linear.reply.{issueId}" }
   }
   ↓
-SkillDispatcherPlugin routes to protoMaker, which creates the board feature
+SkillDispatcherPlugin routes to the in-process proto DeepAgent
   ↓
-ProtoMaker's response is published on linear.reply.{issueId}
+proto's result is published on linear.reply.{issueId}
   ↓
-LinearPlugin outbound subscriber comments on the Linear issue:
-  "Filed on board as feature ENG-XXX..."
+LinearPlugin outbound subscriber posts it as a Linear comment.
 ```
 
-### Filing close-the-loop is done; "feature done" close-the-loop is deferred
+Issues without the label are dropped at the bridge (the `linear_agent_respond` mention/assignment path above is independent). The bridge holds **no state** — `reply.topic` is the entire close-the-loop contract; `code.execute` is one-shot.
 
-When the protoMaker board feature later transitions to **done**, ideally a comment is posted back on the Linear issue. This isn't yet wired — there's no bus event today for board feature lifecycle (only skill-completion events from `SkillDispatcherPlugin`).
+## GitHub issues → protoMaker board (not Linear)
 
-Once protoMaker emits a `protomaker.feature.completed` (or similar) event on the bus, adding the done-loop is a ~10-line subscriber here that maps `featureId → linearIssueId` and publishes `linear.reply.{linearIssueId}` with the completion text.
-
-### What this plugin doesn't do
-
-- Doesn't import from `lib/plugins/linear.ts`.
-- Doesn't import from anything protoMaker-specific.
-- Doesn't reach Linear or protoMaker over the network — every operation is a bus publish.
-
-That's the no-cross-plugin-dependency contract.
+The "Linear issue → protoMaker board" wiring that older docs describe **no longer exists**. The path that feeds protoMaker's board is `lib/plugins/protomaker-board-bridge.ts`, which subscribes to **`github.issue.opened`** (not Linear) and POSTs the issue to protoMaker's `/api/engine/signal/submit` intake. protoMaker serves **no `/a2a` endpoint** — it is reached over HTTP, not A2A. See the [GitHub integration doc](github) for that flow.

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -64,7 +64,9 @@ The `workspace/` directory holds all runtime configuration. Start from the bundl
 cp workspace/agents/ava.yaml.example   workspace/agents/ava.yaml
 cp workspace/agents/frank.yaml.example workspace/agents/frank.yaml
 
-# External A2A agent registry — list the protoMaker team, quinn, etc.
+# External A2A agent registry — the only live A2A agent is protopen
+# (security/pentest, remote). Quinn, proto, and protobot are in-process
+# DeepAgents, defined in workspace/agents/, NOT here.
 cp workspace/agents.yaml.example workspace/agents.yaml
 ```
 
@@ -81,7 +83,7 @@ systemPrompt: |
   You are Ava, a conversational protoAgent. You answer questions
   and think out loud with the user. You have no tools — when a
   request needs action, suggest which agent is best suited:
-  protoMaker team for board ops, Quinn for PR review, Frank for infra.
+  Quinn (in-process) for PR review, proto (in-process) for code tasks.
 tools: []
 maxTurns: 6
 skills:


### PR DESCRIPTION
Part of #683 (theme 3). Docs-only. Two corrections: (a) in-process DeepAgents were wrongly documented as A2A services, and (b) the renamed/retired Linear bridge plus the current Linear routing/gating.

## Per-file summary

- **docs/integrations/linear.md** — Rewrote the bogus "Linear → protoMaker board bridge" section (nonexistent `LinearProtoMakerBridgePlugin` + `linear-board-mappings.yaml` + `manage_feature`@protomaker) into the real **`linear-proto-bridge`** (label `proto-task`, `code.execute`@`proto`, env `LINEAR_PROTO_BRIDGE_LABEL`), plus a separate note that the GitHub-issue → protoMaker path is `protomaker-board-bridge.ts` (cross-ref github doc), not Linear. Fixed the routing narrative: Ava responds only when @mentioned or assigned; router drops un-hinted Linear events (never keyword-routes); skill is `linear_agent_respond` not `chat`. Added an actor=app OAuth subsection (posts AS Ava; `LINEAR_API_KEY` is the fallback).
- **docs/architecture/flow-linear-bridges.md** — Restructured from two bridges to the one real Linear bridge (`linear-proto-bridge`); removed all `linear-protomaker-bridge` / `linear-board-mappings.yaml` / `manage_feature` content; added the skillHint-only + @mention/assignee gating note and a pointer to the GitHub→protoMaker forwarder.
- **docs/architecture/flow-inbound-message.md** — Fixed the linear-protomaker-bridge references; added the Linear skillHint-only / @mention-or-assignee gating note; removed the deleted `ActionDispatcher` from the `agent.skill.request` publisher list (real publishers: Router, linear-proto-bridge, dispatcher mailbox-drain); dropped the unwired `ProtoSdkExecutor` from the executor spine.
- **docs/architecture/index.md** — Fixed the flow-2 bridge description to the real `proto-task` → `code.execute`@`proto`; dropped `ProtoSdkExecutor` from the spine ASCII.
- **docs/guides/add-an-agent.md** — Quinn shown as `type:"deep-agent"` (was a2a); replaced the protoMaker A2A `/api/agents` example with `protopen`; noted protoMaker integrates via HTTP/webhooks, not A2A.
- **docs/tutorials/getting-started.md** — Quinn/proto/protobot listed as in-process DeepAgents, not external A2A.
- **docs/how-to/use-quinn-pr-review.md** — "A2APlugin routes to Quinn" → in-process RouterPlugin → SkillDispatcher → DeepAgentExecutor path. Vector-pipeline section kept (accurate).
- **docs/guides/a2a-streaming.md** — Replaced sunsetted `researcher` agent example with `protopen`; fixed `:dev` image tag → `:main`.
- **docs/extensions/cost-v1.md** — Refreshed the reference-implementation table off the standalone `protoLabsAI/quinn` repo + Python/SQLite path; noted in-process DeepAgents have no JSON-RPC round-trip / SQLite cost layer.

## Verify
`cd docs && bun install && bunx vitepress build` — passes (build complete, no errors).

## Left for other themes
- Theme 1 (planner/GOAP claims) untouched per scope — including the `"goap"` example in the `CostSample.systemActor` comment in cost-v1.md.
- Theme 5 cost/confidence store-consumer + cold-start factual fixes left alone.
- Auto-generated `docs/reference/http-api.md` + `bus-topics.md` and the `docs/decisions/*` ADRs untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to clarify Linear integration as skillHint-gated (processes only `@mentions` and assigned issues).
  * Simplified Linear-to-proto bridge documentation to reflect single bridge path with label-based triggering.
  * Updated executor registry and agent examples across guides and getting started materials.
  * Clarified that protoMaker board integration is GitHub-driven, not Linear-driven.
  * Refined cost tracking and A2A streaming documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/688?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->