### PR TITLE
feat(console): agent-card capability discovery — probe A2A agents (ADR-0004 P3 day 3)

### DIFF
--- a/dashboard/src/components/Console.tsx
+++ b/dashboard/src/components/Console.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { Button, Badge, Card, Empty, Divider, type Status } from "@protolabsai/ui";
-import { RefreshCw, Plus, Trash2, CircleCheck, Pencil, X } from "lucide-react";
+import { RefreshCw, Plus, Trash2, CircleCheck, Pencil, X, Globe } from "lucide-react";
 import { ConfirmDialog } from "./ConfirmDialog";
 import {
   getAgentsRuntime,
@@ -9,6 +9,7 @@ import {
   updateAgent,
   deleteAgent,
   getAgentDef,
+  probeAgentCard,
   getAdminKey,
   setAdminKey,
   type AgentsRuntimeResponse,
@@ -45,6 +46,8 @@ export default function Console() {
   const [result, setResult] = useState<{ ok: boolean; msg: string } | null>(null);
   const [pendingDelete, setPendingDelete] = useState<string | null>(null);
   const [editing, setEditing] = useState<string | null>(null); // agent name being edited; null = create mode
+  const [probeUrl, setProbeUrl] = useState("");
+  const [probe, setProbe] = useState<{ reachable: boolean; name?: string; skills: string[]; error?: string } | null>(null);
 
   const refresh = useCallback(async () => {
     try {
@@ -117,6 +120,23 @@ export default function Console() {
     } else {
       setResult({ ok: false, msg: `${r.status}: ${(r.body?.error as string) ?? "load failed"}` });
     }
+  }
+
+  async function onProbe() {
+    setBusy(true);
+    setProbe(null);
+    const r = await probeAgentCard(probeUrl.trim());
+    setBusy(false);
+    if (!r.ok) {
+      setProbe({ reachable: false, skills: [], error: `${r.status}: ${(r.body?.error as string) ?? "probe failed"}` });
+      return;
+    }
+    setProbe({
+      reachable: Boolean(r.body?.reachable),
+      name: r.body?.name as string | undefined,
+      skills: (r.body?.skills as string[] | undefined) ?? [],
+      error: r.body?.error as string | undefined,
+    });
   }
 
   async function doDelete(name: string) {
@@ -199,6 +219,41 @@ export default function Console() {
               </span>
             )}
           </div>
+        </div>
+      </Card>
+
+      <Card>
+        <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+          <div>
+            <strong style={{ color: "var(--text-primary)", fontSize: "14px" }}>Discover an A2A agent</strong>
+            <p style={{ color: "var(--text-secondary)", fontSize: "12px", margin: "2px 0 0" }}>
+              Probe a remote agent's card for reachability + skills before wiring it in.
+            </p>
+          </div>
+          <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+            <input
+              value={probeUrl}
+              placeholder="https://agent.example/ (base URL)"
+              onChange={(e) => setProbeUrl(e.currentTarget.value)}
+              style={{ ...inputStyle, fontFamily: "inherit", flex: 1 }}
+            />
+            <Button onClick={onProbe} disabled={busy || !probeUrl.trim()}>
+              <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}><Globe size={14} /> Probe</span>
+            </Button>
+          </div>
+          {probe && (
+            probe.reachable ? (
+              <div style={{ display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
+                <Badge status="success">reachable</Badge>
+                <strong style={{ color: "var(--text-primary)", fontSize: "13px" }}>{probe.name}</strong>
+                {probe.skills.length === 0
+                  ? <span style={{ color: "var(--text-secondary)", fontSize: "12px" }}>no skills advertised</span>
+                  : probe.skills.map((s) => <Badge key={s} status="neutral">{s}</Badge>)}
+              </div>
+            ) : (
+              <span style={{ color: "var(--text-danger)", fontSize: "13px" }}>✗ {probe.error}</span>
+            )
+          )}
         </div>
       </Card>
 

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -202,3 +202,6 @@ export const deleteAgent = (name: string) =>
 /** Read one agent's full definition (to pre-fill the edit form). */
 export const getAgentDef = (name: string) =>
   adminFetch(`/api/agents/${encodeURIComponent(name)}`, "GET");
+/** Probe an A2A agent's card for reachability + skills (capability discovery). */
+export const probeAgentCard = (url: string) =>
+  adminFetch("/api/a2a/probe", "POST", { url });

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -6,7 +6,7 @@ title: HTTP API
 
 ## Summary
 
-- **77** HTTP routes across **33** path groups
+- **78** HTTP routes across **33** path groups
 - **14** routes carry a resolved one-line description
 
 Each row links to the route definition as `path:line` so jumping from this index to the source is a click. Routes are defined as `{ method, path, handler }` literals in `src/api/*.ts` and collected by `src/api/index.ts`.
@@ -32,6 +32,7 @@ Each row links to the route definition as `path:line` so jumping from this index
 | `POST` | `/api/a2a/chat` | `src/api/ava-tools.ts:348` | multi-turn conversation with an agent over the bus. |
 | `POST` | `/api/a2a/delegate` | `src/api/ava-tools.ts:349` | fire-and-forget task dispatch to an agent. |
 | `POST` | `/api/a2a/input` | `src/api/human-input.ts:115` | — |
+| `POST` | `/api/a2a/probe` | `src/api/agents-crud.ts:66` | — |
 | `GET` | `/api/a2a/task/:correlationId` | `src/api/ava-tools.ts:350` | correlationId — fetch the result of a dispatch that a chat caller stopped awaiting (timed out). |
 
 ### `/api/agent`
@@ -45,12 +46,12 @@ Each row links to the route definition as `path:line` so jumping from this index
 | Method | Path | Source | Description |
 |---|---|---|---|
 | `GET` | `/api/agents` | `src/api/operations.ts:250` | — |
-| `POST` | `/api/agents` | `src/api/agents-crud.ts:103` | — |
-| `GET` | `/api/agents/:name` | `src/api/agents-crud.ts:66` | — |
-| `PUT` | `/api/agents/:name` | `src/api/agents-crud.ts:133` | — |
-| `DELETE` | `/api/agents/:name` | `src/api/agents-crud.ts:151` | — |
+| `POST` | `/api/agents` | `src/api/agents-crud.ts:142` | — |
+| `GET` | `/api/agents/:name` | `src/api/agents-crud.ts:105` | — |
+| `PUT` | `/api/agents/:name` | `src/api/agents-crud.ts:172` | — |
+| `DELETE` | `/api/agents/:name` | `src/api/agents-crud.ts:190` | — |
 | `GET` | `/api/agents/runtime` | `src/api/agents-runtime.ts:67` | — |
-| `POST` | `/api/agents/test` | `src/api/agents-crud.ts:84` | — |
+| `POST` | `/api/agents/test` | `src/api/agents-crud.ts:123` | — |
 
 ### `/api/board`
 

--- a/src/api/__tests__/agents-crud.test.ts
+++ b/src/api/__tests__/agents-crud.test.ts
@@ -137,4 +137,14 @@ describe("agents-crud control-plane API", () => {
     const missing = await route("GET", "/api/agents/:name").handler(reqWith(undefined), { name: "ghost" });
     expect(missing.status).toBe(404);
   });
+
+  test("POST /api/a2a/probe — rejects non-URL (400); unreachable host → reachable:false", async () => {
+    const bad = await route("POST", "/api/a2a/probe").handler(reqWith({ url: "not-a-url" }), {});
+    expect(bad.status).toBe(400);
+
+    // 127.0.0.1:1 refuses immediately → the card fetch throws → reachable:false (no hang).
+    const unreach = await route("POST", "/api/a2a/probe").handler(reqWith({ url: "http://127.0.0.1:1" }), {});
+    const body = (await unreach.json()) as { reachable: boolean };
+    expect(body.reachable).toBe(false);
+  });
 });

--- a/src/api/agents-crud.ts
+++ b/src/api/agents-crud.ts
@@ -64,6 +64,45 @@ export function createRoutes(ctx: ApiContext): Route[] {
 
   return [
     {
+      // Capability discovery (ADR-0004 P3): probe an A2A agent's card for
+      // reachability + skills, so the operator picks from real capabilities
+      // instead of a free-text guess. Admin-gated; 5s timeout; tries the
+      // canonical agent-card.json then the legacy agent.json.
+      method: "POST",
+      path: "/api/a2a/probe",
+      handler: async (req) => {
+        if (!authorized(req)) return unauthorized();
+        let body: { url?: string };
+        try { body = (await req.json()) as { url?: string }; } catch { return badJson(); }
+        const raw = (body.url ?? "").trim();
+        if (!/^https?:\/\//.test(raw)) {
+          return Response.json({ success: false, error: "url must be an http(s) URL" }, { status: 400 });
+        }
+        const base = raw.replace(/\/+$/, "");
+        for (const cardUrl of [`${base}/.well-known/agent-card.json`, `${base}/.well-known/agent.json`]) {
+          try {
+            const res = await fetch(cardUrl, { signal: AbortSignal.timeout(5000) });
+            if (!res.ok) continue;
+            const card = (await res.json()) as {
+              name?: string;
+              description?: string;
+              skills?: Array<{ id?: string; name?: string; description?: string }>;
+            };
+            const skills = (card.skills ?? [])
+              .map((s) => s.id ?? s.name ?? "")
+              .filter((s): s is string => Boolean(s));
+            return Response.json({
+              success: true, reachable: true, cardUrl,
+              name: card.name ?? base, description: card.description ?? "", skills,
+            });
+          } catch {
+            // try the next candidate
+          }
+        }
+        return Response.json({ success: true, reachable: false, error: `No agent card at ${base}/.well-known/agent-card.json` });
+      },
+    },
+    {
       // Read one agent's full definition (for the Console's edit form). The
       // earlier-registered GET /api/agents/runtime wins for the literal
       // "runtime", so this only sees real agent names.


### PR DESCRIPTION
Adds **capability discovery** — the operator picks from an agent's real skills instead of a free-text guess (the ORBIS gap ADR-0004 calls out).

- **`POST /api/a2a/probe` { url }** — fetches the agent card (`/.well-known/agent-card.json`, legacy fallback; 5s timeout; admin-gated; http(s)-only) → `{ reachable, name, description, skills }`.
- **Console** — a *Discover an A2A agent* panel: paste a base URL → **Probe** → reachability + name + skills (branded Badges) before wiring it in. lucide `Globe`.

Tests: non-URL → 400; unreachable host → `reachable:false` (fast-fail). Backend **886/0**, dashboard **20/0**, tsc clean, lint baseline. `http-api.md` regenerated.

Remaining for P3 (#710): **A2A-endpoint persistence** — write `workspace/agents.yaml` + extend hot-reload to SkillBroker so added A2A agents apply without a restart (day 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)