### PR TITLE
feat(console): edit-in-place + GET /api/agents/:name (ADR-0004 P3 day 2)

### DIFF
--- a/dashboard/src/components/Console.tsx
+++ b/dashboard/src/components/Console.tsx
@@ -1,12 +1,14 @@
 import { useState, useEffect, useCallback } from "react";
 import { Button, Badge, Card, Empty, Divider, type Status } from "@protolabsai/ui";
-import { RefreshCw, Plus, Trash2, CircleCheck } from "lucide-react";
+import { RefreshCw, Plus, Trash2, CircleCheck, Pencil, X } from "lucide-react";
 import { ConfirmDialog } from "./ConfirmDialog";
 import {
   getAgentsRuntime,
   testAgent,
   createAgent,
+  updateAgent,
   deleteAgent,
+  getAgentDef,
   getAdminKey,
   setAdminKey,
   type AgentsRuntimeResponse,
@@ -42,6 +44,7 @@ export default function Console() {
   const [busy, setBusy] = useState(false);
   const [result, setResult] = useState<{ ok: boolean; msg: string } | null>(null);
   const [pendingDelete, setPendingDelete] = useState<string | null>(null);
+  const [editing, setEditing] = useState<string | null>(null); // agent name being edited; null = create mode
 
   const refresh = useCallback(async () => {
     try {
@@ -81,18 +84,38 @@ export default function Console() {
     );
   }
 
-  async function onCreate() {
+  function resetForm() {
+    setEditing(null);
+    setDraft(TEMPLATE);
+    setResult(null);
+  }
+
+  async function onSubmit() {
     const def = parseDraft();
     if (def === null) return;
     setBusy(true);
-    const r = await createAgent(def);
+    const r = editing ? await updateAgent(editing, def) : await createAgent(def);
     setBusy(false);
     if (r.ok) {
-      setResult({ ok: true, msg: `Created "${(r.body?.name as string) ?? ""}" — live in ~5s via hot-reload.` });
+      const verb = editing ? "Updated" : "Created";
+      const who = editing ?? (r.body?.name as string) ?? "";
+      setResult({ ok: true, msg: `${verb} "${who}" — live in ~5s via hot-reload.` });
+      resetForm();
       setTimeout(() => void refresh(), 5500);
       void refresh();
     } else {
-      setResult({ ok: false, msg: `${r.status}: ${(r.body?.error as string) ?? "create failed"}` });
+      setResult({ ok: false, msg: `${r.status}: ${(r.body?.error as string) ?? "save failed"}` });
+    }
+  }
+
+  async function onEdit(name: string) {
+    const r = await getAgentDef(name);
+    if (r.ok && r.body?.def) {
+      setEditing(name);
+      setDraft(JSON.stringify(r.body.def, null, 2));
+      setResult({ ok: true, msg: `Loaded "${name}" — edit below and Save.` });
+    } else {
+      setResult({ ok: false, msg: `${r.status}: ${(r.body?.error as string) ?? "load failed"}` });
     }
   }
 
@@ -146,7 +169,9 @@ export default function Console() {
 
       <Card>
         <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
-          <strong style={{ color: "var(--text-primary)", fontSize: "14px" }}>New agent</strong>
+          <strong style={{ color: "var(--text-primary)", fontSize: "14px" }}>
+            {editing ? `Editing "${editing}"` : "New agent"}
+          </strong>
           <textarea
             value={draft}
             onChange={(e) => setDraft(e.currentTarget.value)}
@@ -158,9 +183,16 @@ export default function Console() {
             <Button onClick={onValidate} disabled={busy}>
               <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}><CircleCheck size={14} /> Validate</span>
             </Button>
-            <Button variant="primary" onClick={onCreate} disabled={busy}>
-              <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}><Plus size={14} /> Create</span>
+            <Button variant="primary" onClick={onSubmit} disabled={busy}>
+              <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}>
+                {editing ? <CircleCheck size={14} /> : <Plus size={14} />} {editing ? "Save" : "Create"}
+              </span>
             </Button>
+            {editing && (
+              <Button onClick={resetForm} disabled={busy}>
+                <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}><X size={14} /> Cancel</span>
+              </Button>
+            )}
             {result && (
               <span style={{ color: result.ok ? "var(--text-success)" : "var(--text-danger)", fontSize: "13px" }}>
                 {result.ok ? "✓ " : "✗ "}{result.msg}
@@ -192,9 +224,14 @@ export default function Console() {
                     ))}
                   </span>
                   {a.type === "deep-agent" && (
-                    <Button onClick={() => setPendingDelete(a.name)} disabled={busy}>
-                      <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}><Trash2 size={14} /> Remove</span>
-                    </Button>
+                    <>
+                      <Button onClick={() => void onEdit(a.name)} disabled={busy}>
+                        <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}><Pencil size={14} /> Edit</span>
+                      </Button>
+                      <Button onClick={() => setPendingDelete(a.name)} disabled={busy}>
+                        <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}><Trash2 size={14} /> Remove</span>
+                      </Button>
+                    </>
                   )}
                 </div>
               </Card>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -199,3 +199,6 @@ export const updateAgent = (name: string, def: unknown) =>
 /** Remove an agent by name (→ unregistered in ~5s). */
 export const deleteAgent = (name: string) =>
   adminFetch(`/api/agents/${encodeURIComponent(name)}`, "DELETE");
