### PR TITLE
feat(roxy): portfolio-sitrep ceremony (OFF) + point agents.yaml at the control-plane home

### DIFF
--- a/workspace/agents.yaml
+++ b/workspace/agents.yaml
@@ -66,31 +66,10 @@ agents:
     subscribesTo:
       - message.inbound.discord.#
 
-  # roxy — ProtoMaker Portfolio Manager. Monitors + unblocks the ProtoMaker
-  # portfolio (board / features / PRs / CI), takes the smallest unblocking
-  # action, reports a sitrep — she does NOT write code. protoAgent A2A fork.
-  # The "missing piece" between org-intake (Ava/Linear) and execution.
-  #
-  # Runs as a docker service on the shared network → reachable as roxy:7870
-  # (no Tailscale, so NOT external — unlike protopen).
-  #
-  # STAGED, not yet live — uncomment once ALL of:
-  #   1. roxy is deployed on the shared docker-ai network (roxy:7870 resolves
-  #      from this container), and
-  #   2. ROXY_API_KEY is provisioned in Infisical (ai/prod), matching roxy's side, and
-  #   3. roxy's agent card advertises her operational skill (e.g. project_operations)
-  #      + a real description — it's currently the protoAgent template default
-  #      (only `chat`), so until then the fleet can only summon her via `chat`,
-  #      not route `skill: project_operations` to her (ceremony/event paths).
-  # Leaving it commented avoids registering a dead executor + 10-min card-
-  # discovery spam for the whole fleet (same policy as frank above).
-  #
-  # - name: roxy
-  #   url: http://roxy:7870/a2a
-  #   auth:
-  #     scheme: apiKey
-  #     credentialsEnv: ROXY_API_KEY
-  #   streaming: true
-  #   subscribesTo:
-  #     - message.inbound.discord.#
-  #     - message.inbound.github.#
+  # roxy — ProtoMaker Portfolio Manager (monitors + unblocks the protoMaker
+  # portfolio; read-only on code). Deliberately NOT registered here: she is
+  # control-plane-managed (ADR-0004), registered live to workspace/agents.d/roxy.yaml
+  # via POST /api/a2a-endpoints and re-registered idempotently on deploy by her own
+  # stack (homelab-iac/stacks/roxy). url http://roxy:7870/a2a on the shared network,
+  # auth ROXY_API_KEY. Do NOT add a roxy entry here — agents.d/ wins the dedup, so a
+  # hand entry would be shadowed, and two homes drift.

--- a/workspace/ceremonies/portfolio-sitrep.yaml
+++ b/workspace/ceremonies/portfolio-sitrep.yaml
@@ -1,0 +1,23 @@
+id: portfolio-sitrep
+name: "Portfolio Sitrep (Roxy)"
+description: >
+  Roxy sweeps the protoMaker portfolio — board / features / PRs / CI — flags
+  stalls and blockers, takes the smallest unblocking action (nudge, re-dispatch,
+  escalate), and reports a portfolio sitrep. This is the deeper per-project
+  operational pass; Ava's portfolio-checkin (10am) is the higher-level helm read.
+
+  Dispatches Roxy's `portfolio_sitrep` skill over A2A (she's control-plane-
+  registered in agents.d/roxy.yaml). Roxy is read-only on code — she manages the
+  board via her automaker MCP server; PR review stays Quinn's.
+# DEFAULTED OFF — this is recurring autonomous behavior with real cost (each run
+# is an LLM pass + board/MCP calls) and real side effects (unblocking actions).
+# Flip enabled:true when you're ready for Roxy to run on a schedule; tune the
+# cron then. Until then it hot-reloads as inert.
+schedule: "0 13 * * 1-5"
+skill: portfolio_sitrep
+targets:
+  - roxy
+# Fleet "updates" Discord webhook (CeremonyNotifier maps slug → DISCORD_WEBHOOK_<SLUG>).
+notifyChannel: "updates"
+timeoutMs: 300000
+enabled: false


### PR DESCRIPTION
Follow-on to Roxy joining the fleet (she's live via the control-plane → `agents.d/roxy.yaml`). Per the cross-team decision (**home = A**, control-plane-managed; her stack re-registers idempotently on deploy):

- **`workspace/agents.yaml`** — replace the staged #743 commented `roxy` stub with a **pointer note**. Going with A means we do *not* hand-register her here; `agents.d/` wins the dedup so a hand entry would be shadowed, and two homes drift. The note tells the next person not to re-add her.
- **`workspace/ceremonies/portfolio-sitrep.yaml`** — Roxy's recurring portfolio sweep (board/features/PRs/CI → smallest unblocking action → sitrep), dispatching her `portfolio_sitrep` skill over A2A. **Defaulted OFF** (`enabled: false`) — recurring autonomous behavior with real cost + side effects; flip on + tune the cron when ready. Hot-reloads as inert until then. Complements Ava's higher-level `portfolio-checkin` (10am).

Still queued: Discord channel route (needs a channel id), event-driven CI/PR/stall → `unblock_feature` (its own PR, not auto-live).

948 tests pass; YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Portfolio Sitrep ceremony that generates portfolio reports on weekdays at 1:00 PM. Currently disabled by default.

* **Chores**
  * Updated agent registry documentation for clarity on configuration management practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->