### PR TITLE
docs: document current behavior + factual fixes (#683 theme 5)

### DIFF
--- a/docs/architecture/flow-pr-review.md
+++ b/docs/architecture/flow-pr-review.md
@@ -18,7 +18,18 @@ Quinn's executor (DeepAgent) executes `pr_review` and decides one of three verdi
 | `review_comment` | COMMENTED |
 | `review_request_changes` | CHANGES_REQUESTED |
 
-The verdict tool call publishes to `message.outbound.github.{owner}.{repo}.{number}` and GitHubPlugin posts to the GitHub API.
+These tool calls land on the PR-inspector HTTP backend (`POST /api/pr/inspect`, implemented in [`src/api/pr-inspector.ts`](../../src/api/pr-inspector.ts)), which authenticates as `@protoquinn[bot]` and POSTs the review to the GitHub REST API. On success it publishes `quinn.review.submitted` on the bus for any verdict-reactive subscriber (dashboards, embeds).
+
+### Chokepoint invariant: terminal-CI guard
+
+`pr-inspector.ts` enforces `guardTerminalCi` before a **formal** verdict (`APPROVE` / `REQUEST_CHANGES`) is posted. A formal verdict locks in a settled judgment — APPROVE enables auto-merge, REQUEST_CHANGES sets `reviewDecision` and blocks it — so it must not land while CI is still in flight:
+
+- If any CI check is not yet terminal (`status !== "completed"`), the verdict is **held to COMMENT** (non-blocking). The formal PASS/FAIL lands on a later pass once every check is terminal. Repos with no checks at all are terminal by definition.
+- The guard **fails closed**: an unknown CI state is never treated as terminal.
+
+This is the same chokepoint-invariant shape as cooldown / target-guard / actor-filter / destructive-verdict (see [chokepoint-invariants](chokepoint-invariants.md)).
+
+**CI-access (403) gap.** If the reviewer's token gets a `403` reading check-runs (an App-scope / reviewer-side access gap, surfaced as `CiAccessError`), the guard cannot confirm CI is terminal, so it also holds the verdict to COMMENT rather than locking one in on unverified CI. `check_ci` reports the 403 plainly; the formal verdict waits until CI is actually readable and terminal.
 
 ---
 
@@ -59,19 +70,20 @@ The verdict tool call publishes to `message.outbound.github.{owner}.{repo}.{numb
    │                          │             review_comment /
    │                          │             review_request_changes."
    └──────────────┬───────────┘
-                  │ tool call
+                  │ tool call → POST /api/pr/inspect
                   ▼
    ┌──────────────────────────┐
-   │ message.outbound.github. │  payload: { type: "review_approve" | … ,
-   │   {owner}.{repo}.{n}     │             body, event }
+   │ pr-inspector.ts          │  guardTerminalCi:
+   │  (auth @protoquinn[bot]) │   APPROVE/REQUEST_CHANGES held to
+   │                          │   COMMENT unless every CI check terminal
    └──────────────┬───────────┘
-                  ▼
-            GitHubPlugin._postComment()
-                  │
+                  │ also publishes quinn.review.submitted
                   ▼
             GitHub REST API
         POST /repos/{owner}/{repo}/pulls/{n}/reviews
 ```
+
+The chat-reply path (Quinn answering a comment, no verdict) still flows through `message.outbound.github.{o}.{r}.{n}` → `GitHubPlugin._postComment`. Only the formal verdict tools use the `pr-inspector.ts` backend.
 
 ---
 
@@ -129,7 +141,8 @@ sequenceDiagram
 | `message.inbound.github.{o}.{r}.pull_request.{n}` | GitHubPlugin._handleAutoReview | RouterPlugin | `lib/plugins/github.ts:697,632` |
 | `agent.skill.request` (skill=pr_review) | RouterPlugin (re-emits with target) | SkillDispatcher | `src/router/router-plugin.ts:272` |
 | `agent.skill.response.{correlationId}` | SkillDispatcher | GitHubPlugin (pendingComments match) | `src/executor/skill-dispatcher-plugin.ts:96,182,195` |
-| `message.outbound.github.{o}.{r}.{n}` | Quinn (via tool call) | GitHubPlugin._postComment | `lib/plugins/github.ts:298,375` |
+| `message.outbound.github.{o}.{r}.{n}` | Quinn (chat-reply path, via tool call) | GitHubPlugin._postComment | `lib/plugins/github.ts:298,375` |
+| `quinn.review.submitted` | PR-inspector backend (after a verdict posts) | dashboards / verdict-reactive subscribers | `src/api/pr-inspector.ts` |
 | `flow.item.{created,updated,completed}` | SkillDispatcher | telemetry / dashboard PR-1/2/3 tiles | `src/executor/skill-dispatcher-plugin.ts:275,370,418` |
 
 ---
@@ -178,7 +191,7 @@ Note this is separate from #437 cooldown (which is per-skill-per-repo and 30s) �
 
 - **Cooldown silently drops review #2 within 30s** — if a PR is opened and immediately rebased, the second event hits dispatcher cooldown and silently drops. Operator sees no review for the second push. Visible only in `console.warn`. See [chokepoint-invariants](chokepoint-invariants.md) re: missing dispatch-drop telemetry.
 - **No timeout on Quinn's execution** — same as the general dispatcher gap; Quinn could hang indefinitely on a large diff. Mitigation: DeepAgent has its own `maxTurns` limit and per-tool timeouts.
-- **Verdict tool calls are advisory** — Quinn could in principle issue no verdict (just a chat reply). The PR-review prompt instructs the verdict, but it's an LLM, not a formal contract. If no verdict is issued, GitHubPlugin posts the text response as a comment (default outbound path) and no formal review event is created on GitHub.
+- **Formal verdicts are guarded, not unconditional** — a `review_approve` / `review_request_changes` tool call does **not** unconditionally post that GitHub review. `guardTerminalCi` (in `pr-inspector.ts`) downgrades it to COMMENT whenever CI is still pending or unreadable (403). So a verdict tool call carries a real contract: it posts the formal review only once every CI check is terminal. Quinn may also issue no verdict at all (just a chat reply), in which case no formal review event is created.
 - **Self-cascade guard does NOT apply to PRs** — by design. Quinn-authored PRs *should* be reviewed. If Quinn ever starts auto-resolving its own reviews (approving her own PR), it would loop. Watch for that.
 
 ---

--- a/docs/explanation/agent-identity.md
+++ b/docs/explanation/agent-identity.md
@@ -76,9 +76,9 @@ If a message hits the shared protoBot client (guild @-mention, DM to protoBot di
 
 The `onboard_project` skill is owned by the protoMaker team, but the `provision_discord` skill that creates Discord channels is owned by Quinn. This is a chain: protoMaker calls Quinn via `chain[onboard_project]: quinn/provision_discord`.
 
-The reason is that Quinn has the Discord API client code and the knowledge of the standard channel structure (dev, alerts, releases). The protoMaker team handles the broader project provisioning logic (GitHub scaffold, write-back to `projects.yaml`). The chain keeps these responsibilities separate.
+The reason is that Quinn has the Discord API client code and the knowledge of the standard channel structure (dev, alerts, releases). The protoMaker team handles the broader project provisioning logic (GitHub scaffold, write-back to the protoMaker project registry — the source of truth for project metadata). The chain keeps these responsibilities separate.
 
-When the channel IDs come back from Discord, they are written to both `settings.json` in the target repo and `projects.yaml` in the protoWorkstacean repo. This makes the IDs available to both the agent running in the target repo context and the workstacean routing layer.
+When the channel IDs come back from Discord, they are written to `settings.json` in the target repo and recorded in the protoMaker project registry. This makes the IDs available to both the agent running in the target repo context and the workstacean routing layer.
 
 ---
 

--- a/docs/explanation/clawpatch-checkouts.md
+++ b/docs/explanation/clawpatch-checkouts.md
@@ -2,7 +2,7 @@
 title: Clawpatch checkouts — on-demand source for any repo
 ---
 
-_RFC + design for the checkout cache that lets Quinn's `clawpatch_review` work against every repo in `workspace/projects.yaml`, not just the three currently mounted into the container._
+_RFC + design for the checkout cache that lets Quinn's `clawpatch_review` work against every repo in the protoMaker project registry, not just the few that used to be bind-mounted into the container. Shipped: `src/api/clawpatch.ts` now resolves repos through a `CheckoutCache` gated by the project registry — there is no `BUILT_IN_REPO_PATHS` and no `projects.yaml`._
 
 ---
 
@@ -15,7 +15,7 @@ _RFC + design for the checkout cache that lets Quinn's `clawpatch_review` work a
 
 A repo without an entry — or with an entry whose mount the operator forgot to add to the compose file — gets a hard error: _"repo 'X' is not mounted in this container — only mapped+mounted repos work today (…). On-demand PR checkouts are not implemented."_
 
-That ceiling is everywhere Quinn touches a repo she didn't grow up with. As we keep onboarding repos (every entry in `workspace/projects.yaml` is a candidate), the gap widens: edit compose, redeploy, then she can review it. Worse, the mount is a snapshot of the operator's local checkout, not the PR's actual code — Quinn was technically reviewing whatever ref happened to be checked out on the host, not the PR head.
+That ceiling is everywhere Quinn touches a repo she didn't grow up with. As we keep onboarding repos (every entry in the protoMaker project registry is a candidate), the gap widens: edit compose, redeploy, then she can review it. Worse, the mount is a snapshot of the operator's local checkout, not the PR's actual code — Quinn was technically reviewing whatever ref happened to be checked out on the host, not the PR head.
 
 We want a self-service checkout cache: when Quinn asks to review a PR on a repo she's never seen, the API fetches the exact ref from GitHub, extracts it locally, hands the path to clawpatch, and caches the extracted tree for the next call.
 
@@ -75,7 +75,7 @@ Eviction lives in a daily ceremony, **not** inline on each request — see [C3](
 
 Three guards, all enforced before the extract:
 
-1. **Allowlist gate**: `repo` must match an entry in `workspace/projects.yaml`. Same registry that `create_github_issue` checks. No arbitrary `owner/name` from a tool call extracts code into our data volume — Quinn can only review repos we've already declared we manage.
+1. **Allowlist gate**: `repo` must match a GitHub coordinate in the protoMaker **project registry** (`projectRegistry.getGithubCoords()` in `src/api/clawpatch.ts`). Same registry boundary that `create_github_issue` checks. No arbitrary `owner/name` from a tool call extracts code into our data volume — Quinn can only review repos we've already declared we manage.
 2. **Tarball entry sanitization**: every entry path is rejected if it
    * starts with `/`,
    * contains `..` segments,
@@ -108,7 +108,7 @@ export interface CheckoutCache {
    * the new path. Touches last-access on hit.
    *
    * Throws if:
-   *   - repo is not in the projects.yaml allowlist
+   *   - repo is not in the project-registry allowlist
    *   - the GitHub API returns non-2xx
    *   - tarball validation fails (oversize, traversal, symlink)
    */
@@ -122,19 +122,18 @@ export interface CheckoutCache {
 }
 ```
 
-`src/api/clawpatch.ts:resolveRepoPath()` becomes:
+As shipped, `src/api/clawpatch.ts:resolveRepoPath()` (now `resolveRepoPath`) routes every repo through the project-registry allowlist gate and then the `CheckoutCache` — there is no `BUILT_IN_REPO_PATHS` bind-mount fast path (see the sign-off decision below). The only local-dev escape hatch is the `CLAWPATCH_REPO_PATH_MAP` override; everything else extracts the PR head SHA on demand:
 
 ```ts
-async function resolveRepoPath(repo: string, sha: string): Promise<string | null> {
-  const override = readOverrideMap()[repo];
-  if (override && existsSync(override)) return override;            // fast path for dev
-  const builtIn = BUILT_IN_REPO_PATHS[repo];
-  if (builtIn && existsSync(builtIn)) return builtIn;               // fast path for mounted repos
-  return await checkoutCache.resolve(repo, sha);                    // on-demand path
-}
+// roughly:
+const allow = new Set(projectRegistry?.getGithubCoords() ?? []);
+if (!allow.has(repo)) { /* reject — not a managed repo */ }
+const override = readOverrideMap()[repo];
+if (override && existsSync(override)) return override;            // local-dev only
+return await getCheckoutCache().resolve(repo, since);             // on-demand checkout
 ```
 
-Note: the function gets a new `sha` parameter, so the route handler now requires `since` (the PR head SHA) when the repo isn't mounted. That's already what clawpatch is given for diff anchoring — no new caller-side change, we just route it through the resolver. Existing built-in callers that don't pass a SHA still hit the fast path because the override / built-in check happens first.
+The handler requires `since` (the PR head SHA) so the cache is content-addressed by ref — that's already what clawpatch is given for diff anchoring, so there's no new caller-side change.
 
 ---
 

--- a/docs/extensions/confidence-v1.md
+++ b/docs/extensions/confidence-v1.md
@@ -92,9 +92,9 @@ Agents that don't implement the extension return normal A2A responses — the in
 
 ---
 
-## Dashboard + fleet-health integration
+## Dashboard integration
 
-`defaultConfidenceStore` is read by `AgentFleetHealthPlugin` to surface per-(agent, skill) calibration metrics in the fleet view: `highConfFailures`, `avgConfidenceOnSuccess`, calibration-inversion detection. External consumers can pull `GET /api/confidence-summaries` for the same data.
+`defaultConfidenceStore` is read by the **observability API** (`src/api/observability.ts`, `GET /api/confidence-summaries`) to surface per-(agent, skill) calibration metrics: `highConfFailures`, `avgConfidenceOnSuccess`, calibration-inversion detection. (It is not consumed by `AgentFleetHealthPlugin`, which sources its metrics from `autonomous.outcome.#` events.)
 
 `avgConfidenceOnSuccess` (not the overall average) is the more informative metric — it answers "when this agent succeeds at this skill, how sure is it?" — useful for calibration analysis.
 
@@ -112,5 +112,5 @@ Payload is the raw `ConfidenceSample`. Subscribers: dashboard calibration view, 
 
 ## Related
 
-- [`cost-v1`](cost-v1) — companion metric; surfaced alongside confidence in fleet-health
+- [`cost-v1`](cost-v1) — companion metric; surfaced alongside confidence in the observability API
 - [`effect-domain-v1`](effect-domain-v1) — card-side declaration of effects; observed confidence overrides the declared prior once warm

--- a/docs/extensions/cost-v1.md
+++ b/docs/extensions/cost-v1.md
@@ -2,7 +2,7 @@
 title: "Extension: x-protolabs/cost-v1"
 ---
 
-`x-protolabs/cost-v1` records per-(agent, skill) token + wall-time actuals for every A2A dispatch, feeds a rolling in-memory store, and publishes `autonomous.cost.*` observability events. The store surfaces observed success rate + cost-per-call for dashboards and fleet-health.
+`x-protolabs/cost-v1` records per-(agent, skill) token + wall-time actuals for every A2A dispatch, feeds a rolling in-memory store, and publishes `autonomous.cost.*` observability events. The store surfaces observed success rate + cost-per-call for the observability API's cost-summary dashboards.
 
 **Extension URI**: `https://proto-labs.ai/a2a/ext/cost-v1`
 
@@ -15,7 +15,7 @@ Two signals that the agent card alone can't provide:
 - **Success rate** — how often this (agent, skill) combination actually succeeds, independent of the agent's self-declared confidence
 - **Wall-time cost** — how long a call takes end-to-end, including retries and HITL round-trips
 
-These are *measured* rather than self-advertised: the store accumulates per-key actuals so dashboards and fleet-health reflect observed behavior once samples exist.
+These are *measured* rather than self-advertised: the store accumulates per-key actuals so dashboards reflect observed behavior once samples exist.
 
 ---
 
@@ -75,15 +75,17 @@ const summary = defaultCostStore.summary("quinn", "pr_review");
 // }
 ```
 
-`allSummaries()` returns one entry per (agent, skill) pair seen — drives the fleet cost-per-outcome dashboard view.
+`allSummaries()` returns one entry per (agent, skill) pair seen — read by the observability API (`GET /api/cost-summaries`) to drive the cost-per-outcome dashboard view.
 
 **Intentionally in-memory.** Cost tracking here is observational telemetry, not billing. A durable persistence layer can subscribe to `autonomous.cost.#` and ingest samples independently.
 
 ---
 
-## Fleet-health integration
+## Consumers
 
-`defaultCostStore` is read by `AgentFleetHealthPlugin` to compute per-(agent, skill) success rate, average wall time, and dollar cost. The same data feeds health-weighted dispatch inside `ExecutorRegistry`: when multiple agents serve the same skill, the registry selects probabilistically by `successRate × (1 / (1 + costPerSuccessfulOutcome))`. Cold candidates (< 5 samples) fall back to neutral weight 1.0 so new agents get tried.
+`defaultCostStore` is read by the **observability API** (`src/api/observability.ts`, `GET /api/cost-summaries`), which surfaces per-(agent, skill) success rate, average wall time, and dollar cost for dashboards.
+
+Health-weighted dispatch inside `ExecutorRegistry` is a **separate** path — it sources its metrics from `AgentFleetHealthPlugin` (which aggregates `autonomous.outcome.#` events over a rolling window), not from this cost store. When multiple agents serve the same skill, the registry selects probabilistically **per agent** by `successRate × (1 / (1 + costPerSuccessfulOutcome))` (`_healthWeight` in `executor-registry.ts`). The cold-start gate is on observed outcomes: an agent with **zero recorded outcomes** (`totalOutcomes === 0`) falls back to neutral weight 1.0 so new agents still get tried.
 
 ---
 

--- a/docs/guides/a2a-langfuse-trace-propagation.md
+++ b/docs/guides/a2a-langfuse-trace-propagation.md
@@ -54,9 +54,9 @@ a2a_handler → _submit_task(caller_trace=) → chat_stream_fn_factory(caller_tr
 
 Quinn's Langfuse trace now carries `caller_trace_id` and `caller_span_id` in its metadata. An operator can filter Langfuse by `metadata.caller_trace_id = <uuid>` to find all agent traces spawned from a single Workstacean dispatch.
 
-### Sending side (Workstacean — TODO)
+### Sending side (Workstacean — implemented)
 
-`a2a-executor.ts` needs to stamp the current Langfuse trace context into outbound `params.metadata["a2a.trace"]`. The extension interceptor hook at line 221 is the natural injection point — extensions' metadata is already merged into outbound params.
+`src/index.ts` registers `registerLangfuseTraceExtension()` (`src/executor/extensions/langfuse-trace.ts`), an A2A extension whose `before` hook stamps the trace context onto outbound `params.metadata["a2a.trace"]`. The dispatch's `correlationId` serves as the `traceId` (it uniquely identifies the whole skill-dispatch chain); the extension also stamps `callerAgent`, `skill`, and `project: "protolabs"`. Extensions' metadata is merged into outbound params by `A2AExecutor`, so no per-call wiring is needed.
 
 ## Cross-referencing in Langfuse
 

--- a/docs/integrations/channels.md
+++ b/docs/integrations/channels.md
@@ -98,7 +98,7 @@ When someone @mentions the bot on this repo, RouterPlugin injects `targets: ["qu
     description: Ops escalation channel
 ```
 
-Requires SignalPlugin to be fully wired (currently a stub — see `lib/plugins/signal.ts`).
+SignalPlugin (`lib/plugins/signal.ts`) is fully wired — a WebSocket listener for inbound messages plus an outbound sender. Configure it with `SIGNAL_URL` + `SIGNAL_NUMBER`.
 
 ### Slack
 
@@ -110,34 +110,21 @@ Requires SignalPlugin to be fully wired (currently a stub — see `lib/plugins/s
     agent: quinn
 ```
 
-Requires SlackPlugin (not yet implemented).
+The channel registry accepts `platform: slack` entries, but **no SlackPlugin exists yet** — there is nothing to deliver or receive Slack messages. The schema is registry-ready; the plugin is not implemented.
 
 ---
 
 ## Adding a channel at runtime
 
-No restart required. Use the API:
+Edit `workspace/channels.yaml` directly — the file hot-reloads every 5 seconds, so no restart is required. There is **no** `POST /api/channels` write endpoint; channels are managed through the YAML file.
+
+A read endpoint exists but is currently a **hardcoded empty stub**:
 
 ```bash
-curl -X POST http://localhost:3000/api/channels \
-  -H "Content-Type: application/json" \
-  -d '{
-    "id": "frank-infra",
-    "platform": "discord",
-    "channelId": "1122334455667788",
-    "agent": "frank",
-    "agentBotTokenEnv": "FRANK_DISCORD_TOKEN",
-    "description": "Infrastructure and deployments"
-  }'
+curl http://localhost:3000/api/channels   # GET — always returns { "success": true, "data": [] }
 ```
 
-The entry is written to `workspace/channels.yaml` and the registry reloads within 5 seconds.
-
-List all channels:
-
-```bash
-curl http://localhost:3000/api/channels
-```
+It is wired in `src/api/operations.ts` and does not yet reflect the live registry.
 
 ---
 

--- a/docs/integrations/discord.md
+++ b/docs/integrations/discord.md
@@ -210,6 +210,8 @@ For replies to @mentions and slash commands, match `correlationId` from the inbo
 
 Reacting to any message with 📋 triggers a `bug_triage` skill request using the message content. Useful for quick bug filing from a chat log.
 
+The reaction is **admin-gated** (`lib/plugins/discord/inbound.ts`): the reactor must be in the bot's configured `admins` list, otherwise the reaction is ignored. (If no `admins` list is configured, every reactor is allowed.)
+
 ## Cron Integration
 
 Cron events routed through RouterPlugin that include a `channel` in their payload are delivered to Discord via push:

--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -75,6 +75,7 @@ Fine-grained PAT scoped to the target repo:
 |-------|-----------|-------------|
 | `message.inbound.github.{owner}.{repo}.{event}.{number}` | Inbound | @mention received |
 | `message.outbound.github.{owner}.{repo}.{number}` | Outbound | Reply to post as comment |
+| `github.issue.opened` | Inbound (additive) | Every issue opened/reopened — feeds the protoMaker board bridge (see below) |
 
 ## Inbound Payload
 
@@ -114,6 +115,25 @@ Match `correlationId` from the inbound message — the plugin uses it to look up
 | `pull_request_review_comment` | Review comment containing `@mention` | `pr_review` |
 | `pull_request` | PR opened/updated with `@mention` in body | `pr_review` |
 | `repository` (created) | New repository created in the org | `message.inbound.onboard` |
+
+## GitHub issue → protoMaker board
+
+Independent of the @mention triage path, every opened or reopened issue is forwarded to protoMaker's board as a backlog idea — but only for repos in the project registry.
+
+**Topic.** On `issues` with action `opened` or `reopened`, `GitHubPlugin` publishes `github.issue.opened` (additive — it fires for every such issue regardless of @mention or skill routing). `ProtoMakerBoardBridgePlugin` (`lib/plugins/protomaker-board-bridge.ts`) is the sole subscriber.
+
+**Registry-gating.** The bridge resolves the repo against the project registry (`registry.getByGithub("{owner}/{repo}")`). If the repo is not a managed project, the issue is ignored — workstacean's own triage path owns those independently.
+
+**Forward.** For a managed repo, the bridge POSTs to `{PROTOMAKER_API_BASE}/api/engine/signal/submit` (default `http://protomaker-server:3008`) with header `X-API-Key`. The signal body carries `source: "github"`, the issue title+body as `content`, a `channelContext` with the resolved `projectPath` / `issueNumber` / `repository`, and an `a2a`-style `trace` block (the dispatch `correlationId` as `traceId`) so the GitHub→board→PRD flow links into one Langfuse trace.
+
+**Env.**
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `PROTOMAKER_API_BASE` | protoMaker board-intake base URL | `http://protomaker-server:3008` |
+| `AUTOMAKER_API_KEY` | Value sent as the `X-API-Key` header | (none — if unset, the bridge logs a warning and skips forwarding) |
+
+**Dedup.** protoMaker's `SignalIntakeService.submitSignal` dedups on `github:{repository}#{issueNumber}`, so a reopened or redelivered issue does not double-create a board idea.
 
 ## Org Webhook: repository.created
 

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -18,8 +18,6 @@ protoWorkstacean connects to external services through **plugins** and runs agen
 | [Google Workspace](google-workspace) | Gmail polling, Calendar polling, Drive/Docs write | `GOOGLE_CLIENT_ID` |
 | [Signal](signal) | Inbound/outbound Signal messages | `SIGNAL_URL` + `SIGNAL_NUMBER` |
 
-## Memory
-
 ## Agent runtimes
 
 | Runtime | What it does | When to use |


### PR DESCRIPTION
Final docs-refresh theme (#683 theme 5): document recently-added behavior and apply the remaining factual fixes from the audit. Every claim verified against code before editing. `bunx vitepress build` passes.

## A. Document current behavior (was undocumented)
- **`integrations/github.md`** — new "GitHub issue → protoMaker board" section. `GitHubPlugin` publishes `github.issue.opened` on issue opened/reopened; `ProtoMakerBoardBridgePlugin` (`lib/plugins/protomaker-board-bridge.ts`) subscribes and POSTs to `{PROTOMAKER_API_BASE}/api/engine/signal/submit` with header `X-API-Key` (value from `AUTOMAKER_API_KEY`), gated to repos in the project registry (`getByGithub`), dedup on `github:{repository}#{issueNumber}`.
- **`architecture/flow-pr-review.md`** — Quinn's verdict pipeline lives in `src/api/pr-inspector.ts`. Documented the `guardTerminalCi` chokepoint (formal APPROVE/REQUEST_CHANGES requires every CI check terminal, else held to COMMENT; fails closed; 403 CI-access gap also holds to COMMENT). Pointed the verdict topic `quinn.review.submitted` at `pr-inspector.ts`. Replaced the stale "verdicts are advisory / no formal contract" framing.

## B. Factual fixes
- **`integrations/channels.md`** — removed the nonexistent `POST /api/channels` example; noted `GET /api/channels` is a hardcoded empty stub (`src/api/operations.ts`); dropped the "SignalPlugin is a stub" caveat (fully wired — `lib/plugins/signal.ts`); marked Slack registry-ready-but-no-plugin (no SlackPlugin exists).
- **`extensions/cost-v1.md`** — cost store is read by the **observability API** (`/api/cost-summaries`), not `AgentFleetHealthPlugin` (which sources `autonomous.outcome.#`). Cold-start gate is **zero observed outcomes → 1.0** (`_healthWeight` gates on `totalOutcomes === 0`), not "≥5 samples"; weighting is per-agent.
- **`extensions/confidence-v1.md`** — same wrong-consumer fix: `defaultConfidenceStore` read by the observability API (`/api/confidence-summaries`), not fleet-health.
- **`guides/a2a-langfuse-trace-propagation.md`** — sending side is DONE: `src/index.ts` registers `registerLangfuseTraceExtension`, which stamps `params.metadata["a2a.trace"]` (`src/executor/extensions/langfuse-trace.ts`). Dropped the TODO.
- **`integrations/discord.md`** — noted the 📋 reaction trigger is admin-gated (`lib/plugins/discord/inbound.ts`).
- **`integrations/index.md`** — removed the empty "## Memory" heading.

## C. Leftover projects.yaml (theme 2 remainder)
- **`explanation/agent-identity.md`** — project metadata write-back goes to the protoMaker registry, not `projects.yaml`.
- **`explanation/clawpatch-checkouts.md`** — allowlist is the protoMaker project registry (`projectRegistry.getGithubCoords()` + `CheckoutCache`), no `BUILT_IN_REPO_PATHS`, no `projects.yaml`; updated the stale resolver snippet.

Refs #683.

🤖 Generated with [Claude Code](https://claude.com/claude-code)