+/** Read one agent's full definition (to pre-fill the edit form). */
+export const getAgentDef = (name: string) =>
+  adminFetch(`/api/agents/${encodeURIComponent(name)}`, "GET");

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -6,7 +6,7 @@ title: HTTP API
 
 ## Summary
 
-- **76** HTTP routes across **33** path groups
+- **77** HTTP routes across **33** path groups
 - **14** routes carry a resolved one-line description
 
 Each row links to the route definition as `path:line` so jumping from this index to the source is a click. Routes are defined as `{ method, path, handler }` literals in `src/api/*.ts` and collected by `src/api/index.ts`.
@@ -45,11 +45,12 @@ Each row links to the route definition as `path:line` so jumping from this index
 | Method | Path | Source | Description |
 |---|---|---|---|
 | `GET` | `/api/agents` | `src/api/operations.ts:250` | — |
-| `POST` | `/api/agents` | `src/api/agents-crud.ts:85` | — |
-| `PUT` | `/api/agents/:name` | `src/api/agents-crud.ts:115` | — |
-| `DELETE` | `/api/agents/:name` | `src/api/agents-crud.ts:133` | — |
+| `POST` | `/api/agents` | `src/api/agents-crud.ts:103` | — |
+| `GET` | `/api/agents/:name` | `src/api/agents-crud.ts:66` | — |
+| `PUT` | `/api/agents/:name` | `src/api/agents-crud.ts:133` | — |
+| `DELETE` | `/api/agents/:name` | `src/api/agents-crud.ts:151` | — |
 | `GET` | `/api/agents/runtime` | `src/api/agents-runtime.ts:67` | — |
-| `POST` | `/api/agents/test` | `src/api/agents-crud.ts:66` | — |
+| `POST` | `/api/agents/test` | `src/api/agents-crud.ts:84` | — |
 
 ### `/api/board`
 

--- a/src/api/__tests__/agents-crud.test.ts
+++ b/src/api/__tests__/agents-crud.test.ts
@@ -125,4 +125,16 @@ describe("agents-crud control-plane API", () => {
     });
     expect(existsSync(outside)).toBe(false); // refused — not inside agents/
   });
+
+  test("GET /api/agents/:name returns the full def; 404 for unknown", async () => {
+    await route("POST", "/api/agents").handler(reqWith(AGENT), {});
+    const res = await route("GET", "/api/agents/:name").handler(reqWith(undefined), { name: "tester" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { def: { name: string; skills: Array<{ name: string }> } };
+    expect(body.def.name).toBe("tester");
+    expect(body.def.skills[0]!.name).toBe("chat");
+
+    const missing = await route("GET", "/api/agents/:name").handler(reqWith(undefined), { name: "ghost" });
+    expect(missing.status).toBe(404);
+  });
 });

--- a/src/api/agents-crud.ts
+++ b/src/api/agents-crud.ts
@@ -16,8 +16,8 @@
  */
 
 import { join, resolve, dirname } from "node:path";
-import { existsSync } from "node:fs";
-import { stringify as stringifyYaml } from "yaml";
+import { existsSync, readFileSync } from "node:fs";
+import { stringify as stringifyYaml, parse as parseYaml } from "yaml";
 import type { Route, ApiContext } from "./types.ts";
 import { parseAgentYaml, loadAgentEntries } from "../agent-runtime/agent-definition-loader.ts";
 import type { AgentDefinition, RawAgentYaml } from "../agent-runtime/types.ts";
@@ -63,6 +63,24 @@ export function createRoutes(ctx: ApiContext): Route[] {
   }
 
   return [
+    {
+      // Read one agent's full definition (for the Console's edit form). The
+      // earlier-registered GET /api/agents/runtime wins for the literal
+      // "runtime", so this only sees real agent names.
+      method: "GET",
+      path: "/api/agents/:name",
+      handler: async (req, p) => {
+        if (!authorized(req)) return unauthorized();
+        const file = fileForAgent(p.name);
+        if (!file) return Response.json({ success: false, error: `Agent "${p.name}" not found` }, { status: 404 });
+        try {
+          const def = parseYaml(readFileSync(file, "utf8"));
+          return Response.json({ success: true, name: p.name, file, def });
+        } catch (err) {
+          return Response.json({ success: false, error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+        }
+      },
+    },
     {
       method: "POST",
       path: "/api/agents/test",


### PR DESCRIPTION
Completes the in-process agent CRUD loop from the Console — **create / read / update / delete, all live, no restart**.

- **`GET /api/agents/:name`** returns the full agent definition (admin-gated). Registered after `GET /api/agents/runtime`, which the first-match router resolves first for the literal `runtime`, so the param route only sees real names.
- **Console edit-in-place** — per-agent **Edit** loads the def (`getAgentDef`) into the editor; the form switches to "Editing <name>" / **Save** (PUT) with a **Cancel**; **Create** stays for new agents. lucide `Pencil`/`X` icons; destructive **Remove** still goes through the custom `ConfirmDialog`.

Tests: GET returns def + 404 unknown. Backend **885/0**, dashboard **20/0**, tsc clean, lint baseline. `http-api.md` regenerated.

Remaining for P3 (#710): **A2A-endpoint CRUD + agent-card capability discovery** (reachability/card test before save) — day 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)