### PR TITLE
feat(a2a): poll endpoint reports "working" for in-flight in-process dispatches

### DIFF
--- a/src/api/__tests__/ava-tools.test.ts
+++ b/src/api/__tests__/ava-tools.test.ts
@@ -141,7 +141,9 @@ describe("/api/a2a/task/:correlationId (poll)", () => {
     const taskTracker = {
       getAll: () => [{ correlationId: "c-working", taskId: "t1", agentName: "protopen" }],
     } as unknown as ApiContext["taskTracker"];
-    const { poll } = routesFor({ bus, executorRegistry: fakeRegistry(["protopen"]), taskTracker, skillResponseCache });
+    // In-flight in-process dispatch: not cached, not tracked, but actively executing.
+    const activeDispatchCheck = (id: string) => id === "c-inproc";
+    const { poll } = routesFor({ bus, executorRegistry: fakeRegistry(["protopen"]), taskTracker, skillResponseCache, activeDispatchCheck });
 
     const done = await poll(new Request("http://x/api/a2a/task/c-done"), { correlationId: "c-done" });
     const dj = (await done.json()) as { data: Record<string, unknown> };
@@ -152,6 +154,14 @@ describe("/api/a2a/task/:correlationId (poll)", () => {
     const wj = (await working.json()) as { data: Record<string, unknown> };
     expect(wj.data.pending).toBe(true);
     expect(wj.data.taskState).toBe("working");
+    expect(wj.data.taskId).toBe("t1"); // A2A working carries taskId
+
+    // In-flight in-process dispatch → working (no taskId), not "unknown"
+    const inproc = await poll(new Request("http://x/api/a2a/task/c-inproc"), { correlationId: "c-inproc" });
+    const ij = (await inproc.json()) as { data: Record<string, unknown> };
+    expect(ij.data.pending).toBe(true);
+    expect(ij.data.taskState).toBe("working");
+    expect(ij.data.taskId).toBeUndefined();
 
     const unknown = await poll(new Request("http://x/api/a2a/task/c-nope"), { correlationId: "c-nope" });
     const uj = (await unknown.json()) as { data: Record<string, unknown> };

--- a/src/api/ava-tools.ts
+++ b/src/api/ava-tools.ts
@@ -218,13 +218,15 @@ export function createRoutes(ctx: ApiContext): Route[] {
 
   /**
    * GET /api/a2a/task/:correlationId — fetch the result of a dispatch that a
-   * chat caller stopped awaiting (timed out). Reads the SkillResponseCache
-   * (covers both in-process and A2A results), falling back to TaskTracker's
-   * live tracked state for "still working".
+   * chat caller stopped awaiting (timed out). Resolves in this order:
+   *   1. SkillResponseCache — terminal result (in-process or A2A)        → done
+   *   2. TaskTracker — a tracked, in-flight long-running A2A task        → working (+taskId)
+   *   3. activeDispatchCheck — an in-flight in-process dispatch          → working
+   *   4. none of the above                                              → unknown
    *
    * Returns one of:
    *   { done: true, response, error?, taskState, … }   — terminal result available
-   *   { pending: true, taskState: "working", taskId }  — still running
+   *   { pending: true, taskState: "working", taskId? } — still running (taskId only for A2A)
    *   { pending: false, taskState: "unknown" }         — never seen / aged out
    */
   function handleTaskPoll(req: Request, params: Record<string, string>): Response {
@@ -264,13 +266,23 @@ export function createRoutes(ctx: ApiContext): Route[] {
       });
     }
 
+    // In-flight in-process dispatch: no cached result yet, and TaskTracker only
+    // covers A2A. The dispatcher knows it's still executing — report "working"
+    // so the caller can keep polling instead of mistaking it for "unknown".
+    if (ctx.activeDispatchCheck?.(correlationId)) {
+      return Response.json({
+        success: true,
+        data: { pending: true, taskState: "working", correlationId },
+      });
+    }
+
     return Response.json({
       success: true,
       data: {
         pending: false,
         taskState: "unknown",
         correlationId,
-        note: "No tracked task and no cached result — it may never have been dispatched, or its result aged out.",
+        note: "No in-flight dispatch, tracked task, or cached result — it may never have been dispatched, or its result aged out.",
       },
     });
   }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -62,6 +62,13 @@ export interface ApiContext {
    * (dispatcher inline) and A2A (TaskTracker) results. Wired in src/index.ts.
    */
   skillResponseCache?: SkillResponseCache;
+  /**
+   * True while a dispatch (in-process or A2A) is still executing. Lets the
+   * task-poll endpoint report a "working" state for in-process dispatches that
+   * aren't yet in the SkillResponseCache and aren't tracked by TaskTracker
+   * (which only covers long-running A2A tasks). Backed by SkillDispatcher.isActive.
+   */
+  activeDispatchCheck?: (correlationId: string) => boolean;
   /** Source of truth for project metadata (slug, path, github coordinates). */
   projectRegistry?: ProjectRegistry;
   /** Channels registry — used by routes that need per-project channel lookups. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,12 @@ const contextMailbox = new ContextMailbox();
 import { TaskTracker } from "./executor/task-tracker.ts";
 const taskTracker = new TaskTracker({ bus });
 
+// Handle to the dispatcher's in-flight check — assigned when its (lazy) factory
+// runs below. Read via a closure in apiContext so the poll endpoint can report
+// a "working" state for in-process dispatches still executing (not yet in the
+// SkillResponseCache and not tracked by TaskTracker — that path only covers A2A).
+let skillDispatcher: { isActive(correlationId: string): boolean } | undefined;
+
 // --- Agent key registry — resolves per-agent X-API-Key headers to identities
 //     so ceremony / cron endpoints (and any future per-agent permission gates)
 //     can enforce ownership. Falls back to admin-only mode when
@@ -384,7 +390,9 @@ const pluginRegistry: PluginRegistryEntry[] = [
     condition: () => true,
     factory: async () => {
       const { SkillDispatcherPlugin } = await import("./executor/skill-dispatcher-plugin.js");
-      return new SkillDispatcherPlugin(executorRegistry, workspaceDir, contextMailbox, taskTracker);
+      const dispatcher = new SkillDispatcherPlugin(executorRegistry, workspaceDir, contextMailbox, taskTracker);
+      skillDispatcher = dispatcher;
+      return dispatcher;
     },
   },
   {
@@ -589,6 +597,8 @@ const apiContext: ApiContext = {
   taskTracker,
   busHistory: busHistoryRecorder,
   skillResponseCache,
+  // Lazy in-flight check — true while a dispatch (in-process or A2A) is executing.
+  activeDispatchCheck: (correlationId: string) => skillDispatcher?.isActive(correlationId) ?? false,
   projectRegistry,
   channelRegistry,
 };


### PR DESCRIPTION
Closes the rough edge we found shaking out the SkillResponseCache (#675): `GET /api/a2a/task/:correlationId` returned **`unknown`** for an in-process dispatch that was *still running* — indistinguishable from "never existed" — because the result isn't cached yet and `TaskTracker` only covers long-running **A2A** tasks. (Saw it live in the Ava→protopen shakeout: polling Ava's in-process result hit `unknown` until it completed.)

**Fix:** the dispatcher already knows — `SkillDispatcherPlugin.isActive(correlationId)` is true for the whole dispatch (set before the first await, cleared in `finally`). Exposed it to the poll endpoint via an **`activeDispatchCheck`** closure on `ApiContext` (resolves the lazily-built dispatcher at request time — no init-order coupling). New resolution order:
1. SkillResponseCache → `done`
2. TaskTracker (in-flight A2A) → `working` (+taskId)
3. **activeDispatchCheck (in-flight in-process) → `working`** ← new
4. else → `unknown` (now genuinely means gone)

**Tests:** ava-tools poll test covers the in-process `working` case (working, no taskId) and confirms `unknown` still means truly-gone. 867 pass, tsc + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Task status polling now accurately reports in-process tasks as "working" instead of "unknown" while actively executing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoWorkstacean/pull/698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->