### PR TITLE
chore(release): bump to v0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean",
-  "version": "0.7.22",
+  "version": "0.8.0",
   "type": "module",
   "scripts": {
     "start": "bun run src/index.ts",


### PR DESCRIPTION
Auto-generated by prepare-release.yml. Once this PR merges, manually trigger auto-release.yml to tag main and cut the GitHub Release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.8.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->