### PR TITLE
feat(dashboard): adopt @protolabsai/design brand tokens

### DIFF
--- a/dashboard/bun.lock
+++ b/dashboard/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "workstacean-dashboard",
       "dependencies": {
+        "@protolabsai/design": "^0.2.0",
         "@xyflow/react": "^12.10.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -119,6 +120,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@protolabsai/design": ["@protolabsai/design@0.2.0", "", {}, "sha512-h85XpF4h0YNML0DxePbG/F1H8fEdxvGu40xDF74cg59PCJJaQFrVrNqi5GgwlAoyB1wukGtVjG5RSnHRB26tog=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@protolabsai/design": "^0.2.0",
     "@xyflow/react": "^12.10.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/dashboard/src/components/AgentNode.tsx
+++ b/dashboard/src/components/AgentNode.tsx
@@ -29,10 +29,10 @@ export interface AgentNodeData {
 }
 
 const STATUS_COLOR: Record<AgentStatus, string> = {
-  idle: "#30363d",
-  running: "#3fb950",     // GitHub green
-  completed: "#58a6ff",   // GitHub blue
-  error: "#f85149",       // GitHub red
+  idle: "var(--border-default)",
+  running: "var(--text-success)",     // GitHub green
+  completed: "var(--accent-fg)",   // GitHub blue
+  error: "var(--text-danger)",       // GitHub red
 };
 
 const TYPE_LABEL: Record<string, string> = {
@@ -57,8 +57,8 @@ export default function AgentNode({ data }: { data: AgentNodeData }) {
   return (
     <div
       style={{
-        background: "#0d1117",
-        color: "#e6edf3",
+        background: "var(--bg-canvas)",
+        color: "var(--text-primary)",
         border: `1px solid ${statusColor}`,
         borderRadius: 8,
         padding: 10,
@@ -69,19 +69,19 @@ export default function AgentNode({ data }: { data: AgentNodeData }) {
         boxShadow: status === "running" ? `0 0 12px ${statusColor}40` : "none",
       }}
     >
-      <Handle type="target" position={Position.Left} style={{ background: "#30363d" }} />
-      <Handle type="source" position={Position.Right} style={{ background: "#30363d" }} />
+      <Handle type="target" position={Position.Left} style={{ background: "var(--border-default)" }} />
+      <Handle type="source" position={Position.Right} style={{ background: "var(--border-default)" }} />
 
       {/* Header: name + type badge + status pill */}
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <strong style={{ fontSize: 13, color: "#e6edf3" }}>{data.label}</strong>
+        <strong style={{ fontSize: 13, color: "var(--text-primary)" }}>{data.label}</strong>
         <span
           style={{
             fontSize: 9,
             padding: "1px 5px",
-            border: "1px solid #30363d",
+            border: "1px solid var(--border-default)",
             borderRadius: 3,
-            color: "#8b949e",
+            color: "var(--text-secondary)",
           }}
         >
           {TYPE_LABEL[data.type] ?? data.type}
@@ -102,22 +102,22 @@ export default function AgentNode({ data }: { data: AgentNodeData }) {
 
       {/* Current skill */}
       {activity?.currentSkill && (
-        <div style={{ fontSize: 10, color: "#8b949e", marginBottom: 4 }}>
-          skill: <span style={{ color: "#e6edf3" }}>{activity.currentSkill}</span>
+        <div style={{ fontSize: 10, color: "var(--text-secondary)", marginBottom: 4 }}>
+          skill: <span style={{ color: "var(--text-primary)" }}>{activity.currentSkill}</span>
           {activity.startedAt && status === "running" && (
-            <span style={{ marginLeft: 6, color: "#6e7681" }}>· {relativeTime(activity.startedAt)}</span>
+            <span style={{ marginLeft: 6, color: "var(--text-secondary)" }}>· {relativeTime(activity.startedAt)}</span>
           )}
         </div>
       )}
 
       {/* Tool call history */}
       {activity && activity.toolCalls.length > 0 && (
-        <div style={{ borderTop: "1px solid #21262d", paddingTop: 4, marginTop: 4 }}>
+        <div style={{ borderTop: "1px solid var(--border-muted)", paddingTop: 4, marginTop: 4 }}>
           {activity.toolCalls.slice(0, 4).map((call, idx) => (
-            <div key={idx} style={{ fontSize: 10, color: "#8b949e", lineHeight: 1.4 }}>
-              <span style={{ color: "#7ee787" }}>↳</span>{" "}
-              <span style={{ color: "#e6edf3" }}>{call.tools.join(", ")}</span>
-              <span style={{ marginLeft: 6, color: "#6e7681" }}>{relativeTime(call.timestamp)}</span>
+            <div key={idx} style={{ fontSize: 10, color: "var(--text-secondary)", lineHeight: 1.4 }}>
+              <span style={{ color: "var(--text-success)" }}>↳</span>{" "}
+              <span style={{ color: "var(--text-primary)" }}>{call.tools.join(", ")}</span>
+              <span style={{ marginLeft: 6, color: "var(--text-secondary)" }}>{relativeTime(call.timestamp)}</span>
             </div>
           ))}
         </div>
@@ -127,11 +127,11 @@ export default function AgentNode({ data }: { data: AgentNodeData }) {
       {status === "completed" && activity?.resultPreview && (
         <div
           style={{
-            borderTop: "1px solid #21262d",
+            borderTop: "1px solid var(--border-muted)",
             paddingTop: 4,
             marginTop: 4,
             fontSize: 10,
-            color: "#8b949e",
+            color: "var(--text-secondary)",
             fontStyle: "italic",
             whiteSpace: "nowrap",
             overflow: "hidden",

--- a/dashboard/src/components/AgentsView.tsx
+++ b/dashboard/src/components/AgentsView.tsx
@@ -147,7 +147,7 @@ export default function AgentsView() {
           font-size: 12px;
           padding: 3px 10px;
           border-radius: 12px;
-          background: rgba(88, 166, 255, 0.1);
+          background: rgba(var(--accent-rgb), 0.1);
           color: var(--accent-fg);
           font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
         }
@@ -244,7 +244,7 @@ export default function AgentsView() {
               key={agent.name}
               style={{
                 borderColor: agent.registered
-                  ? "rgba(63, 185, 80, 0.3)"
+                  ? "rgba(var(--success-rgb), 0.3)"
                   : "var(--border-default)",
               }}
             >
@@ -255,8 +255,8 @@ export default function AgentsView() {
                 <span
                   className="agent-status-dot"
                   style={{
-                    background: agent.registered ? "#3fb950" : "#8b949e",
-                    boxShadow: agent.registered ? "0 0 4px #3fb950" : "none",
+                    background: agent.registered ? "var(--text-success)" : "var(--text-secondary)",
+                    boxShadow: agent.registered ? "0 0 4px var(--text-success)" : "none",
                   }}
                 />
                 <span className="agent-name">{agent.name}</span>
@@ -264,7 +264,7 @@ export default function AgentsView() {
                   <span
                     className="agent-type-badge"
                     style={{
-                      background: "rgba(88, 166, 255, 0.1)",
+                      background: "rgba(var(--accent-rgb), 0.1)",
                       color: "var(--accent-fg)",
                     }}
                   >
@@ -305,7 +305,7 @@ export default function AgentsView() {
                           <span
                             className="ceremony-enabled"
                             style={{
-                              background: c.enabled !== false ? "#3fb950" : "#8b949e",
+                              background: c.enabled !== false ? "var(--text-success)" : "var(--text-secondary)",
                             }}
                           />
                           <span className="ceremony-name">{c.name || c.id}</span>

--- a/dashboard/src/components/EventStream.tsx
+++ b/dashboard/src/components/EventStream.tsx
@@ -128,8 +128,8 @@ export default function EventStream() {
           position: sticky;
           top: -24px;
           z-index: 10;
-          background: linear-gradient(180deg, #161b22 0%, #12161d 100%);
-          border-bottom: 1px solid #30363d;
+          background: linear-gradient(180deg, var(--bg-default) 0%, var(--bg-default) 100%);
+          border-bottom: 1px solid var(--border-default);
           box-shadow: 0 4px 12px -8px rgba(0, 0, 0, 0.5);
           backdrop-filter: blur(8px);
         }
@@ -148,14 +148,14 @@ export default function EventStream() {
           top: 0;
           width: 3px;
           height: 100%;
-          background: linear-gradient(180deg, #58a6ff 0%, #1f6feb 100%);
+          background: linear-gradient(180deg, var(--accent-fg) 0%, var(--accent-emphasis) 100%);
           border-radius: 0 0 2px 2px;
           opacity: 0.8;
         }
         .es-header-title {
           font-size: 13px;
           font-weight: 600;
-          color: #c9d1d9;
+          color: var(--text-primary);
           letter-spacing: 0.3px;
           text-transform: uppercase;
           display: flex;
@@ -164,7 +164,7 @@ export default function EventStream() {
         }
         .es-header-title::before {
           content: "◉";
-          color: #58a6ff;
+          color: var(--accent-fg);
           font-size: 14px;
           animation: es-pulse-dot 2s ease-in-out infinite;
         }
@@ -175,43 +175,43 @@ export default function EventStream() {
         .es-tabs {
           display: flex;
           gap: 2px;
-          background: #0d1117;
+          background: var(--bg-canvas);
           border-radius: 6px;
           padding: 2px;
-          border: 1px solid #21262d;
+          border: 1px solid var(--border-muted);
         }
         .es-tab {
           padding: 5px 16px;
           font-size: 12px;
           border-radius: 4px;
           cursor: pointer;
-          color: #8b949e;
+          color: var(--text-secondary);
           border: none;
           background: transparent;
           font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
           font-weight: 500;
           transition: all 0.15s;
         }
-        .es-tab:hover { color: #c9d1d9; }
+        .es-tab:hover { color: var(--text-primary); }
         .es-tab.active {
-          background: #21262d;
-          color: #c9d1d9;
-          box-shadow: 0 0 0 1px rgba(88, 166, 255, 0.2);
+          background: var(--bg-subtle);
+          color: var(--text-primary);
+          box-shadow: 0 0 0 1px rgba(var(--accent-rgb), 0.2);
         }
 
         .status-dot {
           width: 8px;
           height: 8px;
           border-radius: 50%;
-          background: #f85149;
+          background: var(--text-danger);
           transition: background 0.2s;
           flex-shrink: 0;
         }
         .status-dot.connected {
-          background: #3fb950;
-          box-shadow: 0 0 6px rgba(63, 185, 80, 0.6);
+          background: var(--text-success);
+          box-shadow: 0 0 6px rgba(var(--success-rgb), 0.6);
         }
-        .status-dot.connecting { background: #d29922; animation: es-pulse 1s infinite; }
+        .status-dot.connecting { background: var(--text-warning); animation: es-pulse 1s infinite; }
         @keyframes es-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
 
         .es-status {
@@ -221,17 +221,17 @@ export default function EventStream() {
           font-size: 12px;
           padding: 4px 10px;
           border-radius: 12px;
-          background: #21262d;
-          color: #c9d1d9;
+          background: var(--bg-subtle);
+          color: var(--text-primary);
           font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
-          border: 1px solid #30363d;
+          border: 1px solid var(--border-default);
         }
         .es-badge {
           font-size: 11px;
-          background: #30363d;
+          background: var(--border-default);
           padding: 3px 10px;
           border-radius: 10px;
-          color: #c9d1d9;
+          color: var(--text-primary);
           font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
           font-weight: 500;
           margin-left: auto;
@@ -244,9 +244,9 @@ export default function EventStream() {
           flex-wrap: wrap;
         }
         .es-filter {
-          background: #0d1117;
-          border: 1px solid #30363d;
-          color: #c9d1d9;
+          background: var(--bg-canvas);
+          border: 1px solid var(--border-default);
+          color: var(--text-primary);
           padding: 6px 10px;
           border-radius: 6px;
           font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
@@ -254,12 +254,12 @@ export default function EventStream() {
           width: 260px;
           outline: none;
         }
-        .es-filter:focus { border-color: #58a6ff; }
-        .es-filter::placeholder { color: #484f58; }
+        .es-filter:focus { border-color: var(--accent-fg); }
+        .es-filter::placeholder { color: var(--text-secondary); }
         .es-btn {
-          background: #21262d;
-          border: 1px solid #30363d;
-          color: #c9d1d9;
+          background: var(--bg-subtle);
+          border: 1px solid var(--border-default);
+          color: var(--text-primary);
           padding: 6px 12px;
           border-radius: 6px;
           font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
@@ -267,9 +267,9 @@ export default function EventStream() {
           cursor: pointer;
           transition: background 0.15s;
         }
-        .es-btn:hover { background: #30363d; }
-        .es-btn.active { background: #1f6feb; border-color: #1f6feb; }
-        .es-btn.paused { background: #da3633; border-color: #da3633; }
+        .es-btn:hover { background: var(--border-default); }
+        .es-btn.active { background: var(--accent-emphasis); border-color: var(--accent-emphasis); }
+        .es-btn.paused { background: var(--text-danger); border-color: var(--text-danger); }
 
         .es-list {
           flex: 1;
@@ -278,8 +278,8 @@ export default function EventStream() {
           font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
         }
         .es-list::-webkit-scrollbar { width: 8px; }
-        .es-list::-webkit-scrollbar-track { background: #0d1117; }
-        .es-list::-webkit-scrollbar-thumb { background: #30363d; border-radius: 4px; }
+        .es-list::-webkit-scrollbar-track { background: var(--bg-canvas); }
+        .es-list::-webkit-scrollbar-thumb { background: var(--border-default); border-radius: 4px; }
 
         .es-empty {
           display: flex;
@@ -287,7 +287,7 @@ export default function EventStream() {
           align-items: center;
           justify-content: center;
           height: 200px;
-          color: #484f58;
+          color: var(--text-secondary);
           gap: 8px;
           font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
           font-size: 14px;
@@ -299,15 +299,15 @@ export default function EventStream() {
           align-items: flex-start;
           gap: 12px;
           padding: 8px 16px;
-          border-bottom: 1px solid #21262d;
+          border-bottom: 1px solid var(--border-muted);
           cursor: pointer;
           transition: background 0.1s;
           overflow-x: auto;
         }
-        .event-row:hover { background: #161b22; }
+        .event-row:hover { background: var(--bg-default); }
         .event-time {
           font-size: 11px;
-          color: #484f58;
+          color: var(--text-secondary);
           white-space: nowrap;
           min-width: 70px;
           padding-top: 2px;
@@ -320,17 +320,17 @@ export default function EventStream() {
           font-weight: 500;
           letter-spacing: 0.5px;
         }
-        .event-topic.source-agent { background: #1a1932; color: #bc8cff; }
-        .event-topic.source-cli { background: #122d20; color: #3fb950; }
-        .event-topic.source-signal { background: #2d1f12; color: #d29922; }
-        .event-topic.source-echo { background: #1f2330; color: #79c0ff; }
-        .event-topic.source-scheduler { background: #2d1229; color: #f778ba; }
-        .event-topic.source-logger { background: #1a2332; color: #58a6ff; }
-        .event-topic.source-event-viewer { background: #2d2a12; color: #e3b341; }
-        .event-topic.source-default { background: #21262d; color: #8b949e; }
+        .event-topic.source-agent { background: rgba(var(--accent-rgb), 0.12); color: var(--accent-fg); }
+        .event-topic.source-cli { background: rgba(var(--success-rgb), 0.12); color: var(--text-success); }
+        .event-topic.source-signal { background: rgba(var(--warning-rgb), 0.12); color: var(--text-warning); }
+        .event-topic.source-echo { background: rgba(var(--accent-rgb), 0.12); color: var(--accent-fg); }
+        .event-topic.source-scheduler { background: rgba(var(--accent-rgb), 0.12); color: var(--accent-fg); }
+        .event-topic.source-logger { background: rgba(var(--accent-rgb), 0.12); color: var(--accent-fg); }
+        .event-topic.source-event-viewer { background: rgba(var(--warning-rgb), 0.12); color: var(--text-warning); }
+        .event-topic.source-default { background: var(--bg-subtle); color: var(--text-secondary); }
         .event-preview {
           font-size: 12px;
-          color: #8b949e;
+          color: var(--text-secondary);
           overflow: hidden;
           text-overflow: ellipsis;
           white-space: nowrap;
@@ -339,19 +339,19 @@ export default function EventStream() {
         .event-detail {
           display: none;
           padding: 0 16px 12px 98px;
-          background: #0d1117;
-          border-bottom: 1px solid #21262d;
+          background: var(--bg-canvas);
+          border-bottom: 1px solid var(--border-muted);
         }
         .event-detail.open { display: block; }
         .event-detail pre {
-          background: #161b22;
-          border: 1px solid #30363d;
+          background: var(--bg-default);
+          border: 1px solid var(--border-default);
           border-radius: 6px;
           padding: 12px;
           font-size: 12px;
           overflow: auto;
           max-height: 400px;
-          color: #c9d1d9;
+          color: var(--text-primary);
           line-height: 1.5;
         }
         .event-detail-toolbar {
@@ -360,16 +360,16 @@ export default function EventStream() {
           margin-bottom: 6px;
         }
         .detail-btn {
-          background: #21262d;
-          border: 1px solid #30363d;
-          color: #8b949e;
+          background: var(--bg-subtle);
+          border: 1px solid var(--border-default);
+          color: var(--text-secondary);
           padding: 3px 8px;
           border-radius: 4px;
           font-size: 11px;
           cursor: pointer;
           font-family: inherit;
         }
-        .detail-btn:hover { background: #30363d; color: #c9d1d9; }
+        .detail-btn:hover { background: var(--border-default); color: var(--text-primary); }
 
         /* Log rows */
         .log-row {
@@ -377,11 +377,11 @@ export default function EventStream() {
           align-items: flex-start;
           gap: 12px;
           padding: 4px 16px;
-          border-bottom: 1px solid #161b22;
+          border-bottom: 1px solid var(--bg-default);
           cursor: pointer;
           transition: background 0.1s;
         }
-        .log-row:hover { background: #161b22; }
+        .log-row:hover { background: var(--bg-default); }
         .log-level {
           font-size: 10px;
           padding: 1px 6px;
@@ -392,14 +392,14 @@ export default function EventStream() {
           min-width: 44px;
           text-align: center;
         }
-        .log-level.log { background: #21262d; color: #8b949e; }
-        .log-level.debug { background: #1a2332; color: #58a6ff; }
-        .log-level.info { background: #122d20; color: #3fb950; }
-        .log-level.warn { background: #2d1f12; color: #d29922; }
-        .log-level.error { background: #2d1215; color: #f85149; }
+        .log-level.log { background: var(--bg-subtle); color: var(--text-secondary); }
+        .log-level.debug { background: rgba(var(--accent-rgb), 0.12); color: var(--accent-fg); }
+        .log-level.info { background: rgba(var(--success-rgb), 0.12); color: var(--text-success); }
+        .log-level.warn { background: rgba(var(--warning-rgb), 0.12); color: var(--text-warning); }
+        .log-level.error { background: rgba(var(--danger-rgb), 0.12); color: var(--text-danger); }
         .log-message {
           font-size: 12px;
-          color: #6e7681;
+          color: var(--text-secondary);
           flex: 1;
           white-space: nowrap;
           overflow: hidden;
@@ -408,19 +408,19 @@ export default function EventStream() {
         .log-detail {
           display: none;
           padding: 0 16px 12px 98px;
-          background: #0d1117;
-          border-bottom: 1px solid #161b22;
+          background: var(--bg-canvas);
+          border-bottom: 1px solid var(--bg-default);
         }
         .log-detail.open { display: block; }
         .log-detail pre {
-          background: #161b22;
-          border: 1px solid #30363d;
+          background: var(--bg-default);
+          border: 1px solid var(--border-default);
           border-radius: 6px;
           padding: 12px;
           font-size: 12px;
           overflow: auto;
           max-height: 400px;
-          color: #c9d1d9;
+          color: var(--text-primary);
           line-height: 1.5;
         }
       `}</style>

--- a/dashboard/src/components/LatencyHistogram.tsx
+++ b/dashboard/src/components/LatencyHistogram.tsx
@@ -165,9 +165,9 @@ const STYLES = `
     min-width: 260px;
     max-width: 360px;
     background: rgba(13, 17, 23, 0.92);
-    border: 1px solid #30363d;
+    border: 1px solid var(--border-default);
     border-radius: 6px;
-    color: #c9d1d9;
+    color: var(--text-primary);
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     font-size: 0.8rem;
     backdrop-filter: blur(4px);
@@ -175,25 +175,25 @@ const STYLES = `
   }
   .lh-head {
     padding: 0.5rem 0.75rem 0.4rem;
-    border-bottom: 1px solid #21262d;
+    border-bottom: 1px solid var(--border-muted);
   }
   .lh-head h3 {
     margin: 0;
     font-size: 0.85rem;
-    color: #e6edf3;
+    color: var(--text-primary);
   }
   .lh-meta {
     margin: 0.2rem 0 0;
-    color: #8b949e;
+    color: var(--text-secondary);
     font-size: 0.7rem;
   }
   .lh-status { font-weight: 500; }
-  .lh-status--connected    { color: #3fb950; }
-  .lh-status--connecting   { color: #d29922; }
-  .lh-status--disconnected { color: #f85149; }
+  .lh-status--connected    { color: var(--text-success); }
+  .lh-status--connecting   { color: var(--text-warning); }
+  .lh-status--disconnected { color: var(--text-danger); }
   .lh-empty {
     padding: 0.75rem;
-    color: #8b949e;
+    color: var(--text-secondary);
     font-size: 0.75rem;
   }
   .lh-table {
@@ -203,25 +203,25 @@ const STYLES = `
   }
   .lh-table thead th {
     text-align: left;
-    color: #6e7681;
+    color: var(--text-secondary);
     font-weight: 500;
     padding: 0.4rem 0.5rem;
-    border-bottom: 1px solid #21262d;
+    border-bottom: 1px solid var(--border-muted);
   }
   .lh-table th.lh-num { text-align: right; }
   .lh-table td {
     padding: 0.3rem 0.5rem;
-    border-bottom: 1px dashed #21262d;
+    border-bottom: 1px dashed var(--border-muted);
   }
   .lh-table tbody tr:last-child td { border-bottom: none; }
   .lh-num { text-align: right; width: 4rem; }
   .lh-skill {
-    color: #c9d1d9;
+    color: var(--text-primary);
     max-width: 12rem;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-  .lh-p95 { color: #d29922; }
-  .lh-max { color: #f85149; }
+  .lh-p95 { color: var(--text-warning); }
+  .lh-max { color: var(--text-danger); }
 `;

--- a/dashboard/src/components/MessageDrawer.tsx
+++ b/dashboard/src/components/MessageDrawer.tsx
@@ -121,9 +121,9 @@ const DRAWER_STYLES = `
     height: 100vh;
     width: 480px;
     max-width: 90vw;
-    background: #0d1117;
-    border-left: 1px solid #30363d;
-    color: #c9d1d9;
+    background: var(--bg-canvas);
+    border-left: 1px solid var(--border-default);
+    color: var(--text-primary);
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     z-index: 101;
     display: flex;
@@ -135,32 +135,32 @@ const DRAWER_STYLES = `
     align-items: flex-start;
     justify-content: space-between;
     padding: 1rem 1.25rem 0.75rem;
-    border-bottom: 1px solid #21262d;
+    border-bottom: 1px solid var(--border-muted);
   }
   .md-title {
     margin: 0;
     font-size: 0.95rem;
-    color: #58a6ff;
+    color: var(--accent-fg);
     word-break: break-all;
   }
   .md-meta {
     margin: 0.25rem 0 0;
-    color: #8b949e;
+    color: var(--text-secondary);
     font-size: 0.8rem;
   }
   .md-close {
     background: transparent;
     border: none;
-    color: #8b949e;
+    color: var(--text-secondary);
     font-size: 1.5rem;
     line-height: 1;
     cursor: pointer;
     padding: 0 0.25rem;
   }
-  .md-close:hover { color: #f85149; }
+  .md-close:hover { color: var(--text-danger); }
   .md-empty {
     padding: 2rem 1.25rem;
-    color: #8b949e;
+    color: var(--text-secondary);
     font-size: 0.85rem;
     line-height: 1.5;
   }
@@ -174,7 +174,7 @@ const DRAWER_STYLES = `
   .md-row {
     margin-bottom: 1rem;
     padding-bottom: 1rem;
-    border-bottom: 1px dashed #21262d;
+    border-bottom: 1px dashed var(--border-muted);
   }
   .md-row:last-child { border-bottom: none; }
   .md-row-head {
@@ -183,24 +183,24 @@ const DRAWER_STYLES = `
     justify-content: space-between;
     margin-bottom: 0.35rem;
   }
-  .md-ts { color: #8b949e; font-size: 0.8rem; }
+  .md-ts { color: var(--text-secondary); font-size: 0.8rem; }
   .md-trace-link {
-    color: #58a6ff;
+    color: var(--accent-fg);
     text-decoration: none;
     font-size: 0.8rem;
   }
   .md-trace-link:hover { text-decoration: underline; }
-  .md-no-trace { color: #6e7681; font-size: 0.75rem; font-style: italic; }
+  .md-no-trace { color: var(--text-secondary); font-size: 0.75rem; font-style: italic; }
   .md-corr {
     display: block;
-    color: #c9d1d9;
+    color: var(--text-primary);
     font-size: 0.75rem;
     margin-bottom: 0.35rem;
     opacity: 0.7;
     word-break: break-all;
   }
   .md-payload {
-    background: #161b22;
+    background: var(--bg-default);
     padding: 0.6rem;
     margin: 0;
     border-radius: 4px;
@@ -208,6 +208,6 @@ const DRAWER_STYLES = `
     overflow-x: auto;
     max-height: 240px;
     overflow-y: auto;
-    color: #c9d1d9;
+    color: var(--text-primary);
   }
 `;

--- a/dashboard/src/components/OverviewGrid.tsx
+++ b/dashboard/src/components/OverviewGrid.tsx
@@ -139,17 +139,17 @@ const CARD_CONFIGS: CardFetcher[] = [
 
 function HealthCardView({ label, metric, status }: CardState) {
   const dotStyle: Record<Status, string> = {
-    green: "#3fb950",
-    yellow: "#d29922",
-    red: "#f85149",
-    loading: "#8b949e",
+    green: "var(--text-success)",
+    yellow: "var(--text-warning)",
+    red: "var(--text-danger)",
+    loading: "var(--text-secondary)",
   };
 
   const borderColor: Record<Status, string> = {
-    green: "rgba(63, 185, 80, 0.3)",
-    yellow: "rgba(210, 153, 34, 0.3)",
-    red: "rgba(248, 81, 73, 0.3)",
-    loading: "#21262d",
+    green: "rgba(var(--success-rgb), 0.3)",
+    yellow: "rgba(var(--warning-rgb), 0.3)",
+    red: "rgba(var(--danger-rgb), 0.3)",
+    loading: "var(--border-muted)",
   };
 
   return (

--- a/dashboard/src/components/QuinnVerdictCounters.tsx
+++ b/dashboard/src/components/QuinnVerdictCounters.tsx
@@ -157,9 +157,9 @@ const STYLES = `
     min-width: 220px;
     max-width: 320px;
     background: rgba(13, 17, 23, 0.92);
-    border: 1px solid #30363d;
+    border: 1px solid var(--border-default);
     border-radius: 6px;
-    color: #c9d1d9;
+    color: var(--text-primary);
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     font-size: 0.8rem;
     backdrop-filter: blur(4px);
@@ -167,25 +167,25 @@ const STYLES = `
   }
   .qvc-head {
     padding: 0.5rem 0.75rem 0.4rem;
-    border-bottom: 1px solid #21262d;
+    border-bottom: 1px solid var(--border-muted);
   }
   .qvc-head h3 {
     margin: 0;
     font-size: 0.85rem;
-    color: #e6edf3;
+    color: var(--text-primary);
   }
   .qvc-meta {
     margin: 0.2rem 0 0;
-    color: #8b949e;
+    color: var(--text-secondary);
     font-size: 0.7rem;
   }
   .qvc-status { font-weight: 500; }
-  .qvc-status--connected    { color: #3fb950; }
-  .qvc-status--connecting   { color: #d29922; }
-  .qvc-status--disconnected { color: #f85149; }
+  .qvc-status--connected    { color: var(--text-success); }
+  .qvc-status--connecting   { color: var(--text-warning); }
+  .qvc-status--disconnected { color: var(--text-danger); }
   .qvc-empty {
     padding: 0.75rem;
-    color: #8b949e;
+    color: var(--text-secondary);
     font-size: 0.75rem;
   }
   .qvc-table {
@@ -195,30 +195,30 @@ const STYLES = `
   }
   .qvc-table thead th {
     text-align: left;
-    color: #6e7681;
+    color: var(--text-secondary);
     font-weight: 500;
     padding: 0.4rem 0.5rem;
-    border-bottom: 1px solid #21262d;
+    border-bottom: 1px solid var(--border-muted);
   }
   .qvc-table td {
     padding: 0.3rem 0.5rem;
-    border-bottom: 1px dashed #21262d;
+    border-bottom: 1px dashed var(--border-muted);
   }
   .qvc-table tbody tr:last-child td { border-bottom: none; }
   .qvc-num { text-align: right; width: 2.4rem; }
-  .qvc-approve { color: #3fb950; }
-  .qvc-block   { color: #f85149; }
-  .qvc-comment { color: #58a6ff; }
+  .qvc-approve { color: var(--text-success); }
+  .qvc-block   { color: var(--text-danger); }
+  .qvc-comment { color: var(--accent-fg); }
   .qvc-repo {
-    color: #c9d1d9;
+    color: var(--text-primary);
     max-width: 14rem;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
   .qvc-total-row td {
-    border-top: 1px solid #30363d;
-    color: #e6edf3;
+    border-top: 1px solid var(--border-default);
+    color: var(--text-primary);
     font-weight: 500;
   }
 `;

--- a/dashboard/src/components/ServiceNode.tsx
+++ b/dashboard/src/components/ServiceNode.tsx
@@ -17,9 +17,9 @@ export default function ServiceNode({ data }: { data: ServiceNodeData }) {
   return (
     <div
       style={{
-        background: "#161b22",
-        color: "#e6edf3",
-        border: "1px dashed #58a6ff",
+        background: "var(--bg-default)",
+        color: "var(--text-primary)",
+        border: "1px dashed var(--accent-fg)",
         borderRadius: 999,
         padding: "6px 14px",
         fontFamily: "ui-monospace, SFMono-Regular, monospace",
@@ -30,8 +30,8 @@ export default function ServiceNode({ data }: { data: ServiceNodeData }) {
       }}
       title={data.description}
     >
-      <Handle type="target" position={Position.Left} style={{ background: "#58a6ff", opacity: 0.4 }} />
-      <Handle type="source" position={Position.Right} style={{ background: "#58a6ff", opacity: 0.4 }} />
+      <Handle type="target" position={Position.Left} style={{ background: "var(--accent-fg)", opacity: 0.4 }} />
+      <Handle type="source" position={Position.Right} style={{ background: "var(--accent-fg)", opacity: 0.4 }} />
       {data.icon ? <span style={{ marginRight: 4 }}>{data.icon}</span> : null}
       <span>{data.label}</span>
     </div>

--- a/dashboard/src/components/SkillTrace.tsx
+++ b/dashboard/src/components/SkillTrace.tsx
@@ -195,8 +195,8 @@ const TRACE_STYLES = `
         .skill-trace {
           padding: 1.5rem;
           font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-          color: #c9d1d9;
-          background: #0d1117;
+          color: var(--text-primary);
+          background: var(--bg-canvas);
           min-height: 100%;
         }
         .trace-header {
@@ -205,7 +205,7 @@ const TRACE_STYLES = `
           justify-content: space-between;
           margin-bottom: 1rem;
           padding-bottom: 0.75rem;
-          border-bottom: 1px solid #21262d;
+          border-bottom: 1px solid var(--border-muted);
         }
         .trace-header h2 {
           margin: 0;
@@ -213,33 +213,33 @@ const TRACE_STYLES = `
         }
         .trace-meta {
           margin: 0.25rem 0 0;
-          color: #8b949e;
+          color: var(--text-secondary);
           font-size: 0.85rem;
         }
         .langfuse-link {
           padding: 0.4rem 0.75rem;
-          background: #21262d;
-          color: #58a6ff;
+          background: var(--bg-subtle);
+          color: var(--accent-fg);
           text-decoration: none;
           border-radius: 4px;
           font-size: 0.85rem;
         }
         .langfuse-link:hover {
-          background: #30363d;
+          background: var(--border-default);
         }
         .trace-empty {
           padding: 2rem;
-          color: #8b949e;
+          color: var(--text-secondary);
           font-family: ui-monospace, monospace;
         }
-        .trace-error h3 { color: #f85149; }
+        .trace-error h3 { color: var(--text-danger); }
         .trace-list {
           list-style: none;
           padding: 0;
           margin: 0;
         }
         .trace-row {
-          border-left: 2px solid #30363d;
+          border-left: 2px solid var(--border-default);
           padding-left: 0.75rem;
           margin-bottom: 0.5rem;
         }
@@ -258,14 +258,14 @@ const TRACE_STYLES = `
           cursor: pointer;
         }
         .trace-row-toggle:hover {
-          background: #161b22;
+          background: var(--bg-default);
         }
-        .trace-ts { color: #8b949e; }
-        .trace-topic { color: #58a6ff; }
-        .trace-source { color: #7ee787; text-align: right; }
+        .trace-ts { color: var(--text-secondary); }
+        .trace-topic { color: var(--accent-fg); }
+        .trace-source { color: var(--text-success); text-align: right; }
         .trace-payload {
-          background: #161b22;
-          color: #c9d1d9;
+          background: var(--bg-default);
+          color: var(--text-primary);
           padding: 0.75rem;
           margin: 0.25rem 0 0;
           border-radius: 4px;
@@ -279,9 +279,9 @@ const TRACE_STYLES = `
           gap: 0.5rem;
         }
         .trace-search input {
-          background: #0d1117;
-          color: #c9d1d9;
-          border: 1px solid #30363d;
+          background: var(--bg-canvas);
+          color: var(--text-primary);
+          border: 1px solid var(--border-default);
           padding: 0.4rem 0.6rem;
           border-radius: 4px;
           font-family: inherit;
@@ -289,7 +289,7 @@ const TRACE_STYLES = `
           min-width: 18rem;
         }
         .trace-search button {
-          background: #238636;
+          background: var(--text-success);
           color: white;
           border: none;
           padding: 0.4rem 0.9rem;
@@ -297,5 +297,5 @@ const TRACE_STYLES = `
           font-size: 0.85rem;
           cursor: pointer;
         }
-        .trace-search button:hover { background: #2ea043; }
+        .trace-search button:hover { background: var(--text-success); }
 `;

--- a/dashboard/src/components/SystemGraph.tsx
+++ b/dashboard/src/components/SystemGraph.tsx
@@ -147,9 +147,9 @@ function buildGraph({ plugins, agents, agentActivity, activeEdges }: BuildArgs):
       position: PLACEHOLDER_POS,
       data: { label: p.name },
       style: {
-        background: "#161b22",
-        color: "#e6edf3",
-        border: "1px solid #30363d",
+        background: "var(--bg-default)",
+        color: "var(--text-primary)",
+        border: "1px solid var(--border-default)",
         borderRadius: 6,
         padding: "6px 10px",
         fontSize: 11,
@@ -186,8 +186,8 @@ function buildGraph({ plugins, agents, agentActivity, activeEdges }: BuildArgs):
           target: `plugin-${subscriber.name}`,
           label: topic,
           animated: active,
-          style: { stroke: active ? "#3fb950" : "#21262d", strokeWidth: active ? 1.5 : 1 },
-          labelStyle: { fill: "#6e7681", fontSize: 9, fontFamily: "ui-monospace, monospace" },
+          style: { stroke: active ? "var(--text-success)" : "var(--border-muted)", strokeWidth: active ? 1.5 : 1 },
+          labelStyle: { fill: "var(--text-secondary)", fontSize: 9, fontFamily: "ui-monospace, monospace" },
         });
       }
     }
@@ -201,7 +201,7 @@ function buildGraph({ plugins, agents, agentActivity, activeEdges }: BuildArgs):
         id: `${pluginName}->${svcId}`,
         source: `plugin-${pluginName}`,
         target: svcId,
-        style: { stroke: "#58a6ff", strokeDasharray: "4 4", opacity: 0.5 },
+        style: { stroke: "var(--accent-fg)", strokeDasharray: "4 4", opacity: 0.5 },
       });
     }
   }
@@ -218,7 +218,7 @@ function buildGraph({ plugins, agents, agentActivity, activeEdges }: BuildArgs):
       source: `plugin-${hostPlugin}`,
       target: `agent-${a.name}`,
       animated: live,
-      style: { stroke: live ? "#3fb950" : "#30363d", strokeWidth: live ? 2 : 1 },
+      style: { stroke: live ? "var(--text-success)" : "var(--border-default)", strokeWidth: live ? 2 : 1 },
     });
   }
 
@@ -259,9 +259,9 @@ function buildGraph({ plugins, agents, agentActivity, activeEdges }: BuildArgs):
       position: PLACEHOLDER_POS,
       data: { label: "api-routes" },
       style: {
-        background: "#1c2128",
-        color: "#d29922",
-        border: "1px dashed #d29922",
+        background: "var(--bg-default)",
+        color: "var(--text-warning)",
+        border: "1px dashed var(--text-warning)",
         borderRadius: 6,
         padding: "6px 10px",
         fontSize: 11,
@@ -277,12 +277,12 @@ function buildGraph({ plugins, agents, agentActivity, activeEdges }: BuildArgs):
         label: topic,
         animated: active,
         style: {
-          stroke: active ? "#3fb950" : "#d29922",
+          stroke: active ? "var(--text-success)" : "var(--text-warning)",
           strokeWidth: active ? 1.5 : 1,
           strokeDasharray: active ? undefined : "4 4",
           opacity: active ? 1 : 0.7,
         },
-        labelStyle: { fill: "#d29922", fontSize: 9, fontFamily: "ui-monospace, monospace" },
+        labelStyle: { fill: "var(--text-warning)", fontSize: 9, fontFamily: "ui-monospace, monospace" },
       });
     }
   }
@@ -470,10 +470,10 @@ export default function SystemGraph() {
   );
 
   if (error) {
-    return <div style={{ padding: 24, color: "#f85149", fontFamily: "monospace" }}>topology error: {error}</div>;
+    return <div style={{ padding: 24, color: "var(--text-danger)", fontFamily: "monospace" }}>topology error: {error}</div>;
   }
   if (!topology) {
-    return <div style={{ padding: 24, color: "#8b949e" }}>loading topology…</div>;
+    return <div style={{ padding: 24, color: "var(--text-secondary)" }}>loading topology…</div>;
   }
 
   const drawerMessages = useMemo(
@@ -484,7 +484,7 @@ export default function SystemGraph() {
   );
 
   return (
-    <div style={{ width: "100%", height: "calc(100vh - 64px)", background: "#0d1117", position: "relative" }}>
+    <div style={{ width: "100%", height: "calc(100vh - 64px)", background: "var(--bg-canvas)", position: "relative" }}>
       <ReactFlow
         nodes={nodes}
         edges={edges}
@@ -499,7 +499,7 @@ export default function SystemGraph() {
           if (topic) setOpenTopic(topic);
         }}
       >
-        <Background color="#21262d" gap={16} />
+        <Background color="var(--bg-subtle)" gap={16} />
         <Controls position="bottom-right" />
       </ReactFlow>
       <QuinnVerdictCounters />

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -1,19 +1,34 @@
-/* GitHub dark palette #0d1117 */
+/* Brand tokens come from @protolabsai/design (the studio's --pl-* design system:
+   dark-first ground, Geist, violet gradient). The dashboard's own semantic
+   tokens below map onto them, so the whole UI restyles from that one source —
+   change a brand token, the dashboard follows. */
+@import "@protolabsai/design/css";
+
 :root {
-  --bg-canvas: #0d1117;
-  --bg-default: #161b22;
-  --bg-subtle: #21262d;
-  --bg-inset: #010409;
-  --border-default: #30363d;
-  --border-muted: #21262d;
-  --text-primary: #c9d1d9;
-  --text-secondary: #8b949e;
-  --text-link: #58a6ff;
-  --text-success: #3fb950;
-  --text-warning: #d29922;
-  --text-danger: #f85149;
-  --accent-fg: #58a6ff;
-  --accent-emphasis: #1f6feb;
+  /* Surfaces */
+  --bg-canvas: var(--pl-color-bg);            /* #0a0a0c */
+  --bg-default: var(--pl-color-bg-raised);    /* #131316 — cards, sidebar, header */
+  --bg-subtle: #1c1c22;                       /* one step above raised (hover); no brand token */
+  --bg-inset: #060608;                        /* below canvas — code blocks */
+  /* Borders */
+  --border-default: var(--pl-color-border-strong);  /* rgba(255,255,255,.18) */
+  --border-muted: var(--pl-color-border);           /* rgba(255,255,255,.08) */
+  /* Text */
+  --text-primary: var(--pl-color-fg);               /* #ededed */
+  --text-secondary: var(--pl-color-fg-muted);       /* #a1a1aa */
+  --text-link: var(--pl-color-brand-violet-light);  /* #a78bfa */
+  --text-success: var(--pl-color-status-success);
+  --text-warning: var(--pl-color-status-warning);
+  --text-danger: var(--pl-color-status-error);
+  /* Brand accent (violet — replaces the old GitHub blue) */
+  --accent-fg: var(--pl-color-brand-violet-light);  /* #a78bfa */
+  --accent-emphasis: var(--pl-color-brand-indigo);  /* #6366f1 */
+  /* RGB channels for translucent accent fills — var() can't be nested in rgba() */
+  --accent-rgb: 167, 139, 250;
+  --success-rgb: 76, 175, 110;
+  --warning-rgb: 210, 153, 34;
+  --danger-rgb: 230, 90, 80;
+  /* Layout */
   --sidebar-width: 220px;
   --header-height: 56px;
 }
@@ -31,8 +46,7 @@ body {
   height: 100%;
   background-color: var(--bg-canvas);
   color: var(--text-primary);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial,
-    sans-serif;
+  font-family: var(--pl-font-sans);
   font-size: 14px;
   line-height: 1.5;
 }
@@ -48,7 +62,7 @@ a:hover {
 
 code,
 pre {
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-family: var(--pl-font-mono);
   font-size: 12px;
 }
 
@@ -78,22 +92,22 @@ h4 {
 }
 
 .badge-green {
-  background: rgba(63, 185, 80, 0.15);
+  background: rgba(var(--success-rgb), 0.15);
   color: var(--text-success);
 }
 
 .badge-yellow {
-  background: rgba(210, 153, 34, 0.15);
+  background: rgba(var(--warning-rgb), 0.15);
   color: var(--text-warning);
 }
 
 .badge-red {
-  background: rgba(248, 81, 73, 0.15);
+  background: rgba(var(--danger-rgb), 0.15);
   color: var(--text-danger);
 }
 
 .badge-blue {
-  background: rgba(88, 166, 255, 0.15);
+  background: rgba(var(--accent-rgb), 0.15);
   color: var(--accent-fg);
 }
 


### PR DESCRIPTION
## What

The dashboard now styles from the studio's shared **`@protolabsai/design`** system instead of its hand-rolled GitHub-dark palette. The package is **public on npm** (verified via unauthenticated registry GET → 200), so it installs with **zero auth** — no `NPM_TOKEN` in CI or the Docker build.

This is the brand follow-up to the React 19 migration (#700) and closes out the consumer side of protoContent#69.

## Changes

- Add `@protolabsai/design@^0.2.0`. `global.css` does `@import "@protolabsai/design/css"` — pulls the `--pl-*` tokens (`dist/tokens.css`) + base layer.
- **Remap** the dashboard's semantic tokens (`--bg-*`, `--text-*`, `--accent-*`, `--border-*`) onto `--pl-*`, so the whole UI restyles from one source: dark-first ground (`#0a0a0c`), Geist / Geist Mono, **violet accent** (`#a78bfa` / `#6366f1`) replacing GitHub blue. Added `--accent-rgb` + status `*-rgb` channels for translucent fills (CSS `var()` can't nest inside `rgba()`).
- **Swap every hardcoded GitHub-palette literal** across the 12 components to the semantic vars — blue `#58a6ff`/`#1f6feb` → violet, dark surfaces/borders/text → brand tokens, status hues → status vars. Shadows (`rgba(0,0,0,…)`) left as-is. `EventRow`/`LogRow` had no color literals.

Pure restyle — no markup, logic, or data-flow changes.

## Verification

- `tsc --noEmit && vite build` — clean; brand tokens inline into the bundle (CSS 19 → 22.6 kB)
- dashboard `bun test` — **20 / 0**
- built CSS contains `--pl-color-bg: #0a0a0c`, `Geist`, and the violet gradient stops

## Note on auth

`design` installs unauthenticated like every other public `@protolabsai/*` package — confirmed against `https://registry.npmjs.org/@protolabsai/design` (200, public tarball). No build-path token changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)