### PR TITLE
fix(dashboard): System view crash — hoist useMemo above early returns + ErrorBoundary

### DIFF
--- a/dashboard/src/Layout.tsx
+++ b/dashboard/src/Layout.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { NavLink, Outlet, useLocation } from "react-router-dom";
 import { WebSocketManager } from "./lib/websocket";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import "./Layout.css";
 
 const NAV_ITEMS = [
@@ -79,7 +80,11 @@ export default function Layout() {
         </header>
 
         <main className={`main-content${fullBleed ? " main-content--full" : ""}`}>
-          <Outlet />
+          {/* Keyed by path so a crash in one pane resets when you navigate away,
+              and never takes down the sidebar/nav with it. */}
+          <ErrorBoundary key={pathname}>
+            <Outlet />
+          </ErrorBoundary>
         </main>
       </div>
     </div>

--- a/dashboard/src/components/ErrorBoundary.tsx
+++ b/dashboard/src/components/ErrorBoundary.tsx
@@ -1,0 +1,45 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+// Contains a render-time crash to the routed content area so a single bad pane
+// can't blank the whole app (the sidebar + nav stay usable). Also surfaces the
+// error message + stack so the failure is diagnosable instead of a blank screen.
+// Keyed by route path in Layout so navigating away resets it.
+
+interface Props {
+  children: ReactNode;
+}
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error("[dashboard] pane crashed:", error, info.componentStack);
+  }
+
+  render(): ReactNode {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+    return (
+      <div style={{ padding: 24, color: "var(--text-primary)", fontFamily: "ui-monospace, monospace", maxWidth: 880 }}>
+        <h3 style={{ color: "var(--text-danger)", margin: "0 0 8px" }}>This pane crashed</h3>
+        <p style={{ color: "var(--text-secondary)", fontSize: 13, margin: "0 0 12px" }}>
+          The rest of the dashboard is fine — use the sidebar to switch views, or reload.
+        </p>
+        <pre style={{
+          background: "var(--bg-default)", border: "1px solid var(--border-default)", borderRadius: 6,
+          padding: 12, fontSize: 12, color: "var(--text-danger)", whiteSpace: "pre-wrap", overflow: "auto",
+        }}>
+          {error.message}
+          {error.stack ? `\n\n${error.stack}` : ""}
+        </pre>
+      </div>
+    );
+  }
+}

--- a/dashboard/src/components/SystemGraph.tsx
+++ b/dashboard/src/components/SystemGraph.tsx
@@ -469,19 +469,24 @@ export default function SystemGraph() {
     [topology, agents, agentActivity, activeEdges],
   );
 
-  if (error) {
-    return <div style={{ padding: 24, color: "var(--text-danger)", fontFamily: "monospace" }}>topology error: {error}</div>;
-  }
-  if (!topology) {
-    return <div style={{ padding: 24, color: "var(--text-secondary)" }}>loading topology…</div>;
-  }
-
+  // ALL hooks must run before any conditional return (Rules of Hooks). This
+  // useMemo previously sat AFTER the error/loading early-returns: the first
+  // render (topology null) skipped it, then once topology loaded the return was
+  // skipped and the hook ran — a changing hook count that crashed the whole
+  // /system view (and, with no ErrorBoundary, blanked the app). Keep it here.
   const drawerMessages = useMemo(
     () => (openTopic ? topicHistoryRef.current.get(openTopic) ?? [] : []),
     // drawerTick is the WS-driven invalidation signal; openTopic re-runs when
     // the drawer switches topics.
     [openTopic, drawerTick],
   );
+
+  if (error) {
+    return <div style={{ padding: 24, color: "var(--text-danger)", fontFamily: "monospace" }}>topology error: {error}</div>;
+  }
+  if (!topology) {
+    return <div style={{ padding: 24, color: "var(--text-secondary)" }}>loading topology…</div>;
+  }
 
   return (
     <div style={{ width: "100%", height: "calc(100vh - 64px)", background: "var(--bg-canvas)", position: "relative" }}>


### PR DESCRIPTION
## Problem

`/system` rendered a **blank screen and dropped the sidebar** ("kinda crashes out").

Root cause: a **Rules-of-Hooks violation** in `SystemGraph.tsx`. The `drawerMessages` `useMemo` was placed *after* the `error` / `!topology` early returns:
```jsx
if (error) return <…/>;
if (!topology) return <div>loading topology…</div>;   // first render hits this
const drawerMessages = useMemo(…);                     // ← skipped first render, runs after topology loads
```
First render (`topology === null`) → early return → the hook is skipped. The topology fetch resolves → re-render → return skipped → the hook now runs → **hook count changed between renders → React throws** ("rendered more hooks than during the previous render"). With **no ErrorBoundary** anywhere, that throw unmounted the entire app — blank screen, no sidebar. It reproduced every time `/system` loaded, right after "loading topology…".

## Fix
1. **Root cause** — hoist the `drawerMessages` `useMemo` above the early returns so all hooks run unconditionally on every render.
2. **Defense-in-depth** — add an `ErrorBoundary` around the routed `<Outlet>` in `Layout` (keyed by path). A pane crash is now **contained**: the sidebar/nav stay usable and the error message + stack are shown, instead of silently blanking the app. (The dashboard had no error boundary at all.)

## Test
- Dashboard 20 pass, `tsc --noEmit` clean, `vite build` clean.
- No DOM test harness in the dashboard (pure-logic tests only), so verification is build + post-deploy reload of `/system`.

Surfaced during Fleet Control Plane QA follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error boundary to gracefully handle and display crashes within dashboard panes with a user-friendly error message and technical details.

* **Bug Fixes**
  * Fixed error state reset when navigating between different panes.
  * Resolved stability issues with hook execution order in component initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->