### PR TITLE
fix(a2a): keep SSE streams alive + fan agent progress to A2A callers

### DIFF
--- a/src/api/__tests__/a2a-server.test.ts
+++ b/src/api/__tests__/a2a-server.test.ts
@@ -477,4 +477,68 @@ describe("BusAgentExecutor (Phase 7)", () => {
     );
     expect(canceledEvt).toBeDefined();
   });
+
+  test("emits periodic working heartbeats while awaiting a slow terminal result (keeps SSE alive)", async () => {
+    // The real failure mode: a long in-process turn emits no events between the
+    // initial `working` and the terminal status, so an idle-timeout proxy cuts
+    // the SSE stream. With a low heartbeat interval and a delayed reply, the
+    // adapter should emit ≥1 intermediate `working` heartbeat before terminal.
+    const prev = process.env.A2A_STREAM_HEARTBEAT_MS;
+    process.env.A2A_STREAM_HEARTBEAT_MS = "20";
+    try {
+      const bus = new InMemoryEventBus();
+      const ctx: ApiContext = {
+        workspaceDir: "/tmp",
+        bus,
+        plugins: [],
+        executorRegistry: new ExecutorRegistry(),
+      };
+
+      // Reply only after ~90ms — long enough for several 20ms heartbeats — and
+      // emit no progress events of our own, mimicking a silent DeepAgent turn.
+      bus.subscribe("agent.skill.request", "test", (msg) => {
+        const cid = msg.correlationId!;
+        const replyTopic = msg.reply!.topic!;
+        setTimeout(() => bus.publish(replyTopic, {
+          id: crypto.randomUUID(), correlationId: cid, topic: replyTopic, timestamp: Date.now(),
+          payload: { content: "slow result", correlationId: cid },
+        }), 90);
+      });
+
+      const adapter = new BusAgentExecutor(ctx);
+      const eventBus = new DefaultExecutionEventBus();
+      const collected: AgentExecutionEvent[] = [];
+      eventBus.on("event", (e) => collected.push(e));
+      const done = new Promise<void>(resolve => eventBus.on("finished", () => resolve()));
+
+      await adapter.execute(makeRequestContext("Slow silent task"), eventBus);
+      await done;
+
+      type StatusUpdate = AgentExecutionEvent & { kind: "status-update"; final: boolean; status: { state: string } };
+      const workingEvts = collected.filter(
+        (e): e is StatusUpdate =>
+          e.kind === "status-update" &&
+          "status" in e &&
+          (e as StatusUpdate).status.state === "working",
+      );
+      // We emit no progress of our own, so every `working` beyond the initial
+      // pre-dispatch transition is a heartbeat. Expect ≥2 (initial + ≥1 beat),
+      // all non-final.
+      expect(workingEvts.length).toBeGreaterThanOrEqual(2);
+      expect(workingEvts.every(e => e.final === false)).toBe(true);
+
+      // Heartbeats stop once settled — no `working` update after the terminal
+      // completed event (the interval is cleared and guarded by `settled`).
+      const completedIdx = collected.findIndex(
+        e => e.kind === "status-update" && "status" in e && (e as StatusUpdate).status.state === "completed",
+      );
+      const workingAfterTerminal = collected.slice(completedIdx + 1).some(
+        e => e.kind === "status-update" && "status" in e && (e as StatusUpdate).status.state === "working",
+      );
+      expect(workingAfterTerminal).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.A2A_STREAM_HEARTBEAT_MS;
+      else process.env.A2A_STREAM_HEARTBEAT_MS = prev;
+    }
+  });
 });

