### PR TITLE
feat(agent-runtime): hot-reload apply — add/modify/remove agents with no restart (ADR-0004 P1 day 2)

### DIFF
--- a/src/agent-runtime/__tests__/agent-hot-reload.test.ts
+++ b/src/agent-runtime/__tests__/agent-hot-reload.test.ts
@@ -1,0 +1,112 @@
+/**
+ * AgentRuntimePlugin hot-reload apply (ADR-0004 P1, day 2): reconcile the live
+ * ExecutorRegistry against workspace/agents/ on change — add / reload / remove,
+ * with the parse-error-keeps-running safety guard. Drives the apply directly
+ * with an injected fake executor factory + a real ExecutorRegistry + a temp dir.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AgentRuntimePlugin } from "../agent-runtime-plugin.ts";
+import { ExecutorRegistry } from "../../executor/executor-registry.ts";
+import type { IExecutor } from "../../executor/types.ts";
+import type { AgentDefinition } from "../types.ts";
+import type { EventBus } from "../../../lib/types.ts";
+
+const FAKE_BUS = { subscribe: () => "s", unsubscribe: () => {}, publish: () => {} } as unknown as EventBus;
+
+function agentYaml(name: string, skills: string[], model = "m"): string {
+  const skillBlock = skills.map((s) => `  - name: ${s}\n    description: ${s} skill\n    keywords: []`).join("\n");
+  return `name: ${name}\nrole: general\nmodel: ${model}\nsystemPrompt: hi\nskills:\n${skillBlock}\n`;
+}
+
+/** (skill@agentName) pairs currently registered. */
+function pairs(reg: ExecutorRegistry): string[] {
+  return reg.list().map((r) => `${r.skill}@${r.agentName}`).sort();
+}
+
+describe("AgentRuntimePlugin hot-reload apply", () => {
+  let root: string;
+  let agentsDir: string;
+  let registry: ExecutorRegistry;
+  let plugin: AgentRuntimePlugin;
+  let disposed: string[];
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "agents-"));
+    agentsDir = join(root, "agents");
+    mkdirSync(agentsDir);
+    registry = new ExecutorRegistry();
+    disposed = [];
+    const buildExecutor = (def: AgentDefinition): IExecutor => ({
+      type: "fake",
+      execute: async () => ({ text: "", isError: false, correlationId: "" }),
+      dispose: () => { disposed.push(def.name); },
+    });
+    plugin = new AgentRuntimePlugin({ workspaceDir: root }, registry, { buildExecutor });
+  });
+
+  afterEach(() => {
+    plugin.uninstall();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  async function apply(): Promise<void> {
+    (plugin as unknown as { _applyAgentChanges: () => void })._applyAgentChanges();
+    // Executor disposal is best-effort/deferred (a microtask, so it never blocks
+    // the apply); flush it before asserting on `disposed`.
+    await new Promise((r) => setTimeout(r, 0));
+  }
+
+  test("install registers the agents present at boot", () => {
+    writeFileSync(join(agentsDir, "ava.yaml"), agentYaml("ava", ["chat"]));
+    plugin.install(FAKE_BUS);
+    expect(pairs(registry)).toEqual(["chat@ava"]);
+  });
+
+  test("add: a new agent file is registered with no restart", async () => {
+    writeFileSync(join(agentsDir, "ava.yaml"), agentYaml("ava", ["chat"]));
+    plugin.install(FAKE_BUS);
+
+    writeFileSync(join(agentsDir, "quinn.yaml"), agentYaml("quinn", ["review"]));
+    await apply();
+    expect(pairs(registry)).toEqual(["chat@ava", "review@quinn"]);
+  });
+
+  test("change: skills re-registered (dropped skill removed, new skill added), old executor disposed", async () => {
+    writeFileSync(join(agentsDir, "ava.yaml"), agentYaml("ava", ["chat"]));
+    plugin.install(FAKE_BUS);
+
+    // ava now serves "triage" instead of "chat"
+    writeFileSync(join(agentsDir, "ava.yaml"), agentYaml("ava", ["triage"]));
+    await apply();
+    expect(pairs(registry)).toEqual(["triage@ava"]); // chat gone, triage added, no dup
+    expect(disposed).toContain("ava"); // old executor torn down
+  });
+
+  test("remove: deleting the file unregisters the agent + disposes it", async () => {
+    writeFileSync(join(agentsDir, "ava.yaml"), agentYaml("ava", ["chat"]));
+    writeFileSync(join(agentsDir, "quinn.yaml"), agentYaml("quinn", ["review"]));
+    plugin.install(FAKE_BUS);
+    expect(pairs(registry)).toEqual(["chat@ava", "review@quinn"]);
+
+    unlinkSync(join(agentsDir, "quinn.yaml"));
+    await apply();
+    expect(pairs(registry)).toEqual(["chat@ava"]);
+    expect(disposed).toContain("quinn");
+  });
+
+  test("parse error keeps the running agent (a typo never drops a live agent)", async () => {
+    writeFileSync(join(agentsDir, "ava.yaml"), agentYaml("ava", ["chat"]));
+    plugin.install(FAKE_BUS);
+
+    // Corrupt the file (missing required `model`) — it no longer parses to "ava",
+    // but the file still EXISTS, so the running instance must be kept.
+    writeFileSync(join(agentsDir, "ava.yaml"), "name: ava\nrole: general\nsystemPrompt: hi\nskills: []\n");
+    await apply();
+    expect(pairs(registry)).toEqual(["chat@ava"]); // still registered
+    expect(disposed).not.toContain("ava");
+  });
+});

