### PR TITLE
fix(event-viewer): buffer proxied request body — fixes 502 after a rejected POST

### DIFF
--- a/lib/plugins/event-viewer.ts
+++ b/lib/plugins/event-viewer.ts
@@ -122,10 +122,19 @@ export class EventViewerPlugin implements Plugin {
   private async proxyToMainServer(req: Request, url: URL): Promise<Response> {
     const target = `http://localhost:${this.mainServerPort}${url.pathname}${url.search}`;
     try {
+      // Buffer the request body before forwarding — never pass req.body as a
+      // stream. Bun pools the outbound keep-alive connection to the main server;
+      // if the backend rejects a request without draining its body (e.g. a 401
+      // before auth, or a 400 on validation), the half-consumed stream leaves the
+      // pooled connection corrupt and the NEXT proxied POST fails → 502. A fully
+      // buffered body is sent in one shot, so the connection stays clean.
+      // (Surfaced by control-plane QA: a no-key 401 then a create 502'd.)
+      const hasBody = req.method !== "GET" && req.method !== "HEAD";
+      const reqBody = hasBody ? await req.arrayBuffer() : undefined;
       const proxyReq = new Request(target, {
         method: req.method,
         headers: req.headers,
-        body: req.method !== "GET" && req.method !== "HEAD" ? req.body : undefined,
+        body: reqBody && reqBody.byteLength > 0 ? reqBody : undefined,
       });
       const res = await fetch(proxyReq);
       const body = await res.arrayBuffer();


### PR DESCRIPTION
## Problem (found by control-plane QA)

After #738 let `/api/agents` proxy through, the live smoke hit an intermittent **`502 "Main server unavailable"`** on create. Pinned the exact trigger:

```
POST /api/agents  (no key)  → 401      # backend rejects without reading the body
POST /api/agents  (valid)   → 502      # next proxied POST fails
POST /api/agents  (valid, lone) → 201  # fine on its own
```

Root cause: `proxyToMainServer` forwarded `req.body` as a **stream**. Bun pools the outbound keep-alive connection to the main server; when the backend rejects a bodied request **without draining the body** (401/400), the half-consumed stream leaves the pooled connection corrupt, so the **next** proxied POST on it fails → 502. This bites the Console's normal "validation error → fix → resubmit" flow.

## Fix

Buffer the request body (`await req.arrayBuffer()`) and forward it in one shot — no half-consumed streams, the connection stays clean, content-length is set correctly. Standard correct reverse-proxy behavior; keep-alive preserved.

## Test
- 944 backend pass, typecheck clean, lint at baseline.
- Post-deploy I'll re-run the exact `401-then-create` sequence through `:8081` (expect 401 then **201**, no 502) and the full control-plane smoke (expect **19/19**).

Follow-up to #738 · Fleet Control Plane QA (ADR-0004/0005).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved request handling in the event viewer proxy to ensure non-GET/HEAD requests are properly transmitted to the main server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->