### PR TITLE
fix(docs): escape angle brackets in generated bus-topics prose — unbreak docs deploy

### DIFF
--- a/docs/reference/bus-topics.md
+++ b/docs/reference/bus-topics.md
@@ -55,7 +55,7 @@ Each row links to the original call site as `path:line` so jumping from this ind
 | Topic | Declared | Payload | Publishers | Subscribers |
 |---|---|---|---|---|
 | `autonomous.outcome` | ✅ `AUTONOMOUS_OUTCOME_PREFIX` (`ACTION_TOPICS`) | — | _(none)_ | _(none)_ |
-| `autonomous.outcome.#` | — | — | _(none)_ | `src/plugins/agent-fleet-health-plugin.ts:188` |
+| `autonomous.outcome.#` | — | — | _(none)_ | `src/plugins/agent-fleet-health-plugin.ts:206` |
 
 **`autonomous.outcome`** — Published by SkillDispatcherPlugin after every task reaches terminal state. Full topic is `autonomous.outcome.{systemActor}.{skill}`.
 
@@ -81,7 +81,7 @@ Each row links to the original call site as `path:line` so jumping from this ind
 | `command.agent.upsert` | ✅ `COMMAND_AGENT_UPSERT` (`ACTION_TOPICS`) | — | _(none)_ | `src/plugins/control-plane-registrar-plugin.ts:41` |
 | `command.schedule` | — | — | _(none)_ | `lib/plugins/scheduler.ts:73` |
 
-**`command.a2a.upsert`** — A2A-endpoint mutations (ADR-0004 P3). The registrar persists the entry to workspace/agents.d/<name>.yaml; SkillBroker registers/unregisters the A2AExecutor live in the same turn (no restart). command.a2a.upsert — { name, file, yaml, entry } command.a2a.remove — { name, file }
+**`command.a2a.upsert`** — A2A-endpoint mutations (ADR-0004 P3). The registrar persists the entry to workspace/agents.d/&lt;name&gt;.yaml; SkillBroker registers/unregisters the A2AExecutor live in the same turn (no restart). command.a2a.upsert — { name, file, yaml, entry } command.a2a.remove — { name, file }
 
 **`command.agent.upsert`** — Control-plane mutations (ADR-0004 P2). The write API publishes these; the ControlPlaneRegistrar is the sole subscriber + the only writer of the workspace config files. Auditable in bus-history. The file write triggers the agent-runtime hot-reload (P1), so the change goes live within ~5s. command.agent.upsert  — { name, file, yaml }  → atomic write command.agent.remove  — { name, file }        → delete
 
@@ -351,7 +351,7 @@ Each row links to the original call site as `path:line` so jumping from this ind
 
 | Topic | Declared | Payload | Publishers | Subscribers |
 |---|---|---|---|---|
-| `{topic}` | — | — | `src/world/extensions/CeremonyStateExtension.ts:120`<br>`src/agent-runtime/agent-runtime-plugin.ts:200`<br>`src/executor/executors/proto-sdk-executor.ts:86`<br>`src/executor/task-tracker.ts:282`<br>`src/executor/extensions/effect-domain.ts:85`<br>`src/executor/extensions/cost.ts:210`<br>`src/executor/extensions/confidence.ts:166`<br>`src/executor/skill-dispatcher-plugin.ts:713`<br>`src/executor/skill-dispatcher-plugin.ts:788`<br>`src/executor/skill-dispatcher-plugin.ts:812`<br>`src/executor/skill-dispatcher-plugin.ts:861`<br>`src/api/agents-crud.ts:55`<br>`src/api/operations.ts:80`<br>`src/api/operations.ts:115`<br>`src/api/operations.ts:133`<br>`lib/plugins/linear.ts:430`<br>`lib/plugins/linear.ts:477`<br>`lib/plugins/linear.ts:556`<br>`lib/plugins/linear.ts:603`<br>`lib/plugins/linear.ts:636`<br>`lib/plugins/linear.ts:853`<br>`lib/plugins/github.ts:393`<br>`lib/plugins/github.ts:635`<br>`lib/plugins/github.ts:715`<br>`lib/plugins/operator-routing.ts:128`<br>`lib/plugins/feature-notifier.ts:98`<br>`lib/plugins/debug.ts:31`<br>`lib/plugins/google/gmail.ts:152`<br>`lib/plugins/onboarding.ts:325` | `src/executor/executors/workflow-executor.ts:93`<br>`src/index.ts:747` |
+| `{topic}` | — | — | `src/world/extensions/CeremonyStateExtension.ts:120`<br>`src/agent-runtime/agent-runtime-plugin.ts:200`<br>`src/executor/executors/proto-sdk-executor.ts:86`<br>`src/executor/task-tracker.ts:282`<br>`src/executor/extensions/effect-domain.ts:85`<br>`src/executor/extensions/cost.ts:210`<br>`src/executor/extensions/confidence.ts:166`<br>`src/executor/skill-dispatcher-plugin.ts:713`<br>`src/executor/skill-dispatcher-plugin.ts:788`<br>`src/executor/skill-dispatcher-plugin.ts:812`<br>`src/executor/skill-dispatcher-plugin.ts:861`<br>`src/api/agents-crud.ts:55`<br>`src/api/operations.ts:80`<br>`src/api/operations.ts:115`<br>`src/api/operations.ts:133`<br>`lib/plugins/linear.ts:430`<br>`lib/plugins/linear.ts:477`<br>`lib/plugins/linear.ts:556`<br>`lib/plugins/linear.ts:603`<br>`lib/plugins/linear.ts:636`<br>`lib/plugins/linear.ts:853`<br>`lib/plugins/github.ts:393`<br>`lib/plugins/github.ts:635`<br>`lib/plugins/github.ts:715`<br>`lib/plugins/operator-routing.ts:128`<br>`lib/plugins/feature-notifier.ts:98`<br>`lib/plugins/debug.ts:31`<br>`lib/plugins/google/gmail.ts:152`<br>`lib/plugins/onboarding.ts:325` | `src/executor/executors/workflow-executor.ts:93`<br>`src/index.ts:754` |
 
 ## Unresolved call sites
 
