### PR TITLE
ci(docs): broaden docs-deploy trigger to generator inputs

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -4,8 +4,19 @@ on:
   push:
     branches:
       - main
+    # The reference docs are generated from code at deploy time (bun run docs:gen),
+    # so a code change can change the published docs without touching docs/**.
+    # Trigger on the generator inputs too — deterministic generators mean a push
+    # that doesn't actually change any doc produces an identical build (harmless
+    # no-op redeploy; the `pages` concurrency group supersedes overlapping runs).
     paths:
-      - 'docs/**'
+      - 'docs/**'                       # content + VitePress config
+      - 'src/**'                        # API routes, bus topics, agent tools, env schema
+      - 'lib/**'                        # bus topics, env (process.env reads)
+      - 'workspace/agents/**'           # agent tool → agent mapping
+      - 'scripts/gen-*.ts'              # the generators
+      - 'scripts/audit-bus-topics.ts'
+      - '.github/workflows/docs-deploy.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Follow-up to the docs auto-generation work (#683). The reference docs are generated from code at deploy time (`bun run docs:gen`), so a **code** change can change the published docs without touching `docs/**`. This widens the `docs-deploy` trigger to the generator inputs:

- `src/**` (API routes, bus topics, agent tools, env schema)
- `lib/**` (bus topics, `process.env` reads)
- `workspace/agents/**` (tool → agent mapping)
- `scripts/gen-*.ts` + `audit-bus-topics.ts` (the generators)
- the workflow itself

Generators are deterministic, so a push that doesn't actually change a doc just rebuilds identically (harmless no-op redeploy); the `pages` concurrency group cancels overlapping runs. Net: the live docs stay fresh on code-only changes, completing the 'generate automatically' goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)