### PR TITLE
fix(event-viewer): stop intercepting /api/agents — proxy control-plane mutations through

### DIFF
--- a/lib/plugins/event-viewer.ts
+++ b/lib/plugins/event-viewer.ts
@@ -1,7 +1,5 @@
-import { resolve, dirname, join } from "node:path";
-import { readFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { parse as parseYaml } from "yaml";
 import type { ServerWebSocket } from "bun";
 import type { Plugin, EventBus, BusMessage } from "../types";
 
@@ -18,12 +16,10 @@ export class EventViewerPlugin implements Plugin {
   private subscriptionId: string | null = null;
   private port: number;
   private viewerDir: string;
-  private workspaceDir: string;
 
   constructor(port: number = 8080) {
     this.port = port;
     this.viewerDir = resolve(__dirname, "../../dashboard/dist");
-    this.workspaceDir = resolve(process.env.WORKSPACE_DIR || join(process.cwd(), "workspace"));
   }
 
   install(bus: EventBus): void {
@@ -49,7 +45,12 @@ export class EventViewerPlugin implements Plugin {
         if (url.pathname === "/api/events") return this.handleApiEvents(req);
         if (url.pathname === "/api/topics") return this.handleApiTopics();
         if (url.pathname === "/api/consumers") return this.handleApiConsumers();
-        if (url.pathname === "/api/agents") return this.handleApiAgents();
+        // NOTE: no /api/agents interception here. The control plane (ADR-0004)
+        // owns /api/agents on the main server — GET /api/agents/runtime plus the
+        // POST/PUT/DELETE write API. A legacy exact-match handler used to dump
+        // agents.yaml here and swallowed the Console's mutations (returned 200,
+        // never proxied), breaking create/edit/delete from the UI. Everything
+        // under /api/ now proxies straight through.
 
         if (url.pathname.startsWith("/api/")) return this.proxyToMainServer(req, url);
 
@@ -114,24 +115,6 @@ export class EventViewerPlugin implements Plugin {
 
   private handleApiConsumers(): Response {
     return Response.json(this.bus?.consumers() ?? []);
-  }
-
-  private handleApiAgents(): Response {
-    return this._serveYaml("agents.yaml", "agents");
-  }
-
-  private _serveYaml(filename: string, key: string): Response {
-    const filePath = join(this.workspaceDir, filename);
-    if (!existsSync(filePath)) {
-      return Response.json({ success: false, error: `${filename} not found` }, { status: 404 });
-    }
-    try {
-      const raw = readFileSync(filePath, "utf8");
-      const parsed = parseYaml(raw) as Record<string, unknown>;
-      return Response.json({ success: true, data: parsed[key] ?? [] });
-    } catch (err) {
-      return Response.json({ success: false, error: `Failed to parse ${filename}` }, { status: 500 });
-    }
   }
 
   private mainServerPort: number = parseInt(process.env.PORT || "3000", 10);


### PR DESCRIPTION
## Problem

Surfaced by the live control-plane QA: agent CRUD passed against the backend directly but **failed through the `:8081` dashboard proxy** — `POST /api/agents` returned `200` (not 201/401) and never reached the write API.

Root cause: `lib/plugins/event-viewer.ts` (the dashboard proxy on `:8080`) had a legacy exact-match route —
```ts
if (url.pathname === "/api/agents") return this.handleApiAgents(); // dumps agents.yaml, ALL methods
```
ahead of its generic `/api/` proxy. The **Console is served same-origin behind this proxy**, so its create/edit/delete-agent calls hit this handler and silently no-op'd in the browser. (A2A + MCP endpoints have no exact-match collision, so they proxied fine — which is why only agent CRUD broke.)

## Fix

The legacy route is **dead** — the dashboard reads agents via `/api/agents/runtime` and `/api/control-plane/state`; nothing consumes the bare `/api/agents` yaml dump. Per greenfield, removed it so every `/api/` path proxies straight to the main server, and dropped the now-orphaned `_serveYaml` method, the `workspaceDir` field, and the `yaml`/`node:fs` imports they were the sole users of. This aligns `/api/agents` with how A2A/MCP already behave.

## Test
- 944 backend pass, typecheck clean, lint at baseline (13/28), dashboard builds.
- Post-deploy I'll re-run the control-plane smoke through `:8081` to confirm `POST /api/agents` now proxies (→ 201 / 401), matching the backend.

Follow-up from the Fleet Control Plane QA (ADR-0004/0005).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected API request routing so agent data requests are now properly handled by the main control plane instead of being intercepted by the plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->