### PR TITLE
ci(release): bump release-tools v0.1.0 → v1.1.0 (SHA-pinned)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           echo "Diffing $PREV → $TAG"
 
       - name: Post release notes to Discord
-        uses: protoLabsAI/release-tools@v0.1.0
+        uses: protoLabsAI/release-tools@b7c3531dd67accb57ca09242f47d8c0eb1ace8eb # v1.1.0
         with:
           version: ${{ steps.tags.outputs.version }}
           previous-version: ${{ steps.tags.outputs.previous }}


### PR DESCRIPTION
Workstacean's `release.yml` posted release notes via `release-tools@v0.1.0` — the pre-v1-rewrite version, still carrying the now-dead `dev`-branch squash-merge fallback. Bumps to **v1.1.0**, SHA-pinned (`b7c3531`) to satisfy the repo's zizmor `unpinned-uses` posture.

Part of getting the release cadence prod-ready (last cut was v0.7.22, Apr 28). With a current pin, the next release produces correctly-formatted notes.

Fleet pin drift noted for follow-up: protoAgent/roxy float `@v1`; ORBIS SHA-pins the stale `v0.1.3`; pwnDeck's `release.yml` doesn't call release-tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to use an updated release tool version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->