--- a/src/agent-runtime/agent-definition-loader.ts
+++ b/src/agent-runtime/agent-definition-loader.ts
@@ -137,14 +137,26 @@ export function parseAgentYaml(raw: RawAgentYaml, fileName: string): AgentDefini
   };
 }
 
+/** A parsed agent definition + the file it came from (one agent per file). */
+export interface AgentEntry {
+  def: AgentDefinition;
+  /** Absolute path to the source YAML — used by hot-reload to tell removal from a parse error. */
+  file: string;
+}
+
 /**
- * Load all agent definitions from workspace/agents/*.yaml.
+ * Load all agent definitions from workspace/agents/*.yaml, each paired with its
+ * source file.
  *
  * - Files matching *.example are skipped.
- * - Files that fail to parse are logged and skipped (startup continues).
+ * - Files that fail to parse are logged and skipped (startup + reload continue).
  * - Returns an empty array if the agents/ directory doesn't exist.
+ *
+ * Does not log per-agent (callers do, once, at the right moment — startup logs
+ * each agent; hot-reload logs only the deltas, so it doesn't re-log the fleet
+ * every poll).
  */
-export function loadAgentDefinitions(workspaceDir: string): AgentDefinition[] {
+export function loadAgentEntries(workspaceDir: string): AgentEntry[] {
   const agentsDir = join(workspaceDir, "agents");
   if (!existsSync(agentsDir)) return [];
 
@@ -152,15 +164,14 @@ export function loadAgentDefinitions(workspaceDir: string): AgentDefinition[] {
     (f) => (f.endsWith(".yaml") || f.endsWith(".yml")) && !f.endsWith(".example"),
   );
 
-  const definitions: AgentDefinition[] = [];
+  const entries: AgentEntry[] = [];
 
   for (const file of files) {
     const filePath = join(agentsDir, file);
     try {
       const raw = parseYaml(readFileSync(filePath, "utf8")) as RawAgentYaml;
       const def = parseAgentYaml(raw, file);
-      definitions.push(def);
-      console.log(`[agent-runtime] Loaded agent "${def.name}" (${def.role}, model: ${def.model})`);
+      entries.push({ def, file: filePath });
     } catch (err) {
       console.error(
         `[agent-runtime] Skipping ${file}: ${err instanceof Error ? err.message : String(err)}`,
@@ -168,5 +179,10 @@ export function loadAgentDefinitions(workspaceDir: string): AgentDefinition[] {
     }
   }
 
-  return definitions;
+  return entries;
+}
+
+/** Convenience: just the definitions (drops the source-file pairing). */
+export function loadAgentDefinitions(workspaceDir: string): AgentDefinition[] {
+  return loadAgentEntries(workspaceDir).map((e) => e.def);
 }

--- a/src/agent-runtime/agent-runtime-plugin.ts
+++ b/src/agent-runtime/agent-runtime-plugin.ts
@@ -25,11 +25,12 @@ import type { ExecutorRegistry } from "../executor/executor-registry.ts";
 import type { IExecutor } from "../executor/types.ts";
 import { DeepAgentExecutor } from "../executor/executors/deep-agent-executor.ts";
 import { ProtoSdkExecutor } from "../executor/executors/proto-sdk-executor.ts";
-import { loadAgentDefinitions } from "./agent-definition-loader.ts";
+import { loadAgentEntries, type AgentEntry } from "./agent-definition-loader.ts";
 import type { AgentDefinition } from "./types.ts";
-import { WorkspaceWatcher, type FileDiff } from "../../lib/workspace-watcher.ts";
-import { computeAgentDiff, hashDefinition, isEmptyAgentDiff } from "./agent-diff.ts";
-import { join } from "node:path";
+import { WorkspaceWatcher } from "../../lib/workspace-watcher.ts";
+import { computeAgentDiff, hashDefinition } from "./agent-diff.ts";
+import { existsSync } from "node:fs";
+import { join, basename } from "node:path";
 
 export interface AgentRuntimeConfig {
   workspaceDir: string;
@@ -37,6 +38,14 @@ export interface AgentRuntimeConfig {
   gatewayApiKey?: string;
   apiBaseUrl?: string;
   apiKey?: string;
+}
+
+/** A running agent: its executor, the skills it's registered for, content hash, and source file. */
+interface RegisteredAgent {
+  executor: IExecutor;
+  skills: string[];
+  hash: string;
+  file: string;
 }
 
 export class AgentRuntimePlugin implements Plugin {
@@ -48,75 +57,123 @@ export class AgentRuntimePlugin implements Plugin {
   private readonly config: AgentRuntimeConfig;
   private readonly executorRegistry: ExecutorRegistry;
   private bus?: EventBus;
-  /** Currently-registered agents: name → content hash. The "running" set the on-disk state is diffed against. */
-  private readonly registered = new Map<string, string>();
+  /** Running agents by name — the live set the on-disk definitions are reconciled against. */
+  private readonly registered = new Map<string, RegisteredAgent>();
   private watcher?: WorkspaceWatcher;
+  /** Executor factory — injectable for tests; defaults to the real DeepAgent / ProtoSDK builder. */
+  private readonly buildExecutor: (def: AgentDefinition) => IExecutor;
 
-  constructor(config: AgentRuntimeConfig, executorRegistry: ExecutorRegistry) {
+  constructor(
+    config: AgentRuntimeConfig,
+    executorRegistry: ExecutorRegistry,
+    opts: { buildExecutor?: (def: AgentDefinition) => IExecutor } = {},
+  ) {
     this.config = config;
     this.executorRegistry = executorRegistry;
+    this.buildExecutor = opts.buildExecutor ?? ((def) => this._buildExecutor(def));
   }
 
   install(bus: EventBus): void {
     this.bus = bus;
-    const definitions = loadAgentDefinitions(this.config.workspaceDir);
+    const entries = loadAgentEntries(this.config.workspaceDir);
 
     const counts = { "deep-agent": 0, "proto-sdk": 0 };
-    for (const def of definitions) {
-      const executor = this._buildExecutor(def);
+    for (const { def, file } of entries) {
       counts[def.runtime ?? "deep-agent"] += 1;
-
-      for (const skill of def.skills) {
-        this.executorRegistry.register(skill.name, executor, {
-          agentName: def.name,
-          priority: 10,
-        });
-      }
-      this.registered.set(def.name, hashDefinition(def));
+      this._register(def, file);
+      console.log(`[agent-runtime] Loaded agent "${def.name}" (${def.role}, model: ${def.model})`);
     }
 
-    const agentNames = definitions.map(d => `${d.name}(${d.runtime ?? "deep-agent"})`).join(", ") || "(none)";
+    const agentNames = entries.map(e => `${e.def.name}(${e.def.runtime ?? "deep-agent"})`).join(", ") || "(none)";
     console.log(
-      `[agent-runtime] Registered ${definitions.length} agent(s) ` +
+      `[agent-runtime] Registered ${entries.length} agent(s) ` +
       `[deep-agent: ${counts["deep-agent"]}, proto-sdk: ${counts["proto-sdk"]}]: ${agentNames}`,
     );
 
-    // ADR-0004 P1 (day 1 — detect-only): watch workspace/agents/ and report
-    // drift between the on-disk definitions and the running set. The apply path
-    // (build/register added, unregister/dispose removed) lands in P1 day 2.
+    // ADR-0004 P1: hot-reload. Watch workspace/agents/ and reconcile the live
+    // registry on every change — add / reload / remove an agent with no restart.
     this.watcher = new WorkspaceWatcher({
       dirs: [join(this.config.workspaceDir, "agents")],
-      onChange: (diff) => this._onAgentsChanged(diff),
+      onChange: () => this._applyAgentChanges(),
     });
     this.watcher.start();
   }
 
+  /** Build an executor for `def`, register its skills, and record it as running. */
+  private _register(def: AgentDefinition, file: string): void {
+    const executor = this.buildExecutor(def);
+    const skills = def.skills.map(s => s.name);
+    for (const skill of skills) {
+      this.executorRegistry.register(skill, executor, { agentName: def.name, priority: 10 });
+    }
+    this.registered.set(def.name, { executor, skills, hash: hashDefinition(def), file });
+  }
+
   /**
-   * Detect-only handler (P1 day 1): a workspace/agents/ file changed. Reload the
-   * definitions and log how the on-disk state has drifted from the running set.
-   * Does NOT mutate the registry yet — that's P1 day 2.
+   * P1 apply: reload workspace/agents/ and reconcile the live registry —
+   * register added agents, re-register changed ones, unregister + dispose
+   * removed ones. No restart.
+   *
+   * Safety: a file that fails to parse is dropped from the loaded set, which
+   * would otherwise look like a removal. We only treat an agent as removed when
+   * its source file is actually GONE; if the file is still present, the agent
+   * vanished due to a parse error and we KEEP the running instance — a typo
+   * never silently drops a live agent.
    */
-  private _onAgentsChanged(diff: FileDiff): void {
-    let definitions: AgentDefinition[];
+  private _applyAgentChanges(): void {
+    let entries: AgentEntry[];
     try {
-      definitions = loadAgentDefinitions(this.config.workspaceDir);
+      entries = loadAgentEntries(this.config.workspaceDir);
     } catch (err) {
       console.error(`[agent-runtime] reload failed: ${err instanceof Error ? err.message : String(err)}`);
       return;
     }
-    const agentDiff = computeAgentDiff(this.registered, definitions);
-    if (isEmptyAgentDiff(agentDiff)) {
-      // File touched but no semantic agent change (comment, whitespace, mtime-only).
-      return;
+
+    const fileByName = new Map(entries.map(e => [e.def.name, e.file]));
+    const registeredHashes = new Map([...this.registered].map(([name, r]) => [name, r.hash]));
+    const diff = computeAgentDiff(registeredHashes, entries.map(e => e.def));
+
+    for (const name of diff.removed) {
+      const reg = this.registered.get(name);
+      if (!reg) continue;
+      if (existsSync(reg.file)) {
+        console.warn(
+          `[agent-runtime] "${name}" no longer parses from ${basename(reg.file)} — keeping the running instance (fix or delete the file)`,
+        );
+        continue;
+      }
+      this._removeAgent(name, reg);
     }
-    const fileSummary = `+${diff.added.length} ~${diff.changed.length} -${diff.removed.length} file(s)`;
-    console.log(
-      `[agent-runtime] workspace/agents changed (${fileSummary}) — on-disk agents drift from running: ` +
-      `added=[${agentDiff.added.map(d => d.name).join(", ")}] ` +
-      `changed=[${agentDiff.changed.map(d => d.name).join(", ")}] ` +
-      `removed=[${agentDiff.removed.join(", ")}]. ` +
-      `Detect-only (P1 day 1); restart or the P1 day-2 apply picks these up.`,
-    );
+
+    for (const def of diff.added) {
+      this._register(def, fileByName.get(def.name) ?? "");
+      console.log(`[agent-runtime] + "${def.name}" hot-added (${def.skills.length} skill(s)) — no restart`);
+    }
+
+    for (const def of diff.changed) {
+      const old = this.registered.get(def.name);
+      if (!old) continue;
+      for (const skill of old.skills) this.executorRegistry.unregister(skill, def.name);
+      this._register(def, fileByName.get(def.name) ?? old.file);
+      this._disposeExecutor(def.name, old.executor);
+      console.log(`[agent-runtime] ~ "${def.name}" reloaded (${def.skills.length} skill(s)) — no restart`);
+    }
+  }
+
+  private _removeAgent(name: string, reg: RegisteredAgent): void {
+    for (const skill of reg.skills) this.executorRegistry.unregister(skill, name);
+    this.registered.delete(name);
+    this._disposeExecutor(name, reg.executor);
+    console.log(`[agent-runtime] - "${name}" hot-removed (${reg.skills.length} skill(s) unregistered) — no restart`);
+  }
+
+  /** Best-effort executor teardown — never blocks the apply or aborts in-flight work. */
+  private _disposeExecutor(name: string, executor: IExecutor): void {
+    void Promise.resolve()
+      .then(() => executor.dispose?.())
+      .catch((err) =>
+        console.warn(`[agent-runtime] dispose("${name}") failed: ${err instanceof Error ? err.message : String(err)}`),
+      );
   }
 
   uninstall(): void {

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -796,6 +796,16 @@ export class DeepAgentExecutor implements IExecutor {
     return built;
   }
 
+  /**
+   * Release idle resources when this executor is unregistered (ADR-0004
+   * hot-swap). Drops the per-model ChatOpenAI cache so the instances can be
+   * GC'd. Safe with an in-flight `execute()` — that call already holds its own
+   * model + agent references, so clearing the cache never touches running work.
+   */
+  dispose(): void {
+    this.modelCache.clear();
+  }
+
   async execute(req: SkillRequest): Promise<SkillResult> {
     const prompt = req.content ?? req.prompt ?? this._buildPrompt(req);
 

--- a/src/executor/types.ts
+++ b/src/executor/types.ts
@@ -82,6 +82,14 @@ export interface IExecutor {
   /** Identifies the executor type for logging and diagnostics. */
   readonly type: string;
   execute(req: SkillRequest): Promise<SkillResult>;
+  /**
+   * Optional teardown when this executor is unregistered (agent removed or
+   * reloaded — ADR-0004 hot-swap). Best-effort + safe to call while a dispatch
+   * is in flight: an in-flight `execute()` holds its own references, so dispose
+   * only releases idle resources (caches, pooled connections). Must not abort
+   * running work.
+   */
+  dispose?(): void | Promise<void>;
 }
 
 // ── Registry types ────────────────────────────────────────────────────────────


### PR DESCRIPTION
**Completes P1 — agent registry hot-reload** (#708, ADR-0004). Day-1 watched + logged drift; day-2 **applies** it.

## What
On any `workspace/agents/` change, reconcile the live `ExecutorRegistry`:
- **add** → build executor + register skills
- **change** → unregister old skills → register new set (no dup; `register` appends) → dispose old executor
- **remove** → unregister + dispose

Adding/editing/removing an agent YAML now takes effect within ~5s — **no restart.**

## Safety (the two failure modes that matter)
- **A typo never drops a live agent.** A changed file that fails to parse falls out of the loaded set (looks like a removal). We only remove an agent when its **source file is actually gone**; if the file's still there, we keep the running instance + warn. `loadAgentEntries` now carries the source file per agent for this.
- **In-flight work is never aborted.** A replaced/removed executor's in-flight `execute()` holds its own refs and finishes; `unregister` stops only *new* dispatches; `dispose()` is best-effort + deferred and frees only idle resources. New optional `IExecutor.dispose?()` (DeepAgent clears its model cache). The apply's `unregister→register` runs with no `await` between, so single-threaded execution gives no observable gap.

## Testability
`AgentRuntimePlugin` gains an injectable executor factory (optional 3rd ctor arg, defaults to the real builder), so the apply is tested with fake executors + a real `ExecutorRegistry` + a temp dir.

## Verification
Tests: add / change / remove / parse-error-keeps-running. Full suite **876/0**, tsc clean, lint unchanged.

Closes #708. Next: **P2 (#709)** — the control-plane write API (`POST/PUT/DELETE /api/agents` → `command.agent.*` → registrar → atomic YAML write → this watcher applies it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)