### PR TITLE
docs(quinn): workflow_run/check_suite events + Checks:Read for CI re-review (#721)

### DIFF
--- a/docs/how-to/use-quinn-pr-review.md
+++ b/docs/how-to/use-quinn-pr-review.md
@@ -51,7 +51,9 @@ For a single repository: **Settings → Webhooks → Add webhook**
 | Content type | `application/json` |
 | Secret | Value of `GITHUB_WEBHOOK_SECRET` |
 | SSL verification | Enable |
-| Events | Issue comments, Issues, Pull request review comments, Pull requests |
+| Events | Issue comments, Issues, Pull request review comments, Pull requests, **Workflow runs**, **Check suites** |
+
+> **Workflow runs + Check suites are required for the CI-completion re-review** (#721): Quinn posts a provisional `COMMENT` while CI is in flight and only upgrades to a formal `APPROVE`/`REQUEST_CHANGES` once every check is terminal. Without these two events nothing re-invokes Quinn when CI finishes, so clean PRs stall at the provisional comment. If you registered the webhook before 2026-06, **edit the existing hook to add them** (`PATCH orgs/protoLabsAI/hooks/<id>` with the full events list).
 
 ### Org-level webhook (recommended)
 
@@ -69,7 +71,9 @@ gh api orgs/protoLabsAI/hooks \
   --field "events[]=issues" \
   --field "events[]=issue_comment" \
   --field "events[]=pull_request" \
-  --field "events[]=pull_request_review_comment"
+  --field "events[]=pull_request_review_comment" \
+  --field "events[]=workflow_run" \
+  --field "events[]=check_suite"
 ```
 
 ---
@@ -83,7 +87,10 @@ Fine-grained PAT scoped to the target repo:
 | Issues | Read & Write |
 | Pull requests | Read & Write |
 | Actions | Read |
+| Checks | Read |
 | Contents | Read |
+
+> **Checks: Read** backs the CI-completion re-review's terminal gate (#721) — Quinn reads `commits/{sha}/check-runs` to confirm every check has finished before posting a formal verdict. If it's missing the gate fails *open* (Quinn still re-reviews, just without waiting for full terminality).
 
 ---
 


### PR DESCRIPTION
Follow-up to #730 (the CI-completion re-review). The setup guide didn't mention the two webhook events or the token permission the fix relies on:

- **§3** — add **Workflow runs** + **Check suites** to the event table and the org-hook `gh api` snippet, with a note to PATCH pre-existing hooks.
- **§4** — add **Checks: Read** (backs the all-checks-terminal gate; fails open if absent).

Doc-only; `bun run build` clean. Mirrors the operator action needed to make #730 live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub webhook setup documentation to include Workflow runs and Check suites events at repository and organization levels, with guidance on upgrading existing hooks.
  * Enhanced GitHub token permissions configuration to include Checks: Read and Contents: Read permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->