### PR TITLE
feat(dashboard): Console — fleet control surface (ADR-0004 P3, day 1)

### DIFF
--- a/dashboard/bun.lock
+++ b/dashboard/bun.lock
@@ -6,7 +6,9 @@
       "name": "workstacean-dashboard",
       "dependencies": {
         "@protolabsai/design": "^0.2.0",
+        "@protolabsai/ui": "^0.3.0",
         "@xyflow/react": "^12.10.2",
+        "lucide-react": "^1.17.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.1.0",
@@ -122,6 +124,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@protolabsai/design": ["@protolabsai/design@0.2.0", "", {}, "sha512-h85XpF4h0YNML0DxePbG/F1H8fEdxvGu40xDF74cg59PCJJaQFrVrNqi5GgwlAoyB1wukGtVjG5RSnHRB26tog=="],
+
+    "@protolabsai/ui": ["@protolabsai/ui@0.3.0", "", { "dependencies": { "@protolabsai/design": "0.3.0", "@types/react": "^19.0.0", "@types/react-dom": "^19.0.0" }, "peerDependencies": { "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-iJCkwP+MGT8hkkhF+czW7+59bZFaqVtx4CYBEOPE9OHSrfPueQkeqOyNyLUc7LalupTyxA9krQK6I0lofAEkVQ=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
@@ -261,6 +265,8 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
+    "lucide-react": ["lucide-react@1.17.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
@@ -306,5 +312,7 @@
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
+
+    "@protolabsai/ui/@protolabsai/design": ["@protolabsai/design@0.3.0", "", { "bin": { "protolabs-sync-assets": "bin/sync-assets.mjs" } }, "sha512-vitFVJ9c7L66idoskukAyd48uCTHXy0Y3oQKmcm9osmwZmfogFSPqrGEB1Ot7ZblWDFgsOBr7aRf6iBJMU+k2g=="],
   }
 }

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.2.0",
+    "@protolabsai/ui": "^0.3.0",
     "@xyflow/react": "^12.10.2",
+    "lucide-react": "^1.17.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.1.0"

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -5,6 +5,7 @@ import SystemGraph from "./components/SystemGraph";
 import SkillTrace from "./components/SkillTrace";
 import EventStream from "./components/EventStream";
 import AgentsView from "./components/AgentsView";
+import Console from "./components/Console";
 
 export default function App() {
   return (
@@ -15,6 +16,7 @@ export default function App() {
         <Route path="/trace" element={<SkillTrace />} />
         <Route path="/events" element={<EventStream />} />
         <Route path="/agents" element={<AgentsView />} />
+        <Route path="/console" element={<Console />} />
       </Route>
     </Routes>
   );

--- a/dashboard/src/Layout.tsx
+++ b/dashboard/src/Layout.tsx
@@ -9,6 +9,7 @@ const NAV_ITEMS = [
   { to: "/trace", label: "Trace", title: "Skill Trace" },
   { to: "/events", label: "Events", title: "Events" },
   { to: "/agents", label: "Agents", title: "Agents" },
+  { to: "/console", label: "Console", title: "Console" },
 ] as const;
 
 // Routes whose component manages its own scroll/height (graph, live feeds) —

--- a/dashboard/src/components/ConfirmDialog.tsx
+++ b/dashboard/src/components/ConfirmDialog.tsx
@@ -1,0 +1,92 @@
+import { AlertTriangle } from "lucide-react";
+import { useEffect } from "react";
+
+// Custom confirmation modal for destructive actions — used instead of the
+// browser's window.confirm so an accidental click can't silently drop a live
+// agent. Click-outside or Escape cancels. Mirrors the protoAgent operator
+// console's ConfirmDialog (the house pattern), built on the --pl-* tokens; a
+// candidate to contribute upstream into @protolabsai/ui (which lacks a dialog).
+
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = "Remove",
+  danger = true,
+  onConfirm,
+  onCancel,
+}: {
+  open: boolean;
+  title: string;
+  message?: string;
+  confirmLabel?: string;
+  danger?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onCancel(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      onClick={onCancel}
+      style={{
+        position: "fixed", inset: 0, zIndex: 50,
+        background: "rgba(0, 0, 0, 0.6)",
+        display: "flex", alignItems: "center", justifyContent: "center",
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: "var(--bg-default)",
+          border: "1px solid var(--border-default)",
+          borderRadius: "8px",
+          padding: "20px",
+          width: "min(420px, 90vw)",
+          boxShadow: "0 12px 48px rgba(0,0,0,0.5)",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: "8px", color: danger ? "var(--text-danger)" : "var(--text-primary)" }}>
+          {danger && <AlertTriangle size={16} />}
+          <h2 style={{ fontSize: "15px", margin: 0, color: "var(--text-primary)" }}>{title}</h2>
+        </div>
+        {message && <p style={{ color: "var(--text-secondary)", fontSize: "13px", marginBottom: "16px" }}>{message}</p>}
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: "8px" }}>
+          <button
+            type="button"
+            onClick={onCancel}
+            style={{
+              padding: "6px 14px", borderRadius: "6px", fontSize: "13px", cursor: "pointer",
+              background: "transparent", color: "var(--text-secondary)", border: "1px solid var(--border-default)",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            autoFocus
+            style={{
+              padding: "6px 14px", borderRadius: "6px", fontSize: "13px", cursor: "pointer", fontWeight: 500,
+              background: "transparent",
+              color: danger ? "var(--text-danger)" : "var(--accent-fg)",
+              border: `1px solid ${danger ? "var(--text-danger)" : "var(--accent-emphasis)"}`,
+            }}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/Console.tsx
+++ b/dashboard/src/components/Console.tsx
@@ -1,0 +1,220 @@
+import { useState, useEffect, useCallback } from "react";
+import { Button, Badge, Card, Empty, Divider, type Status } from "@protolabsai/ui";
+import { RefreshCw, Plus, Trash2, CircleCheck } from "lucide-react";
+import { ConfirmDialog } from "./ConfirmDialog";
+import {
+  getAgentsRuntime,
+  testAgent,
+  createAgent,
+  deleteAgent,
+  getAdminKey,
+  setAdminKey,
+  type AgentsRuntimeResponse,
+} from "../lib/api";
+
+// The Console is the fleet's WRITE surface (ADR-0004 P3) — distinct from the
+// read-only debug panes. Brand-native via @protolabsai/ui + the --pl-* tokens.
+// Drives the P2 control-plane API; mutations apply live via hot-reload (~5s).
+
+type Agent = AgentsRuntimeResponse["agents"][number];
+
+const TEMPLATE = `{
+  "name": "my-agent",
+  "role": "general",
+  "model": "protolabs/reasoning",
+  "systemPrompt": "What this agent does.",
+  "tools": ["list_agents"],
+  "skills": [
+    { "name": "my_skill", "description": "what it handles", "keywords": [] }
+  ]
+}`;
+
+function typeStatus(a: Agent): Status {
+  if (a.pendingDiscovery) return "warning";
+  if (a.type === "deep-agent") return "info";
+  return "neutral";
+}
+
+export default function Console() {
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [key, setKey] = useState(getAdminKey());
+  const [draft, setDraft] = useState(TEMPLATE);
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<{ ok: boolean; msg: string } | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await getAgentsRuntime(true);
+      setAgents(data.agents ?? []);
+    } catch (err) {
+      setResult({ ok: false, msg: `Failed to load fleet: ${err instanceof Error ? err.message : String(err)}` });
+    }
+  }, []);
+
+  useEffect(() => { void refresh(); }, [refresh]);
+
+  function saveKey(v: string) {
+    setKey(v);
+    setAdminKey(v);
+  }
+
+  function parseDraft(): unknown | null {
+    try {
+      return JSON.parse(draft);
+    } catch (err) {
+      setResult({ ok: false, msg: `Invalid JSON: ${err instanceof Error ? err.message : String(err)}` });
+      return null;
+    }
+  }
+
+  async function onValidate() {
+    const def = parseDraft();
+    if (def === null) return;
+    setBusy(true);
+    const r = await testAgent(def);
+    setBusy(false);
+    setResult(
+      r.ok
+        ? { ok: true, msg: `Valid — "${(r.body?.name as string) ?? "?"}" · skills: ${(r.body?.skills as string[] | undefined)?.join(", ") || "none"}` }
+        : { ok: false, msg: `${r.status}: ${(r.body?.error as string) ?? "validation failed"}` },
+    );
+  }
+
+  async function onCreate() {
+    const def = parseDraft();
+    if (def === null) return;
+    setBusy(true);
+    const r = await createAgent(def);
+    setBusy(false);
+    if (r.ok) {
+      setResult({ ok: true, msg: `Created "${(r.body?.name as string) ?? ""}" — live in ~5s via hot-reload.` });
+      setTimeout(() => void refresh(), 5500);
+      void refresh();
+    } else {
+      setResult({ ok: false, msg: `${r.status}: ${(r.body?.error as string) ?? "create failed"}` });
+    }
+  }
+
+  async function doDelete(name: string) {
+    setPendingDelete(null);
+    setBusy(true);
+    const r = await deleteAgent(name);
+    setBusy(false);
+    setResult(
+      r.ok
+        ? { ok: true, msg: `Removed "${name}" — unregistered in ~5s.` }
+        : { ok: false, msg: `${r.status}: ${(r.body?.error as string) ?? "delete failed"}` },
+    );
+    setTimeout(() => void refresh(), 5500);
+  }
+
+  const inputStyle = {
+    background: "var(--bg-default)",
+    color: "var(--text-primary)",
+    border: "1px solid var(--border-default)",
+    borderRadius: "6px",
+    padding: "8px 10px",
+    fontSize: "13px",
+    width: "100%",
+    fontFamily: "var(--pl-font-mono)",
+  } as const;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "20px", maxWidth: "880px" }}>
+      <div>
+        <h2 style={{ color: "var(--text-primary)", marginBottom: "4px" }}>Console</h2>
+        <p style={{ color: "var(--text-secondary)", fontSize: "13px" }}>
+          The fleet's control plane. Changes apply live (~5s) — no restart. Admin key required for writes.
+        </p>
+      </div>
+
+      <Card>
+        <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+          <label style={{ color: "var(--text-secondary)", fontSize: "12px", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+            Admin key
+          </label>
+          <input
+            type="password"
+            value={key}
+            placeholder="WORKSTACEAN_API_KEY"
+            onChange={(e) => saveKey(e.currentTarget.value)}
+            style={{ ...inputStyle, fontFamily: "inherit", maxWidth: "360px" }}
+          />
+        </div>
+      </Card>
+
+      <Card>
+        <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+          <strong style={{ color: "var(--text-primary)", fontSize: "14px" }}>New agent</strong>
+          <textarea
+            value={draft}
+            onChange={(e) => setDraft(e.currentTarget.value)}
+            spellCheck={false}
+            rows={11}
+            style={{ ...inputStyle, resize: "vertical" }}
+          />
+          <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+            <Button onClick={onValidate} disabled={busy}>
+              <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}><CircleCheck size={14} /> Validate</span>
+            </Button>
+            <Button variant="primary" onClick={onCreate} disabled={busy}>
+              <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}><Plus size={14} /> Create</span>
+            </Button>
+            {result && (
+              <span style={{ color: result.ok ? "var(--text-success)" : "var(--text-danger)", fontSize: "13px" }}>
+                {result.ok ? "✓ " : "✗ "}{result.msg}
+              </span>
+            )}
+          </div>
+        </div>
+      </Card>
+
+      <div>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "8px" }}>
+          <strong style={{ color: "var(--text-primary)", fontSize: "14px" }}>Fleet ({agents.length})</strong>
+          <Button onClick={() => void refresh()} disabled={busy}>
+            <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}><RefreshCw size={14} /> Refresh</span>
+          </Button>
+        </div>
+        {agents.length === 0 ? (
+          <Empty>No agents registered.</Empty>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+            {agents.map((a) => (
+              <Card key={a.name}>
+                <div style={{ display: "flex", alignItems: "center", gap: "10px", flexWrap: "wrap" }}>
+                  <strong style={{ color: "var(--text-primary)", fontSize: "14px" }}>{a.name}</strong>
+                  <Badge status={typeStatus(a)}>{a.pendingDiscovery ? "discovering" : a.type}</Badge>
+                  <span style={{ flex: 1, display: "flex", gap: "6px", flexWrap: "wrap" }}>
+                    {a.skills.map((s) => (
+                      <Badge key={s} status="neutral">{s}</Badge>
+                    ))}
+                  </span>
+                  {a.type === "deep-agent" && (
+                    <Button onClick={() => setPendingDelete(a.name)} disabled={busy}>
+                      <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}><Trash2 size={14} /> Remove</span>
+                    </Button>
+                  )}
+                </div>
+              </Card>
+            ))}
+          </div>
+        )}
+        <Divider />
+        <p style={{ color: "var(--text-secondary)", fontSize: "12px" }}>
+          In-process (deep-agent) agents are managed here. A2A agents are registered in <code>workspace/agents.yaml</code> (control-plane support coming).
+        </p>
+      </div>
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title={`Remove "${pendingDelete ?? ""}"?`}
+        message="Unregisters the agent from the live fleet (~5s) and deletes its YAML from workspace/agents/."
+        confirmLabel="Remove"
+        onConfirm={() => { if (pendingDelete) void doDelete(pendingDelete); }}
+        onCancel={() => setPendingDelete(null)}
+      />
+    </div>
+  );
+}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -7,9 +7,11 @@
 //  - Stale-while-revalidate: components get cached data instantly, fresh in background
 //  - invalidate() to force refresh
 //
