### PR TITLE
feat(fleet): stage Roxy A2A registration (ProtoMaker portfolio manager)

### DIFF
--- a/workspace/agents.yaml
+++ b/workspace/agents.yaml
@@ -65,3 +65,32 @@ agents:
     external: true
     subscribesTo:
       - message.inbound.discord.#
+
+  # roxy — ProtoMaker Portfolio Manager. Monitors + unblocks the ProtoMaker
+  # portfolio (board / features / PRs / CI), takes the smallest unblocking
+  # action, reports a sitrep — she does NOT write code. protoAgent A2A fork.
+  # The "missing piece" between org-intake (Ava/Linear) and execution.
+  #
+  # Runs as a docker service on the shared network → reachable as roxy:7870
+  # (no Tailscale, so NOT external — unlike protopen).
+  #
+  # STAGED, not yet live — uncomment once ALL of:
+  #   1. roxy is deployed on the shared docker-ai network (roxy:7870 resolves
+  #      from this container), and
+  #   2. ROXY_API_KEY is provisioned in Infisical (ai/prod), matching roxy's side, and
+  #   3. roxy's agent card advertises her operational skill (e.g. project_operations)
+  #      + a real description — it's currently the protoAgent template default
+  #      (only `chat`), so until then the fleet can only summon her via `chat`,
+  #      not route `skill: project_operations` to her (ceremony/event paths).
+  # Leaving it commented avoids registering a dead executor + 10-min card-
+  # discovery spam for the whole fleet (same policy as frank above).
+  #
+  # - name: roxy
+  #   url: http://roxy:7870/a2a
+  #   auth:
+  #     scheme: apiKey
+  #     credentialsEnv: ROXY_API_KEY
+  #   streaming: true
+  #   subscribesTo:
+  #     - message.inbound.discord.#
+  #     - message.inbound.github.#


### PR DESCRIPTION
Kicks off wiring **Roxy** — the ProtoMaker portfolio-manager/unblocker (protoAgent A2A fork) — into the fleet as the missing piece between org-intake (Ava/Linear) and execution.

Per your call: Roxy runs as a **docker service on the shared network** (`roxy:7870`, not Tailscale → not `external`), apiKey auth via `ROXY_API_KEY`. Staged **commented (frank-style)** so we don't register a dead executor or spam card-discovery 404s before she's up. The block documents the flip-on prereq chain.

### Flip-on prerequisites (gating)
1. **Roxy deployed on the shared `docker-ai` network** so `roxy:7870` resolves from the workstacean container.
2. **`ROXY_API_KEY` in Infisical** (`ai/prod`), matching Roxy's side.
3. **Roxy's agent card advertises a real operational skill** (e.g. `project_operations`) + a real description — it's currently the protoAgent **template default** (only `chat`). Until then the fleet can summon her via `chat` but can't route `skill: project_operations` to her — which the ceremony + event-driven paths need.

### Remaining integration (queued, after she's live)
- **Recurring sitrep ceremony** (`portfolio-sitrep.yaml` → Roxy) — depends on prereq #3.
- **Discord channel → Roxy** (`channels.yaml`).
- **Event-driven** (CI-fail / stalled-PR → Roxy unblock) — router wiring.
- **Ava delegates on-demand** — ~free; she auto-discovers registered agents (#674).

All downstream dispatch is guarded (target-registry guard + cooldown) so it degrades cleanly if Roxy isn't yet reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration and documentation for the roxy agent (ProtoMaker Portfolio Manager) integration. Includes service endpoint setup, authentication configuration, streaming support, and example subscription configurations for Discord and GitHub integration. Agent entry is currently disabled pending full deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->