### PR TITLE
feat(agent-runtime): watch workspace/agents/ + report drift (ADR-0004 P1, day 1)

### DIFF
--- a/lib/__tests__/workspace-watcher.test.ts
+++ b/lib/__tests__/workspace-watcher.test.ts
@@ -1,0 +1,66 @@
+/**
+ * WorkspaceWatcher — the shared poll-based file/dir diff primitive (ADR-0004 P1).
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  WorkspaceWatcher,
+  diffSnapshots,
+  snapshotPaths,
+  YAML_FILTER,
+  type FileDiff,
+} from "../workspace-watcher.ts";
+
+describe("workspace-watcher", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "ww-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  test("diffSnapshots classifies added / changed / removed", () => {
+    const prev = new Map([["a", "1:10"], ["b", "1:20"]]);
+    const next = new Map([["a", "1:10"], ["b", "2:25"], ["c", "1:5"]]);
+    expect(diffSnapshots(prev, next)).toEqual({ added: ["c"], changed: ["b"], removed: [] });
+    expect(diffSnapshots(next, prev)).toEqual({ added: [], changed: ["b"], removed: ["c"] });
+  });
+
+  test("YAML_FILTER takes .yaml/.yml, rejects .example + non-yaml", () => {
+    expect(YAML_FILTER("ava.yaml")).toBe(true);
+    expect(YAML_FILTER("ava.yml")).toBe(true);
+    expect(YAML_FILTER("ava.yaml.example")).toBe(false);
+    expect(YAML_FILTER("README.md")).toBe(false);
+  });
+
+  test("snapshotPaths ignores .example templates + honors the filter", () => {
+    writeFileSync(join(dir, "real.yaml"), "name: real\n");
+    writeFileSync(join(dir, "tmpl.yaml.example"), "name: tmpl\n");
+    const snap = snapshotPaths([dir], [], YAML_FILTER);
+    expect(snap.size).toBe(1);
+    expect([...snap.keys()][0]).toBe(join(dir, "real.yaml"));
+  });
+
+  test("poll() reports add → change → remove against a primed baseline, and stays quiet when nothing changes", () => {
+    writeFileSync(join(dir, "ava.yaml"), "name: ava\n");
+    const diffs: FileDiff[] = [];
+    const w = new WorkspaceWatcher({ dirs: [dir], onChange: (d) => diffs.push(d) });
+    w.prime(); // existing ava.yaml is the baseline — not reported as "added"
+
+    writeFileSync(join(dir, "quinn.yaml"), "name: quinn\n");
+    w.poll();
+    expect(diffs.at(-1)).toMatchObject({ added: [join(dir, "quinn.yaml")], changed: [], removed: [] });
+
+    writeFileSync(join(dir, "ava.yaml"), "name: ava\nrole: general\n"); // size differs → changed
+    w.poll();
+    expect(diffs.at(-1)!.changed).toContain(join(dir, "ava.yaml"));
+
+    unlinkSync(join(dir, "quinn.yaml"));
+    w.poll();
+    expect(diffs.at(-1)!.removed).toContain(join(dir, "quinn.yaml"));
+
+    const seen = diffs.length;
+    w.poll(); // no change since last poll
+    expect(diffs.length).toBe(seen);
+  });
+});

--- a/lib/workspace-watcher.ts
+++ b/lib/workspace-watcher.ts
@@ -1,0 +1,143 @@
+/**
+ * WorkspaceWatcher — a small, reusable poll-based file/dir watcher that emits
+ * structured {added, changed, removed} diffs.
+ *
+ * The fleet has several config surfaces that hot-reload by polling a directory
+ * (ceremonies, channels) — each grew its own ad-hoc snapshot loop. This is the
+ * shared primitive (ADR-0004): give it directories and/or individual files, a
+ * filter, and an interval; it snapshots (mtime+size per file) and calls
+ * onChange with the diff whenever something changes.
+ *
+ * Poll-based (not fs.watch) on purpose: works uniformly across bind-mounts and
+ * container filesystems where inotify is unreliable, and `poll()` is directly
+ * unit-testable without real timers.
+ */
+
+import { readdirSync, statSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+export interface FileDiff {
+  added: string[];
+  changed: string[];
+  removed: string[];
+}
+
+/** path → "mtimeMs:size" signature. */
+export type FileSnapshot = Map<string, string>;
+
+/** Default: YAML files, excluding `*.example` templates. */
+export const YAML_FILTER = (f: string): boolean =>
+  (f.endsWith(".yaml") || f.endsWith(".yml")) && !f.endsWith(".example");
+
+export function snapshotPaths(
+  dirs: string[],
+  files: string[],
+  filter: (f: string) => boolean,
+): FileSnapshot {
+  const snap: FileSnapshot = new Map();
+  for (const dir of dirs) {
+    if (!existsSync(dir)) continue;
+    let entries: string[];
+    try {
+      entries = readdirSync(dir).filter(filter);
+    } catch {
+      continue; // dir vanished mid-scan
+    }
+    for (const name of entries) {
+      const p = join(dir, name);
+      try {
+        const s = statSync(p);
+        snap.set(p, `${s.mtimeMs}:${s.size}`);
+      } catch {
+        // transient (file removed between readdir and stat) — skip
+      }
+    }
+  }
+  for (const f of files) {
+    if (!existsSync(f)) continue;
+    try {
+      const s = statSync(f);
+      snap.set(f, `${s.mtimeMs}:${s.size}`);
+    } catch {
+      // transient — skip
+    }
+  }
+  return snap;
+}
+
+export function diffSnapshots(prev: FileSnapshot, next: FileSnapshot): FileDiff {
+  const added: string[] = [];
+  const changed: string[] = [];
+  const removed: string[] = [];
+  for (const [p, sig] of next) {
+    const old = prev.get(p);
+    if (old === undefined) added.push(p);
+    else if (old !== sig) changed.push(p);
+  }
+  for (const p of prev.keys()) {
+    if (!next.has(p)) removed.push(p);
+  }
+  return { added, changed, removed };
+}
+
+export function isEmptyDiff(d: FileDiff): boolean {
+  return d.added.length === 0 && d.changed.length === 0 && d.removed.length === 0;
+}
+
+export interface WorkspaceWatcherOptions {
+  /** Directories scanned (non-recursive) for files matching `filter`. */
+  dirs?: string[];
+  /** Individual files to watch (filter not applied to these). */
+  files?: string[];
+  /** Dir-entry filter. Default: YAML, excluding `*.example`. */
+  filter?: (filename: string) => boolean;
+  /** Poll interval in ms. Default 5000. */
+  intervalMs?: number;
+  /** Called with the diff whenever a poll detects changes. */
+  onChange: (diff: FileDiff) => void;
+}
+
+export class WorkspaceWatcher {
+  private readonly dirs: string[];
+  private readonly files: string[];
+  private readonly filter: (f: string) => boolean;
+  private readonly intervalMs: number;
+  private readonly onChange: (diff: FileDiff) => void;
+  private snapshot: FileSnapshot = new Map();
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(opts: WorkspaceWatcherOptions) {
+    this.dirs = opts.dirs ?? [];
+    this.files = opts.files ?? [];
+    this.filter = opts.filter ?? YAML_FILTER;
+    this.intervalMs = opts.intervalMs ?? 5000;
+    this.onChange = opts.onChange;
+  }
+
+  /** Snapshot current state WITHOUT firing onChange — call after the initial load so existing files aren't reported as "added". */
+  prime(): void {
+    this.snapshot = snapshotPaths(this.dirs, this.files, this.filter);
+  }
+
+  /** One poll cycle: diff against the last snapshot, fire onChange if non-empty, advance the snapshot. Directly callable in tests. */
+  poll(): void {
+    const next = snapshotPaths(this.dirs, this.files, this.filter);
+    const diff = diffSnapshots(this.snapshot, next);
+    this.snapshot = next;
+    if (!isEmptyDiff(diff)) this.onChange(diff);
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.prime();
+    this.timer = setInterval(() => this.poll(), this.intervalMs);
+    (this.timer as { unref?: () => void }).unref?.();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/src/agent-runtime/__tests__/agent-diff.test.ts
+++ b/src/agent-runtime/__tests__/agent-diff.test.ts
@@ -1,0 +1,59 @@
+/**
+ * computeAgentDiff / hashDefinition — agent-definition diffing for hot-reload (ADR-0004 P1).
+ */
+
+import { describe, test, expect } from "bun:test";
+import { computeAgentDiff, hashDefinition } from "../agent-diff.ts";
+import type { AgentDefinition } from "../types.ts";
+
+function def(name: string, extra: Partial<AgentDefinition> = {}): AgentDefinition {
+  return {
+    name,
+    role: "general",
+    model: "m",
+    systemPrompt: "p",
+    tools: [],
+    skills: [],
+    ...extra,
+  } as AgentDefinition;
+}
+
+describe("computeAgentDiff", () => {
+  test("classifies added / changed / removed by name + content hash", () => {
+    const registered = new Map([
+      ["ava", hashDefinition(def("ava"))],
+      ["quinn", hashDefinition(def("quinn"))],
+    ]);
+    const next = [
+      def("ava"),                               // unchanged
+      def("quinn", { systemPrompt: "changed" }), // changed
+      def("proto"),                              // added
+    ];
+    const d = computeAgentDiff(registered, next);
+    expect(d.added.map((a) => a.name)).toEqual(["proto"]);
+    expect(d.changed.map((a) => a.name)).toEqual(["quinn"]);
+    expect(d.removed).toEqual([]);
+  });
+
+  test("reports removed agents that disappear from disk", () => {
+    const registered = new Map([
+      ["ava", hashDefinition(def("ava"))],
+      ["old", hashDefinition(def("old"))],
+    ]);
+    const d = computeAgentDiff(registered, [def("ava")]);
+    expect(d.removed).toEqual(["old"]);
+    expect(d.added).toEqual([]);
+    expect(d.changed).toEqual([]);
+  });
+
+  test("hashDefinition is stable and sensitive to content", () => {
+    expect(hashDefinition(def("ava"))).toBe(hashDefinition(def("ava")));
+    expect(hashDefinition(def("ava"))).not.toBe(hashDefinition(def("ava", { model: "other" })));
+  });
+
+  test("duplicate agent names — last definition wins", () => {
+    const d = computeAgentDiff(new Map(), [def("ava", { model: "a" }), def("ava", { model: "b" })]);
+    expect(d.added.length).toBe(1);
+    expect(d.added[0]!.model).toBe("b");
+  });
+});

--- a/src/agent-runtime/agent-diff.ts
+++ b/src/agent-runtime/agent-diff.ts
@@ -1,0 +1,59 @@
+/**
+ * Agent-definition diffing for hot-reload (ADR-0004, P1).
+ *
+ * The WorkspaceWatcher reports which files changed; this maps a freshly-loaded
+ * set of AgentDefinitions against the currently-registered set (by name +
+ * content hash) into added / changed / removed. Pure + synchronous so it's
+ * unit-testable and reused by both the detect-only (P1 day 1) and apply
+ * (P1 day 2) paths.
+ */
+
+import { createHash } from "node:crypto";
+import type { AgentDefinition } from "./types.ts";
+
+/** Stable content hash of a definition — changes iff anything that affects the executor changes. */
+export function hashDefinition(def: AgentDefinition): string {
+  return createHash("sha256").update(JSON.stringify(def)).digest("hex").slice(0, 16);
+}
+
+export interface AgentDiff {
+  /** Agents present now but not before. */
+  added: AgentDefinition[];
+  /** Agents present before and now, with a changed content hash. */
+  changed: AgentDefinition[];
+  /** Names of agents present before but gone now. */
+  removed: string[];
+}
+
+export function isEmptyAgentDiff(d: AgentDiff): boolean {
+  return d.added.length === 0 && d.changed.length === 0 && d.removed.length === 0;
+}
+
+/**
+ * Diff a freshly-loaded definition set against the registered (name → hash) map.
+ * `next` may contain duplicate names (two files declaring the same agent) — the
+ * last one wins, matching how a Map-based registry would resolve them.
+ */
+export function computeAgentDiff(
+  registered: ReadonlyMap<string, string>,
+  next: AgentDefinition[],
+): AgentDiff {
+  const added: AgentDefinition[] = [];
+  const changed: AgentDefinition[] = [];
+  const nextByName = new Map<string, AgentDefinition>();
+  for (const def of next) nextByName.set(def.name, def); // last-wins on dup names
+
+  for (const [name, def] of nextByName) {
+    const prevHash = registered.get(name);
+    const nextHash = hashDefinition(def);
+    if (prevHash === undefined) added.push(def);
+    else if (prevHash !== nextHash) changed.push(def);
+  }
+
+  const removed: string[] = [];
+  for (const name of registered.keys()) {
+    if (!nextByName.has(name)) removed.push(name);
+  }
+
+  return { added, changed, removed };
+}

--- a/src/agent-runtime/agent-runtime-plugin.ts
+++ b/src/agent-runtime/agent-runtime-plugin.ts
@@ -27,6 +27,9 @@ import { DeepAgentExecutor } from "../executor/executors/deep-agent-executor.ts"
 import { ProtoSdkExecutor } from "../executor/executors/proto-sdk-executor.ts";
 import { loadAgentDefinitions } from "./agent-definition-loader.ts";
 import type { AgentDefinition } from "./types.ts";
+import { WorkspaceWatcher, type FileDiff } from "../../lib/workspace-watcher.ts";
+import { computeAgentDiff, hashDefinition, isEmptyAgentDiff } from "./agent-diff.ts";
+import { join } from "node:path";
 
 export interface AgentRuntimeConfig {
   workspaceDir: string;
@@ -45,6 +48,9 @@ export class AgentRuntimePlugin implements Plugin {
   private readonly config: AgentRuntimeConfig;
   private readonly executorRegistry: ExecutorRegistry;
   private bus?: EventBus;
+  /** Currently-registered agents: name → content hash. The "running" set the on-disk state is diffed against. */
+  private readonly registered = new Map<string, string>();
+  private watcher?: WorkspaceWatcher;
 
   constructor(config: AgentRuntimeConfig, executorRegistry: ExecutorRegistry) {
     this.config = config;
@@ -66,6 +72,7 @@ export class AgentRuntimePlugin implements Plugin {
           priority: 10,
         });
       }
+      this.registered.set(def.name, hashDefinition(def));
     }
 
     const agentNames = definitions.map(d => `${d.name}(${d.runtime ?? "deep-agent"})`).join(", ") || "(none)";
@@ -73,9 +80,49 @@ export class AgentRuntimePlugin implements Plugin {
       `[agent-runtime] Registered ${definitions.length} agent(s) ` +
       `[deep-agent: ${counts["deep-agent"]}, proto-sdk: ${counts["proto-sdk"]}]: ${agentNames}`,
     );
+
+    // ADR-0004 P1 (day 1 — detect-only): watch workspace/agents/ and report
+    // drift between the on-disk definitions and the running set. The apply path
+    // (build/register added, unregister/dispose removed) lands in P1 day 2.
+    this.watcher = new WorkspaceWatcher({
+      dirs: [join(this.config.workspaceDir, "agents")],
+      onChange: (diff) => this._onAgentsChanged(diff),
+    });
+    this.watcher.start();
   }
 
-  uninstall(): void {}
+  /**
+   * Detect-only handler (P1 day 1): a workspace/agents/ file changed. Reload the
+   * definitions and log how the on-disk state has drifted from the running set.
+   * Does NOT mutate the registry yet — that's P1 day 2.
+   */
+  private _onAgentsChanged(diff: FileDiff): void {
+    let definitions: AgentDefinition[];
+    try {
+      definitions = loadAgentDefinitions(this.config.workspaceDir);
+    } catch (err) {
+      console.error(`[agent-runtime] reload failed: ${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+    const agentDiff = computeAgentDiff(this.registered, definitions);
+    if (isEmptyAgentDiff(agentDiff)) {
+      // File touched but no semantic agent change (comment, whitespace, mtime-only).
+      return;
+    }
+    const fileSummary = `+${diff.added.length} ~${diff.changed.length} -${diff.removed.length} file(s)`;
+    console.log(
+      `[agent-runtime] workspace/agents changed (${fileSummary}) — on-disk agents drift from running: ` +
+      `added=[${agentDiff.added.map(d => d.name).join(", ")}] ` +
+      `changed=[${agentDiff.changed.map(d => d.name).join(", ")}] ` +
+      `removed=[${agentDiff.removed.join(", ")}]. ` +
+      `Detect-only (P1 day 1); restart or the P1 day-2 apply picks these up.`,
+    );
+  }
+
+  uninstall(): void {
+    this.watcher?.stop();
+    this.watcher = undefined;
+  }
 
   /**
    * Shared tool-call telemetry hook — fires per tool_use event into


### PR DESCRIPTION
First slice of **P1 — agent registry hot-reload** (#708, part of #707 / ADR-0004). **Detect-only**; the apply path is day 2.

## What
- **`lib/workspace-watcher.ts`** — the reusable poll-based file/dir watcher emitting `{added, changed, removed}` diffs (mtime+size snapshots; `poll()` directly unit-testable; poll-based, not `fs.watch`, for bind-mount/container reliability). This is the shared primitive ADR-0004 calls for — the ad-hoc ceremony/channel loops can converge on it next.
- **`src/agent-runtime/agent-diff.ts`** — `computeAgentDiff` + `hashDefinition`: diffs a freshly-loaded `AgentDefinition[]` against the running `name→hash` set. Pure; reused by the day-2 apply.
- **`AgentRuntimePlugin`** — records the running set at install, watches `workspace/agents/`, and on change **logs the drift** (`added=[…] changed=[…] removed=[…]`) without mutating the registry. Watcher stopped on `uninstall`.

## Why detect-only first
De-risks the apply (executor lifecycle + register/unregister + in-flight drain, day 2) and is independently useful: an agent-yaml change is invisible-until-restart today; now it surfaces within ~5s.

## Verification
Tests: watcher (add/change/remove/quiet + `.example` exclusion) + agent-diff (added/changed/removed, stable+sensitive hash, dup-name last-wins). Full suite **871/0**, tsc clean, lint unchanged.

Next (day 2, #708): apply the diff — build+register added agents, unregister+dispose removed ones, drain in-flight before disposal — landing "add/modify an agent with no restart."

🤖 Generated with [Claude Code](https://claude.com/claude-code)