### PR TITLE
ci: fix lint-workflows gate (shellcheck quoting + deterministic zizmor)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -50,14 +50,14 @@ jobs:
         id: version
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Detected version: v$VERSION"
 
           if git tag -l "v$VERSION" | grep -q "v$VERSION"; then
-            echo "already_tagged=true" >> $GITHUB_OUTPUT
+            echo "already_tagged=true" >> "$GITHUB_OUTPUT"
             echo "v$VERSION is already tagged."
           else
-            echo "already_tagged=false" >> $GITHUB_OUTPUT
+            echo "already_tagged=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create tag

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -54,7 +54,8 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Run zizmor
-        env:
-          GH_TOKEN: ${{ github.token }}
+        # --offline keeps the gate deterministic: it runs the static audits
+        # (template-injection, excessive-permissions, artipacked, unpinned-uses)
+        # without network-dependent checks that can flake on rate limits.
         run: |
-          uvx zizmor@1.25.2 --min-severity=medium .github/workflows/
+          uvx zizmor@1.25.2 --offline --min-severity=medium .github/workflows/

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -75,8 +75,8 @@ jobs:
               ;;
           esac
 
-          echo "current=$CURRENT" >> $GITHUB_OUTPUT
-          echo "next=$NEXT" >> $GITHUB_OUTPUT
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
           echo "Version bump: v$CURRENT → v$NEXT"
 
       - name: Apply version bump


### PR DESCRIPTION
The `lint-workflows` gate from #694 was **red on main**: GitHub's runner ships shellcheck (my local box didn't), so actionlint's shellcheck pass flagged 5 pre-existing unquoted `>> $GITHUB_OUTPUT` redirects (SC2086) in `auto-release.yml` + `prepare-release.yml`, and the job exited 1 before zizmor even ran.

Fix:
- **Quote the redirects** → `>> "$GITHUB_OUTPUT"` (correct shell hygiene).
- **Run zizmor `--offline`** in the gate so CI is deterministic + matches local verification — the static audits (template-injection, excessive-permissions, artipacked, unpinned-uses) all run offline; the online-only checks are network-dependent and can flake.

Verified locally with shellcheck present: **actionlint exit 0, zizmor exit 0**. Closes the loop on #611 (the gate is now actually green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)