### PR TITLE
feat(control-plane): agent CRUD write API + command.agent.* + registrar (ADR-0004 P2)

### DIFF
--- a/docs/reference/bus-topics.md
+++ b/docs/reference/bus-topics.md
@@ -6,11 +6,11 @@ title: Bus Topics
 
 ## Summary
 
-- **84** distinct topics seen across the codebase
-- **16** declared in `src/event-bus/all-topics.ts` (TOPICS constant)
+- **86** distinct topics seen across the codebase
+- **18** declared in `src/event-bus/all-topics.ts` (TOPICS constant)
 - **68** raw-string / template topics not in TOPICS (candidates to register)
 - **18** topics that couldn't be statically resolved (computed at runtime)
-- **99** publish call sites, **53** subscribe call sites
+- **100** publish call sites, **55** subscribe call sites
 
 Each row links to the original call site as `path:line` so jumping from this index to the source is a click.
 
@@ -75,7 +75,11 @@ Each row links to the original call site as `path:line` so jumping from this ind
 
 | Topic | Declared | Payload | Publishers | Subscribers |
 |---|---|---|---|---|
+| `command.agent.remove` | ✅ `COMMAND_AGENT_REMOVE` (`ACTION_TOPICS`) | — | _(none)_ | `src/plugins/control-plane-registrar-plugin.ts:50` |
+| `command.agent.upsert` | ✅ `COMMAND_AGENT_UPSERT` (`ACTION_TOPICS`) | — | _(none)_ | `src/plugins/control-plane-registrar-plugin.ts:49` |
 | `command.schedule` | — | — | _(none)_ | `lib/plugins/scheduler.ts:73` |
+
+**`command.agent.upsert`** — Control-plane mutations (ADR-0004 P2). The write API publishes these; the ControlPlaneRegistrar is the sole subscriber + the only writer of the workspace config files. Auditable in bus-history. The file write triggers the agent-runtime hot-reload (P1), so the change goes live within ~5s. command.agent.upsert  — { name, file, yaml }  → atomic write command.agent.remove  — { name, file }        → delete
 
 ## `config.*`
 
@@ -343,7 +347,7 @@ Each row links to the original call site as `path:line` so jumping from this ind
 
 | Topic | Declared | Payload | Publishers | Subscribers |
 |---|---|---|---|---|
-| `{topic}` | — | — | `src/world/extensions/CeremonyStateExtension.ts:120`<br>`src/agent-runtime/agent-runtime-plugin.ts:96`<br>`src/executor/executors/proto-sdk-executor.ts:86`<br>`src/executor/task-tracker.ts:282`<br>`src/executor/extensions/effect-domain.ts:85`<br>`src/executor/extensions/cost.ts:210`<br>`src/executor/extensions/confidence.ts:166`<br>`src/executor/skill-dispatcher-plugin.ts:713`<br>`src/executor/skill-dispatcher-plugin.ts:788`<br>`src/executor/skill-dispatcher-plugin.ts:812`<br>`src/executor/skill-dispatcher-plugin.ts:861`<br>`src/api/operations.ts:80`<br>`src/api/operations.ts:115`<br>`src/api/operations.ts:133`<br>`lib/plugins/linear.ts:430`<br>`lib/plugins/linear.ts:477`<br>`lib/plugins/linear.ts:556`<br>`lib/plugins/linear.ts:603`<br>`lib/plugins/linear.ts:636`<br>`lib/plugins/linear.ts:853`<br>`lib/plugins/github.ts:393`<br>`lib/plugins/github.ts:635`<br>`lib/plugins/github.ts:715`<br>`lib/plugins/operator-routing.ts:128`<br>`lib/plugins/feature-notifier.ts:98`<br>`lib/plugins/debug.ts:31`<br>`lib/plugins/google/gmail.ts:152`<br>`lib/plugins/onboarding.ts:325` | `src/executor/executors/workflow-executor.ts:93`<br>`src/index.ts:744` |
+| `{topic}` | — | — | `src/world/extensions/CeremonyStateExtension.ts:120`<br>`src/agent-runtime/agent-runtime-plugin.ts:200`<br>`src/executor/executors/proto-sdk-executor.ts:86`<br>`src/executor/task-tracker.ts:282`<br>`src/executor/extensions/effect-domain.ts:85`<br>`src/executor/extensions/cost.ts:210`<br>`src/executor/extensions/confidence.ts:166`<br>`src/executor/skill-dispatcher-plugin.ts:713`<br>`src/executor/skill-dispatcher-plugin.ts:788`<br>`src/executor/skill-dispatcher-plugin.ts:812`<br>`src/executor/skill-dispatcher-plugin.ts:861`<br>`src/api/agents-crud.ts:55`<br>`src/api/operations.ts:80`<br>`src/api/operations.ts:115`<br>`src/api/operations.ts:133`<br>`lib/plugins/linear.ts:430`<br>`lib/plugins/linear.ts:477`<br>`lib/plugins/linear.ts:556`<br>`lib/plugins/linear.ts:603`<br>`lib/plugins/linear.ts:636`<br>`lib/plugins/linear.ts:853`<br>`lib/plugins/github.ts:393`<br>`lib/plugins/github.ts:635`<br>`lib/plugins/github.ts:715`<br>`lib/plugins/operator-routing.ts:128`<br>`lib/plugins/feature-notifier.ts:98`<br>`lib/plugins/debug.ts:31`<br>`lib/plugins/google/gmail.ts:152`<br>`lib/plugins/onboarding.ts:325` | `src/executor/executors/workflow-executor.ts:93`<br>`src/index.ts:747` |
 
 ## Unresolved call sites
 