--- a/src/api/__tests__/discord-progress.test.ts
+++ b/src/api/__tests__/discord-progress.test.ts
@@ -1,0 +1,74 @@
+/**
+ * /api/discord/progress fans an agent's mid-task update onto the A2A progress
+ * bus, not just Discord. This is what lets A2A callers (e.g. ORBIS over /a2a)
+ * see intermediate status: the a2a-server bridges agent.skill.progress.{cid}
+ * → `working` status-updates on the SSE stream. An A2A conversation has no
+ * Discord message behind its correlationId, so a missing Discord message must
+ * NOT fail the call.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { ExecutorRegistry } from "../../executor/executor-registry.ts";
+import { createRoutes } from "../discord.ts";
+import type { ApiContext, Route } from "../types.ts";
+import type { BusMessage } from "../../../lib/types.ts";
+
+function progressRoute(ctx: ApiContext): Route {
+  const route = createRoutes(ctx).find(
+    r => r.method === "POST" && r.path === "/api/discord/progress",
+  );
+  if (!route) throw new Error("progress route not found");
+  return route;
+}
+
+function postProgress(route: Route, correlationId: string, content: string): Promise<Response> {
+  const req = new Request("http://localhost/api/discord/progress", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ correlationId, content }),
+  });
+  return route.handler(req, {}) as Promise<Response>;
+}
+
+describe("/api/discord/progress → A2A progress bus", () => {
+  test("publishes agent.skill.progress.{cid} even with no Discord message, and succeeds", async () => {
+    const bus = new InMemoryEventBus();
+    const ctx: ApiContext = { workspaceDir: "/tmp", bus, plugins: [], executorRegistry: new ExecutorRegistry() };
+    const cid = crypto.randomUUID();
+
+    const received: BusMessage[] = [];
+    bus.subscribe(`agent.skill.progress.${cid}`, "test", (m) => { received.push(m); });
+
+    const res = await postProgress(progressRoute(ctx), cid, "Quinn is reviewing the PR now");
+    const body = (await res.json()) as { success: boolean; delivered?: { bus: boolean; discord: boolean } };
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    // No Discord message in pendingReplies for this cid — bus delivered, Discord did not.
+    expect(body.delivered).toEqual({ bus: true, discord: false });
+
+    // The progress event reached the bus with the agent's text intact.
+    expect(received.length).toBe(1);
+    expect((received[0]!.payload as { text: string }).text).toBe("Quinn is reviewing the PR now");
+    expect(received[0]!.correlationId).toBe(cid);
+  });
+
+  test("still validates input + throttles", async () => {
+    const bus = new InMemoryEventBus();
+    const ctx: ApiContext = { workspaceDir: "/tmp", bus, plugins: [], executorRegistry: new ExecutorRegistry() };
+    const route = progressRoute(ctx);
+
+    // Missing content → 400, nothing published.
+    const cid = crypto.randomUUID();
+    const bad = await postProgress(route, cid, "");
+    expect(bad.status).toBe(400);
+
+    // First update for a fresh cid passes; a second within 5s is throttled (429).
+    const cid2 = crypto.randomUUID();
+    const first = await postProgress(route, cid2, "first");
+    expect(first.status).toBe(200);
+    const second = await postProgress(route, cid2, "second");
+    expect(second.status).toBe(429);
+  });
+});

--- a/src/api/a2a-server.ts
+++ b/src/api/a2a-server.ts
@@ -292,6 +292,29 @@ class BusAgentExecutor implements AgentExecutor {
       final: false,
     });
 
+    // Keep the stream warm. A long in-process turn (DeepAgent runs can take
+    // 20–40s) emits no events between this `working` and the terminal status,
+    // and idle-timeout proxies in front of the A2A endpoint cut a byte-silent
+    // SSE stream (~10s observed). Emit a periodic `working` heartbeat until the
+    // task settles so the connection survives and the caller keeps seeing the
+    // task is alive. Real narration still arrives via the progress subscriber
+    // above when the agent emits it (agent.skill.progress.{cid}); this is the
+    // floor beneath that. Cleared on settle/cancel.
+    const heartbeatMs = Number(process.env.A2A_STREAM_HEARTBEAT_MS) || 8000;
+    const heartbeat = setInterval(() => {
+      if (settled) return;
+      eventBus.publish({
+        kind: "status-update",
+        taskId,
+        contextId,
+        status: {
+          state: "working",
+          timestamp: new Date().toISOString(),
+        },
+        final: false,
+      });
+    }, heartbeatMs);
+
     // Dispatch to the bus. SkillDispatcherPlugin handles the rest.
     this.ctx.bus.publish("agent.skill.request", {
       id: crypto.randomUUID(),
@@ -310,6 +333,7 @@ class BusAgentExecutor implements AgentExecutor {
     });
 
     await done;
+    clearInterval(heartbeat);
     if (cancelled) {
       console.log(`[a2a-server] Task ${taskId.slice(0, 8)}… canceled`);
     }

--- a/src/api/discord.ts
+++ b/src/api/discord.ts
@@ -327,17 +327,40 @@ export function createRoutes(ctx: ApiContext): Route[] {
           return Response.json({ success: false, error: "Throttled — last update was < 5s ago", throttled: true }, { status: 429 });
         }
 
+        const content = body.content.slice(0, 2000);
+
+        // Fan the update onto the A2A progress bus first. A2A callers (e.g.
+        // ORBIS over /a2a) have no Discord message behind their correlationId,
+        // but they stream `agent.skill.progress.{cid}` → working status-updates
+        // (see a2a-server.ts). This is what makes the agent's mid-task narration
+        // reach A2A streaming/poll clients instead of being Discord-only.
+        const progressTopic = `agent.skill.progress.${body.correlationId}`;
+        ctx.bus.publish(progressTopic, {
+          id: crypto.randomUUID(),
+          correlationId: body.correlationId,
+          topic: progressTopic,
+          timestamp: Date.now(),
+          payload: { text: content },
+          source: { interface: "api" },
+        });
+
+        // Mirror to Discord when this conversation has a live Discord message.
+        // Its absence is normal for an A2A conversation — not an error — so we
+        // don't fail the call on it.
         const pending = pendingReplies.get(body.correlationId);
-        if (!pending?.message) {
-          return Response.json({ success: false, error: "No pending message for this correlationId" }, { status: 404 });
+        let discordDelivered = false;
+        if (pending?.message) {
+          try {
+            await (pending.message.channel as any).send({ content });
+            discordDelivered = true;
+          } catch (e) {
+            console.warn(
+              `[discord/progress] Discord send failed for ${body.correlationId.slice(0, 8)}… (bus publish already succeeded): ${e instanceof Error ? e.message : String(e)}`,
+            );
+          }
         }
 
-        try {
-          await (pending.message.channel as any).send({ content: body.content.slice(0, 2000) });
-          return Response.json({ success: true });
-        } catch (e) {
-          return Response.json({ success: false, error: e instanceof Error ? e.message : String(e) }, { status: 500 });
-        }
+        return Response.json({ success: true, delivered: { bus: true, discord: discordDelivered } });
       },
     },
   ];


### PR DESCRIPTION
## Problem

Ava advertises `streaming: true`, but chatting with her over `/a2a` streaming dies at a fixed ~10s — an idle-timeout proxy cutting a byte-silent SSE stream. Root cause (confirmed in code, not ORBIS-side):

- A long in-process turn (DeepAgent runs 20–40s) emits **nothing** between the initial `working` status (`a2a-server.ts:284`) and the terminal result.
- The in-process executor never publishes `agent.skill.progress.{cid}` — only the legacy `ProtoSdkExecutor` does (`proto-sdk-executor.ts:85`). Ava's `send_update` tool posts to `/api/discord/progress`, which was **Discord-only** and even **404'd when no Discord message existed** — exactly the A2A case.
- No SSE keepalive in the stream route.

→ Stream goes silent for 20–40s → proxy kills it before the answer.

## Fix

**A. Heartbeat** (`src/api/a2a-server.ts`) — while awaiting the terminal result, `BusAgentExecutor` emits a periodic `working` status-update (`A2A_STREAM_HEARTBEAT_MS`, default **8s**) until the task settles. Keeps the stream warm through idle proxies, schema-correct for long-running tasks, cleared on settle/cancel and guarded by `settled` so nothing fires after the terminal event.

**B. Progress fan-out** (`src/api/discord.ts`) — `/api/discord/progress` now publishes `agent.skill.progress.{cid}` on the bus (which `a2a-server` already bridges → `working` status-updates with text). Discord delivery becomes best-effort/optional instead of a 404 gate, so an A2A conversation (no Discord message) still gets Ava's mid-task narration on the stream.

Together, `streaming: true` becomes truthful **and** robust. Push notifications were already correctly wired (durable `SqlitePushNotificationStore` + sender) and remain the recommended transport for buffer-then-answer agents — ORBIS preferring push/poll for Ava is still sound.

## Tests

- `a2a-server.test.ts`: a slow, silent task emits ≥1 intermediate `working` heartbeat and **none** after the terminal event.
- `discord-progress.test.ts` (new): `/api/discord/progress` publishes to `agent.skill.progress.{cid}` with no Discord message present (returns `delivered.bus=true, discord=false`), and still validates input + throttles.
- Full suite **855 / 0**, `tsc --noEmit` clean, lint unchanged vs main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added periodic status updates during long-running tasks to maintain stream connectivity
  * Enhanced progress endpoint to support A2A message delivery alongside Discord updates

* **Tests**
  * Added test coverage for periodic status heartbeats during extended operations
  * Added comprehensive test suite for progress endpoint with validation and throttling verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->