@@ -446,7 +446,7 @@ These sites pass a non-literal topic that the static scan couldn't resolve to a 
 | `src/executor/skill-dispatcher-plugin.ts:861` | publish | `topic` |
 | `src/executor/task-tracker.ts:282` | publish | `topic` |
 | `src/executor/task-tracker.ts:330` | publish | `task.replyTopic` |
-| `src/index.ts:747` | subscribe | `topic` |
+| `src/index.ts:754` | subscribe | `topic` |
 | `src/plugins/ceremony-skill-executor-plugin.ts:123` | publish | `executeTopic` |
 | `src/plugins/CeremonyPlugin.ts:344` | publish | `executeTopic` |
 | `src/plugins/CeremonyPlugin.ts:372` | subscribe | `replyTopic` |

--- a/scripts/audit-bus-topics.ts
+++ b/scripts/audit-bus-topics.ts
@@ -130,6 +130,19 @@ function readJsDoc(node: ts.Node): string | undefined {
   return undefined;
 }
 
+/**
+ * Escape bare `<`/`>` in prose so VitePress (Vue's template compiler) doesn't
+ * try to parse e.g. `agents.d/<name>.yaml` as an unclosed HTML element. Code
+ * spans (backtick-delimited) are left intact — a generic like `Record<string>`
+ * inside ticks must render literally, not as entities.
+ */
+function escapeAngleProse(text: string): string {
+  return text
+    .split(/(`[^`]*`)/) // keep backtick spans as their own (odd-index) chunks
+    .map((chunk, i) => (i % 2 === 1 ? chunk : chunk.replace(/</g, "&lt;").replace(/>/g, "&gt;")))
+    .join("");
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Build payload-type binding from src/event-bus/payloads.ts
 //
@@ -389,7 +402,7 @@ function renderMarkdown(entries: TopicEntry[]): string {
     // Per-topic notes (only when there's documentation worth surfacing)
     for (const e of (byGroup.get(g) ?? [])) {
       if (e.doc) {
-        lines.push(`**\`${e.topic}\`** — ${e.doc}`);
+        lines.push(`**\`${e.topic}\`** — ${escapeAngleProse(e.doc)}`);
         lines.push("");
       }
     }


### PR DESCRIPTION
## Problem

The **Deploy Docs to GitHub Pages** workflow has failed on **every `main` commit since 47215b7 (#723)**. Root cause: the `command.a2a.upsert` topic's source comment contains `workspace/agents.d/<name>.yaml`. The bus-topics generator emits topic descriptions verbatim, so `<name>` reached the rendered page and Vue's template compiler parsed it as an unclosed HTML element:

```
reference/bus-topics.md (260:165): Element is missing end tag.
```

(Code-side CI / container image were unaffected and kept deploying — only the docs site was down.)

## Fix

At the generator (`scripts/audit-bus-topics.ts`), not the symptom: `escapeAngleProse()` converts bare `<`/`>` to `&lt;`/`&gt;` in description prose while leaving backtick code spans intact — so a generic like `` `Record<string>` `` still renders literally rather than as entities. Prevents recurrence for any future topic comment.

Regenerated `docs/reference/bus-topics.md`: the only prose change is the escape; the remaining diff is line-number drift picked up from P5a/P5b (e.g. `index.ts:747`→`754`).

## Test
- `cd docs && bun run build` — **build complete**, was failing before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)