@@ -374,7 +378,7 @@ These sites pass a non-literal topic that the static scan couldn't resolve to a 
 | `lib/plugins/scheduler.ts:263` | publish | `def.topic` |
 | `lib/plugins/scheduler.ts:374` | publish | `reply.topic` |
 | `lib/plugins/signal.ts:103` | publish | `msg.topic` |
-| `src/agent-runtime/agent-runtime-plugin.ts:96` | publish | `topic` |
+| `src/agent-runtime/agent-runtime-plugin.ts:200` | publish | `topic` |
 | `src/api/a2a-server.ts:133` | publish | `{
       kind: "task",
       id: taskId,
@@ -415,6 +419,7 @@ These sites pass a non-literal topic that the static scan couldn't resolve to a 
         taskId,
         contextId,
         stat` |
+| `src/api/agents-crud.ts:55` | publish | `topic` |
 | `src/api/discord.ts:338` | publish | `progressTopic` |
 | `src/api/human-input.ts:82` | publish | `requestTopic` |
 | `src/api/human-input.ts:143` | publish | `responseTopic` |
@@ -437,7 +442,7 @@ These sites pass a non-literal topic that the static scan couldn't resolve to a 
 | `src/executor/skill-dispatcher-plugin.ts:861` | publish | `topic` |
 | `src/executor/task-tracker.ts:282` | publish | `topic` |
 | `src/executor/task-tracker.ts:330` | publish | `task.replyTopic` |
-| `src/index.ts:744` | subscribe | `topic` |
+| `src/index.ts:747` | subscribe | `topic` |
 | `src/plugins/ceremony-skill-executor-plugin.ts:123` | publish | `executeTopic` |
 | `src/plugins/CeremonyPlugin.ts:344` | publish | `executeTopic` |
 | `src/plugins/CeremonyPlugin.ts:372` | subscribe | `replyTopic` |

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -6,7 +6,7 @@ title: HTTP API
 
 ## Summary
 
-- **72** HTTP routes across **33** path groups
+- **76** HTTP routes across **33** path groups
 - **14** routes carry a resolved one-line description
 
 Each row links to the route definition as `path:line` so jumping from this index to the source is a click. Routes are defined as `{ method, path, handler }` literals in `src/api/*.ts` and collected by `src/api/index.ts`.
@@ -45,7 +45,11 @@ Each row links to the route definition as `path:line` so jumping from this index
 | Method | Path | Source | Description |
 |---|---|---|---|
 | `GET` | `/api/agents` | `src/api/operations.ts:250` | — |
+| `POST` | `/api/agents` | `src/api/agents-crud.ts:85` | — |
+| `PUT` | `/api/agents/:name` | `src/api/agents-crud.ts:115` | — |
+| `DELETE` | `/api/agents/:name` | `src/api/agents-crud.ts:133` | — |
 | `GET` | `/api/agents/runtime` | `src/api/agents-runtime.ts:67` | — |
