### PR TITLE
feat(observability): durable fleet health — persist outcomes, rehydrate on restart (ADR-0004 P5a)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,12 @@ import { TelemetryService } from "./telemetry/telemetry-service.js";
 const telemetry = new TelemetryService(`${dataDir}/knowledge.db`);
 telemetry.init();
 
+// Durable backing for fleet health — persists outcomes + rehydrates the 24h
+// window on restart, so fleet visibility survives redeploys (ADR-0004 P5).
+import { FleetStateRepository } from "./knowledge/fleet-state.js";
+const fleetStateRepo = new FleetStateRepository(`${dataDir}/knowledge.db`);
+fleetStateRepo.init();
+
 // Core plugins — always loaded, statically imported (no dynamic overhead needed)
 const debugPlugin = new DebugPlugin();
 debugPlugin.install(bus);
@@ -434,7 +440,8 @@ const pluginRegistry: PluginRegistryEntry[] = [
     factory: async () => {
       const { AgentFleetHealthPlugin } = await import("./plugins/agent-fleet-health-plugin.js");
       // executorRegistry wired for outcome attribution whitelist (#459).
-      return new AgentFleetHealthPlugin(executorRegistry);
+      // fleetStateRepo wired for durable persistence + restart hydration (ADR-0004 P5).
+      return new AgentFleetHealthPlugin(executorRegistry, fleetStateRepo);
     },
   },
   {

--- a/src/knowledge/__tests__/fleet-state.test.ts
+++ b/src/knowledge/__tests__/fleet-state.test.ts
@@ -1,0 +1,99 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { FleetStateRepository, type OutcomeRecord } from "../fleet-state.ts";
+
+const TEST_DB_PATH = join(import.meta.dir, ".test-fleet-state.db");
+
+function rec(overrides: Partial<OutcomeRecord> = {}): OutcomeRecord {
+  return {
+    systemActor: "ava",
+    skill: "triage",
+    success: true,
+    durationMs: 1200,
+    costUsd: 0.0042,
+    correlationId: crypto.randomUUID(),
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+function cleanup() {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    const p = TEST_DB_PATH + suffix;
+    if (existsSync(p)) rmSync(p);
+  }
+}
+
+describe("FleetStateRepository", () => {
+  let repo: FleetStateRepository;
+
+  beforeEach(() => {
+    cleanup();
+    repo = new FleetStateRepository(TEST_DB_PATH);
+    repo.init();
+  });
+
+  afterEach(() => {
+    repo.close();
+    cleanup();
+  });
+
+  test("recordOutcome persists and hydrateRecords reads it back (oldest-first)", () => {
+    const now = Date.now();
+    repo.recordOutcome(rec({ skill: "old", timestamp: now - 1000 }));
+    repo.recordOutcome(rec({ skill: "new", timestamp: now }));
+
+    const hydrated = repo.hydrateRecords(24);
+    expect(hydrated.map((r) => r.skill)).toEqual(["old", "new"]);
+    expect(hydrated[0]!.systemActor).toBe("ava");
+    expect(hydrated[1]!.success).toBe(true);
+  });
+
+  test("optional fields survive the round-trip", () => {
+    repo.recordOutcome(
+      rec({
+        success: false,
+        failureReason: "timeout",
+        model: "protolabs/reasoning",
+        inputTokens: 800,
+        outputTokens: 200,
+      }),
+    );
+    const [r] = repo.hydrateRecords(24);
+    expect(r!.success).toBe(false);
+    expect(r!.failureReason).toBe("timeout");
+    expect(r!.model).toBe("protolabs/reasoning");
+    expect(r!.inputTokens).toBe(800);
+    expect(r!.outputTokens).toBe(200);
+  });
+
+  test("hydrateRecords honors the time window", () => {
+    const now = Date.now();
+    repo.recordOutcome(rec({ skill: "stale", timestamp: now - 26 * 60 * 60 * 1000 }));
+    repo.recordOutcome(rec({ skill: "fresh", timestamp: now }));
+
+    const hydrated = repo.hydrateRecords(24);
+    expect(hydrated.map((r) => r.skill)).toEqual(["fresh"]);
+  });
+
+  test("prunes to the last 500 records per actor; other actors untouched", () => {
+    const now = Date.now();
+    for (let i = 0; i < 520; i++) {
+      repo.recordOutcome(rec({ systemActor: "ava", timestamp: now - (520 - i) }));
+    }
+    repo.recordOutcome(rec({ systemActor: "quinn", timestamp: now }));
+
+    const all = repo.hydrateRecords(48);
+    expect(all.filter((r) => r.systemActor === "ava").length).toBe(500);
+    expect(all.filter((r) => r.systemActor === "quinn").length).toBe(1);
+  });
+
+  test("degrades to a no-op when the DB never opened", () => {
+    const broken = new FleetStateRepository(join(import.meta.dir, "no-such-dir", "\0bad", "x.db"));
+    broken.init(); // swallows the error, leaves db null
+    expect(broken.recordOutcome(rec())).toBe(false);
+    expect(broken.hydrateRecords(24)).toEqual([]);
+    broken.close();
+  });
+});

--- a/src/knowledge/fleet-state.ts
+++ b/src/knowledge/fleet-state.ts
@@ -1,0 +1,191 @@
+/**
+ * FleetStateRepository — durable backing for fleet outcome records (ADR-0004 P5).
+ *
+ * AgentFleetHealthPlugin keeps a 24h rolling window of agent outcomes in memory
+ * for health-weighted dispatch and alerts. That window evaporates on restart —
+ * every redeploy blinded the fleet view until traffic refilled it. This repo
+ * persists each outcome to knowledge.db and rehydrates the window on startup, so
+ * health survives restarts.
+ *
+ * Follows the CeremonyOutcomesRepository / TelemetryService pattern: WAL mode,
+ * transactional writes, per-agent pruning to bound growth, and graceful
+ * degradation to a no-op when the DB can't be opened (the in-memory path is
+ * unchanged — durability is purely additive).
+ *
+ * Write path: fire-and-forget persist after the in-memory update.
+ * Read path: hydrate the most recent N hours into the in-memory window on boot.
+ */
+
+import { Database } from "bun:sqlite";
+import { mkdirSync, existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+/** Keep at most this many records per system-actor; older rows are pruned on write. */
+const MAX_PER_AGENT = 500;
+
+export interface OutcomeRecord {
+  systemActor: string;
+  skill: string;
+  success: boolean;
+  durationMs: number;
+  costUsd: number;
+  correlationId: string;
+  failureReason?: string;
+  model?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  timestamp: number; // Unix ms
+}
+
+export class FleetStateRepository {
+  private db: Database | null = null;
+  private readonly dbPath: string;
+
+  constructor(dbPath?: string) {
+    this.dbPath = resolve(dbPath ?? "data/knowledge.db");
+  }
+
+  /** Open the database and ensure the schema exists. Degrades to a no-op on failure. */
+  init(): void {
+    try {
+      const dir = dirname(this.dbPath);
+      if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+      }
+
+      this.db = new Database(this.dbPath);
+      this.db.exec("PRAGMA journal_mode=WAL;");
+      this.db.exec("PRAGMA synchronous=NORMAL;");
+
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS fleet_outcome_records (
+          id              INTEGER PRIMARY KEY AUTOINCREMENT,
+          system_actor    TEXT    NOT NULL,
+          skill           TEXT    NOT NULL,
+          success         INTEGER NOT NULL,
+          duration_ms     INTEGER NOT NULL,
+          cost_usd        REAL    NOT NULL DEFAULT 0,
+          correlation_id  TEXT    NOT NULL,
+          failure_reason  TEXT,
+          model           TEXT,
+          input_tokens    INTEGER,
+          output_tokens   INTEGER,
+          timestamp       INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_fleet_outcome_actor_ts
+          ON fleet_outcome_records(system_actor, timestamp);
+        CREATE INDEX IF NOT EXISTS idx_fleet_outcome_skill
+          ON fleet_outcome_records(skill, timestamp);
+      `);
+
+      console.log(`[fleet-state] DB ready: ${this.dbPath}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[fleet-state] DB init failed, running in-memory only: ${msg}`);
+      this.db = null;
+    }
+  }
+
+  /** Persist one outcome and prune the actor's history to MAX_PER_AGENT. Returns true on success. */
+  recordOutcome(record: OutcomeRecord): boolean {
+    if (!this.db) return false;
+
+    try {
+      const tx = this.db.transaction(() => {
+        this.db!
+          .query(`
+            INSERT INTO fleet_outcome_records
+              (system_actor, skill, success, duration_ms, cost_usd, correlation_id,
+               failure_reason, model, input_tokens, output_tokens, timestamp)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `)
+          .run(
+            record.systemActor,
+            record.skill,
+            record.success ? 1 : 0,
+            record.durationMs,
+            record.costUsd,
+            record.correlationId,
+            record.failureReason ?? null,
+            record.model ?? null,
+            record.inputTokens ?? null,
+            record.outputTokens ?? null,
+            record.timestamp,
+          );
+
+        this.db!
+          .query(`
+            DELETE FROM fleet_outcome_records
+            WHERE system_actor = ?
+              AND id NOT IN (
+                SELECT id FROM fleet_outcome_records
+                WHERE system_actor = ?
+                ORDER BY timestamp DESC
+                LIMIT ?
+              )
+          `)
+          .run(record.systemActor, record.systemActor, MAX_PER_AGENT);
+      });
+
+      tx();
+      return true;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[fleet-state] recordOutcome failed: ${msg}`);
+      return false;
+    }
+  }
+
+  /** Return outcome records from the last `hoursBack` hours, oldest first (for window hydration). */
+  hydrateRecords(hoursBack = 24): OutcomeRecord[] {
+    if (!this.db) return [];
+
+    try {
+      const cutoff = Date.now() - hoursBack * 60 * 60 * 1000;
+      const rows = this.db
+        .query<{
+          system_actor: string;
+          skill: string;
+          success: number;
+          duration_ms: number;
+          cost_usd: number;
+          correlation_id: string;
+          failure_reason: string | null;
+          model: string | null;
+          input_tokens: number | null;
+          output_tokens: number | null;
+          timestamp: number;
+        }, [number]>(`
+          SELECT * FROM fleet_outcome_records
+          WHERE timestamp >= ?
+          ORDER BY timestamp ASC
+        `)
+        .all(cutoff);
+
+      return rows.map((r) => ({
+        systemActor: r.system_actor,
+        skill: r.skill,
+        success: r.success === 1,
+        durationMs: r.duration_ms,
+        costUsd: r.cost_usd,
+        correlationId: r.correlation_id,
+        failureReason: r.failure_reason ?? undefined,
+        model: r.model ?? undefined,
+        inputTokens: r.input_tokens ?? undefined,
+        outputTokens: r.output_tokens ?? undefined,
+        timestamp: r.timestamp,
+      }));
+    } catch (err) {
+      console.error("[fleet-state] hydrateRecords failed:", err);
+      return [];
+    }
+  }
+
+  /** Close the database connection. */
+  close(): void {
+    if (this.db) {
+      this.db.close();
+      this.db = null;
+    }
+  }
+}

--- a/src/plugins/agent-fleet-health-plugin.test.ts
+++ b/src/plugins/agent-fleet-health-plugin.test.ts
@@ -1,6 +1,9 @@
-import { describe, test, expect, beforeEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
 import { InMemoryEventBus } from "../../lib/bus.ts";
 import { AgentFleetHealthPlugin } from "./agent-fleet-health-plugin.ts";
+import { FleetStateRepository } from "../knowledge/fleet-state.ts";
 import { ExecutorRegistry } from "../executor/executor-registry.ts";
 import type { IExecutor, SkillRequest, SkillResult } from "../executor/types.ts";
 import type { AutonomousOutcomePayload } from "../event-bus/payloads.ts";
@@ -498,6 +501,79 @@ describe("AgentFleetHealthPlugin", () => {
       const ava = plugin.getFleetHealth().agents.find(a => a.agentName === "ava")!;
       // Falls back to default rate
       expect(ava.costPerSuccessfulOutcome).toBeCloseTo(0.018, 4);
+    });
+  });
+
+  describe("durable persistence (ADR-0004 P5)", () => {
+    const DB = join(import.meta.dir, ".test-fleet-health-hydrate.db");
+    const wipe = () => {
+      for (const s of ["", "-wal", "-shm"]) if (existsSync(DB + s)) rmSync(DB + s);
+    };
+
+    beforeEach(wipe);
+    afterEach(wipe);
+
+    test("persists outcomes and rehydrates the window on install", async () => {
+      const registry = makeRegistry(["ava"]);
+
+      // First lifetime: record an outcome, then tear down.
+      const repo1 = new FleetStateRepository(DB);
+      repo1.init();
+      const p1 = new AgentFleetHealthPlugin(registry, repo1);
+      p1.install(bus);
+      bus.publish("autonomous.outcome.completed", makeOutcomeMsg({
+        systemActor: "ava",
+        skill: "plan",
+        success: true,
+        durationMs: 1000,
+      }));
+      await new Promise((r) => setTimeout(r, 10));
+      expect(p1.getFleetHealth().agents).toHaveLength(1);
+      p1.uninstall();
+      repo1.close();
+
+      // Second lifetime: a fresh plugin + bus hydrates the prior outcome from disk.
+      const bus2 = new InMemoryEventBus();
+      const repo2 = new FleetStateRepository(DB);
+      repo2.init();
+      const p2 = new AgentFleetHealthPlugin(registry, repo2);
+      p2.install(bus2);
+
+      const ava = p2.getFleetHealth().agents.find((a) => a.agentName === "ava");
+      expect(ava).toBeDefined();
+      expect(ava!.totalOutcomes).toBe(1);
+      expect(ava!.successRate).toBe(1);
+      p2.uninstall();
+      repo2.close();
+    });
+
+    test("hydration routes unregistered actors to systemActors[]", async () => {
+      const registry = makeRegistry(["ava"]); // pr-remediator is NOT registered
+
+      const repo1 = new FleetStateRepository(DB);
+      repo1.init();
+      const p1 = new AgentFleetHealthPlugin(registry, repo1);
+      p1.install(bus);
+      bus.publish("autonomous.outcome.completed", makeOutcomeMsg({
+        systemActor: "pr-remediator",
+        skill: "remediate",
+        success: true,
+      }));
+      await new Promise((r) => setTimeout(r, 10));
+      p1.uninstall();
+      repo1.close();
+
+      const bus2 = new InMemoryEventBus();
+      const repo2 = new FleetStateRepository(DB);
+      repo2.init();
+      const p2 = new AgentFleetHealthPlugin(registry, repo2);
+      p2.install(bus2);
+
+      const snap = p2.getFleetHealth();
+      expect(snap.agents.find((a) => a.agentName === "pr-remediator")).toBeUndefined();
+      expect(snap.systemActors.find((s) => s.systemActor === "pr-remediator")).toBeDefined();
+      p2.uninstall();
+      repo2.close();
     });
   });
 });

