### PR TITLE
feat(control-plane): A2A-endpoint persistence + live register/unregister (ADR-0004 P3 day 4a)

### DIFF
--- a/docs/reference/bus-topics.md
+++ b/docs/reference/bus-topics.md
@@ -6,11 +6,11 @@ title: Bus Topics
 
 ## Summary
 
-- **86** distinct topics seen across the codebase
-- **18** declared in `src/event-bus/all-topics.ts` (TOPICS constant)
+- **88** distinct topics seen across the codebase
+- **20** declared in `src/event-bus/all-topics.ts` (TOPICS constant)
 - **68** raw-string / template topics not in TOPICS (candidates to register)
 - **18** topics that couldn't be statically resolved (computed at runtime)
-- **100** publish call sites, **55** subscribe call sites
+- **100** publish call sites, **59** subscribe call sites
 
 Each row links to the original call site as `path:line` so jumping from this index to the source is a click.
 
@@ -75,9 +75,13 @@ Each row links to the original call site as `path:line` so jumping from this ind
 
 | Topic | Declared | Payload | Publishers | Subscribers |
 |---|---|---|---|---|
-| `command.agent.remove` | ✅ `COMMAND_AGENT_REMOVE` (`ACTION_TOPICS`) | — | _(none)_ | `src/plugins/control-plane-registrar-plugin.ts:50` |
-| `command.agent.upsert` | ✅ `COMMAND_AGENT_UPSERT` (`ACTION_TOPICS`) | — | _(none)_ | `src/plugins/control-plane-registrar-plugin.ts:49` |
+| `command.a2a.remove` | ✅ `COMMAND_A2A_REMOVE` (`ACTION_TOPICS`) | — | _(none)_ | `src/plugins/skill-broker-plugin.ts:140`<br>`src/plugins/control-plane-registrar-plugin.ts:44` |
+| `command.a2a.upsert` | ✅ `COMMAND_A2A_UPSERT` (`ACTION_TOPICS`) | — | _(none)_ | `src/plugins/skill-broker-plugin.ts:136`<br>`src/plugins/control-plane-registrar-plugin.ts:43` |
+| `command.agent.remove` | ✅ `COMMAND_AGENT_REMOVE` (`ACTION_TOPICS`) | — | _(none)_ | `src/plugins/control-plane-registrar-plugin.ts:42` |
+| `command.agent.upsert` | ✅ `COMMAND_AGENT_UPSERT` (`ACTION_TOPICS`) | — | _(none)_ | `src/plugins/control-plane-registrar-plugin.ts:41` |
 | `command.schedule` | — | — | _(none)_ | `lib/plugins/scheduler.ts:73` |
+
+**`command.a2a.upsert`** — A2A-endpoint mutations (ADR-0004 P3). The registrar persists the entry to workspace/agents.d/<name>.yaml; SkillBroker registers/unregisters the A2AExecutor live in the same turn (no restart). command.a2a.upsert — { name, file, yaml, entry } command.a2a.remove — { name, file }
 
 **`command.agent.upsert`** — Control-plane mutations (ADR-0004 P2). The write API publishes these; the ControlPlaneRegistrar is the sole subscriber + the only writer of the workspace config files. Auditable in bus-history. The file write triggers the agent-runtime hot-reload (P1), so the change goes live within ~5s. command.agent.upsert  — { name, file, yaml }  → atomic write command.agent.remove  — { name, file }        → delete
 
@@ -178,7 +182,7 @@ Each row links to the original call site as `path:line` so jumping from this ind
 | `message.outbound.discord.alert` | ✅ `MESSAGE_OUTBOUND_DISCORD_ALERT` (`MESSAGE_TOPICS`) | — | `src/plugins/quinn-review-notifier-plugin.ts:113`<br>`src/plugins/alert-skill-executor-plugin.ts:135`<br>`lib/plugins/pr-remediator.ts:1241`<br>`lib/plugins/pr-remediator.ts:1638` | _(none)_ |
 | `message.outbound.discord.dm.user.#` | — | — | _(none)_ | `lib/plugins/discord/outbound.ts:129` |
 | `message.outbound.discord.push.{AGENT_OPS_CHANNEL}` | — | — | `src/api/ava-tools.ts:117`<br>`src/api/ava-tools.ts:181` | _(none)_ |
