### PR TITLE
docs: retire dev-branch workflow + fix deploy/test docs (#683 theme 4)

### DIFF
--- a/docs/contributing/merge-policy.md
+++ b/docs/contributing/merge-policy.md
@@ -8,19 +8,21 @@ We allow all three merge modes (merge commit, squash, rebase). The rule:
 
 | When | Use |
 |---|---|
-| One-off PR targeting `main` / `dev` | Squash (default) |
-| Stacked PR (base is another PR's branch) | **Merge commit** |
+| One-off PR targeting `main` | Squash (default) |
+| Stacked PR (base is another PR's branch off `main`) | **Merge commit** |
 | Anything else | Squash |
 
 Plus one local git config change for everyone: `git config --global rebase.updateRefs true`.
+
+All PRs target `main` directly — there is no intermediate `dev` branch. Every merge to `main` auto-deploys via watchtower; the release ritual is decoupled (manual `auto-release.yml` `workflow_dispatch` when cutting a version).
 
 ---
 
 ## Why this matters
 
-Squash-merge collapses a PR's commits into one new commit with a fresh SHA on dev. When PR B is stacked on PR A and A gets squash-merged, B's history still references A's original commits. Git's rebase algorithm can't tell which commits are "already on dev as part of the squash" vs "still need to apply" — so it tries to re-apply them, hitting conflicts that should have been mechanical.
+Squash-merge collapses a PR's commits into one new commit with a fresh SHA on `main`. When PR B is stacked on PR A and A gets squash-merged, B's history still references A's original commits. Git's rebase algorithm can't tell which commits are "already on `main` as part of the squash" vs "still need to apply" — so it tries to re-apply them, hitting conflicts that should have been mechanical.
 
-Merge commits don't have this problem. The original commit SHAs are preserved on dev, so when you rebase the next stacked PR, git correctly identifies what's already upstream.
+Merge commits don't have this problem. The original commit SHAs are preserved on `main`, so when you rebase the next stacked PR, git correctly identifies what's already upstream.
 
 ---
 
@@ -57,30 +59,14 @@ Do this on every active repo where stacking happens.
 
 ## Step 3 — Branch protection check (admin, per repo)
 
-The rule differs by branch:
-
-### `dev` — linear history must be OFF
+`main` must allow merge commits so the merge-commit-for-stacks workflow can be applied.
 
 1. Go to `https://github.com/protoLabsAI/<repo>/settings/branches`
-2. Open the rule for `dev`
+2. Open the rule for `main`
 3. **Verify "Require linear history" is OFF**
-   - If it's ON, merge commits are forbidden on dev regardless of the merge-button settings — uncheck it.
+   - If it's ON, merge commits are forbidden on `main` regardless of the merge-button settings — uncheck it. Stacked PRs land via merge commit, so linear history can't be required.
 
-This is what makes the merge-commit-for-stacks workflow actually work. Stacked PRs target `dev`; if dev forbids merge commits, the policy can't be applied.
-
-### `main` — linear history stays ON (intentional)
-
-`main` is the release branch. Each commit on `main` should be one release.
-
-1. **Leave "Require linear history" ON** for `main`
-2. Promotion PRs (`dev → main`) get squashed or rebased into a single release commit, which is what we want
-3. The detailed per-PR history stays on `dev` where it's useful for debugging; main stays a clean tagged log
-
-**Do not flip this OFF thinking it's required by the merge-commit policy.** The policy only applies to PRs targeting `dev`. Promotion PRs are inherently single-unit work and benefit from being squashed.
-
-### Everything else
-
-Required status checks, required reviews — leave as-is. Both `dev` and `main` keep the same check requirements.
+Required status checks and required reviews — leave as-is.
 
 ---
 
@@ -107,7 +93,7 @@ git config --global --get rebase.updateRefs
 
 For everyone, every PR:
 
-- **If your PR's base is `main` or `dev`** (one-off PR): click **Squash and merge** (the default).
+- **If your PR's base is `main`** (one-off PR): click **Squash and merge** (the default).
 - **If your PR's base is another PR's branch** (stacked PR): click the dropdown next to the merge button and pick **Create a merge commit** instead.
 
 ### How to recognize a stacked PR
@@ -118,7 +104,7 @@ The PR header on GitHub shows the base branch:
 chore/foo wants to merge 3 commits into chore/bar
 ```
 
-If you see anything other than `main` or `dev` after "into," it's a stacked PR — use merge commit.
+If you see anything other than `main` after "into," it's a stacked PR — use merge commit.
 
 ---
 
@@ -127,7 +113,7 @@ If you see anything other than `main` or `dev` after "into," it's a stacked PR �
 If you're the one stacking PRs, two habits make life easier:
 
 1. **Don't enable auto-merge until the entire stack has stopped moving.** Auto-merge captures the head SHA at the moment you click it. If you then rebase the branch, auto-merge fires against the old SHA and skips your new commits. Auto-merge remains the right default for *isolated* PRs — the rule only applies when a PR is part of a stack. If you must arm auto-merge mid-stack, arm only the bottom PR; merge the dependents manually as each one lands.
-2. **When dev advances, rebase the bottom of your stack first**, then let `rebase.updateRefs` cascade the change to the dependents. If a conflict in the middle of the stack forces a manual rebase, use `git rebase --onto <new-base> <old-base>` rather than relying on git's default upstream-detection — the default gets confused with merged-and-squashed predecessors.
+2. **When `main` advances, rebase the bottom of your stack first**, then let `rebase.updateRefs` cascade the change to the dependents. If a conflict in the middle of the stack forces a manual rebase, use `git rebase --onto <new-base> <old-base>` rather than relying on git's default upstream-detection — the default gets confused with merged-and-squashed predecessors.
 
 ---
 
@@ -183,7 +169,7 @@ Yes — see [`git-spice`](https://abhinav.github.io/git-spice/), [`git-branchles
 
 - [ ] Admin: org settings updated (Step 1)
 - [ ] Admin: repo settings updated for `protoWorkstacean` (Step 2)
-- [ ] Admin: branch protection verified on `main` and `dev` (Step 3)
+- [ ] Admin: branch protection verified on `main` (Step 3)
 - [ ] Admin: repo settings + branch protection done for other active repos
 - [ ] Everyone: `rebase.updateRefs` set locally (Step 4)
 - [ ] Team: briefed on the merge-button rule (Step 5)

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -16,7 +16,7 @@ Wire up the plugins you need against `InMemoryEventBus`, publish a message, and 
 
 ```typescript
 import { describe, it, expect } from 'bun:test';
-import { InMemoryEventBus } from '../lib/bus/in-memory-event-bus';
+import { InMemoryEventBus } from '../lib/bus';
 import { SchedulerPlugin } from '../lib/plugins/scheduler';
 
 describe('SchedulerPlugin', () => {

--- a/docs/guides/deploy-with-docker.md
+++ b/docs/guides/deploy-with-docker.md
@@ -2,12 +2,26 @@
 title: Deploy with Docker
 ---
 
-This guide covers a production-ready Docker Compose deployment: building the image, mounting the workspace volume, wiring secrets via environment variables, and verifying health.
+This guide covers a production deployment: how code and config ship, building the image, mounting the workspace volume, wiring secrets, and verifying health.
 
 ## Prerequisites
 
 - Docker >= 24
 - Docker Compose v2
+
+## How deployment works
+
+protoWorkstacean separates **code** from **config**:
+
+- **Code ships as an image.** Production runs `ghcr.io/protolabsai/workstacean:main`. [watchtower](https://containrrr.dev/watchtower/) watches that tag and auto-pulls + restarts the container whenever a new `:main` image is published (CI builds and pushes on every merge to `main`).
+- **Workspace config ships as a host bind-mount.** The `workspace/` directory (agent YAMLs, ceremonies, `channels.yaml`) is mounted into the container and updated on the host with `git pull` — it is *not* baked into the image. This means config changes don't require an image rebuild.
+
+Two config reload behaviours follow from that:
+
+- **Ceremonies hot-reload.** Editing or adding a file under `workspace/ceremonies/` (then `git pull` on the host) is picked up live — no restart.
+- **Agent YAMLs need a container restart.** Changes to `workspace/agents/*.yaml` or `workspace/agents.yaml` are read at startup; `docker compose restart workstacean` to apply them.
+
+So the operational model is: **code lands via watchtower automatically; config lands via `git pull` on the host, with a restart only when you touched agent YAMLs.**
 
 ## Docker Compose
 
@@ -18,7 +32,7 @@ services:
   workstacean:
     build:
       context: .
-      target: production
+      target: release
     restart: unless-stopped
     env_file: .env
     environment:
@@ -26,25 +40,19 @@ services:
       - DATA_DIR=/data
       - TZ=America/New_York
     ports:
-      # Expose the HTTP API on the host (adjust or remove for internal-only)
-      - "3000:3000"
-      # Expose the Astro dashboard + WebSocket event stream (disable with DISABLE_EVENT_VIEWER)
+      # Single HTTP server: API + Astro dashboard + WebSocket event stream
       - "8080:8080"
     volumes:
-      # Workspace config (agents, goals, actions, ceremonies, domains)
+      # Workspace config (agents, ceremonies, channels) — bind-mounted from host
       - ./workspace:/workspace
       # Persistent SQLite event log
       - data:/data
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
-      start_period: 15s
 
 volumes:
   data:
 ```
+
+The Dockerfile defines two runnable stages: `dev` (`bun run --watch`, used by the checked-in compose default) and `release` (`bun run`, no watcher — use it for production). There is no `production` stage. The checked-in `docker-compose.yml` targets `dev` for local development; flip `target` to `release` for a production build, or just run the published `ghcr.io/protolabsai/workstacean:main` image and let watchtower keep it current.
 
 ## Environment file
 
@@ -71,7 +79,7 @@ GITHUB_WEBHOOK_SECRET=your-webhook-secret
 ROUTER_DEFAULT_SKILL=sitrep
 
 # ── HTTP ──────────────────────────────────────────────────────────────────────
-WORKSTACEAN_HTTP_PORT=3000
+WORKSTACEAN_HTTP_PORT=8080
 
 # ── Storage ───────────────────────────────────────────────────────────────────
 WORKSPACE_DIR=/workspace
@@ -82,7 +90,7 @@ For a full list of all supported variables, see [reference/env-vars.md](../../re
 
 ## Workspace volume
 
-The `workspace/` directory is mounted read-write so configuration changes can be applied without rebuilding the image:
+The `workspace/` directory is bind-mounted read-write, so configuration changes are applied on the host (via `git pull`) without rebuilding the image:
 
 ```
 ./workspace/                  ← bind-mounted to /workspace in container
@@ -90,20 +98,19 @@ The `workspace/` directory is mounted read-write so configuration changes can be
     ava.yaml
     frank.yaml
   agents.yaml
-  projects.yaml
   channels.yaml
   ceremonies/
     daily-standup.yaml
     security-triage.yaml
 ```
 
-After editing any workspace file, restart the container:
+After editing **agent** YAMLs, restart the container:
 
 ```bash
 docker compose restart workstacean
 ```
 
-Hot-reload for workspace YAML files is not supported in the current version (except `projects.yaml` and skill keywords via `RouterPlugin`).
+Ceremonies under `workspace/ceremonies/` hot-reload — no restart needed.
 
 ## Starting the stack
 
@@ -112,36 +119,26 @@ docker compose up -d
 docker compose logs -f workstacean
 ```
 
-Expected startup output:
-
-```
-[agent-runtime] loaded agent: ava (general, 1 skill)           ← in-process chat agent
-[skill-broker] Registered 3 A2A agent(s)                       ← protomaker, quinn, etc.
-[ceremony-plugin] loaded 5 ceremonies
-[http] listening on :3000
-[workstacean] ready
-```
-
 ## Health check
 
 The `/health` endpoint returns `200 OK` when the server is ready:
 
 ```bash
-curl http://localhost:3000/health
-# {"status":"ok","uptime":42.3}
+curl http://localhost:8080/health
+# {"status":"ok","timestamp":1748534400000}
 ```
 
-Docker's healthcheck (`test: curl -f ...`) will restart the container if this endpoint stops responding.
+Put a healthcheck behind your orchestrator or reverse proxy against this endpoint.
 
 ## Dashboard
 
-The Astro dashboard is built during the Docker image build and served by the event-viewer plugin on port `8080`. Once the stack is up:
+The Astro dashboard is built into the image (the Dockerfile's `dashboard-build` stage) and served by the same HTTP server on port `8080`. Once the stack is up:
 
 ```bash
 open http://localhost:8080
 ```
 
-Set `DISABLE_EVENT_VIEWER=1` in `.env` to skip the plugin entirely (e.g. for headless deployments). See the [Dashboard reference](../../reference/dashboard) for pages, API client, and cache behavior.
+Set `DISABLE_EVENT_VIEWER=1` in `.env` to skip the event-viewer plugin entirely (e.g. for headless deployments). See the [Dashboard reference](../../reference/dashboard) for pages, API client, and cache behavior.
 
 ## Production docker-compose with ava
 
@@ -150,7 +147,7 @@ If you run ava alongside workstacean in the same Compose project:
 ```yaml
 services:
   workstacean:
-    build: .
+    image: ghcr.io/protolabsai/workstacean:main
     restart: unless-stopped
     env_file: .env
     environment:
@@ -163,11 +160,6 @@ services:
     depends_on:
       ava:
         condition: service_healthy
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
 
   ava:
     image: protoLabsAI/protoMaker:latest


### PR DESCRIPTION
Part of #683 (theme 4: stale git-workflow + deploy/test docs). The `dev` branch was retired 2026-05-26; several docs still described it and the deploy guide had a build-breaking instruction.

## `docs/contributing/merge-policy.md`
- Removed all `dev`-branch workflow: the `main`/`dev` table row, the `dev → main` promotion-PR concept, the "fresh/preserved SHA on dev" prose, the entire Step-3 "`dev` — linear history OFF" section, and the "anything other than `main` or `dev`" recognition rule.
- Reframed stacked PRs as basing on another PR's branch off `main`.
- Step 3 branch-protection check is now main-only (linear history OFF so merge commits can land).
- Kept the core rule (squash for one-off PRs to `main`, merge commit for stacks) and `git config --global rebase.updateRefs true`.

## `docs/guides/deploy-with-docker.md`
- Fixed the broken build: `target: production` does not exist in the Dockerfile (stages are `dev` and `release`) → switched to `release` and explained the `dev`/`release` split.
- Reconciled the compose snippet with the real `docker-compose.yml`: single HTTP port `8080` (dropped the nonexistent `3000` mapping).
- Documented the real deploy model: watchtower auto-pulls `ghcr.io/protolabsai/workstacean:main` (code via image); workspace config ships via host bind-mount + `git pull` (ceremonies hot-reload, agent YAMLs need a restart) — replacing the blanket "docker compose restart".
- Fixed the `/health` example payload from `{status, uptime}` to the real `{status, timestamp}` (verified in `src/api/operations.ts`).

## `docs/contributing/testing.md`
- Fixed the `InMemoryEventBus` import from `../lib/bus/in-memory-event-bus` to `../lib/bus` (the only path that exists). CI tsc command already matched `build.yml` (`bun run tsc --noEmit`); mock guidance left intact since it matches the real tests under `src/executor/__tests__/`.

Verified: `bunx vitepress build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)