### PR TITLE
feat(roxy): route sitrep updates to the dev channel (notifyChannel: roxy)

### DIFF
--- a/workspace/ceremonies/portfolio-sitrep.yaml
+++ b/workspace/ceremonies/portfolio-sitrep.yaml
@@ -17,7 +17,11 @@ schedule: "0 13 * * 1-5"
 skill: portfolio_sitrep
 targets:
   - roxy
-# Fleet "updates" Discord webhook (CeremonyNotifier maps slug → DISCORD_WEBHOOK_<SLUG>).
-notifyChannel: "updates"
+# Roxy's updates land in the dev channel (1509787856351133746). The notifier
+# resolves the slug → DISCORD_WEBHOOK_ROXY (a webhook URL, NOT a channel id) and
+# posts an embed that includes her sitrep result. OPS: create a Discord webhook
+# on channel 1509787856351133746 and set DISCORD_WEBHOOK_ROXY (Infisical ai/prod);
+# until it exists the notifier falls back to the default webhook.
+notifyChannel: "roxy"
 timeoutMs: 300000
 enabled: false


### PR DESCRIPTION
Per operator: **skip the dedicated inbound Roxy channel** (Ava delegates to her on-demand — that path's free), and send her **sitrep updates to the dev channel `1509787856351133746`**.

How ceremony notifications work: the notifier resolves `notifyChannel: <slug>` → `DISCORD_WEBHOOK_<SLUG>` (a **webhook URL**, not a channel id), and the embed includes the ceremony **Result** field — i.e. Roxy's actual sitrep text (≤1024 chars), not just pass/fail. So pointing the slug at the dev channel's webhook delivers her real updates there.

- `portfolio-sitrep.yaml`: `notifyChannel: "updates"` → `"roxy"`.

### Ops (gating — only `DISCORD_WEBHOOK_UPDATES` exists today)
Create a Discord webhook on channel `1509787856351133746` and set **`DISCORD_WEBHOOK_ROXY`** in Infisical (`ai/prod`). Until then the notifier falls back to the default webhook. The ceremony is still **OFF**, so nothing fires before that's wired — no rush, no noise.

Closes the channel question; event-driven (CI/PR/stall → `unblock_feature`) is the remaining piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Roxy sitrep notification routing to use a dedicated Discord channel instead of the shared updates channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->