-| `message.outbound.discord.push.{opsChannel}` | — | — | `src/plugins/skill-broker-plugin.ts:137` | _(none)_ |
+| `message.outbound.discord.push.{opsChannel}` | — | — | `src/plugins/skill-broker-plugin.ts:178` | _(none)_ |
 | `message.outbound.github.#` | — | — | _(none)_ | `lib/plugins/github.ts:318` |
 | `message.outbound.google.docs` | — | — | _(none)_ | `lib/plugins/google/docs.ts:60` |
 | `message.outbound.google.drive` | — | — | _(none)_ | `lib/plugins/google/drive.ts:61` |

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -6,8 +6,8 @@ title: HTTP API
 
 ## Summary
 
-- **78** HTTP routes across **33** path groups
-- **14** routes carry a resolved one-line description
+- **81** HTTP routes across **34** path groups
+- **15** routes carry a resolved one-line description
 
 Each row links to the route definition as `path:line` so jumping from this index to the source is a click. Routes are defined as `{ method, path, handler }` literals in `src/api/*.ts` and collected by `src/api/index.ts`.
 
@@ -32,8 +32,16 @@ Each row links to the route definition as `path:line` so jumping from this index
 | `POST` | `/api/a2a/chat` | `src/api/ava-tools.ts:348` | multi-turn conversation with an agent over the bus. |
 | `POST` | `/api/a2a/delegate` | `src/api/ava-tools.ts:349` | fire-and-forget task dispatch to an agent. |
 | `POST` | `/api/a2a/input` | `src/api/human-input.ts:115` | — |
-| `POST` | `/api/a2a/probe` | `src/api/agents-crud.ts:66` | — |
+| `POST` | `/api/a2a/probe` | `src/api/agents-crud.ts:105` | — |
 | `GET` | `/api/a2a/task/:correlationId` | `src/api/ava-tools.ts:350` | correlationId — fetch the result of a dispatch that a chat caller stopped awaiting (timed out). |
+
+### `/api/a2a-endpoints`
+
+| Method | Path | Source | Description |
+|---|---|---|---|
+| `POST` | `/api/a2a-endpoints` | `src/api/agents-crud.ts:245` | A2A endpoints — control-plane-managed remote agents (agents.d/) |
+| `PUT` | `/api/a2a-endpoints/:name` | `src/api/agents-crud.ts:266` | — |
+| `DELETE` | `/api/a2a-endpoints/:name` | `src/api/agents-crud.ts:286` | — |
 
 ### `/api/agent`
 
@@ -46,12 +54,12 @@ Each row links to the route definition as `path:line` so jumping from this index
 | Method | Path | Source | Description |
 |---|---|---|---|
 | `GET` | `/api/agents` | `src/api/operations.ts:250` | — |
-| `POST` | `/api/agents` | `src/api/agents-crud.ts:142` | — |
-| `GET` | `/api/agents/:name` | `src/api/agents-crud.ts:105` | — |
-| `PUT` | `/api/agents/:name` | `src/api/agents-crud.ts:172` | — |
-| `DELETE` | `/api/agents/:name` | `src/api/agents-crud.ts:190` | — |
+| `POST` | `/api/agents` | `src/api/agents-crud.ts:181` | — |
+| `GET` | `/api/agents/:name` | `src/api/agents-crud.ts:144` | — |
+| `PUT` | `/api/agents/:name` | `src/api/agents-crud.ts:211` | — |
+| `DELETE` | `/api/agents/:name` | `src/api/agents-crud.ts:229` | — |
 | `GET` | `/api/agents/runtime` | `src/api/agents-runtime.ts:67` | — |
-| `POST` | `/api/agents/test` | `src/api/agents-crud.ts:123` | — |
+| `POST` | `/api/agents/test` | `src/api/agents-crud.ts:162` | — |
 
 ### `/api/board`
 

--- a/src/api/__tests__/agents-crud.test.ts
+++ b/src/api/__tests__/agents-crud.test.ts
@@ -147,4 +147,24 @@ describe("agents-crud control-plane API", () => {
     const body = (await unreach.json()) as { reachable: boolean };
     expect(body.reachable).toBe(false);
   });
+
+  test("A2A endpoints: create → agents.d/ file (409 dup, 400 bad-url), delete removes", async () => {
+    const A2A = { name: "frank", url: "http://frank:7880/a2a", streaming: true };
+    const created = await route("POST", "/api/a2a-endpoints").handler(reqWith(A2A), {});
+    expect(created.status).toBe(201);
+    expect(existsSync(join(root, "agents.d", "frank.yaml"))).toBe(true);
+
+    const dup = await route("POST", "/api/a2a-endpoints").handler(reqWith(A2A), {});
+    expect(dup.status).toBe(409);
+
+    const bad = await route("POST", "/api/a2a-endpoints").handler(reqWith({ name: "x", url: "ftp://nope" }), {});
+    expect(bad.status).toBe(400);
+
+    const del = await route("DELETE", "/api/a2a-endpoints/:name").handler(reqWith(undefined), { name: "frank" });
+    expect(del.status).toBe(200);
+    expect(existsSync(join(root, "agents.d", "frank.yaml"))).toBe(false);
+
+    const missing = await route("DELETE", "/api/a2a-endpoints/:name").handler(reqWith(undefined), { name: "frank" });
+    expect(missing.status).toBe(404);
+  });
 });

