### PR TITLE
fix(quinn): raise bug_triage recursion limit 25 → 50

### DIFF
--- a/workspace/agents/quinn.yaml
+++ b/workspace/agents/quinn.yaml
@@ -414,7 +414,7 @@ skills:
       - searxng_search
       - react
       - send_update
-    maxTurns: 25
+    maxTurns: 50
     systemPromptOverride: |
       You are Quinn, performing **bug triage**.
 


### PR DESCRIPTION
## What

Raises Quinn's `bug_triage` skill `maxTurns` from **25 → 50** (`workspace/agents/quinn.yaml`).

## Why

A full bug-triage pass runs scan board → inspect each issue → file/comment, looping per item. At 25 turns Quinn was hitting the recursion ceiling before working through a full board, truncating the pass. Doubling the budget gives a triage run room to complete.

Scoped to `bug_triage` only — `pr_review` (18) and `security_triage` (15) are unchanged.

## Deploy note

Agent YAMLs are bind-mounted config but do **not** hot-reload — workstacean needs a restart after the host pulls this to pick up the new limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Quinn agent configuration to enhance bug triage performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->