### PR TITLE
docs: agents hot-reload now (ADR-0004 P1) — fix stale restart claims

### DIFF
--- a/docs/decisions/0004-fleet-control-plane-and-hot-swappable-extension.md
+++ b/docs/decisions/0004-fleet-control-plane-and-hot-swappable-extension.md
@@ -25,7 +25,7 @@ protoWorkstacean is the switchboard: `trigger → router → dispatcher → exec
 | Channels (`workspace/channels.yaml`) | ✅ hot-reload (5 s watch) |
 | Crons (SchedulerPlugin) | ⚠️ runtime add/remove via bus command; no file-watch |
 | A2A agent **skills** (remote card change) | ✅ auto re-register (`ExecutorRegistry.unregister()` already exists) |
-| **DeepAgents (`workspace/agents/*.yaml`)** | ❌ **boot-only load → container restart** |
+| **DeepAgents (`workspace/agents/*.yaml`)** | ~~❌ boot-only → restart~~ → ✅ **hot-reload (P1 shipped, #714/#715)** |
 | **A2A agent entries (`workspace/agents.yaml`)** | ❌ **boot-only load → restart** |
 | **Workspace plugins (`workspace/plugins/*.ts`)** | ❌ restart, Node module-cache pins the old code, **and they can't import app modules** |
 
@@ -138,7 +138,7 @@ On add/test of an A2A agent or MCP server, fetch its descriptor (`/.well-known/a
 
 ## 5. Phased plan (impact → effort)
 
-1. **P1 — Agent registry hot-reload.** Watch `workspace/agents/` + `agents.yaml`; diff-and-apply via `ExecutorRegistry.register`/`unregister` + executor lifecycle (construct/dispose). *Kills restart-to-add-agent — the biggest win, lowest risk (proven file-watch pattern).*
+1. ✅ **P1 — Agent registry hot-reload** *(shipped — #714 watch+detect, #715 apply).* `WorkspaceWatcher` (reusable poll-based file/dir diff) watches `workspace/agents/`; `AgentRuntimePlugin` reconciles the live registry via `ExecutorRegistry.register`/`unregister` + `IExecutor.dispose?()`. Add/edit/remove a DeepAgent YAML applies in ~5s, no restart; a parse error keeps the running agent; in-flight dispatch is never aborted. *(`workspace/agents.yaml` A2A entries still need a restart — extends in a later slice.)*
 2. **P2 — Control-plane write API + `command.*` + registrar** for agents (then crons/channels), modeled on the existing `/api/ceremonies` CRUD. Create/edit/remove an agent via API → persisted → live, no restart.
 3. **P3 — Management UI (separate Console surface) + capability discovery** (agent-card/MCP probe + test-before-save), mirroring ORBIS `DelegatesSettings`.
 4. **P4 — MCP client tier + capability grants + trust tiers**; **retire the `workspace/plugins/*.ts` loader**. (Larger — likely its own sprint.)

--- a/docs/guides/add-an-agent.md
+++ b/docs/guides/add-an-agent.md
@@ -78,7 +78,7 @@ When a `agent.skill.request` message arrives, `SkillDispatcherPlugin` calls `Exe
 
 ### Registering the executor
 
-`AgentRuntimePlugin` calls `executorRegistry.register(skill.name, executor, { agentName: agent.name })` for each skill in the YAML. No restart is required if you add a new agent file — restart is required currently; hot-reload is not implemented for agent definitions.
+`AgentRuntimePlugin` calls `executorRegistry.register(skill.name, executor, { agentName: agent.name })` for each skill in the YAML. **In-process agents hot-reload (ADR-0004 P1): adding, editing, or removing a `workspace/agents/*.yaml` is reconciled into the live registry within ~5s — no restart.** A file that fails to parse keeps the running agent and logs a warning (a typo never drops a live agent), and in-flight dispatches finish on the old executor before it's disposed. (Remote A2A agents in `workspace/agents.yaml` still need a restart to add/remove the entry — see [Deploy with Docker](./deploy-with-docker).)
 
 ### Minimal example
 

--- a/docs/guides/deploy-with-docker.md
+++ b/docs/guides/deploy-with-docker.md
@@ -16,12 +16,13 @@ protoWorkstacean separates **code** from **config**:
 - **Code ships as an image.** Production runs `ghcr.io/protolabsai/workstacean:main`. [watchtower](https://containrrr.dev/watchtower/) watches that tag and auto-pulls + restarts the container whenever a new `:main` image is published (CI builds and pushes on every merge to `main`).
 - **Workspace config ships as a host bind-mount.** The `workspace/` directory (agent YAMLs, ceremonies, `channels.yaml`) is mounted into the container and updated on the host with `git pull` — it is *not* baked into the image. This means config changes don't require an image rebuild.
 
-Two config reload behaviours follow from that:
+Config reload behaviour by surface:
 
 - **Ceremonies hot-reload.** Editing or adding a file under `workspace/ceremonies/` (then `git pull` on the host) is picked up live — no restart.
-- **Agent YAMLs need a container restart.** Changes to `workspace/agents/*.yaml` or `workspace/agents.yaml` are read at startup; `docker compose restart workstacean` to apply them.
+- **In-process agents hot-reload.** Adding, editing, or removing a `workspace/agents/*.yaml` (DeepAgent) is reconciled live within ~5s — no restart (ADR-0004 P1). A YAML that fails to parse keeps the running agent + logs a warning; in-flight work is never interrupted.
+- **A2A agent entries still need a restart.** Changes to `workspace/agents.yaml` (remote A2A agents) are read at startup; `docker compose restart workstacean` to apply them. (Their *skills* still auto-refresh from the agent card every 10 min — only adding/removing the agent entry needs the restart, until the control-plane work extends hot-reload there.)
 
-So the operational model is: **code lands via watchtower automatically; config lands via `git pull` on the host, with a restart only when you touched agent YAMLs.**
+So the operational model is: **code lands via watchtower automatically; config lands via `git pull` on the host; ceremonies and in-process agents apply live, and only `workspace/agents.yaml` (A2A) edits need a restart.**
 
 ## Docker Compose
 
@@ -104,7 +105,7 @@ The `workspace/` directory is bind-mounted read-write, so configuration changes 
     security-triage.yaml
 ```
 
-After editing **agent** YAMLs, restart the container:
+In-process agents (`workspace/agents/*.yaml`) hot-reload — no restart. After editing **`workspace/agents.yaml`** (A2A entries), restart the container:
 
 ```bash
 docker compose restart workstacean


### PR DESCRIPTION
Follows P1 (#714/#715), which made `workspace/agents/*.yaml` (in-process DeepAgents) hot-reload. Updates docs that still claimed agents need a restart, distinguishing **in-process agents (now live, ~5s)** from **A2A entries in `workspace/agents.yaml` (still restart)**:
- `deploy-with-docker.md` — reload-behaviour list + post-edit restart note
- `add-an-agent.md` — removes "hot-reload is not implemented"; documents the live reconcile + parse-error-keeps-running guard
- `ADR-0004` — marks the DeepAgents row + P1 plan entry shipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)