+| `POST` | `/api/agents/test` | `src/api/agents-crud.ts:66` | — |
 
 ### `/api/board`
 

--- a/src/api/__tests__/agents-crud.test.ts
+++ b/src/api/__tests__/agents-crud.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Agent control-plane write API (ADR-0004 P2) — end-to-end with a real
+ * InMemoryEventBus + the ControlPlaneRegistrar installed + a temp workspace.
+ * POST/PUT/DELETE publish command.agent.*; the registrar (sole writer) persists
+ * synchronously; the API verifies and responds.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, existsSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { ExecutorRegistry } from "../../executor/executor-registry.ts";
+import { ControlPlaneRegistrarPlugin } from "../../plugins/control-plane-registrar-plugin.ts";
+import { createRoutes } from "../agents-crud.ts";
+import type { ApiContext, Route } from "../types.ts";
+
+const AGENT = {
+  name: "tester",
+  role: "general",
+  model: "m",
+  systemPrompt: "hi",
+  skills: [{ name: "chat", description: "d", keywords: [] }],
+};
+
+describe("agents-crud control-plane API", () => {
+  let root: string;
+  let agentsDir: string;
+  let bus: InMemoryEventBus;
+  let ctx: ApiContext;
+  let routes: Route[];
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "agents-crud-"));
+    agentsDir = join(root, "agents");
+    mkdirSync(agentsDir);
+    bus = new InMemoryEventBus();
+    new ControlPlaneRegistrarPlugin(root).install(bus);
+    ctx = { workspaceDir: root, bus, plugins: [], executorRegistry: new ExecutorRegistry() };
+    routes = createRoutes(ctx);
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  function route(method: string, path: string): Route {
+    const r = routes.find((x) => x.method === method && x.path === path);
+    if (!r) throw new Error(`no route ${method} ${path}`);
+    return r;
+  }
+  function reqWith(body?: unknown, headers: Record<string, string> = {}): Request {
+    return new Request("http://localhost", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...headers },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+  }
+
+  test("POST creates the agent file via the registrar (synchronous write)", async () => {
+    const res = await route("POST", "/api/agents").handler(reqWith(AGENT), {});
+    expect(res.status).toBe(201);
+    const file = join(agentsDir, "tester.yaml");
+    expect(existsSync(file)).toBe(true);
+    expect((parseYaml(readFileSync(file, "utf8")) as { name: string }).name).toBe("tester");
+  });
+
+  test("POST a duplicate name → 409", async () => {
+    await route("POST", "/api/agents").handler(reqWith(AGENT), {});
+    const dup = await route("POST", "/api/agents").handler(reqWith(AGENT), {});
+    expect(dup.status).toBe(409);
+  });
+
+  test("POST an invalid definition → 400, nothing written", async () => {
+    const bad = { name: "broken", role: "general", systemPrompt: "x", skills: [] }; // missing model
+    const res = await route("POST", "/api/agents").handler(reqWith(bad), {});
+    expect(res.status).toBe(400);
+    expect(existsSync(join(agentsDir, "broken.yaml"))).toBe(false);
+  });
+
+  test("PUT updates an existing agent; 404 when it doesn't exist", async () => {
+    await route("POST", "/api/agents").handler(reqWith(AGENT), {});
+    const updated = { ...AGENT, model: "m2" };
+    const ok = await route("PUT", "/api/agents/:name").handler(reqWith(updated), { name: "tester" });
+    expect(ok.status).toBe(200);
+    expect((parseYaml(readFileSync(join(agentsDir, "tester.yaml"), "utf8")) as { model: string }).model).toBe("m2");
+
+    const missing = await route("PUT", "/api/agents/:name").handler(reqWith({ ...AGENT, name: "ghost" }), { name: "ghost" });
+    expect(missing.status).toBe(404);
+  });
+
+  test("DELETE removes the file; 404 when missing", async () => {
+    await route("POST", "/api/agents").handler(reqWith(AGENT), {});
+    const del = await route("DELETE", "/api/agents/:name").handler(reqWith(undefined), { name: "tester" });
+    expect(del.status).toBe(200);
+    expect(existsSync(join(agentsDir, "tester.yaml"))).toBe(false);
+
+    const again = await route("DELETE", "/api/agents/:name").handler(reqWith(undefined), { name: "tester" });
+    expect(again.status).toBe(404);
+  });
+
+  test("POST /api/agents/test validates without persisting", async () => {
+    const ok = await route("POST", "/api/agents/test").handler(reqWith(AGENT), {});
+    const body = (await ok.json()) as { valid: boolean; skills: string[] };
+    expect(body.valid).toBe(true);
+    expect(body.skills).toEqual(["chat"]);
+    expect(existsSync(join(agentsDir, "tester.yaml"))).toBe(false);
+
+    const bad = await route("POST", "/api/agents/test").handler(reqWith({ name: "x" }), {});
+    expect(bad.status).toBe(400);
+  });
+
+  test("admin key enforced when ctx.apiKey is set", async () => {
+    ctx = { ...ctx, apiKey: "secret" };
+    routes = createRoutes(ctx);
+    const noKey = await route("POST", "/api/agents").handler(reqWith(AGENT), {});
+    expect(noKey.status).toBe(401);
+    const withKey = await route("POST", "/api/agents").handler(reqWith(AGENT, { "x-api-key": "secret" }), {});
+    expect(withKey.status).toBe(201);
+  });
+
+  test("registrar refuses writes outside workspace/agents (path-traversal guard)", () => {
+    const outside = join(root, "escape.yaml");
+    bus.publish("command.agent.upsert", {
+      id: "x", correlationId: "c", topic: "command.agent.upsert", timestamp: 0,
+      payload: { name: "evil", file: outside, yaml: "name: evil\n" },
+    });
+    expect(existsSync(outside)).toBe(false); // refused — not inside agents/
+  });
+});

