### PR TITLE
feat(mcp): live MCP client tier — connect servers, register tools as executors (ADR-0005 P4, day 3)

### DIFF
--- a/src/api/__tests__/mcp-crud.test.ts
+++ b/src/api/__tests__/mcp-crud.test.ts
@@ -118,6 +118,18 @@ describe("mcp-crud control-plane API", () => {
     const noKey = await route("POST", "/api/mcp-servers").handler(req(STDIO), {});
     expect(noKey.status).toBe(401);
   });
+
+  test("POST /test validates then probes — bad def 400; valid-but-unreachable → reachable:false", async () => {
+    const bad = await route("POST", "/api/mcp-servers/test").handler(req({ name: "x", transport: "stdio" }), {});
+    expect(bad.status).toBe(400); // no command → never attempts a connection
+
+    const unreach = await route("POST", "/api/mcp-servers/test").handler(
+      req({ name: "ghost", transport: "stdio", command: ["this-command-does-not-exist-pw99"] }), {},
+    );
+    const body = (await unreach.json()) as { success: boolean; reachable: boolean };
+    expect(body.success).toBe(true);
+    expect(body.reachable).toBe(false);
+  }, 12_000);
 });
 
 describe("mcpEnabled — trust-tier auto-enable (ADR-0005 D2)", () => {

--- a/src/api/mcp-crud.ts
+++ b/src/api/mcp-crud.ts
@@ -20,6 +20,11 @@ import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { stringify as stringifyYaml, parse as parseYaml } from "yaml";
 import type { Route, ApiContext } from "./types.ts";
 import type { McpServerDef, TrustTier, McpTransport, CapabilityGrant } from "../mcp/types.ts";
+import { mcpEnabled, probeMcpServer } from "../mcp/mcp-connect.ts";
+
+// Canonical trust-tier enable gate lives in mcp-connect (shared with the plugin);
+// re-exported so existing importers (and the unified read) keep their path.
+export { mcpEnabled };
 
 const TRUST_TIERS: TrustTier[] = ["builtin", "trusted", "community"];
 const TRANSPORTS: McpTransport[] = ["stdio", "sse"];
@@ -37,13 +42,6 @@ export interface McpServerSummary {
   enabled: boolean;
   grants: CapabilityGrant[];
   description?: string;
-}
-
-/** Effective enabled state: explicit `enabled`, else builtin/trusted auto-enable, community off (ADR-0005 D2). */
-export function mcpEnabled(def: Pick<McpServerDef, "trust" | "enabled">): boolean {
-  if (typeof def.enabled === "boolean") return def.enabled;
-  const trust = def.trust ?? "community";
-  return trust === "builtin" || trust === "trusted";
 }
 
 /** Every MCP server registered on disk (workspace/mcp-servers.d/*.yaml). Shared with the unified read. */
@@ -125,6 +123,22 @@ export function createRoutes(ctx: ApiContext): Route[] {
   const knownNames = () => new Set(listMcpServers(ctx.workspaceDir).map((s) => s.name));
 
   return [
+    {
+      // Capability discovery (ADR-0005): connect to a candidate MCP server and
+      // list its tools, so the operator sees real capabilities before saving —
+      // the test-before-save mirror of /api/a2a/probe. Validates the def first.
+      method: "POST",
+      path: "/api/mcp-servers/test",
+      handler: async (req) => {
+        if (!authorized(req)) return unauthorized();
+        let body: unknown;
+        try { body = await req.json(); } catch { return badJson(); }
+        const v = validate(body);
+        if ("error" in v) return v.error;
+        const probe = await probeMcpServer(v.def);
+        return Response.json({ success: true, ...probe });
+      },
+    },
     {
       method: "GET",
       path: "/api/mcp-servers",

--- a/src/index.ts
+++ b/src/index.ts
@@ -326,6 +326,17 @@ const pluginRegistry: PluginRegistryEntry[] = [
     },
   },
   {
+    // MCP client tier (ADR-0005 P4): connects to enabled MCP servers from
+    // workspace/mcp-servers.d/ and registers one McpExecutor per discovered
+    // tool. Control-plane-managed (command.mcp.*); hot-reloads with no restart.
+    name: "mcp-client",
+    condition: () => true,
+    factory: async () => {
+      const { McpClientPlugin } = await import("./mcp/mcp-client-plugin.js");
+      return new McpClientPlugin(workspaceDir, executorRegistry);
+    },
+  },
+  {
     // Registers Discord-alert FunctionExecutors for `alert.*` skills that
     // have no agent-backed handler. Crons/ceremonies can dispatch alert.*
     // skills directly without needing an agent.
@@ -525,13 +536,13 @@ for (const entry of pluginRegistry) {
 {
   const hasDispatcher = registeredPlugins.some(p => p.name === "skill-dispatcher");
   const hasRegistrar = registeredPlugins.some(p =>
-    p.name === "agent-runtime" || p.name === "skill-broker",
+    p.name === "agent-runtime" || p.name === "skill-broker" || p.name === "mcp-client",
   );
   if (hasDispatcher && !hasRegistrar) {
     console.warn(
-      "[startup] skill-dispatcher is installed but no executor registrar (agent-runtime / skill-broker) is active. " +
+      "[startup] skill-dispatcher is installed but no executor registrar (agent-runtime / skill-broker / mcp-client) is active. " +
       "All agent.skill.request messages will be dropped. " +
-      "Add workspace/agents/*.yaml or workspace/agents.yaml to register at least one agent.",
+      "Add workspace/agents/*.yaml, workspace/agents.yaml, or workspace/mcp-servers.d/ to register at least one agent or MCP server.",
     );
   }
 }

--- a/src/mcp/__tests__/mcp-connect.test.ts
+++ b/src/mcp/__tests__/mcp-connect.test.ts
@@ -1,0 +1,86 @@
+/**
+ * MCP config resolution + the trust/filter gates (ADR-0005 P4). Pure, plus one
+ * bounded probe against a non-existent command to exercise the reachable:false
+ * path without a real MCP server.
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { resolveServerConfig, mcpEnabled, toolAllowed, probeMcpServer } from "../mcp-connect.ts";
+import { mcpSkillName } from "../mcp-client-plugin.ts";
+import type { McpServerDef } from "../types.ts";
+
+describe("mcpEnabled (trust-tier gate, ADR-0005 D2)", () => {
+  test("explicit enabled wins over trust", () => {
+    expect(mcpEnabled({ trust: "community", enabled: true })).toBe(true);
+    expect(mcpEnabled({ trust: "builtin", enabled: false })).toBe(false);
+  });
+  test("builtin/trusted auto-enable; community (and default) off", () => {
+    expect(mcpEnabled({ trust: "builtin" })).toBe(true);
+    expect(mcpEnabled({ trust: "trusted" })).toBe(true);
+    expect(mcpEnabled({ trust: "community" })).toBe(false);
+    expect(mcpEnabled({})).toBe(false);
+  });
+});
+
+describe("resolveServerConfig", () => {
+  test("applies defaults (community/stdio), grants→[], enabled from trust", () => {
+    const cfg = resolveServerConfig({ name: "x", command: ["server"] });
+    expect(cfg.trust).toBe("community");
+    expect(cfg.transport).toBe("stdio");
+    expect(cfg.grants).toEqual([]);
+    expect(cfg.enabled).toBe(false); // community default
+  });
+  test("merges command + args into one argv (command[0] is the executable)", () => {
+    const cfg = resolveServerConfig({ name: "x", command: ["npx"], args: ["-y", "pkg", "/data"] });
+    expect(cfg.command).toEqual(["npx", "-y", "pkg", "/data"]);
+  });
+  test("interpolates ${ENV} in env values and url", () => {
+    process.env.MCP_TEST_TOKEN = "sekret";
+    try {
+      const cfg = resolveServerConfig({
+        name: "x", trust: "trusted", transport: "sse",
+        url: "https://host/${MCP_TEST_TOKEN}", env: { TOKEN: "${MCP_TEST_TOKEN}" },
+      });
+      expect(cfg.url).toBe("https://host/sekret");
+      expect(cfg.env).toEqual({ TOKEN: "sekret" });
+      expect(cfg.enabled).toBe(true); // trusted
+    } finally {
+      delete process.env.MCP_TEST_TOKEN;
+    }
+  });
+});
+
+describe("toolAllowed (allow/exclude filter, exclude wins)", () => {
+  const cfg = resolveServerConfig({ name: "x", command: ["s"], allowedTools: ["read", "write"], excludeTools: ["write"] });
+  test("allowed when in allowlist and not excluded", () => {
+    expect(toolAllowed(cfg, "read")).toBe(true);
+  });
+  test("excluded beats allowed", () => {
+    expect(toolAllowed(cfg, "write")).toBe(false);
+  });
+  test("not in allowlist → denied", () => {
+    expect(toolAllowed(cfg, "delete")).toBe(false);
+  });
+  test("no allowlist → everything not-excluded is allowed", () => {
+    const open = resolveServerConfig({ name: "y", command: ["s"], excludeTools: ["danger"] });
+    expect(toolAllowed(open, "anything")).toBe(true);
+    expect(toolAllowed(open, "danger")).toBe(false);
+  });
+});
+
+describe("mcpSkillName", () => {
+  test("namespaces the tool by server to avoid collisions", () => {
+    expect(mcpSkillName("filesystem", "read_file")).toBe("filesystem.read_file");
+  });
+});
+
+describe("probeMcpServer", () => {
+  afterEach(() => {});
+  test("a non-existent stdio command → reachable:false (never throws)", async () => {
+    const def: McpServerDef = { name: "ghost", transport: "stdio", command: ["this-command-does-not-exist-pw4231"] };
+    const result = await probeMcpServer(def);
+    expect(result.reachable).toBe(false);
+    expect(result.name).toBe("ghost");
+    expect(typeof result.error).toBe("string");
+  }, 12_000);
+});

--- a/src/mcp/__tests__/mcp-executor.test.ts
+++ b/src/mcp/__tests__/mcp-executor.test.ts
@@ -1,0 +1,36 @@
+/**
+ * McpExecutor argument/result mapping (ADR-0005 P4) — the pure glue between a
+ * skill request and an MCP callTool.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { toToolArguments, flattenToolContent } from "../mcp-executor.ts";
+
+describe("toToolArguments", () => {
+  test("a JSON object is used as the tool arguments verbatim", () => {
+    expect(toToolArguments('{"path":"/x","depth":2}')).toEqual({ path: "/x", depth: 2 });
+  });
+  test("non-JSON / scalar content is wrapped under `input` (simple single-arg tools)", () => {
+    expect(toToolArguments("just some text")).toEqual({ input: "just some text" });
+    expect(toToolArguments("42")).toEqual({ input: "42" }); // a bare number isn't an object
+    expect(toToolArguments('["a","b"]')).toEqual({ input: '["a","b"]' }); // arrays aren't arg objects
+  });
+  test("empty / undefined content → no arguments", () => {
+    expect(toToolArguments("")).toEqual({});
+    expect(toToolArguments(undefined)).toEqual({});
+  });
+});
+
+describe("flattenToolContent", () => {
+  test("joins text parts; labels non-text parts", () => {
+    expect(flattenToolContent([
+      { type: "text", text: "line one" },
+      { type: "text", text: "line two" },
+    ])).toBe("line one\nline two");
+    expect(flattenToolContent([{ type: "image", mimeType: "image/png", data: "..." }])).toBe("[image image/png]");
+  });
+  test("tolerates non-array / empty content", () => {
+    expect(flattenToolContent(undefined)).toBe("");
+    expect(flattenToolContent([])).toBe("");
+  });
+});

--- a/src/mcp/mcp-client-plugin.ts
+++ b/src/mcp/mcp-client-plugin.ts
@@ -1,0 +1,145 @@
+/**
+ * McpClientPlugin — connects to MCP servers and registers their tools as
+ * executors (ADR-0005 P4). The MCP client tier, mirroring SkillBrokerPlugin's
+ * A2A reconcile shape (ADR-0004 P3 day-4).
+ *
+ * On install it reads workspace/mcp-servers.d/*.yaml, and for each ENABLED
+ * server (trust-tier gate, ADR-0005 D2) connects one shared Client, lists its
+ * tools, and registers one McpExecutor per tool with the ExecutorRegistry under
+ * skill name "<server>.<tool>" + agentName "<server>". command.mcp.upsert/remove
+ * reconcile live — no restart.
+ *
+ * Connecting is fire-and-forget off the bus turn (like SkillBroker's discovery):
+ * an unreachable/slow server never blocks reconcile; its tools simply don't
+ * register and the failure logs loudly.
+ *
+ * This plugin is a registrar only — SkillDispatcherPlugin remains the sole
+ * subscriber to agent.skill.request.
+ *
+ * Config: workspace/mcp-servers.d/<name>.yaml (control-plane-managed).
+ */
+
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
+import type { ExecutorRegistry } from "../executor/executor-registry.ts";
+import type { McpServerDef } from "./types.ts";
+import { McpExecutor } from "./mcp-executor.ts";
+import { resolveServerConfig, connectMcp, toolAllowed, mcpEnabled } from "./mcp-connect.ts";
+
+/** The registry skill name for an MCP tool — namespaced by server to avoid collisions. */
+export function mcpSkillName(serverName: string, toolName: string): string {
+  return `${serverName}.${toolName}`;
+}
+
+export class McpClientPlugin implements Plugin {
+  readonly name = "mcp-client";
+  readonly description = "Connects to MCP servers and registers their tools as executors (ADR-0005)";
+  readonly capabilities = ["executor-registrar", "mcp-client"];
+
+  private readonly workspaceDir: string;
+  private readonly executorRegistry: ExecutorRegistry;
+  private bus?: EventBus;
+  /** Live connected clients, one per server, owned here (closed on unregister/uninstall). */
+  private readonly clients = new Map<string, Client>();
+
+  constructor(workspaceDir: string, executorRegistry: ExecutorRegistry) {
+    this.workspaceDir = workspaceDir;
+    this.executorRegistry = executorRegistry;
+  }
+
+  install(bus: EventBus): void {
+    this.bus = bus;
+    const defs = this._loadServers();
+    for (const def of defs) this._registerServer(def);
+    console.log(`[mcp-client] Reconciling ${defs.length} MCP server(s) from mcp-servers.d/ (tools connect async)`);
+
+    bus.subscribe("command.mcp.upsert", this.name, (msg: BusMessage) => {
+      const entry = (msg.payload as { entry?: McpServerDef })?.entry;
+      if (entry?.name) this._registerServer(entry);
+    });
+    bus.subscribe("command.mcp.remove", this.name, (msg: BusMessage) => {
+      const name = (msg.payload as { name?: string })?.name;
+      if (name) void this._unregisterServer(name);
+    });
+  }
+
+  uninstall(): void {
+    for (const name of [...this.clients.keys()]) void this._unregisterServer(name);
+  }
+
+  /**
+   * Register (or re-register) a server: skip if disabled, else connect + list
+   * tools + register one executor per tool. Idempotent — unregisters first.
+   * The connect is fire-and-forget so a slow/dead server never blocks the turn.
+   */
+  private _registerServer(def: McpServerDef): void {
+    void this._unregisterServer(def.name).then(() => {
+      if (!mcpEnabled(def)) {
+        console.log(`[mcp-client] "${def.name}" registered but disabled (trust=${def.trust ?? "community"}) — set enabled:true to connect`);
+        return;
+      }
+      return this._connectAndRegister(def);
+    });
+  }
+
+  private async _connectAndRegister(def: McpServerDef): Promise<void> {
+    const cfg = resolveServerConfig(def);
+    try {
+      const client = await connectMcp(cfg);
+      this.clients.set(def.name, client);
+      const { tools } = await client.listTools();
+      let registered = 0;
+      for (const tool of tools) {
+        if (!toolAllowed(cfg, tool.name)) continue;
+        const executor = new McpExecutor(client, def.name, tool.name, tool.description);
+        this.executorRegistry.register(mcpSkillName(def.name, tool.name), executor, {
+          agentName: def.name,
+          priority: 5,
+        });
+        registered++;
+      }
+      console.log(`[mcp-client] "${def.name}" connected — registered ${registered}/${tools.length} tool(s)`);
+    } catch (err) {
+      // Loud failure at the boundary (per feedback_fail_fast_and_loud): a server
+      // that won't connect registers no tools, and silence would hide it.
+      this.clients.delete(def.name);
+      console.warn(`[mcp-client] "${def.name}" connect failed — no tools registered: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  /** Unregister every tool a server owns + close its client. */
+  private async _unregisterServer(name: string): Promise<void> {
+    for (const reg of this.executorRegistry.list()) {
+      if (reg.agentName === name && reg.skill) this.executorRegistry.unregister(reg.skill, name);
+    }
+    const client = this.clients.get(name);
+    if (client) {
+      this.clients.delete(name);
+      await client.close().catch(() => {});
+      console.log(`[mcp-client] - MCP server "${name}" disconnected + unregistered`);
+    }
+  }
+
+  /** Control-plane-managed MCP servers: one McpServerDef per file in workspace/mcp-servers.d/. */
+  private _loadServers(): McpServerDef[] {
+    const dir = join(this.workspaceDir, "mcp-servers.d");
+    if (!existsSync(dir)) return [];
+    const out: McpServerDef[] = [];
+    try {
+      for (const f of readdirSync(dir)) {
+        if (!(f.endsWith(".yaml") || f.endsWith(".yml")) || f.endsWith(".example")) continue;
+        try {
+          const def = parseYaml(readFileSync(join(dir, f), "utf8")) as McpServerDef;
+          if (def?.name) out.push(def);
+          else console.warn(`[mcp-client] mcp-servers.d/${f}: missing name — skipped`);
+        } catch (err) {
+          console.error(`[mcp-client] Skipping mcp-servers.d/${f}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+    } catch { /* dir vanished mid-scan */ }
+    return out;
+  }
+}

--- a/src/mcp/mcp-connect.ts
+++ b/src/mcp/mcp-connect.ts
@@ -1,0 +1,113 @@
+/**
+ * MCP connection helpers (ADR-0005 P4) — shared by McpClientPlugin (live tool
+ * registration) and the control-plane probe (POST /api/mcp-servers/test).
+ *
+ * Centralizes the bits that touch the @modelcontextprotocol/sdk client so a SDK
+ * change is one file: config resolution (defaults + env interpolation + the
+ * trust-tier enable gate), connecting a transport, and a bounded probe.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { resolveEnvVars } from "../utils/env-interpolation.ts";
+import type { McpServerDef, McpServerConfig, McpProbeResult, TrustTier } from "./types.ts";
+
+const CONNECT_TIMEOUT_MS = 8_000;
+
+/**
+ * Effective enabled state (ADR-0005 D2): explicit `enabled` wins; otherwise
+ * builtin/trusted auto-enable and community stays off until the operator opts in.
+ */
+export function mcpEnabled(def: Pick<McpServerDef, "trust" | "enabled">): boolean {
+  if (typeof def.enabled === "boolean") return def.enabled;
+  const trust: TrustTier = def.trust ?? "community";
+  return trust === "builtin" || trust === "trusted";
+}
+
+/** Resolve a raw server def into a runtime config: defaults, merged command, interpolated env. */
+export function resolveServerConfig(def: McpServerDef): McpServerConfig {
+  const trust: TrustTier = def.trust ?? "community";
+  const transport = def.transport ?? "stdio";
+
+  // command + args merge into a single argv (command[0] is the executable).
+  const command = (def.command?.length ? [...def.command, ...(def.args ?? [])] : def.args) ?? undefined;
+
+  let env: Record<string, string> | undefined;
+  if (def.env) {
+    env = {};
+    for (const [k, v] of Object.entries(def.env)) env[k] = resolveEnvVars(v, "mcp-client");
+  }
+
+  return {
+    name: def.name,
+    trust,
+    transport,
+    command,
+    env,
+    url: def.url ? resolveEnvVars(def.url, "mcp-client") : undefined,
+    grants: Array.isArray(def.grants) ? def.grants : [],
+    allowedTools: def.allowedTools,
+    excludeTools: def.excludeTools,
+    enabled: mcpEnabled(def),
+    description: def.description,
+  };
+}
+
+/** Whether a tool name passes the server's allow/exclude filter (exclude wins). */
+export function toolAllowed(cfg: McpServerConfig, toolName: string): boolean {
+  if (cfg.excludeTools?.includes(toolName)) return false;
+  if (cfg.allowedTools && cfg.allowedTools.length > 0) return cfg.allowedTools.includes(toolName);
+  return true;
+}
+
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<T>((_, reject) => setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms).unref?.()),
+  ]);
+}
+
+/** Build a transport for the config + connect a fresh MCP client. Throws on failure/timeout. */
+export async function connectMcp(cfg: McpServerConfig): Promise<Client> {
+  const client = new Client({ name: "protoworkstacean", version: "1.0.0" });
+  let transport;
+  if (cfg.transport === "sse") {
+    if (!cfg.url) throw new Error(`MCP server "${cfg.name}" uses sse transport but has no url`);
+    transport = new SSEClientTransport(new URL(cfg.url));
+  } else {
+    const command = cfg.command?.[0];
+    if (!command) throw new Error(`MCP server "${cfg.name}" uses stdio transport but has no command`);
+    transport = new StdioClientTransport({ command, args: cfg.command!.slice(1), env: cfg.env });
+  }
+  await withTimeout(client.connect(transport), CONNECT_TIMEOUT_MS, `connect to "${cfg.name}"`);
+  return client;
+}
+
+/** Connect, list tools, disconnect — capability discovery for test-before-save. Never throws. */
+export async function probeMcpServer(def: McpServerDef): Promise<McpProbeResult> {
+  const cfg = resolveServerConfig(def);
+  const startedAt = Date.now();
+  let client: Client | undefined;
+  try {
+    client = await connectMcp(cfg);
+    const { tools } = await withTimeout(client.listTools(), CONNECT_TIMEOUT_MS, `listTools "${cfg.name}"`);
+    return {
+      name: def.name,
+      reachable: true,
+      latencyMs: Date.now() - startedAt,
+      tools: tools
+        .filter((t) => toolAllowed(cfg, t.name))
+        .map((t) => ({ name: t.name, description: t.description, inputSchema: t.inputSchema })),
+    };
+  } catch (err) {
+    return {
+      name: def.name,
+      reachable: false,
+      latencyMs: Date.now() - startedAt,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    await client?.close().catch(() => {});
+  }
+}

--- a/src/mcp/mcp-executor.ts
+++ b/src/mcp/mcp-executor.ts
@@ -1,0 +1,82 @@
+/**
+ * McpExecutor — exposes a single MCP tool as an IExecutor (ADR-0005 P4).
+ *
+ * One McpExecutor per (server, tool). It does NOT own the MCP connection — the
+ * McpClientPlugin owns one shared `Client` per server (connected once, reused by
+ * every tool) and closes it on unregister. So `dispose()` here is a no-op: an
+ * executor must never tear down a connection its sibling tools still use.
+ *
+ * execute() maps the skill request's `content` (expected to be a JSON object of
+ * tool arguments) into an MCP `callTool`, and flattens the tool's content parts
+ * back into SkillResult.text.
+ */
+
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { IExecutor, SkillRequest, SkillResult } from "../executor/types.ts";
+
+/** Parse the request content into MCP tool arguments. A JSON object is used as-is;
+ *  any other content is passed under `input` so simple single-arg tools still work. */
+export function toToolArguments(content: string | undefined): Record<string, unknown> {
+  const raw = (content ?? "").trim();
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // not JSON — fall through
+  }
+  return { input: raw };
+}
+
+/** Flatten an MCP callTool result's content parts into a single text string. */
+export function flattenToolContent(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      const p = part as Record<string, unknown>;
+      if (p.type === "text" && typeof p.text === "string") return p.text;
+      if (p.type === "image") return `[image ${(p.mimeType as string) ?? ""}]`;
+      if (p.type === "resource") return `[resource]`;
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+export class McpExecutor implements IExecutor {
+  readonly type = "mcp";
+
+  constructor(
+    /** Shared, already-connected client owned by McpClientPlugin. */
+    private readonly client: Client,
+    readonly serverName: string,
+    readonly toolName: string,
+    readonly toolDescription?: string,
+  ) {}
+
+  async execute(req: SkillRequest): Promise<SkillResult> {
+    try {
+      const result = await this.client.callTool({
+        name: this.toolName,
+        arguments: toToolArguments(req.content ?? req.prompt),
+      });
+      const text = flattenToolContent(result.content);
+      return {
+        text,
+        isError: result.isError === true,
+        correlationId: req.correlationId,
+      };
+    } catch (err) {
+      return {
+        text: `MCP tool "${this.serverName}.${this.toolName}" failed: ${err instanceof Error ? err.message : String(err)}`,
+        isError: true,
+        correlationId: req.correlationId,
+      };
+    }
+  }
+
+  /** No-op: the plugin owns the shared client's lifecycle (see class doc). */
+  dispose(): void {}
+}


### PR DESCRIPTION
## What

ADR-0005 (P4) **day 3** — the live MCP client tier. Day 2 landed the registry; this connects it. `McpClientPlugin` reconciles `workspace/mcp-servers.d/` against the live `ExecutorRegistry`, **mirroring `SkillBrokerPlugin`'s A2A shape**: for each **enabled** server (trust-tier gate, ADR-0005 D2) it connects one shared MCP client, lists tools, and registers one `McpExecutor` per tool under skill `"<server>.<tool>"` + `agentName "<server>"`. `command.mcp.upsert`/`remove` reconcile **live, no restart**.

- **`src/mcp/mcp-connect.ts`** — the *only* module touching `@modelcontextprotocol/sdk` (so a SDK bump is one file): `resolveServerConfig` (defaults + command-merge + env interpolation + the trust-tier enable gate), `connectMcp` (stdio/sse, 8s-bounded), `probeMcpServer` (connect→listTools→close). Uses the **correct SDK 1.29 client paths** — the harvested scaffolding's `client/async/client.js` was bogus.
- **`src/mcp/mcp-executor.ts`** — `McpExecutor` maps request content → tool args (JSON object, else `{input}`), `callTool`, flattens content parts → `SkillResult`. `dispose()` is a no-op; the **plugin owns the shared client** (closes on unregister), so one tool's teardown can't sever its siblings.
- **`POST /api/mcp-servers/test`** — capability discovery (validate → probe), the test-before-save mirror of `/api/a2a/probe`.
- Connecting is **fire-and-forget off the bus turn** — a slow/dead server never blocks reconcile; failures log loudly (fail-fast-and-loud).
- `mcpEnabled` hoisted to `mcp-connect` (canonical) + re-exported from `mcp-crud`; `McpClientPlugin` wired into the `index.ts` registry + the registrar guard.

## Test
- `mcp-executor.test.ts` — arg mapping (JSON / scalar / empty) + content flattening.
- `mcp-connect.test.ts` — config resolution + `${ENV}` interpolation, trust gate, allow/exclude filter, skill namespacing, **bounded probe of an unreachable command → reachable:false** (134ms, no hang).
- `mcp-crud.test.ts` — the `/test` route (bad def 400; unreachable → reachable:false).
- Full suite **943 pass / 0 fail**, typecheck clean, lint at baseline (13/28).

## Next (day 4 / 5)
Console MCP pane (add / probe / grant checkboxes / trust badge / enable toggle / remove) + audit-only grant surfacing; then retire the `workspace/plugins/*.ts` loader + wrap.

Part of epic #707 · ADR-0005 · slice #712.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added API endpoint to test MCP server configurations before saving.
  * Introduced automatic MCP server discovery and registration from configuration files.
  * MCP server tools are now registered as executable skills within the platform.

* **Tests**
  * Comprehensive test coverage for MCP server validation, connection handling, and tool execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->