--- a/src/plugins/agent-fleet-health-plugin.ts
+++ b/src/plugins/agent-fleet-health-plugin.ts
@@ -26,6 +26,7 @@ import type { Plugin, EventBus } from "../../lib/types.ts";
 import type { AutonomousOutcomePayload } from "../event-bus/payloads.ts";
 import type { ExecutorRegistry } from "../executor/executor-registry.ts";
 import { MODEL_RATES } from "../../lib/types/budget.ts";
+import type { FleetStateRepository, OutcomeRecord as PersistedOutcomeRecord } from "../knowledge/fleet-state.ts";
 
 const WINDOW_MS = 24 * 60 * 60 * 1_000; // 24 hours
 const WINDOW_1H_MS = 60 * 60 * 1_000; // 1 hour
@@ -180,10 +181,27 @@ export class AgentFleetHealthPlugin implements Plugin {
      * for legacy tests until they opt in.
      */
     private readonly executorRegistry?: ExecutorRegistry,
+    /**
+     * Optional durable backing store (ADR-0004 P5). When set, every outcome is
+     * persisted to knowledge.db and the 24h window is rehydrated from it on
+     * install(), so fleet health survives restarts. Degrades gracefully — when
+     * absent, the in-memory path is unchanged.
+     */
+    private readonly fleetStateRepo?: FleetStateRepository,
   ) {}
 
   install(bus: EventBus): void {
     this.bus = bus;
+
+    // Rehydrate the in-memory window from the durable store on startup.
+    if (this.fleetStateRepo) {
+      const records = this.fleetStateRepo.hydrateRecords(24);
+      for (const r of records) this._addToWindow(r);
+      if (records.length > 0) {
+        console.log(`[agent-fleet-health] hydrated ${records.length} records from knowledge.db`);
+      }
+    }
+
     this.subscriptionIds.push(
       bus.subscribe("autonomous.outcome.#", this.name, (msg) => {
         const p = msg.payload as AutonomousOutcomePayload | undefined;
@@ -328,23 +346,58 @@ export class AgentFleetHealthPlugin implements Plugin {
       const existing = this.agentWindows.get(p.systemActor) ?? [];
       existing.push(record);
       this.agentWindows.set(p.systemActor, existing);
-      return;
+    } else {
+      // Synthetic actor: plugin / subsystem label that isn't a real executor.
+      // Log once per distinct actor so operators can see what's being filtered
+      // without flooding on every outcome.
+      if (!this.seenSyntheticActors.has(p.systemActor)) {
+        this.seenSyntheticActors.add(p.systemActor);
+        console.warn(
+          `[agent-fleet-health] synthetic_actor_filtered systemActor=${p.systemActor} ` +
+            `skill=${p.skill} — not in ExecutorRegistry; aggregating under systemActors[] ` +
+            `instead of agents[]. Fix source so it doesn't masquerade as an agent.`,
+        );
+      }
+      const existing = this.systemActorWindows.get(p.systemActor) ?? [];
+      existing.push(record);
+      this.systemActorWindows.set(p.systemActor, existing);
     }
 
-    // Synthetic actor: plugin / subsystem label that isn't a real executor.
-    // Log once per distinct actor so operators can see what's being filtered
-    // without flooding on every outcome.
-    if (!this.seenSyntheticActors.has(p.systemActor)) {
-      this.seenSyntheticActors.add(p.systemActor);
-      console.warn(
-        `[agent-fleet-health] synthetic_actor_filtered systemActor=${p.systemActor} ` +
-          `skill=${p.skill} — not in ExecutorRegistry; aggregating under systemActors[] ` +
-          `instead of agents[]. Fix source so it doesn't masquerade as an agent.`,
-      );
-    }
-    const existing = this.systemActorWindows.get(p.systemActor) ?? [];
+    // Persist to the durable store (fire-and-forget; degrades to no-op when absent).
+    this.fleetStateRepo?.recordOutcome({
+      systemActor: p.systemActor,
+      skill: p.skill,
+      success: p.success,
+      durationMs: p.durationMs,
+      costUsd,
+      correlationId: p.correlationId,
+      failureReason: record.failureReason,
+      model: p.model,
+      inputTokens: p.usage?.input_tokens,
+      outputTokens: p.usage?.output_tokens,
+      timestamp: record.timestamp,
+    });
+  }
+
+  /**
+   * Add a hydrated record (from FleetStateRepository on startup) to the correct
+   * in-memory window. Mirrors `_record`'s routing without re-persisting or
+   * re-warning, since these rows came from the store.
+   */
+  private _addToWindow(r: PersistedOutcomeRecord): void {
+    const record: OutcomeRecord = {
+      timestamp: r.timestamp,
+      success: r.success,
+      durationMs: r.durationMs,
+      costUsd: r.costUsd,
+      skill: r.skill,
+      correlationId: r.correlationId,
+      failureReason: r.failureReason,
+    };
+    const window = this._isRegisteredAgent(r.systemActor) ? this.agentWindows : this.systemActorWindows;
+    const existing = window.get(r.systemActor) ?? [];
     existing.push(record);
-    this.systemActorWindows.set(p.systemActor, existing);
+    window.set(r.systemActor, existing);
   }
 
   /**


### PR DESCRIPTION
## What

ADR-0004 **P5a** — durable observability state.

`AgentFleetHealthPlugin` keeps a 24h rolling window of agent outcomes in memory, feeding health-weighted dispatch (Arc 8.4) and fleet alerts. That window was **memory-only**: every redeploy blinded the fleet view until live traffic refilled it — exactly when you most want to see what's happening.

`FleetStateRepository` (new, `src/knowledge/fleet-state.ts`) gives it a durable backing:
- Each outcome is persisted to `knowledge.db` → `fleet_outcome_records` (WAL, transactional, pruned to the last 500 per actor).
- On `install()`, the plugin **rehydrates** the last 24h into its in-memory window, so health survives restarts.

### Greenfield / scope discipline
Purely **additive**. When the repo can't open the DB (or isn't wired at all — e.g. legacy test fixtures), `init()` logs and falls back to `db = null`; every method becomes a no-op and the in-memory path is byte-for-byte unchanged. No flags, no fast/slow split.

Follows the established `CeremonyOutcomesRepository` / `TelemetryService` shape (same WAL pragmas, transactional write + prune, graceful degradation). Shares the single `knowledge.db`.

## Test
- `src/knowledge/__tests__/fleet-state.test.ts` — round-trip, optional-field fidelity, time-window filter, 500/actor prune (other actors untouched), no-op when DB never opened.
- `src/plugins/agent-fleet-health-plugin.test.ts` — persists then **rehydrates across a simulated restart** (fresh plugin + bus reads prior outcomes off disk); hydration routes unregistered actors to `systemActors[]` (#459 attribution preserved).
- Full suite: **895 pass / 0 fail**. Typecheck clean. Lint at baseline (13 err / 28 warn — unchanged).

Part of epic #707.

🤖 Generated with [Claude Code](https://claude.com/claude-code)