### PR TITLE
feat(roxy): sitrep notifyChannel → dev (sourced from DISCORD_DEV_CHANNEL)

### DIFF
--- a/workspace/ceremonies/portfolio-sitrep.yaml
+++ b/workspace/ceremonies/portfolio-sitrep.yaml
@@ -17,11 +17,11 @@ schedule: "0 13 * * 1-5"
 skill: portfolio_sitrep
 targets:
   - roxy
-# Roxy's updates land in the dev channel (1509787856351133746). The notifier
-# resolves the slug → DISCORD_WEBHOOK_ROXY (a webhook URL, NOT a channel id) and
-# posts an embed that includes her sitrep result. OPS: create a Discord webhook
-# on channel 1509787856351133746 and set DISCORD_WEBHOOK_ROXY (Infisical ai/prod);
-# until it exists the notifier falls back to the default webhook.
-notifyChannel: "roxy"
+# Roxy's updates land in the dev channel. The notifier resolves the slug →
+# DISCORD_WEBHOOK_DEV (a webhook URL) and posts an embed including her sitrep
+# result. Sourced from the DISCORD_DEV_CHANNEL Infisical secret, mapped to
+# DISCORD_WEBHOOK_DEV in workstacean's env (homelab stacks/ai). Until that's
+# wired the notifier falls back to the default webhook.
+notifyChannel: "dev"
 timeoutMs: 300000
 enabled: false


### PR DESCRIPTION
Per operator: send Roxy's sitrep updates to the **dev channel** via the existing **`DISCORD_DEV_CHANNEL`** Infisical secret (secret-management project), not a new Roxy-specific webhook.

- `notifyChannel: "roxy"` → `"dev"` so the notifier resolves `DISCORD_WEBHOOK_DEV`.
- Companion homelab change maps `DISCORD_WEBHOOK_DEV=${DISCORD_DEV_CHANNEL}` in workstacean's `stacks/ai` env (same pattern as `ROXY_API_KEY=${ROXY_A2A_TOKEN}`, which resolves from that same project — so scope is fine).

Ceremony stays **OFF**; until the env is wired + workstacean restarts to pick it up, the notifier falls back to the default webhook. (`DISCORD_DEV_CHANNEL` is a *secret* → a webhook URL, which is what the notifier POSTs to.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)