--- a/src/api/agents-crud.ts
+++ b/src/api/agents-crud.ts
@@ -16,7 +16,7 @@
  */
 
 import { join, resolve, dirname } from "node:path";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { stringify as stringifyYaml, parse as parseYaml } from "yaml";
 import type { Route, ApiContext } from "./types.ts";
 import { parseAgentYaml, loadAgentEntries } from "../agent-runtime/agent-definition-loader.ts";
@@ -60,6 +60,45 @@ export function createRoutes(ctx: ApiContext): Route[] {
       payload: { name, ...payload },
       source: { interface: "api" },
     });
+  }
+
+  // ── A2A endpoints (control-plane-managed, per-file in workspace/agents.d/) ──
+  const agentsdDir = join(ctx.workspaceDir, "agents.d");
+  /** The managed file for an A2A agent (control-plane writes here; agents.yaml stays hand-maintained). */
+  const a2aManagedFile = (name: string) => join(agentsdDir, `${safeFileName(name)}.yaml`);
+  /** All A2A agent names known today — agents.yaml (hand-maintained) + agents.d/ (managed). */
+  function listA2aNames(): string[] {
+    const names: string[] = [];
+    const yamlPath = join(ctx.workspaceDir, "agents.yaml");
+    if (existsSync(yamlPath)) {
+      try {
+        const p = parseYaml(readFileSync(yamlPath, "utf8")) as { agents?: Array<{ name?: string }> };
+        for (const a of p?.agents ?? []) if (a?.name) names.push(a.name);
+      } catch { /* tolerate a malformed agents.yaml */ }
+    }
+    if (existsSync(agentsdDir)) {
+      try {
+        for (const f of readdirSync(agentsdDir)) {
+          if (!/\.ya?ml$/.test(f) || f.endsWith(".example")) continue;
+          try {
+            const d = parseYaml(readFileSync(join(agentsdDir, f), "utf8")) as { name?: string };
+            if (d?.name) names.push(d.name);
+          } catch { /* skip */ }
+        }
+      } catch { /* dir gone */ }
+    }
+    return names;
+  }
+  /** Validate an A2A entry — name + http(s) url are the essentials SkillBroker needs. */
+  function validateA2a(body: unknown): { entry: Record<string, unknown> } | { error: Response } {
+    const e = (body ?? {}) as Record<string, unknown>;
+    if (!e.name || typeof e.name !== "string") {
+      return { error: Response.json({ success: false, error: "name (string) is required" }, { status: 400 }) };
+    }
+    if (!e.url || typeof e.url !== "string" || !/^https?:\/\//.test(e.url)) {
+      return { error: Response.json({ success: false, error: "url (http/https) is required" }, { status: 400 }) };
+    }
+    return { entry: e };
   }
 
   return [
@@ -199,6 +238,65 @@ export function createRoutes(ctx: ApiContext): Route[] {
           return Response.json({ success: false, error: "delete did not complete (see logs)" }, { status: 500 });
         }
         return Response.json({ success: true, name: p.name, note: "unregistered within ~5s" });
+      },
+    },
+
+    // ── A2A endpoints — control-plane-managed remote agents (agents.d/) ──
+    {
+      method: "POST",
+      path: "/api/a2a-endpoints",
+      handler: async (req) => {
+        if (!authorized(req)) return unauthorized();
+        let body: unknown;
+        try { body = await req.json(); } catch { return badJson(); }
+        const v = validateA2a(body);
+        if ("error" in v) return v.error;
+        const name = v.entry.name as string;
+        if (listA2aNames().includes(name)) {
+          return Response.json({ success: false, error: `A2A agent "${name}" already exists` }, { status: 409 });
+        }
+        const file = a2aManagedFile(name);
+        command("command.a2a.upsert", name, { file, yaml: stringifyYaml(v.entry), entry: v.entry });
+        if (!existsSync(file)) {
+          return Response.json({ success: false, error: "write did not complete (see logs)" }, { status: 500 });
+        }
+        return Response.json({ success: true, name, file, note: "registered live (SkillBroker)" }, { status: 201 });
+      },
+    },
+    {
+      method: "PUT",
+      path: "/api/a2a-endpoints/:name",
+      handler: async (req, p) => {
+        if (!authorized(req)) return unauthorized();
+        let body: unknown;
+        try { body = await req.json(); } catch { return badJson(); }
+        const v = validateA2a(body);
+        if ("error" in v) return v.error;
+        if (v.entry.name !== p.name) {
+          return Response.json({ success: false, error: `body name "${v.entry.name as string}" must match path "${p.name}"` }, { status: 400 });
+        }
+        const file = a2aManagedFile(p.name);
+        if (!existsSync(file)) {
+          return Response.json({ success: false, error: `A2A agent "${p.name}" not found (control-plane managed only — hand-maintained agents.yaml entries are edited there)` }, { status: 404 });
+        }
+        command("command.a2a.upsert", p.name, { file, yaml: stringifyYaml(v.entry), entry: v.entry });
+        return Response.json({ success: true, name: p.name, file, note: "updated live" });
+      },
+    },
+    {
+      method: "DELETE",
+      path: "/api/a2a-endpoints/:name",
+      handler: async (req, p) => {
+        if (!authorized(req)) return unauthorized();
+        const file = a2aManagedFile(p.name);
+        if (!existsSync(file)) {
+          return Response.json({ success: false, error: `A2A agent "${p.name}" not found (control-plane managed only)` }, { status: 404 });
+        }
+        command("command.a2a.remove", p.name, { file });
+        if (existsSync(file)) {
+          return Response.json({ success: false, error: "delete did not complete (see logs)" }, { status: 500 });
+        }
+        return Response.json({ success: true, name: p.name, note: "unregistered live" });
       },
     },
   ];