-// Scope: this dashboard is a read-only debug/observability pane (see
-// docs/architecture/flow-dashboard.md). Every endpoint below is a live
-// backend route — no GOAP/world-state getters, no widget framework.
+// Scope: the debug/observability panes are read-only (see
+// docs/architecture/flow-dashboard.md). The ONE exception is the
+// "Control-plane writes" section at the bottom — the Console surface
+// (ADR-0004 P3): admin-key-gated mutations of the fleet. Everything else is a
+// live read-only backend route.
 
 const API_BASE = "";
 const DEFAULT_TTL = 30_000;
@@ -152,3 +154,48 @@ export interface SecuritySummaryResponse {
   criticalCount: number;
   incidents: Array<{ id: string; title: string; severity: string; status: string }>;
 }
+
+// ── Control-plane writes (Console / ADR-0004 P3 — admin-key gated) ──────────
+// The fleet's write surface. Unlike the read getters, these are NOT cached and
+// return the raw { status, body } so the Console can show 201/409/400/401 etc.
+// The admin key is held in localStorage and sent as X-API-Key.
+
+const ADMIN_KEY_LS = "workstacean.adminKey";
+export function getAdminKey(): string {
+  return (typeof localStorage !== "undefined" && localStorage.getItem(ADMIN_KEY_LS)) || "";
+}
+export function setAdminKey(key: string): void {
+  if (typeof localStorage !== "undefined") localStorage.setItem(ADMIN_KEY_LS, key);
+}
+
+export interface WriteResult {
+  status: number;
+  ok: boolean;
+  body: Record<string, unknown> | null;
+}
+
+async function adminFetch(path: string, method: string, body?: unknown): Promise<WriteResult> {
+  const key = getAdminKey();
+  const res = await fetch(`${API_BASE}${path}`, {
+    method,
+    headers: {
+      "content-type": "application/json",
+      ...(key ? { "x-api-key": key } : {}),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  let parsed: Record<string, unknown> | null = null;
+  try { parsed = (await res.json()) as Record<string, unknown>; } catch { /* empty body */ }
+  return { status: res.status, ok: res.ok, body: parsed };
+}
+
+/** Validate an agent definition without persisting it. */
+export const testAgent = (def: unknown) => adminFetch("/api/agents/test", "POST", def);
+/** Create a new in-process agent (→ hot-reload registers it in ~5s). */
+export const createAgent = (def: unknown) => adminFetch("/api/agents", "POST", def);
+/** Update an existing agent by name. */
+export const updateAgent = (name: string, def: unknown) =>
+  adminFetch(`/api/agents/${encodeURIComponent(name)}`, "PUT", def);
+/** Remove an agent by name (→ unregistered in ~5s). */
+export const deleteAgent = (name: string) =>
+  adminFetch(`/api/agents/${encodeURIComponent(name)}`, "DELETE");


### PR DESCRIPTION
**P3 — the Console** (#710): the fleet's **write surface**, a new `/console` route distinct from the read-only debug panes (ADR-0004 D1). Brand-native **and** built in the house UX style I studied from protoAgent's operator console.

## What
- **`Console.tsx`** — admin-key field (localStorage), the live fleet as branded cards (type + skill `Badge`s), a "new agent" JSON editor with **Validate** + **Create**, and per-agent **Remove**. Drives the P2 API (`POST/PUT/DELETE` + `/test`); mutations apply live via hot-reload (~5s).
- **`ConfirmDialog.tsx`** — custom confirm modal for destructive actions (Escape / click-outside cancel), **mirroring protoAgent's `ConfirmDialog`** — not `window.confirm` (the exact thing they replaced). On `--pl-*` tokens; a candidate to contribute upstream into `@protolabsai/ui` (which has no dialog).
- **`api.ts`** — a delineated, admin-key-gated *control-plane writes* section. Debug panes stay read-only; this is the one write exception.

## Brand + house style (per your two directives)
- **Shared brand**: `@protolabsai/design` tokens (#701) + `@protolabsai/ui@^0.3.0` components — the same palette protoAgent vendors locally, but from the shared package so the Console is reusable anywhere.
- **House UX from protoAgent**: feature-surface layout, **custom ConfirmDialog** (not native confirm), **lucide-react** icons. (protoAgent vendors its theme + custom components; we get the same look from the shared packages + match the patterns.)

## Verification
`tsc` + `vite build` clean; dashboard tests **20/0**.

Day 2 (#710): edit-in-place + agent-card capability discovery + A2A-endpoint CRUD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)