### PR TITLE
feat(control-plane): unified state read + dashboard read/write-split doc (ADR-0004 P5b)

### DIFF
--- a/dashboard/src/components/Console.tsx
+++ b/dashboard/src/components/Console.tsx
@@ -3,7 +3,7 @@ import { Button, Badge, Card, Empty, Divider, type Status } from "@protolabsai/u
 import { RefreshCw, Plus, Trash2, CircleCheck, Pencil, X, Globe } from "lucide-react";
 import { ConfirmDialog } from "./ConfirmDialog";
 import {
-  getAgentsRuntime,
+  getControlPlaneState,
   testAgent,
   createAgent,
   updateAgent,
@@ -15,6 +15,7 @@ import {
   getAdminKey,
   setAdminKey,
   type AgentsRuntimeResponse,
+  type AgentHealthMetrics,
 } from "../lib/api";
 
 // The Console is the fleet's WRITE surface (ADR-0004 P3) — distinct from the
@@ -40,8 +41,16 @@ function typeStatus(a: Agent): Status {
   return "neutral";
 }
 
+/** 24h health → a colored badge: red if any failures in the last hour, amber if <90% success. */
+function healthStatus(m: AgentHealthMetrics): Status {
+  if (m.failureRate1h > 0) return "error";
+  if (m.successRate < 0.9) return "warning";
+  return "success";
+}
+
 export default function Console() {
   const [agents, setAgents] = useState<Agent[]>([]);
+  const [health, setHealth] = useState<Map<string, AgentHealthMetrics>>(new Map());
   const [key, setKey] = useState(getAdminKey());
   const [draft, setDraft] = useState(TEMPLATE);
   const [busy, setBusy] = useState(false);
@@ -54,8 +63,9 @@ export default function Console() {
 
   const refresh = useCallback(async () => {
     try {
-      const data = await getAgentsRuntime(true);
+      const data = await getControlPlaneState(true);
       setAgents(data.agents ?? []);
+      setHealth(new Map((data.health?.agents ?? []).map((h) => [h.agentName, h])));
     } catch (err) {
       setResult({ ok: false, msg: `Failed to load fleet: ${err instanceof Error ? err.message : String(err)}` });
     }
@@ -309,6 +319,14 @@ export default function Console() {
                 <div style={{ display: "flex", alignItems: "center", gap: "10px", flexWrap: "wrap" }}>
                   <strong style={{ color: "var(--text-primary)", fontSize: "14px" }}>{a.name}</strong>
                   <Badge status={typeStatus(a)}>{a.pendingDiscovery ? "discovering" : a.type}</Badge>
+                  {(() => {
+                    const m = health.get(a.name);
+                    return m && m.totalOutcomes > 0 ? (
+                      <Badge status={healthStatus(m)}>
+                        {Math.round(m.successRate * 100)}% · {m.totalOutcomes} runs/24h
+                      </Badge>
+                    ) : null;
+                  })()}
                   <span style={{ flex: 1, display: "flex", gap: "6px", flexWrap: "wrap" }}>
                     {a.skills.map((s) => (
                       <Badge key={s} status="neutral">{s}</Badge>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -98,6 +98,10 @@ export const getHitlPending = () =>
 export const getCeremonies = () =>
   apiFetch<{ data: unknown[] }>("/api/ceremonies", { ttl: 60_000 });
 
+/** GET /api/control-plane/state — unified control-plane read: fleet + durable-backed health. */
+export const getControlPlaneState = (force = false) =>
+  apiFetch<ControlPlaneState>("/api/control-plane/state", { ttl: 15_000, force });
+
 // ── Response types (match actual API shapes after envelope unwrap) ─
 
 /** GET /api/agents/runtime — the live fleet: every registered executor grouped by agent. */
@@ -109,6 +113,27 @@ export interface AgentsRuntimeResponse {
     /** A2A agent known from yaml but not yet discovered (no skills registered). */
     pendingDiscovery?: boolean;
   }>;
+}
+
+/** Per-agent 24h health rollup (subset of the backend FleetHealthSnapshot). */
+export interface AgentHealthMetrics {
+  agentName: string;
+  successRate: number;
+  totalOutcomes: number;
+  failureRate1h: number;
+}
+
+/** GET /api/control-plane/state — unified read: live fleet + (durably-backed) health. */
+export interface ControlPlaneState {
+  agents: AgentsRuntimeResponse["agents"];
+  health: {
+    agents: AgentHealthMetrics[];
+    windowHours: 24;
+    maxFailureRate1h: number;
+    totalCostUsd1d: number;
+    collectedAt: number;
+  } | null;
+  collectedAt: number;
 }
 
 export interface CiHealthResponse {

--- a/docs/architecture/flow-dashboard.md
+++ b/docs/architecture/flow-dashboard.md
@@ -2,19 +2,27 @@
 title: Flow — Dashboard data path
 ---
 
-_The dashboard is a separate Vite + React 19 frontend at `http://ava:3333` (Tailscale-only). It reads from API routes that aggregate live bus events plus rolling-window snapshots. The bus → API → tile chain is one-way; the dashboard does not write to the bus._
+_The dashboard is a separate Vite + React 19 frontend at `http://ava:3333` (Tailscale-only). Almost all of it **reads** from API routes that aggregate live bus events plus rolling-window snapshots. The one **write** surface is the Console (ADR-0004 P3), which mutates the fleet through the admin-gated control-plane API — never by touching the bus directly._
 
 ---
 
 ## What & why
 
-Operators need a single pane to see "what is the fleet doing right now" without tailing logs. The dashboard is intentionally **read-only** and **debug-oriented** — not a control surface. (Memory: "we dont really want to use this as a ui anyhow, more for debugging".)
+Operators need a single pane to see "what is the fleet doing right now" without tailing logs — and, increasingly, to *change* the fleet without editing YAML on the host and redeploying. The dashboard splits cleanly into two halves.
 
-Three classes of data feed the tiles:
+### Read side (debug panes) — the majority
+
+Intentionally **read-only** and **debug-oriented**. The bus → API → tile chain is one-way; these panes never write. Three classes of data feed them:
 
 - **Live bus events** via `BusHistoryRecorder` → API → SSE/poll → tile
 - **Rolling-window snapshots** computed in plugins (`AgentFleetHealth`, `CostStore`) → API JSON → tile
 - **External state** (GitHub PR pipeline, Linear) via per-plugin APIs
+
+### Write side (the Console) — ADR-0004 P3
+
+A single surface that mutates the control plane: create/edit/remove in-process DeepAgents, probe + register/remove remote A2A agents. It is **admin-key gated** (`X-API-Key`) and never publishes to the bus from the browser. Every mutation is an HTTP call to the control-plane API, which validates, publishes a `command.*` topic, and lets the sole `ControlPlaneRegistrar` perform the atomic filesystem write — the change then applies live via hot-reload (~5s). See [the read/write split](#read-write-split) below.
+
+> The split is structural, not cosmetic: read panes call cached `apiFetch` GETs with no key; the Console calls uncached `adminFetch` mutations with the admin key. A read pane cannot accidentally mutate, and the Console cannot serve a stale fleet from cache.
 
 ---
 
@@ -86,17 +94,56 @@ sequenceDiagram
 
 ## API routes table
 
-| Route | Source plugin | Cache TTL | Tile |
+### Read (debug panes) — cached GETs, no key
+
+| Route | Source | Cache TTL | Tile |
 |---|---|---|---|
-| `/api/bus-events` | BusHistoryRecorder | live (SSE / 1s poll) | Live event log, D1 dashboard |
-| `/api/agent-health` | AgentFleetHealth | 15s | Agents tile, agent rows |
-| `/api/outcomes` | AgentFleetHealth | 15s | Outcomes tile, D2/D3 dashboards |
+| `/api/bus/history` | BusHistoryRecorder | live (SSE / poll) | Live event log, D1 dashboard |
+| `/api/agents/runtime` | ExecutorRegistry + agents.yaml/agents.d | 30s | Fleet list |
+| `/api/control-plane/state` | ExecutorRegistry + AgentFleetHealth | 15s | **Unified** read — fleet + 24h health (Console fleet rows) |
 | `/api/cost-summaries` | CostStore | 30s | Fleet cost tile |
 | `/api/pr-pipeline` | GitHubPlugin | 30s | PR-1/-2/-3 review pipeline tiles |
-| `/api/ceremonies` | CeremonyPlugin | 30s | Ceremony status tile |
-| `/api/a2a-status` | SkillBrokerPlugin | 60s | A2A health tile |
+| `/api/ceremonies` | CeremonyPlugin | 60s | Ceremony status tile |
 
-Per [dashboard/src/lib/api.ts:85–95](../../dashboard/src/lib/api.ts).
+`/api/control-plane/state` (ADR-0004 P5b) is the **unified** read: one call returns the live fleet *and* the per-agent 24h health rollup. The health half is served from `AgentFleetHealthPlugin`'s in-memory window, which is **rehydrated from `knowledge.db` on startup** (P5a) — so the numbers survive restarts rather than resetting to zero on every redeploy. Per [dashboard/src/lib/api.ts](../../dashboard/src/lib/api.ts).
+
+### Write (the Console) — uncached, admin-key gated
+
+| Route | Method | Effect |
+|---|---|---|
+| `/api/agents` | POST | Create an in-process DeepAgent (→ `workspace/agents/<name>.yaml`) |
+| `/api/agents/:name` | PUT / DELETE / GET | Update / remove / read one DeepAgent |
+| `/api/agents/test` | POST | Validate a definition without persisting |
+| `/api/a2a/probe` | POST | Capability discovery — probe a remote agent's card |
+| `/api/a2a-endpoints` | POST | Register a remote A2A agent (→ `workspace/agents.d/<name>.yaml`) |
+| `/api/a2a-endpoints/:name` | DELETE | Remove a control-plane-managed A2A agent |
+
+Each write validates, publishes a `command.*` topic, and the `ControlPlaneRegistrar` (sole writer) performs the atomic file write; hot-reload applies it in ~5s.
+
+---
+
+## <a id="read-write-split"></a>Read / write split
+
+```
+  Read pane (no key)                         Console (admin key)
+        │ apiFetch GET (cached)                     │ adminFetch POST/PUT/DELETE (uncached)
+        ▼                                           ▼
+  ┌──────────────────┐                      ┌──────────────────────┐
+  │ src/api/* GET     │                      │ src/api/agents-crud   │
+  │ routes (read-only)│                      │ + a2a-endpoints       │
+  └────────┬─────────┘                      └───────────┬──────────┘
+           │ registry / plugin snapshot                 │ validate → publish command.*
+           ▼                                             ▼
+   (in-memory + knowledge.db)              ControlPlaneRegistrar (sole writer)
+                                                         │ atomic temp+rename
+                                                         ▼
+                                            workspace/agents/ · agents.d/
+                                                         │ file-watch
+                                                         ▼
+                                            hot-reload → live in ~5s
+```
+
+The browser never publishes to the bus. The only path from a click to a bus message is HTTP → API route → `command.*` → registrar, so every mutation is auditable in bus-history and confined to one writer.
 
 ---
 
@@ -149,7 +196,7 @@ This means dashboard data — including PR contents, agent token usage, internal
 
 ## Failure modes & gotchas
 
-- **History is in-memory only** — restart wipes the event log. No "what happened last night while I was asleep" view without external logging.
+- **Bus-event history is in-memory only** — restart wipes the live event log. No "what happened last night while I was asleep" view without external logging. (Fleet *health*, by contrast, is durable as of ADR-0004 P5a — the 24h outcome window rehydrates from `knowledge.db` on startup, so success-rate / cost numbers survive a redeploy even though the raw event stream doesn't.)
 - **Aspirational topics show empty tiles** — anything depending on `agent.runtime.activity.tool.call` or `agent.skill.latency` is empty (see [flow-agent-runtime-telemetry](flow-agent-runtime-telemetry.md)).
 - **Cost can be zero for new models** — `MODEL_RATES` table is hard-coded; LiteLLM adding a model = zero cost recorded until updated.
 - **PR-pipeline tile depends on GitHubPlugin's local cache** — `pr_pipeline` snapshot is built on-demand by hitting GitHub API. Heavy refresh load if many tiles open simultaneously.

--- a/src/api/__tests__/control-plane.test.ts
+++ b/src/api/__tests__/control-plane.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unified control-plane read (ADR-0004 P5b) — GET /api/control-plane/state
+ * returns the live fleet + the (durably-backed) health snapshot in one call.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { ExecutorRegistry } from "../../executor/executor-registry.ts";
+import { AgentFleetHealthPlugin } from "../../plugins/agent-fleet-health-plugin.ts";
+import type { IExecutor, SkillRequest, SkillResult } from "../../executor/types.ts";
+import { createRoutes } from "../control-plane.ts";
+import type { ApiContext, Route } from "../types.ts";
+
+class StubExecutor implements IExecutor {
+  readonly type = "deep-agent";
+  async execute(_req: SkillRequest): Promise<SkillResult> {
+    return { text: "", isError: false, correlationId: "" };
+  }
+}
+
+describe("GET /api/control-plane/state", () => {
+  let root: string;
+  let registry: ExecutorRegistry;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "cp-state-"));
+    registry = new ExecutorRegistry();
+    registry.register("pr_review", new StubExecutor(), { agentName: "quinn" });
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  function ctxWith(plugins: ApiContext["plugins"]): ApiContext {
+    return { workspaceDir: root, bus: new InMemoryEventBus(), plugins, executorRegistry: registry };
+  }
+  function route(ctx: ApiContext): Route {
+    const r = createRoutes(ctx).find((x) => x.method === "GET" && x.path === "/api/control-plane/state");
+    if (!r) throw new Error("route not registered");
+    return r;
+  }
+
+  test("returns the fleet + health snapshot when the plugin is installed", async () => {
+    const bus = new InMemoryEventBus();
+    const plugin = new AgentFleetHealthPlugin(registry);
+    plugin.install(bus);
+    const ctx = { ...ctxWith([plugin]), bus };
+
+    const res = await route(ctx).handler(new Request("http://localhost/api/control-plane/state"), {});
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      data: { agents: Array<{ name: string }>; health: { windowHours: number } | null; collectedAt: number };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data.agents.some((a) => a.name === "quinn")).toBe(true);
+    expect(body.data.health?.windowHours).toBe(24);
+    expect(body.data.collectedAt).toBeGreaterThan(0);
+    plugin.uninstall();
+  });
+
+  test("health is null (not an error) when the fleet-health plugin isn't installed", async () => {
+    const ctx = ctxWith([]); // no plugins
+    const res = await route(ctx).handler(new Request("http://localhost/api/control-plane/state"), {});
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { agents: unknown[]; health: null } };
+    expect(body.data.health).toBeNull();
+    expect(body.data.agents.length).toBeGreaterThan(0); // fleet still served from the registry
+  });
+});

--- a/src/api/agents-runtime.ts
+++ b/src/api/agents-runtime.ts
@@ -30,12 +30,12 @@
  *   }
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
 import type { Route, ApiContext } from "./types.ts";
 
-interface AgentSummary {
+export interface AgentSummary {
   name: string;
   type: string;
   skills: string[];
@@ -49,17 +49,77 @@ interface YamlAgent {
   external?: boolean;
 }
 
-function loadYamlAgents(workspaceDir: string): YamlAgent[] {
-  const path = join(workspaceDir, "agents.yaml");
-  if (!existsSync(path)) return [];
-  try {
-    const parsed = parseYaml(readFileSync(path, "utf8")) as { agents?: YamlAgent[] };
-    return Array.isArray(parsed?.agents) ? parsed.agents : [];
-  } catch {
-    // Tolerate yaml parse errors — the live registry view is still useful
-    // and an over-noisy 500 on /api/agents/runtime breaks the dashboard.
-    return [];
+/**
+ * Names of A2A agents declared on disk: the hand-maintained agents.yaml plus
+ * each control-plane-managed agents.d/*.yaml (ADR-0004 P3). These may not be in
+ * the registry yet (card discovery in flight) but should render eagerly.
+ */
+function loadDeclaredA2aNames(workspaceDir: string): string[] {
+  const names: string[] = [];
+
+  const yamlPath = join(workspaceDir, "agents.yaml");
+  if (existsSync(yamlPath)) {
+    try {
+      const parsed = parseYaml(readFileSync(yamlPath, "utf8")) as { agents?: YamlAgent[] };
+      for (const a of Array.isArray(parsed?.agents) ? parsed.agents : []) {
+        if (a?.name) names.push(a.name);
+      }
+    } catch {
+      // Tolerate parse errors — the live registry view is still useful and an
+      // over-noisy 500 on /api/agents/runtime breaks the dashboard.
+    }
   }
+
+  const dir = join(workspaceDir, "agents.d");
+  if (existsSync(dir)) {
+    for (const file of readdirSync(dir).filter((f) => f.endsWith(".yaml"))) {
+      try {
+        const parsed = parseYaml(readFileSync(join(dir, file), "utf8")) as YamlAgent;
+        if (parsed?.name) names.push(parsed.name);
+      } catch {
+        // skip an unparseable managed file
+      }
+    }
+  }
+
+  return names;
+}
+
+/**
+ * The live fleet: every registered executor grouped by (agentName ?? type),
+ * merged with declared-but-not-yet-discovered A2A agents (pendingDiscovery).
+ * Shared by GET /api/agents/runtime and the unified control-plane read.
+ */
+export function collectFleetAgents(ctx: ApiContext): AgentSummary[] {
+  const byKey = new Map<string, { type: string; skills: Set<string> }>();
+  for (const reg of ctx.executorRegistry.list()) {
+    const key = reg.agentName ?? reg.executor.type;
+    let entry = byKey.get(key);
+    if (!entry) {
+      entry = { type: reg.executor.type, skills: new Set() };
+      byKey.set(key, entry);
+    }
+    if (reg.skill) entry.skills.add(reg.skill);
+  }
+
+  // Merge declared A2A agents. If already in the registry (discovered /
+  // in-process), the registry wins; otherwise mark pendingDiscovery so the
+  // dashboard renders a node with no skills yet.
+  for (const name of loadDeclaredA2aNames(ctx.workspaceDir)) {
+    if (byKey.has(name)) continue;
+    byKey.set(name, { type: "a2a", skills: new Set() });
+  }
+
+  return [...byKey.entries()]
+    .map(([name, { type, skills }]) => {
+      const skillList = [...skills].sort();
+      const summary: AgentSummary = { name, type, skills: skillList };
+      if (type === "a2a" && skillList.length === 0) {
+        summary.pendingDiscovery = true;
+      }
+      return summary;
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export function createRoutes(ctx: ApiContext): Route[] {
@@ -67,47 +127,7 @@ export function createRoutes(ctx: ApiContext): Route[] {
     {
       method: "GET",
       path: "/api/agents/runtime",
-      handler: () => {
-        const registrations = ctx.executorRegistry.list();
-
-        // 1. Group registry entries by (agentName ?? executor.type).
-        const byKey = new Map<string, { type: string; skills: Set<string> }>();
-        for (const reg of registrations) {
-          const key = reg.agentName ?? reg.executor.type;
-          let entry = byKey.get(key);
-          if (!entry) {
-            entry = { type: reg.executor.type, skills: new Set() };
-            byKey.set(key, entry);
-          }
-          if (reg.skill) entry.skills.add(reg.skill);
-        }
-
-        // 2. Merge in yaml-declared A2A agents. If they already have a
-        // registry entry (skills discovered, in-process loaded), the
-        // registry data wins. Otherwise we mark them pendingDiscovery
-        // so the dashboard renders a node with no skills yet.
-        for (const ya of loadYamlAgents(ctx.workspaceDir)) {
-          if (!ya.name) continue;
-          if (byKey.has(ya.name)) continue;
-          byKey.set(ya.name, { type: "a2a", skills: new Set() });
-        }
-
-        const agents: AgentSummary[] = [...byKey.entries()]
-          .map(([name, { type, skills }]) => {
-            const skillList = [...skills].sort();
-            const summary: AgentSummary = { name, type, skills: skillList };
-            // Only A2A agents can be in "discovery pending" — others
-            // either declare their skills via yaml (deep-agents) or are
-            // synthetic plugin-level (function).
-            if (type === "a2a" && skillList.length === 0) {
-              summary.pendingDiscovery = true;
-            }
-            return summary;
-          })
-          .sort((a, b) => a.name.localeCompare(b.name));
-
-        return Response.json({ success: true, data: { agents } });
-      },
+      handler: () => Response.json({ success: true, data: { agents: collectFleetAgents(ctx) } }),
     },
   ];
 }

--- a/src/api/control-plane.ts
+++ b/src/api/control-plane.ts
@@ -1,0 +1,54 @@
+/**
+ * GET /api/control-plane/state — the unified read of the control plane (ADR-0004 P5).
+ *
+ * The control plane has a write side (the command.* bus topics + agents-crud.ts,
+ * driven by the Console) and, until now, a scattered read side: the live fleet
+ * came from /api/agents/runtime while health lived only inside the
+ * AgentFleetHealthPlugin with no HTTP exposure. This route unifies both into a
+ * single snapshot so the Console (and any operator tool) can render "what is the
+ * fleet, and how is it doing" in one fetch:
+ *
+ *   {
+ *     success: true,
+ *     data: {
+ *       agents: AgentSummary[],            // live registry + declared A2A (pendingDiscovery)
+ *       health: FleetHealthSnapshot | null, // 24h rollups, durably-backed (P5a); null if the plugin isn't installed
+ *       collectedAt: number,
+ *     }
+ *   }
+ *
+ * Health is read through the plugin's in-memory window, which is rehydrated from
+ * knowledge.db on startup (P5a) — so the numbers survive restarts. This route is
+ * read-only; all mutation flows through the command.* write API.
+ */
+
+import type { Route, ApiContext } from "./types.ts";
+import { collectFleetAgents } from "./agents-runtime.ts";
+import type { AgentFleetHealthPlugin } from "../plugins/agent-fleet-health-plugin.ts";
+import type { FleetHealthSnapshot } from "../plugins/agent-fleet-health-plugin.ts";
+
+function fleetHealth(ctx: ApiContext): FleetHealthSnapshot | null {
+  const plugin = ctx.plugins.find((p) => p.name === "agent-fleet-health");
+  if (!plugin) return null;
+  return (plugin as unknown as AgentFleetHealthPlugin).getFleetHealth();
+}
+
+export function createRoutes(ctx: ApiContext): Route[] {
+  return [
+    {
+      method: "GET",
+      path: "/api/control-plane/state",
+      handler: () => {
+        const health = fleetHealth(ctx);
+        return Response.json({
+          success: true,
+          data: {
+            agents: collectFleetAgents(ctx),
+            health,
+            collectedAt: health?.collectedAt ?? Date.now(),
+          },
+        });
+      },
+    },
+  ];
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -30,6 +30,7 @@ import { createRoutes as agentsRuntimeRoutes } from "./agents-runtime.ts";
 import { createRoutes as busHistoryRoutes } from "./bus-history.ts";
 import { createRoutes as humanInputRoutes } from "./human-input.ts";
 import { createRoutes as agentsCrudRoutes } from "./agents-crud.ts";
+import { createRoutes as controlPlaneRoutes } from "./control-plane.ts";
 
 export { matchPath } from "./types.ts";
 export type { Route, ApiContext } from "./types.ts";
@@ -59,5 +60,6 @@ export function createAllRoutes(ctx: ApiContext): Route[] {
     ...busHistoryRoutes(ctx),
     ...humanInputRoutes(ctx),
     ...agentsCrudRoutes(ctx),
+    ...controlPlaneRoutes(ctx),
   ];
 }


### PR DESCRIPTION
## What

ADR-0004 **P5b** — the read-side counterpart to the P2/P3 control-plane write API, plus the doc that finally tells the read/write story straight.

### `GET /api/control-plane/state` — unified read
One call returns the whole control-plane picture:
```jsonc
{ "agents": [ /* live registry + declared A2A */ ],
  "health": { /* per-agent 24h rollups, or null if the plugin isn't installed */ },
  "collectedAt": 0 }
```
Until now the fleet came from `/api/agents/runtime` while `AgentFleetHealthPlugin`'s health snapshot had **no HTTP exposure at all** (only an in-process getter for dispatch weighting). This unifies them. The health half is read through the plugin's in-memory window, which is **rehydrated from `knowledge.db` on startup (P5a)** — so the numbers survive restarts.

### Single source for fleet grouping
Extracted `collectFleetAgents()` so `/api/agents/runtime` and the unified read can't drift, and extended it to surface `agents.d/`-managed A2A agents (day-4a), not just `agents.yaml`.

### Console consumes it
The Console fleet rows now show a per-agent **health badge** — 24h success rate + run count, colored by the 1h failure rate (green / amber <90% / red on any recent failure). Not a dead endpoint: this is its consumer.

### Doc: read/write split
`docs/architecture/flow-dashboard.md` claimed the dashboard is "intentionally read-only … not a control surface." The P3 Console makes that false. Rewrote it to document the **structural** split — cached keyless `apiFetch` GETs (read panes) vs uncached admin-gated `adminFetch` → `command.*` → sole `ControlPlaneRegistrar` (Console) — fixed the stale routes table, and noted that fleet health is now durable while bus-event history remains ephemeral.

## Test
- `src/api/__tests__/control-plane.test.ts` — returns fleet + health; `health: null` (not an error) when the plugin isn't installed, fleet still served from the registry.
- Backend **897 pass**, dashboard **20 pass** (`bun run build` clean), typecheck clean, lint at baseline (13/28).

Part of epic #707. Completes the P5 track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)