--- a/src/api/agents-crud.ts
+++ b/src/api/agents-crud.ts
@@ -1,0 +1,148 @@
+/**
+ * Agent control-plane write API (ADR-0004 P2).
+ *
+ *   POST   /api/agents          — create an in-process (DeepAgent) agent
+ *   PUT    /api/agents/:name     — update an existing agent
+ *   DELETE /api/agents/:name     — remove an agent
+ *   POST   /api/agents/test      — validate a definition without persisting
+ *
+ * Each mutation validates the definition (the same `parseAgentYaml` the loader
+ * uses → 400 on a bad def), resolves the target file, and publishes a
+ * `command.agent.*` topic. The ControlPlaneRegistrar is the sole writer; the
+ * file write triggers the agent-runtime hot-reload (P1), so the change is live
+ * within ~5s — no restart. Admin-key gated.
+ *
+ * Reads stay on `GET /api/agents/runtime` (the live registry view).
+ */
+
+import { join, resolve, dirname } from "node:path";
+import { existsSync } from "node:fs";
+import { stringify as stringifyYaml } from "yaml";
+import type { Route, ApiContext } from "./types.ts";
+import { parseAgentYaml, loadAgentEntries } from "../agent-runtime/agent-definition-loader.ts";
+import type { AgentDefinition, RawAgentYaml } from "../agent-runtime/types.ts";
+
+function safeFileName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9-]/g, "-").replace(/^-+|-+$/g, "");
+}
+
+export function createRoutes(ctx: ApiContext): Route[] {
+  const agentsDir = join(ctx.workspaceDir, "agents");
+
+  const authorized = (req: Request): boolean => {
+    if (!ctx.apiKey) return true;
+    if (req.headers.get("x-api-key") === ctx.apiKey) return true;
+    return req.headers.get("authorization") === `Bearer ${ctx.apiKey}`;
+  };
+  const unauthorized = () => Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  const badJson = () => Response.json({ success: false, error: "Invalid JSON" }, { status: 400 });
+
+  /** Validate a raw agent body → the parsed def, or a 400 Response. */
+  function validate(body: unknown): { def: AgentDefinition } | { error: Response } {
+    try {
+      return { def: parseAgentYaml(body as RawAgentYaml, "(request body)") };
+    } catch (err) {
+      return { error: Response.json({ success: false, error: err instanceof Error ? err.message : String(err) }, { status: 400 }) };
+    }
+  }
+
+  /** The source file of a currently-defined agent, by name (one file per agent). */
+  function fileForAgent(name: string): string | undefined {
+    return loadAgentEntries(ctx.workspaceDir).find((e) => e.def.name === name)?.file;
+  }
+
+  function command(topic: string, name: string, payload: Record<string, unknown>): void {
+    ctx.bus.publish(topic, {
+      id: crypto.randomUUID(),
+      correlationId: crypto.randomUUID(),
+      topic,
+      timestamp: Date.now(),
+      payload: { name, ...payload },
+      source: { interface: "api" },
+    });
+  }
+
+  return [
+    {
+      method: "POST",
+      path: "/api/agents/test",
+      handler: async (req) => {
+        if (!authorized(req)) return unauthorized();
+        let body: unknown;
+        try { body = await req.json(); } catch { return badJson(); }
+        const v = validate(body);
+        if ("error" in v) return v.error;
+        return Response.json({
+          success: true,
+          valid: true,
+          name: v.def.name,
+          role: v.def.role,
+          model: v.def.model,
+          skills: v.def.skills.map((s) => s.name),
+        });
+      },
+    },
+    {
+      method: "POST",
+      path: "/api/agents",
+      handler: async (req) => {
+        if (!authorized(req)) return unauthorized();
+        let body: unknown;
+        try { body = await req.json(); } catch { return badJson(); }
+        const v = validate(body);
+        if ("error" in v) return v.error;
+        const name = v.def.name;
+        if (fileForAgent(name)) {
+          return Response.json(
+            { success: false, error: `Agent "${name}" already exists — use PUT /api/agents/${name} to update` },
+            { status: 409 },
+          );
+        }
+        const safe = safeFileName(name);
+        if (!safe) return Response.json({ success: false, error: "agent name has no usable filename characters" }, { status: 400 });
+        const file = resolve(join(agentsDir, `${safe}.yaml`));
+        if (dirname(file) !== resolve(agentsDir)) {
+          return Response.json({ success: false, error: "invalid agent name" }, { status: 400 });
+        }
+        command("command.agent.upsert", name, { file, yaml: stringifyYaml(body) });
+        // Bus dispatch is synchronous → the registrar already wrote the file.
+        if (!existsSync(file)) {
+          return Response.json({ success: false, error: "write did not complete (see logs)" }, { status: 500 });
+        }
+        return Response.json({ success: true, name, file, note: "registered within ~5s via hot-reload" }, { status: 201 });
+      },
+    },
+    {
+      method: "PUT",
+      path: "/api/agents/:name",
+      handler: async (req, p) => {
+        if (!authorized(req)) return unauthorized();
+        let body: unknown;
+        try { body = await req.json(); } catch { return badJson(); }
+        const v = validate(body);
+        if ("error" in v) return v.error;
+        if (v.def.name !== p.name) {
+          return Response.json({ success: false, error: `body name "${v.def.name}" must match path "${p.name}"` }, { status: 400 });
+        }
+        const file = fileForAgent(p.name);
+        if (!file) return Response.json({ success: false, error: `Agent "${p.name}" not found` }, { status: 404 });
+        command("command.agent.upsert", p.name, { file, yaml: stringifyYaml(body) });
+        return Response.json({ success: true, name: p.name, file, note: "reloaded within ~5s" });
+      },
+    },
+    {
+      method: "DELETE",
+      path: "/api/agents/:name",
+      handler: async (req, p) => {
+        if (!authorized(req)) return unauthorized();
+        const file = fileForAgent(p.name);
+        if (!file) return Response.json({ success: false, error: `Agent "${p.name}" not found` }, { status: 404 });
+        command("command.agent.remove", p.name, { file });
+        if (existsSync(file)) {
+          return Response.json({ success: false, error: "delete did not complete (see logs)" }, { status: 500 });
+        }
+        return Response.json({ success: true, name: p.name, note: "unregistered within ~5s" });
+      },
+    },
+  ];
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -29,6 +29,7 @@ import { createRoutes as clawpatchRoutes } from "./clawpatch.ts";
 import { createRoutes as agentsRuntimeRoutes } from "./agents-runtime.ts";
 import { createRoutes as busHistoryRoutes } from "./bus-history.ts";
 import { createRoutes as humanInputRoutes } from "./human-input.ts";
+import { createRoutes as agentsCrudRoutes } from "./agents-crud.ts";
 
 export { matchPath } from "./types.ts";
 export type { Route, ApiContext } from "./types.ts";
@@ -57,5 +58,6 @@ export function createAllRoutes(ctx: ApiContext): Route[] {
     ...agentsRuntimeRoutes(ctx),
     ...busHistoryRoutes(ctx),
     ...humanInputRoutes(ctx),
+    ...agentsCrudRoutes(ctx),
   ];
 }