--- a/src/event-bus/all-topics.ts
+++ b/src/event-bus/all-topics.ts
@@ -77,6 +77,15 @@ export const ACTION_TOPICS = {
    */
   COMMAND_AGENT_UPSERT: "command.agent.upsert",
   COMMAND_AGENT_REMOVE: "command.agent.remove",
+  /**
+   * A2A-endpoint mutations (ADR-0004 P3). The registrar persists the entry to
+   * workspace/agents.d/<name>.yaml; SkillBroker registers/unregisters the
+   * A2AExecutor live in the same turn (no restart).
+   *   command.a2a.upsert — { name, file, yaml, entry }
+   *   command.a2a.remove — { name, file }
+   */
+  COMMAND_A2A_UPSERT: "command.a2a.upsert",
+  COMMAND_A2A_REMOVE: "command.a2a.remove",
 
   /** Wildcard subscription pattern — matches all cron events from SchedulerPlugin. */
   CRON_ALL: "cron.#",

--- a/src/plugins/__tests__/skill-broker-a2a.test.ts
+++ b/src/plugins/__tests__/skill-broker-a2a.test.ts
@@ -1,0 +1,47 @@
+/**
+ * SkillBroker control-plane reconcile (ADR-0004 P3 day-4): command.a2a.upsert
+ * registers an A2A agent's executor + skills live; command.a2a.remove
+ * unregisters them — no restart. (Card discovery + health probes fire async to
+ * the entry's URL; with an unreachable URL they no-op, leaving the yaml skills.)
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { ExecutorRegistry } from "../../executor/executor-registry.ts";
+import { SkillBrokerPlugin } from "../skill-broker-plugin.ts";
+import type { BusMessage } from "../../../lib/types.ts";
+
+function cmd(topic: string, payload: Record<string, unknown>): BusMessage {
+  return { id: "t", correlationId: "c", topic, timestamp: 0, payload };
+}
+
+describe("SkillBroker A2A control-plane reconcile", () => {
+  let root: string;
+  let plugin: SkillBrokerPlugin;
+  afterEach(() => {
+    plugin?.uninstall();
+    if (root) rmSync(root, { recursive: true, force: true });
+  });
+
+  test("command.a2a.upsert registers skills; command.a2a.remove unregisters", () => {
+    root = mkdtempSync(join(tmpdir(), "sb-")); // empty workspace — no agents.yaml, no agents.d/
+    const bus = new InMemoryEventBus();
+    const registry = new ExecutorRegistry();
+    plugin = new SkillBrokerPlugin(root, registry);
+    plugin.install(bus);
+    expect(registry.list().length).toBe(0);
+
+    bus.publish("command.a2a.upsert", cmd("command.a2a.upsert", {
+      name: "frank",
+      // URL is unreachable on purpose — card discovery no-ops; yaml skills register synchronously.
+      entry: { name: "frank", url: "http://127.0.0.1:1/a2a", skills: [{ name: "deploy", description: "ship it" }] },
+    }));
+    expect(registry.list().some((r) => r.agentName === "frank" && r.skill === "deploy")).toBe(true);
+
+    bus.publish("command.a2a.remove", cmd("command.a2a.remove", { name: "frank" }));
+    expect(registry.list().some((r) => r.agentName === "frank")).toBe(false);
+  });
+});

--- a/src/plugins/control-plane-registrar-plugin.ts
+++ b/src/plugins/control-plane-registrar-plugin.ts
@@ -21,33 +21,27 @@ import { writeFileSync, renameSync, unlinkSync, existsSync, mkdirSync } from "no
 import { resolve, dirname } from "node:path";
 import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
 
-interface AgentUpsertPayload {
-  name?: string;
-  file?: string;
-  yaml?: string;
-}
-interface AgentRemovePayload {
-  name?: string;
-  file?: string;
-}
-
 export class ControlPlaneRegistrarPlugin implements Plugin {
   name = "control-plane-registrar";
   description = "Sole writer of workspace config files for control-plane command.* mutations";
   capabilities = ["control-plane", "config-writer"];
 
-  /** Writes are confined to this root — a path-traversal guard. */
-  private readonly agentsRoot: string;
+  /** Writes are confined to these roots — a path-traversal guard. */
+  private readonly agentsRoot: string;   // workspace/agents/   — in-process DeepAgents (P2)
+  private readonly agentsdRoot: string;  // workspace/agents.d/ — A2A endpoints (P3)
   private subscriptionIds: string[] = [];
 
   constructor(workspaceDir: string) {
     this.agentsRoot = resolve(workspaceDir, "agents");
+    this.agentsdRoot = resolve(workspaceDir, "agents.d");
   }
 
   install(bus: EventBus): void {
     this.subscriptionIds.push(
-      bus.subscribe("command.agent.upsert", this.name, (msg) => this._onUpsert(msg)),
-      bus.subscribe("command.agent.remove", this.name, (msg) => this._onRemove(msg)),
+      bus.subscribe("command.agent.upsert", this.name, (msg) => this._write(this.agentsRoot, msg)),
+      bus.subscribe("command.agent.remove", this.name, (msg) => this._delete(this.agentsRoot, msg)),
+      bus.subscribe("command.a2a.upsert", this.name, (msg) => this._write(this.agentsdRoot, msg)),
+      bus.subscribe("command.a2a.remove", this.name, (msg) => this._delete(this.agentsdRoot, msg)),
     );
   }
 
@@ -55,40 +49,40 @@ export class ControlPlaneRegistrarPlugin implements Plugin {
     this.subscriptionIds = [];
   }
 
-  /** Guard: the target must resolve to a file directly inside the agents root. */
-  private _safe(file: string | undefined): string | null {
+  /** Guard: the target must resolve to a file directly inside `root`. */
+  private _safe(file: string | undefined, root: string): string | null {
     if (!file) return null;
     const resolved = resolve(file);
-    if (dirname(resolved) !== this.agentsRoot) {
-      console.warn(`[control-plane] refusing write outside ${this.agentsRoot}: ${file}`);
+    if (dirname(resolved) !== root) {
+      console.warn(`[control-plane] refusing write outside ${root}: ${file}`);
       return null;
     }
     return resolved;
   }
 
-  private _onUpsert(msg: BusMessage): void {
-    const p = (msg.payload ?? {}) as AgentUpsertPayload;
-    const file = this._safe(p.file);
+  private _write(root: string, msg: BusMessage): void {
+    const p = (msg.payload ?? {}) as { name?: string; file?: string; yaml?: string };
+    const file = this._safe(p.file, root);
     if (!file || typeof p.yaml !== "string") return;
     try {
-      if (!existsSync(this.agentsRoot)) mkdirSync(this.agentsRoot, { recursive: true });
+      if (!existsSync(root)) mkdirSync(root, { recursive: true });
       // Atomic: write a temp sibling then rename over the target.
       const tmp = `${file}.tmp-${msg.id}`;
       writeFileSync(tmp, p.yaml, "utf8");
       renameSync(tmp, file);
-      console.log(`[control-plane] wrote agent "${p.name}" → ${file}`);
+      console.log(`[control-plane] wrote "${p.name}" → ${file}`);
     } catch (err) {
-      console.error(`[control-plane] upsert "${p.name}" failed: ${err instanceof Error ? err.message : String(err)}`);
+      console.error(`[control-plane] write "${p.name}" failed: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 
-  private _onRemove(msg: BusMessage): void {
-    const p = (msg.payload ?? {}) as AgentRemovePayload;
-    const file = this._safe(p.file);
+  private _delete(root: string, msg: BusMessage): void {
+    const p = (msg.payload ?? {}) as { name?: string; file?: string };
+    const file = this._safe(p.file, root);
     if (!file) return;
     try {
       if (existsSync(file)) unlinkSync(file);
-      console.log(`[control-plane] removed agent "${p.name}" → ${file}`);
+      console.log(`[control-plane] removed "${p.name}" → ${file}`);
     } catch (err) {
       console.error(`[control-plane] remove "${p.name}" failed: ${err instanceof Error ? err.message : String(err)}`);
     }

--- a/src/plugins/skill-broker-plugin.ts
+++ b/src/plugins/skill-broker-plugin.ts
@@ -17,12 +17,12 @@
  * Config: workspace/agents.yaml (A2A URLs and optional skill overrides)
  */
 
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { ClientFactory, JsonRpcTransportFactory } from "@a2a-js/sdk/client";
 import type { AgentCard } from "@a2a-js/sdk";
-import type { Plugin, EventBus } from "../../lib/types.ts";
+import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
 import type { ExecutorRegistry } from "../executor/executor-registry.ts";
 import { A2AExecutor } from "../executor/executors/a2a-executor.ts";
 import { resolveEnvVars } from "../utils/env-interpolation.ts";
@@ -103,6 +103,11 @@ export class SkillBrokerPlugin implements Plugin {
   private registeredSkills = new Map<string, Set<string>>();
   /** Per-agent liveness probe cache, refreshed every HEARTBEAT_INTERVAL_MS. */
   private fleetHealth = new Map<string, AgentHealthProbe>();
+  /** Live A2A agent set (def + executor) — the source for timers + control-plane reconcile. */
+  private readonly agentDefs = new Map<string, AgentDef>();
+  private readonly executors = new Map<string, A2AExecutor>();
+  private bus?: EventBus;
+  private opsChannel = "";
 
   constructor(workspaceDir: string, executorRegistry: ExecutorRegistry) {
     this.workspaceDir = workspaceDir;
@@ -119,78 +124,92 @@ export class SkillBrokerPlugin implements Plugin {
   }
 
   install(bus: EventBus): void {
-    const agents = this._loadAgents();
-    const opsChannel = process.env.DISCORD_AGENT_OPS_CHANNEL ?? "";
+    this.bus = bus;
+    this.opsChannel = process.env.DISCORD_AGENT_OPS_CHANNEL ?? "";
 
-    for (const agent of agents) {
-      const resolvedUrl = resolveEnvVars(agent.url, "skill-broker");
-      const executor = new A2AExecutor({
-        name: agent.name,
-        url: resolvedUrl,
-        apiKeyEnv: agent.apiKeyEnv,
-        auth: agent.auth,
-        extraHeaders: agent.headers,
-        streaming: agent.streaming ?? false,
-        external: agent.external ?? false,
-        onStreamUpdate: opsChannel
-          ? (update) => {
-              bus.publish(`message.outbound.discord.push.${opsChannel}`, {
-                id: crypto.randomUUID(),
-                correlationId: crypto.randomUUID(),
-                topic: `message.outbound.discord.push.${opsChannel}`,
-                timestamp: Date.now(),
-                payload: {
-                  content: `**${agent.name}** [${update.state ?? update.type}] ${(update.text ?? "").slice(0, 300)}`,
-                },
-              });
-            }
-          : undefined,
-      });
+    for (const agent of this._loadAgents()) this._registerAgent(agent);
+    console.log(`[skill-broker] Registered ${this.agentDefs.size} A2A agent(s) (skills from yaml + agents.d/; discovery in progress)`);
 
-      // Register yaml-declared skills synchronously (explicit overrides)
-      const explicitSkills = new Set<string>();
-      for (const s of agent.skills ?? []) {
-        const skillName = typeof s === "string" ? s : s.name;
-        this.executorRegistry.register(skillName, executor, {
-          agentName: agent.name,
-          priority: 5,
-        });
-        explicitSkills.add(skillName);
-      }
-      this.registeredSkills.set(agent.name, explicitSkills);
+    // Control-plane (ADR-0004 P3): live add/remove of A2A agents. The registrar
+    // persists the entry to workspace/agents.d/; we register/unregister the
+    // executor in the same bus turn, so the change is live without a restart.
+    bus.subscribe("command.a2a.upsert", this.name, (msg: BusMessage) => {
+      const entry = (msg.payload as { entry?: AgentDef })?.entry;
+      if (entry?.name && entry.url) this._registerAgent(entry);
+    });
+    bus.subscribe("command.a2a.remove", this.name, (msg: BusMessage) => {
+      const name = (msg.payload as { name?: string })?.name;
+      if (name) this._unregisterAgent(name);
+    });
 
-      // Kick off async card discovery for any skills not in yaml
-      void this._discoverSkills(agent, executor, resolvedUrl);
-    }
-
-    console.log(`[skill-broker] Registered ${agents.length} A2A agent(s) (skills from yaml; discovery in progress)`);
-
-    // Periodic refresh — picks up new skills without a restart
+    // Periodic skill rediscovery + liveness heartbeat — over the LIVE set, so
+    // control-plane-added agents are refreshed/probed too.
     this.refreshTimer = setInterval(() => {
-      for (const agent of agents) {
-        const executor = this.executorRegistry.list().find(r => r.agentName === agent.name)?.executor;
-        if (executor && executor.type === "a2a") {
-          void this._discoverSkills(agent, executor as A2AExecutor, resolveEnvVars(agent.url, "skill-broker"));
-        }
+      for (const [name, agent] of this.agentDefs) {
+        const executor = this.executors.get(name);
+        if (executor) void this._discoverSkills(agent, executor, resolveEnvVars(agent.url, "skill-broker"));
       }
     }, CARD_REFRESH_INTERVAL_MS);
     this.refreshTimer.unref?.();
 
-    // Fleet liveness heartbeat — probes each agent's card on a faster
-    // cadence than the 10-min skill-discovery refresh. Exposed via
-    // getFleetHealth() so /api/agent-health can report reachability +
-    // latency for on-demand agents alongside the persistent DeepAgents.
     this.heartbeatTimer = setInterval(() => {
-      for (const agent of agents) {
-        void this._probeAgentHealth(agent, resolveEnvVars(agent.url, "skill-broker"));
-      }
+      for (const agent of this.agentDefs.values()) void this._probeAgentHealth(agent, resolveEnvVars(agent.url, "skill-broker"));
     }, HEARTBEAT_INTERVAL_MS);
     this.heartbeatTimer.unref?.();
-    // Kick off an initial probe immediately so the first /api/agent-health
-    // request doesn't return an empty snapshot.
-    for (const agent of agents) {
-      void this._probeAgentHealth(agent, resolveEnvVars(agent.url, "skill-broker"));
+    for (const agent of this.agentDefs.values()) void this._probeAgentHealth(agent, resolveEnvVars(agent.url, "skill-broker"));
+  }
+
+  /** Create + register an A2A agent's executor. Idempotent — re-registers cleanly if the name already exists. */
+  private _registerAgent(agent: AgentDef): void {
+    if (this.agentDefs.has(agent.name)) this._unregisterAgent(agent.name);
+    const bus = this.bus;
+    const opsChannel = this.opsChannel;
+    const resolvedUrl = resolveEnvVars(agent.url, "skill-broker");
+    const executor = new A2AExecutor({
+      name: agent.name,
+      url: resolvedUrl,
+      apiKeyEnv: agent.apiKeyEnv,
+      auth: agent.auth,
+      extraHeaders: agent.headers,
+      streaming: agent.streaming ?? false,
+      external: agent.external ?? false,
+      onStreamUpdate: opsChannel && bus
+        ? (update) => {
+            bus.publish(`message.outbound.discord.push.${opsChannel}`, {
+              id: crypto.randomUUID(),
+              correlationId: crypto.randomUUID(),
+              topic: `message.outbound.discord.push.${opsChannel}`,
+              timestamp: Date.now(),
+              payload: { content: `**${agent.name}** [${update.state ?? update.type}] ${(update.text ?? "").slice(0, 300)}` },
+            });
+          }
+        : undefined,
+    });
+
+    const explicitSkills = new Set<string>();
+    for (const s of agent.skills ?? []) {
+      const skillName = typeof s === "string" ? s : s.name;
+      this.executorRegistry.register(skillName, executor, { agentName: agent.name, priority: 5 });
+      explicitSkills.add(skillName);
     }
+    this.registeredSkills.set(agent.name, explicitSkills);
+    this.agentDefs.set(agent.name, agent);
+    this.executors.set(agent.name, executor);
+    void this._discoverSkills(agent, executor, resolvedUrl);
+    void this._probeAgentHealth(agent, resolvedUrl);
+  }
+
+  /** Unregister an A2A agent and every skill it owns. */
+  private _unregisterAgent(name: string): void {
+    // Sweep ALL registrations for this agent (yaml + discovered), not just the tracked set.
+    for (const reg of this.executorRegistry.list()) {
+      if (reg.agentName === name && reg.skill) this.executorRegistry.unregister(reg.skill, name);
+    }
+    this.registeredSkills.delete(name);
+    this.agentDefs.delete(name);
+    this.executors.delete(name);
+    this.fleetHealth.delete(name);
+    console.log(`[skill-broker] - A2A agent "${name}" unregistered`);
   }
 
   uninstall(): void {
@@ -430,7 +449,7 @@ export class SkillBrokerPlugin implements Plugin {
    * If both are present, the env var wins. If neither resolves to a valid
    * list, the broker registers zero external agents and logs a warning.
    */
-  private _loadAgents(): AgentDef[] {
+  private _loadBaseAgents(): AgentDef[] {
     // Try the env-var path first — deployments use this to avoid file state
     const envOverride = process.env.PROTOLABS_AGENTS_JSON;
     if (envOverride && envOverride.trim()) {
@@ -460,5 +479,37 @@ export class SkillBrokerPlugin implements Plugin {
       console.error("[skill-broker] Failed to load agents.yaml:", err);
       return [];
     }
+  }
+
+  /**
+   * Control-plane-managed A2A entries (ADR-0004 P3): one AgentDef per file in
+   * workspace/agents.d/. Kept separate from the hand-maintained, comment-rich
+   * agents.yaml so writes never clobber its docs.
+   */
+  private _loadAgentsDir(): AgentDef[] {
+    const dir = join(this.workspaceDir, "agents.d");
+    if (!existsSync(dir)) return [];
+    const out: AgentDef[] = [];
+    try {
+      for (const f of readdirSync(dir)) {
+        if (!(f.endsWith(".yaml") || f.endsWith(".yml")) || f.endsWith(".example")) continue;
+        try {
+          const def = parseYaml(readFileSync(join(dir, f), "utf8")) as AgentDef;
+          if (def?.name && def.url) out.push(def);
+          else console.warn(`[skill-broker] agents.d/${f}: missing name/url — skipped`);
+        } catch (err) {
+          console.error(`[skill-broker] Skipping agents.d/${f}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+    } catch { /* dir vanished mid-scan */ }
+    return out;
+  }
+
+  /** agents.yaml (or PROTOLABS_AGENTS_JSON) merged with control-plane agents.d/, deduped by name (managed wins). */
+  private _loadAgents(): AgentDef[] {
+    const byName = new Map<string, AgentDef>();
+    for (const a of this._loadBaseAgents()) byName.set(a.name, a);
+    for (const a of this._loadAgentsDir()) byName.set(a.name, a);
+    return [...byName.values()];
   }
 }


### PR DESCRIPTION
Add/remove **remote A2A agents** from the control plane, applied **live — no restart** (P3 #710).

## What
- **`workspace/agents.d/`** — control-plane-managed A2A entries, one file per agent, separate from the comment-rich hand-maintained `agents.yaml` so writes never clobber its docs. `SkillBroker._loadAgents` merges both (deduped, managed wins).
- **`command.a2a.upsert/remove`** — the registrar (generalized to guard either root) persists per-file to `agents.d/`; **SkillBroker subscribes the same commands** and registers/unregisters the `A2AExecutor` in the same bus turn → live. SkillBroker refactored to track the live agent set so timers + reconcile use it (not a boot snapshot).
- **`POST/PUT/DELETE /api/a2a-endpoints`** — admin-gated; name + http(s) url; 409 dup / 404 non-managed; pairs with the day-3 `/api/a2a/probe` for test-before-save.

Deferred (noted): an A2A agent with a `discordBotTokenEnvKey` still needs a restart for its Discord bot client (pool not reconciled here).

## Verification
Tests: A2A create/dup/bad/delete (API+registrar) + SkillBroker register-on-upsert / unregister-on-remove. Backend **888/0**, tsc clean, lint baseline, docs regenerated.

Next (day-4b): Console A2A add/remove form using the probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added A2A endpoint management API with create, update, and delete operations.
  * Enabled dynamic control-plane updates for A2A agents without requiring system restart.
  * Implemented validation for A2A endpoints (name and HTTPS URL requirements).

* **Documentation**
  * Updated HTTP API reference with new A2A endpoint routes.
  * Updated bus topic reference to reflect new control-plane mutation topics.

* **Tests**
  * Added end-to-end tests for A2A endpoint CRUD operations.
  * Added plugin-level tests for A2A command reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->