### PR TITLE
feat(core): retire the workspace/plugins/*.ts dynamic loader (ADR-0005 P4, day 5)

### DIFF
--- a/docs/decisions/0004-fleet-control-plane-and-hot-swappable-extension.md
+++ b/docs/decisions/0004-fleet-control-plane-and-hot-swappable-extension.md
@@ -27,7 +27,7 @@ protoWorkstacean is the switchboard: `trigger → router → dispatcher → exec
 | A2A agent **skills** (remote card change) | ✅ auto re-register (`ExecutorRegistry.unregister()` already exists) |
 | **DeepAgents (`workspace/agents/*.yaml`)** | ~~❌ boot-only → restart~~ → ✅ **hot-reload (P1 shipped, #714/#715)** |
 | **A2A agent entries (`workspace/agents.yaml` + `agents.d/`)** | ~~❌ boot-only → restart~~ → ✅ **control-plane register/remove, live (P3 day-4, #723/#725)** |
-| **Workspace plugins (`workspace/plugins/*.ts`)** | ❌ restart, Node module-cache pins the old code, **and they can't import app modules** |
+| ~~**Workspace plugins (`workspace/plugins/*.ts`)**~~ | ~~❌ restart, Node module-cache pins the old code~~ → **retired (P4, ADR-0005)** — replaced by out-of-process A2A / MCP |
 
 Two structural facts drive this ADR:
 
@@ -141,7 +141,7 @@ On add/test of an A2A agent or MCP server, fetch its descriptor (`/.well-known/a
 1. ✅ **P1 — Agent registry hot-reload** *(shipped — #714 watch+detect, #715 apply).* `WorkspaceWatcher` (reusable poll-based file/dir diff) watches `workspace/agents/`; `AgentRuntimePlugin` reconciles the live registry via `ExecutorRegistry.register`/`unregister` + `IExecutor.dispose?()`. Add/edit/remove a DeepAgent YAML applies in ~5s, no restart; a parse error keeps the running agent; in-flight dispatch is never aborted.
 2. ✅ **P2 — Control-plane write API + `command.*` + registrar** *(shipped — #717).* `POST/PUT/DELETE /api/agents` + `/api/agents/test` validate, publish `command.agent.*`, and the sole `ControlPlaneRegistrar` performs the atomic YAML write (synchronous, so the API verifies + responds). Create/edit/remove an agent via API → persisted → live via P1, no restart.
 3. ✅ **P3 — Management Console + capability discovery** *(shipped — #718 Console, #719 edit-in-place, #720 agent-card probe, #723/#725 A2A register/remove).* Separate auth-gated Console (`@protolabsai/ui`): DeepAgent CRUD + test-before-save + agent-card capability probe; A2A endpoints register to `workspace/agents.d/` (per-file, so the documented `agents.yaml` is never clobbered) and unregister live via `SkillBroker`. The debug dashboard stays read-only.
-4. **P4 — MCP client tier + capability grants + trust tiers**; **retire the `workspace/plugins/*.ts` loader**. (Its own slice — see [ADR-0005](./0005-mcp-client-tier-and-trust-tiers); #712.)
+4. ✅ **P4 — MCP client tier + capability grants + trust tiers; retire the `workspace/plugins/*.ts` loader** *(shipped — see [ADR-0005](./0005-mcp-client-tier-and-trust-tiers): registry, live client, Console, loader retired).* MCP servers are a control-plane registry (`workspace/mcp-servers.d/`); `McpClientPlugin` connects each enabled server and registers its tools as executors live. Trust tiers gate auto-enable; grants are audit-only (v1). The dynamic TS-plugin loader is removed — extension is out-of-process (A2A/MCP) or compiled-in.
 5. ✅ **P5 (cross-cutting) — Durable + unified state** *(shipped — #726 durable fleet-health, #727 unified read + doc).* `FleetStateRepository` persists outcomes to `knowledge.db`; `AgentFleetHealthPlugin` rehydrates its 24h window on startup (survives restart). `GET /api/control-plane/state` is the one read view (fleet + durable-backed health), consumed by the Console; `flow-dashboard.md` documents the read/write split.
 
 ---

--- a/docs/explanation/plugin-lifecycle.md
+++ b/docs/explanation/plugin-lifecycle.md
@@ -6,18 +6,19 @@ _This is an explanation doc. It explains how the plugin system works conceptuall
 
 ---
 
-## Workspace bus plugins
+## Bus plugins
+
+> **Retired surface:** the dynamic `workspace/plugins/*.ts` loader was removed in [ADR-0005](../decisions/0005-mcp-client-tier-and-trust-tiers) (ADR-0004 P4) — Node's module cache made hot-reload unsafe and bind-mounted workspace files couldn't resolve app modules. First-party plugins are now **statically imported and compiled into the image**; runtime extension is out-of-process via A2A agents / MCP servers (see [plugin-system](plugin-system)).
 
 ### Startup loading
 
-On container start, `src/index.ts` runs `loadWorkspacePlugins()`:
+On container start, `src/index.ts` builds the plugin list from a static registry:
 
-1. Scans `workspace/plugins/` for `.ts` and `.js` files
-2. Dynamically imports each file via `await import(filePath)`
-3. Checks that the default export satisfies the `Plugin` interface (`name`, `install`, `uninstall`)
-4. Calls `plugin.install(bus)` on each valid plugin
+1. Core plugins (Logger, Debug, …) install first
+2. Conditionally-enabled integration + registrar plugins (Discord, GitHub, AgentRuntime, SkillBroker, McpClient, …) install if their config is present
+3. Each plugin's `install(bus)` is called as it's added
 
-The install order is non-deterministic (filesystem scan order). Plugins should not depend on each other's install order.
+Registrars install before `SkillDispatcherPlugin` first processes a message; otherwise plugins should not depend on each other's install order.
 
 ### What happens in `install()`
 
@@ -77,10 +78,8 @@ The SchedulerPlugin has its own internal lifecycle for timers:
 
 ---
 
-## Plugin discovery failure modes
+## Plugin failure modes
 
-If a workspace plugin file fails to import (syntax error, missing dependency), `loadWorkspacePlugins()` logs the error and skips that plugin. Other plugins continue to load. The server starts regardless.
+If a conditionally-enabled plugin's `install()` throws, the error is caught and logged; that plugin is not installed but the server continues. A misconfigured integration therefore never prevents startup — you can always connect and debug.
 
-If a plugin's `install()` throws, the error is caught and logged. The plugin is not installed, but the server continues.
-
-This means a broken plugin in `workspace/plugins/` never prevents the server from starting — you can always connect and debug.
+Out-of-process extensions degrade the same way: an unreachable A2A agent or MCP server registers no skills/tools (logged loudly) without affecting the rest of the fleet.

--- a/docs/explanation/plugin-system.md
+++ b/docs/explanation/plugin-system.md
@@ -73,11 +73,17 @@ Loaded only when their prerequisite environment variable is set:
 
 Skipping a plugin on missing config is safe because all communication is through the bus. If DiscordPlugin is not loaded, messages are never published to `message.inbound.discord.#`, so nothing breaks — there is just no Discord input source.
 
-### Workspace plugins
+### Extension surfaces (no in-process hot-loaded code)
 
-Loaded from `workspace/plugins/`. Each `.ts` file exports a default `Plugin` implementation. These are the right place for deployment-specific extensions that don't belong in the core codebase.
+The dynamic `workspace/plugins/*.ts` loader was **retired in [ADR-0005](../decisions/0005-mcp-client-tier-and-trust-tiers)** (ADR-0004 P4). It was structurally broken: Node's module cache pins old code so it can't safely hot-reload, and the workspace is bind-mounted outside the app's module tree, so a plugin there can't resolve app `lib/` or `node_modules`. There is no in-process hot-loaded-code surface by design.
 
-Workspace plugins are loaded last, after all core and integration plugins. They can safely subscribe to any topic because the topics they care about are already published by the time they receive messages.
+Extend the fleet instead through:
+
+- **A2A agents** — register a remote agent via the control plane (`workspace/agents.d/` + the Console); its skills become executors live.
+- **MCP servers** — register an MCP server via the control plane (`workspace/mcp-servers.d/` + the Console); its tools become executors live (ADR-0005). Trust tiers gate auto-enable.
+- **Compiled-in plugins** — first-party plugins live in `lib/plugins/` and ship in the image.
+
+A2A and MCP are out-of-process (the correct isolation boundary for untrusted extension) and hot-swappable without a restart; compiled-in plugins need an image deploy.
 
 ## Ordering guarantees
 

--- a/docs/reference/config-files.md
+++ b/docs/reference/config-files.md
@@ -291,6 +291,10 @@ lastFired: "2026-04-01T14:00:00.000Z"   # auto-updated by SchedulerPlugin
 
 ---
 
-## workspace/plugins/{name}.ts
+## workspace/mcp-servers.d/{name}.yaml
 
-Workspace plugins are TypeScript/JavaScript files exporting a default object implementing the `Plugin` interface. Loaded on container startup. See [`reference/plugins.md`](plugins) for the full interface contract.
+One MCP server per file (ADR-0005): `name`, `trust` (builtin/trusted/community), `transport` (stdio→`command`/`args`/`env`, sse→`url`), optional `grants`, `allowedTools`/`excludeTools`, `enabled`. `McpClientPlugin` connects each enabled server and registers its tools as executors. Managed via the Console / `POST /api/mcp-servers`.
+
+## ~~workspace/plugins/{name}.ts~~ (retired)
+
+The dynamic TS-plugin loader was removed in [ADR-0005](../decisions/0005-mcp-client-tier-and-trust-tiers). First-party plugins live in `lib/plugins/` (compiled in); runtime extension is out-of-process via A2A agents or MCP servers. See [`reference/plugins.md`](plugins).

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -88,11 +88,13 @@ interface BusMessage {
 
 ---
 
-## Writing a workspace bus plugin
+## Writing a first-party bus plugin
+
+> The dynamic `workspace/plugins/*.ts` loader was retired in [ADR-0005](../decisions/0005-mcp-client-tier-and-trust-tiers). First-party plugins now live in `lib/plugins/` and are statically imported + compiled into the image (register them in `src/index.ts`). For runtime, no-rebuild extension use an **A2A agent** or **MCP server** via the control plane instead.
 
 ```typescript
-// workspace/plugins/my-plugin.ts
-import type { Plugin, EventBus, BusMessage } from "../../lib/types";
+// lib/plugins/my-plugin.ts — register it in src/index.ts's plugin registry
+import type { Plugin, EventBus, BusMessage } from "../types";
 
 export default {
   name: "my-plugin",
@@ -126,4 +128,4 @@ export default {
 
 - Cannot modify the agent's system prompt directly
 - Cannot intercept tool calls at the LLM layer
-- Hot reload requires a container restart (`docker restart workstacean`)
+- Compiled-in: adding/changing one requires an image build + deploy (runtime hot-swap is for A2A agents and MCP servers, not in-process code)

--- a/docs/reference/workspace-files.md
+++ b/docs/reference/workspace-files.md
@@ -155,8 +155,10 @@ enabled?: boolean        # Default: true
 
 ---
 
-## workspace/plugins/
+## workspace/mcp-servers.d/
 
-Directory for hot-loaded workspace plugins. Each `.ts` (or `.js`) file exports a default `Plugin` implementation. Loaded at startup by the plugin loader.
+Control-plane-managed MCP servers (ADR-0005), one `McpServerDef` per `.yaml` file. `McpClientPlugin` connects each enabled server and registers its tools as executors live. Managed via the Console / `POST /api/mcp-servers`; trust tiers gate auto-enable.
 
-This directory is optional — leave it empty or omit it if you don't need custom plugins.
+## ~~workspace/plugins/~~ (retired)
+
+The dynamic TS-plugin loader was removed in [ADR-0005](../decisions/0005-mcp-client-tier-and-trust-tiers) (Node module-cache + workspace module-resolution made it unsafe/broken). First-party plugins live in `lib/plugins/` (compiled in); runtime extension is out-of-process via A2A agents (`agents.d/`) or MCP servers (`mcp-servers.d/`).

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { existsSync, readdirSync, mkdirSync } from "node:fs";
-import { resolve, join, extname } from "node:path";
+import { existsSync, mkdirSync } from "node:fs";
+import { resolve, join } from "node:path";
 import { InMemoryEventBus } from "../lib/bus";
 import { DebugPlugin } from "../lib/plugins/debug";
 import { LoggerPlugin } from "../lib/plugins/logger";
@@ -547,57 +547,15 @@ for (const entry of pluginRegistry) {
   }
 }
 
-// --- Dynamic plugin loading from workspace/plugins/ ---
-function isPlugin(value: unknown): value is Plugin {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    typeof (value as Plugin).name === "string" &&
-    typeof (value as Plugin).install === "function" &&
-    typeof (value as Plugin).uninstall === "function"
-  );
-}
+// The dynamic workspace/plugins/*.ts loader was retired in ADR-0005 (ADR-0004
+// P4). It was structurally broken — Node's module cache pins old code so it
+// can't safely hot-reload, and the workspace is bind-mounted outside the app's
+// module tree so plugins there can't resolve app lib/ or node_modules. Extension
+// is now out-of-process (A2A agents + MCP servers, both control-plane-managed
+// and hot-swappable) or compiled-in under lib/plugins/. There is no in-process
+// hot-loaded-code surface by design.
 
-async function loadWorkspacePlugins(): Promise<Plugin[]> {
-  const pluginsDir = join(workspaceDir, "plugins");
-  if (!existsSync(pluginsDir)) return [];
-
-  const loaded: Plugin[] = [];
-  const files = readdirSync(pluginsDir).filter(
-    (f) => extname(f) === ".ts" || extname(f) === ".js"
-  );
-
-  for (const file of files) {
-    const modulePath = join(pluginsDir, file);
-    try {
-      const mod = await import(modulePath);
-      // Check default export or named exports for Plugin interface.
-      // Deduplicate: Object.values(mod) includes default in some runtimes,
-      // so a plain default export would otherwise be installed twice.
-      const seen = new Set<unknown>();
-      const candidates: unknown[] = [];
-      for (const v of mod.default ? [mod.default, ...Object.values(mod)] : Object.values(mod)) {
-        if (!seen.has(v)) { seen.add(v); candidates.push(v); }
-      }
-
-      for (const candidate of candidates) {
-        if (isPlugin(candidate)) {
-          candidate.install(bus);
-          loaded.push(candidate);
-          console.log(`Loaded workspace plugin: ${candidate.name} (${file})`);
-        }
-      }
-    } catch (err) {
-      console.error(`Failed to load plugin ${file}:`, err);
-    }
-  }
-
-  return loaded;
-}
-
-const workspacePlugins = await loadWorkspacePlugins();
-
-const allPlugins = [...corePlugins, ...registeredPlugins, ...workspacePlugins];
+const allPlugins = [...corePlugins, ...registeredPlugins];
 
 console.log("WorkStacean started.");
 console.log(`Workspace: ${workspaceDir}`);


### PR DESCRIPTION
## What

ADR-0005 (P4) **day 5** — the final slice. Retires the broken dynamic `workspace/plugins/*.ts` loader and closes out P4.

The loader was structurally broken (and documented as such in ADR-0004 §2.3): Node's module cache pins old code so it can't safely hot-reload, and the workspace is bind-mounted outside the app's module tree, so a plugin there can't resolve app `lib/` or `node_modules`. Per greenfield-strict, it's **removed, not shimmed**.

- **`src/index.ts`** — delete `loadWorkspacePlugins()` + `isPlugin()` + the `workspacePlugins` splice; `allPlugins = core + registered`. Drop the now-unused `readdirSync`/`extname` imports. A comment records why the surface is gone.
- Extension is now **exclusively** out-of-process (A2A agents + MCP servers — control-plane-managed + hot-swappable) or **compiled-in** under `lib/plugins/`.
- **Docs** — rewrite `plugin-system` / `plugin-lifecycle` / `reference/plugins` / `workspace-files` / `config-files` to drop the retired surface and point at A2A/MCP + `lib/plugins`; document `mcp-servers.d/`. ADR-0004 §5 P4 + the hot-reload audit row marked shipped.

## P4 complete
`✅ ADR-0005 · ✅ registry (#732) · ✅ live client (#735) · ✅ Console+grants (#736) · ✅ retire loader (this)` — the MCP client tier is the last of ADR-0004 §4.7's four extension tiers.

## Test
- Backend **944 pass / 0 fail**, typecheck clean, lint at baseline (13/28), docs `bun run build` clean (no dead links).

Closes #712 · completes epic #707.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated plugin architecture documentation to reflect system changes
* Clarified that dynamic workspace plugin loading is no longer available; runtime extension now uses MCP servers or compiled plugins
* Added MCP server configuration reference documentation
* Revised plugin lifecycle and extension model documentation

## Chores
* Removed the workspace plugin loader from the system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->