--- a/src/event-bus/all-topics.ts
+++ b/src/event-bus/all-topics.ts
@@ -67,6 +67,17 @@ export const ACTION_TOPICS = {
    */
   AGENT_INPUT_RESPONSE_PREFIX: "agent.input.response",
 
+  /**
+   * Control-plane mutations (ADR-0004 P2). The write API publishes these; the
+   * ControlPlaneRegistrar is the sole subscriber + the only writer of the
+   * workspace config files. Auditable in bus-history. The file write triggers
+   * the agent-runtime hot-reload (P1), so the change goes live within ~5s.
+   *   command.agent.upsert  — { name, file, yaml }  → atomic write
+   *   command.agent.remove  — { name, file }        → delete
+   */
+  COMMAND_AGENT_UPSERT: "command.agent.upsert",
+  COMMAND_AGENT_REMOVE: "command.agent.remove",
+
   /** Wildcard subscription pattern — matches all cron events from SchedulerPlugin. */
   CRON_ALL: "cron.#",
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { CLIPlugin } from "../lib/plugins/cli";
 import { SignalPlugin } from "../lib/plugins/signal";
 import { SchedulerPlugin } from "../lib/plugins/scheduler";
 import { A2ADeliveryPlugin } from "../lib/plugins/a2a-delivery";
+import { ControlPlaneRegistrarPlugin } from "./plugins/control-plane-registrar-plugin.ts";
 import type { Plugin, } from "../lib/types";
 import { parseEnv } from "./config/env.ts";
 // Fail-fast env validation — exits immediately on misconfiguration.
@@ -129,6 +130,8 @@ const corePlugins: Plugin[] = [
   new SignalPlugin(),
   new SchedulerPlugin(dataDir),
   new A2ADeliveryPlugin(workspaceDir),
+  // ADR-0004 P2: sole writer of workspace config for control-plane command.* mutations.
+  new ControlPlaneRegistrarPlugin(workspaceDir),
 ];
 
 for (const plugin of corePlugins) {

--- a/src/plugins/control-plane-registrar-plugin.ts
+++ b/src/plugins/control-plane-registrar-plugin.ts
@@ -1,0 +1,96 @@
+/**
+ * ControlPlaneRegistrarPlugin — the sole writer of workspace config files for
+ * control-plane mutations (ADR-0004 P2).
+ *
+ * The write API (src/api/agents-crud.ts) validates + serializes a mutation and
+ * publishes a `command.agent.*` topic; this registrar is the only subscriber
+ * and performs the atomic filesystem write. Keeping all mutations on the bus
+ * makes them auditable in bus-history, and the resulting file change triggers
+ * the agent-runtime hot-reload (P1), so the agent goes live within ~5s.
+ *
+ * This is the documented exemption to "no plugin writes another plugin's
+ * state": a registrar operating on a shared resource (the workspace dir), not
+ * calling another plugin's methods.
+ *
+ * Writes are synchronous (writeFileSync + renameSync; unlinkSync) so they
+ * complete within the synchronous bus dispatch — the publishing API handler can
+ * verify the result immediately after `publish()` returns.
+ */
+
+import { writeFileSync, renameSync, unlinkSync, existsSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
+
+interface AgentUpsertPayload {
+  name?: string;
+  file?: string;
+  yaml?: string;
+}
+interface AgentRemovePayload {
+  name?: string;
+  file?: string;
+}
+
+export class ControlPlaneRegistrarPlugin implements Plugin {
+  name = "control-plane-registrar";
+  description = "Sole writer of workspace config files for control-plane command.* mutations";
+  capabilities = ["control-plane", "config-writer"];
+
+  /** Writes are confined to this root — a path-traversal guard. */
+  private readonly agentsRoot: string;
+  private subscriptionIds: string[] = [];
+
+  constructor(workspaceDir: string) {
+    this.agentsRoot = resolve(workspaceDir, "agents");
+  }
+
+  install(bus: EventBus): void {
+    this.subscriptionIds.push(
+      bus.subscribe("command.agent.upsert", this.name, (msg) => this._onUpsert(msg)),
+      bus.subscribe("command.agent.remove", this.name, (msg) => this._onRemove(msg)),
+    );
+  }
+
+  uninstall(): void {
+    this.subscriptionIds = [];
+  }
+
+  /** Guard: the target must resolve to a file directly inside the agents root. */
+  private _safe(file: string | undefined): string | null {
+    if (!file) return null;
+    const resolved = resolve(file);
+    if (dirname(resolved) !== this.agentsRoot) {
+      console.warn(`[control-plane] refusing write outside ${this.agentsRoot}: ${file}`);
+      return null;
+    }
+    return resolved;
+  }
+
+  private _onUpsert(msg: BusMessage): void {
+    const p = (msg.payload ?? {}) as AgentUpsertPayload;
+    const file = this._safe(p.file);
+    if (!file || typeof p.yaml !== "string") return;
+    try {
+      if (!existsSync(this.agentsRoot)) mkdirSync(this.agentsRoot, { recursive: true });
+      // Atomic: write a temp sibling then rename over the target.
+      const tmp = `${file}.tmp-${msg.id}`;
+      writeFileSync(tmp, p.yaml, "utf8");
+      renameSync(tmp, file);
+      console.log(`[control-plane] wrote agent "${p.name}" → ${file}`);
+    } catch (err) {
+      console.error(`[control-plane] upsert "${p.name}" failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  private _onRemove(msg: BusMessage): void {
+    const p = (msg.payload ?? {}) as AgentRemovePayload;
+    const file = this._safe(p.file);
+    if (!file) return;
+    try {
+      if (existsSync(file)) unlinkSync(file);
+      console.log(`[control-plane] removed agent "${p.name}" → ${file}`);
+    } catch (err) {
+      console.error(`[control-plane] remove "${p.name}" failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+}


### PR DESCRIPTION
**P2 — control-plane write API** (#709, ADR-0004). With P1's watcher applying file changes live, agents are now **create/edit/remove over HTTP — no restart.**

## What
- **`src/api/agents-crud.ts`** — `POST /api/agents`, `PUT /api/agents/:name`, `DELETE /api/agents/:name`, `POST /api/agents/test`. Each validates with the loader's own `parseAgentYaml` (→ 400 on a bad def), resolves the target file (one file per agent), and publishes a `command.agent.*` topic. Admin-key gated. create→201, duplicate→409, missing→404.
- **`command.agent.{upsert,remove}`** topics — every mutation rides the bus → auditable in bus-history.
- **`ControlPlaneRegistrarPlugin`** — the **sole writer**: subscribes to `command.agent.*`, does the atomic write (temp+rename) / delete, **confined to `workspace/agents/`** (path-traversal guard). In `corePlugins`.

The in-memory bus dispatches synchronously, so the registrar's write completes within `publish()` — the API verifies and returns a real result; the file write then triggers P1's hot-reload (live within ~5s). This is the documented registrar exemption to "no plugin writes another's state": it operates on the shared workspace dir, driven by bus topics — the API never writes files directly.

## Verification
Tests (end-to-end, real bus + registrar + temp workspace): create / dup-409 / invalid-400 / update / 404 / delete / validate-only / admin-auth / **path-traversal guard**. Full suite **884/0**, tsc clean, lint at baseline. Reference docs regenerated.

Closes #709. Next: **P3 (#710)** — the brand-native Console surface (`@protolabsai/design` + `@protolabsai/ui`) driving this API + agent-card capability discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent management API endpoints: create, update, delete, and test agents.
  * Implemented API key authorization for protected endpoints.
  * Added path traversal protection for agent file operations.

* **Documentation**
  * Updated HTTP API reference with 4 new agent endpoints (76 total routes).
  * Updated bus topics reference with new agent command topics.

* **Tests**
  * Added comprehensive test suite for agent CRUD operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->