### PR TITLE
ci: add actionlint + zizmor workflow-lint gate; fix template-injection + permissions (#611)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  # Namespace.so managed runner label used across the org's fleet CI.
+  labels: [namespace-profile-protolabs-linux]

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -32,6 +32,9 @@ jobs:
 
     steps:
       - name: Checkout main
+        # zizmor: ignore[artipacked] — credentials are required: this job pushes
+        # the release tag with the checked-out token. No artifact upload here, so
+        # there is no credential-leak vector to mitigate by dropping them.
         uses: actions/checkout@v4
         with:
           ref: main
@@ -59,15 +62,17 @@ jobs:
 
       - name: Create tag
         if: steps.version.outputs.already_tagged != 'true' || inputs.force == true
+        env:
+          VERSION_NUM: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="v${{ steps.version.outputs.version }}"
+          VERSION="v${VERSION_NUM}"
           git tag -a -f "$VERSION" -m "$VERSION"
           git push origin "$VERSION" --force-with-lease
 
       - name: Create GitHub Release
         if: steps.version.outputs.already_tagged != 'true' || inputs.force == true
         run: |
-          VERSION="v${{ steps.version.outputs.version }}"
+          VERSION="v${VERSION_NUM}"
 
           # Skip if release already exists (e.g. after a force-retag)
           if gh release view "$VERSION" >/dev/null 2>&1; then
@@ -77,7 +82,7 @@ jobs:
 
           # Generate notes from auto-notes API; filter chore commits out unless
           # they're the only entries.
-          RAW_NOTES=$(gh api "repos/${{ github.repository }}/releases/generate-notes" \
+          RAW_NOTES=$(gh api "repos/${REPO}/releases/generate-notes" \
             -f tag_name="$VERSION" --jq '.body')
 
           ALL_LINES=$(echo "$RAW_NOTES" | grep '^\* ' || true)
@@ -92,11 +97,17 @@ jobs:
           gh release create "$VERSION" --title "$VERSION" --notes "$FILTERED"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION_NUM: ${{ steps.version.outputs.version }}
+          REPO: ${{ github.repository }}
 
       - name: Summary
+        env:
+          VERSION_NUM: ${{ steps.version.outputs.version }}
+          ALREADY_TAGGED: ${{ steps.version.outputs.already_tagged }}
+          FORCE: ${{ inputs.force }}
         run: |
-          VERSION="v${{ steps.version.outputs.version }}"
-          if [ "${{ steps.version.outputs.already_tagged }}" = "true" ] && [ "${{ inputs.force }}" != "true" ]; then
+          VERSION="v${VERSION_NUM}"
+          if [ "$ALREADY_TAGGED" = "true" ] && [ "$FORCE" != "true" ]; then
             echo "Skipped: $VERSION already tagged."
           else
             echo "Tagged $VERSION. release.yml will post Discord notes from the tag push."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,17 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+# Least-privilege default; the build-and-push job opts up to packages: write.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: namespace-profile-protolabs-linux
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -41,6 +47,8 @@ jobs:
     runs-on: namespace-profile-protolabs-linux
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # Astro requires Node.js >= 22.12 at build time. GHA runners default
       # to Node 20, which `bun run build` inherits when it invokes astro,
@@ -83,6 +91,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -19,10 +19,9 @@ on:
       - '.github/workflows/docs-deploy.yml'
   workflow_dispatch:
 
+# Least-privilege default; only the deploy job needs Pages write + OIDC.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Only one deployment at a time; cancel in-progress runs on new push
 concurrency:
@@ -35,6 +34,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -72,6 +73,9 @@ jobs:
     needs: build
     # workspace-config: allow-hosted-runner GitHub Pages deploy requires the hosted Pages environment
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/fleet-config-audit.yml
+++ b/.github/workflows/fleet-config-audit.yml
@@ -28,6 +28,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -99,6 +101,8 @@ jobs:
 
       - name: Fail if any repo drifts
         if: ${{ steps.audit.outputs.drift_count != '0' }}
+        env:
+          DRIFT: ${{ steps.audit.outputs.drift_count }}
         run: |
-          echo "::error::${{ steps.audit.outputs.drift_count }} repo(s) drifting from the workspace-config standard — see job summary."
+          echo "::error::${DRIFT} repo(s) drifting from the workspace-config standard — see job summary."
           exit 1

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,60 @@
+name: Lint Workflows
+
+# Static analysis gate for GitHub Actions workflows (#611).
+#   - actionlint: syntax, expression, and shellcheck-of-run-blocks linting.
+#   - zizmor:     security audits (template-injection, excessive-permissions,
+#                 artipacked credential persistence, etc.).
+#
+# Both tools FAIL the job on findings — this is a real gate, not advisory.
+#
+# Gate severity: zizmor runs at --min-severity=medium, so the CWE-94
+# template-injection class (High) and broad-permissions/credential-persistence
+# (Medium) all block. Informational findings (e.g. step-output interpolation,
+# which is workflow-controlled, not attacker-controllable) are advisory.
+#
+# Policy notes:
+#   - unpinned-uses is configured to `ref-pin` in .github/zizmor.yml: the org
+#     pins actions to release tags (@v4), not commit SHAs. Blanket SHA-pinning
+#     is a separate org-wide decision, out of scope here.
+#   - The release-tools workflow *template* propagation to new repos is tracked
+#     separately (protoMaker#3821).
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.github/zizmor.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.github/zizmor.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint-workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install and run actionlint
+        run: |
+          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -color
+
+      - name: Install uv (for zizmor)
+        uses: astral-sh/setup-uv@v5
+
+      - name: Run zizmor
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          uvx zizmor@1.25.2 --min-severity=medium .github/workflows/

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -33,6 +33,9 @@ jobs:
 
     steps:
       - name: Checkout main
+        # zizmor: ignore[artipacked] — credentials are required: this job pushes
+        # the release branch and opens a PR with the checked-out token. No
+        # artifact upload here, so there is no credential-leak vector.
         uses: actions/checkout@v4
         with:
           ref: main
@@ -46,9 +49,10 @@ jobs:
 
       - name: Compute next version
         id: version
+        env:
+          BUMP: ${{ inputs.bump }}
         run: |
           CURRENT=$(node -p "require('./package.json').version")
-          BUMP="${{ inputs.bump }}"
 
           case "$BUMP" in
             patch|minor|major)
@@ -77,8 +81,9 @@ jobs:
 
       - name: Apply version bump
         if: steps.version.outputs.current != steps.version.outputs.next
+        env:
+          NEXT: ${{ steps.version.outputs.next }}
         run: |
-          NEXT="${{ steps.version.outputs.next }}"
           node -e "
             const fs = require('fs');
             for (const path of ['package.json', 'dashboard/package.json']) {
@@ -91,8 +96,10 @@ jobs:
 
       - name: Commit version bump + open PR to main
         if: steps.version.outputs.current != steps.version.outputs.next && inputs.dry_run != true
+        env:
+          NEXT: ${{ steps.version.outputs.next }}
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
         run: |
-          NEXT="${{ steps.version.outputs.next }}"
           BRANCH="chore/release-v${NEXT}"
 
           # Main has branch protection requiring CodeRabbit — direct pushes
@@ -113,23 +120,26 @@ jobs:
             gh pr merge "$PR_NUM" --merge --auto
             echo "Enabled auto-merge for #${PR_NUM}"
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Dry run summary
         if: inputs.dry_run == true
+        env:
+          NEXT: ${{ steps.version.outputs.next }}
         run: |
           echo "DRY RUN — would have committed:"
           git diff --stat
           echo ""
-          echo "Next version: v${{ steps.version.outputs.next }}"
-          echo "Would open PR on branch chore/release-v${{ steps.version.outputs.next }}"
+          echo "Next version: v${NEXT}"
+          echo "Would open PR on branch chore/release-v${NEXT}"
 
       - name: Summary
         if: inputs.dry_run != true
+        env:
+          CURRENT: ${{ steps.version.outputs.current }}
+          NEXT_RAW: ${{ steps.version.outputs.next }}
         run: |
-          NEXT="v${{ steps.version.outputs.next }}"
-          if [ "${{ steps.version.outputs.current }}" = "${{ steps.version.outputs.next }}" ]; then
+          NEXT="v${NEXT_RAW}"
+          if [ "$CURRENT" = "$NEXT_RAW" ]; then
             echo "No version change (already at $NEXT)."
           else
             echo "Release $NEXT PR opened with auto-merge enabled."

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ on:
         type: string
         required: false
 
+# Read-only: this workflow only reads git history and posts to a Discord webhook.
+permissions:
+  contents: read
+
 jobs:
   post-release-notes:
     runs-on: namespace-profile-protolabs-linux
@@ -27,12 +31,16 @@ jobs:
         with:
           fetch-depth: 0 # full history for git log
           ref: ${{ inputs.tag || github.ref }}
+          persist-credentials: false
 
       - name: Resolve tag pair
         id: tags
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           # Inputs.tag overrides; otherwise use the tag the workflow ran on.
-          TAG="${{ inputs.tag || github.ref_name }}"
+          TAG="${INPUT_TAG:-$REF_NAME}"
           PREV=$(git tag --sort=-v:refname | grep -v "^${TAG}$" | head -1)
           echo "version=$TAG" >> "$GITHUB_OUTPUT"
           echo "previous=$PREV" >> "$GITHUB_OUTPUT"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,11 @@
+# zizmor configuration — github/workflows lint gate (#611)
+#
+# unpinned-uses: the org pins actions to release tags (@v4, @v0.1.0) rather
+# than commit SHAs. Blanket SHA-pinning is a separate org-wide policy decision
+# (tracked outside this gate), so we accept tag pins here and only fail on
+# fully-unpinned refs (e.g. @main, @master).
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "*": ref-pin


### PR DESCRIPTION
Closes #611.

Adds a real CI gate that statically analyzes `.github/workflows/**` with **actionlint** + **zizmor**, and fixes the genuine findings so the gate is GREEN on the current tree.

## New gate — `.github/workflows/lint-workflows.yml`
- Triggers: `pull_request` + `push` to `main` (both filtered to `paths: ['.github/workflows/**', '.github/actionlint.yaml', '.github/zizmor.yml']`) + `workflow_dispatch`.
- One `lint-workflows` job on `ubuntu-latest`, `permissions: contents: read`, read-only checkout (`persist-credentials: false`).
- Installs + runs **actionlint** via the official `download-actionlint.bash`, then `./actionlint -color` — fails on any finding.
- Installs **uv** (`astral-sh/setup-uv@v5`) and runs `uvx zizmor@1.25.2 --min-severity=medium` with `GH_TOKEN: ${{ github.token }}` — fails on medium+ findings.
- The gate workflow is itself clean under both tools.

## Fixes (the real findings)

**template-injection (CWE-94) — fully resolved (0 at default severity).**
Hoisted every `github.*` / `inputs.*` / `steps.*.outputs.*` interpolation out of `run:` blocks into step `env:` and referenced `"$VAR"`:
- `release.yml` — `inputs.tag || github.ref_name` (High, attacker-controllable)
- `prepare-release.yml` — `inputs.bump` (High) + the step-output cases
- `auto-release.yml`, `fleet-config-audit.yml` — step-output cases (informational, but cleaned too)

**excessive-permissions — fixed.**
- `build.yml`: added top-level `permissions: contents: read` (build-and-push keeps its job-level `packages: write`).
- `release.yml`: added `permissions: contents: read`.
- `docs-deploy.yml`: moved `pages: write` / `id-token: write` off the top level down to the `deploy` job only (the `build` job needs neither).

**artipacked — fixed.**
Added `persist-credentials: false` to read-only checkouts: `build.yml` (×3), `docs-deploy.yml`, `fleet-config-audit.yml`, `publish-image.yml`, `release.yml`. The two checkouts that legitimately push with the token (`auto-release.yml` tag push, `prepare-release.yml` branch + PR) keep credentials and carry a precise `# zizmor: ignore[artipacked]` with rationale (no artifact upload in either, so no leak vector).

## Accepted via policy

**unpinned-uses (26) — accepted, not SHA-pinned.**
`.github/zizmor.yml` sets `unpinned-uses` policy to `ref-pin`. The org tag-pins actions (`@v4`, `@v0.1.0`); blanket SHA-pinning is a separate org-wide decision, out of scope here. The gate still fails on fully-unpinned refs (`@main`, etc.).

`.github/actionlint.yaml` registers the self-hosted runner label `namespace-profile-protolabs-linux` (the only actionlint finding — a false positive).

## Gate severity
zizmor runs at `--min-severity=medium`: the injection class (High) and broad-permissions / credential-persistence (Medium) all block. Informational findings (workflow-controlled step-output interpolation) are advisory. In practice the tree is clean at default severity too.

## Local verification
- `actionlint .github/workflows/*.yml` → exit 0, no output.
- `zizmor --offline --min-severity=medium .github/workflows/` → exit 0, no findings.
- `zizmor --offline .github/workflows/` (default severity) → no findings.

Note: the release-tools workflow *template* propagation to new repos is tracked separately (protoMaker#3821).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions security by implementing least-privilege permissions across all workflows and disabling credential persistence in checkout steps.
  * Added automated workflow linting and security scanning with actionlint and zizmor to enforce action pinning and best practices.
  * Standardized environment variable usage in release and deployment workflows for consistency.
  * Updated configuration to support self-hosted runner deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/694?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->