### PR TITLE
ci(release): use org DISCORD_RELEASE_WEBHOOK secret for release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release Notes
 
-# Fires on tag push to post Discord release notes via the
-# DISCORD_WEBHOOK_PROTOWORKSTACEAN_RELEASE webhook.
+# Fires on tag push to post Discord release notes via the org-level
+# DISCORD_RELEASE_WEBHOOK secret.
 #
 # Known gap: tags pushed by auto-release.yml using GITHUB_TOKEN do NOT
 # trigger this workflow (GitHub's recursion-prevention policy on
@@ -53,7 +53,6 @@ jobs:
           previous-version: ${{ steps.tags.outputs.previous }}
         env:
           GATEWAY_API_KEY: ${{ secrets.GATEWAY_API_KEY }}
-          # DISCORD_WEBHOOK_URL was the prior canonical name; the action
-          # reads DISCORD_RELEASE_WEBHOOK. We map the existing webhook
-          # secret across so no secret-renames are needed.
-          DISCORD_RELEASE_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_PROTOWORKSTACEAN_RELEASE }}
+          # Org-level secret — the canonical release webhook shared across the
+          # fleet, read by release-tools directly. Same name in every repo.
+          DISCORD_RELEASE_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}


### PR DESCRIPTION
Posts release notes via the **org-level `DISCORD_RELEASE_WEBHOOK`** secret (read directly by `release-tools`) instead of the repo-specific `DISCORD_WEBHOOK_PROTOWORKSTACEAN_RELEASE`. Same secret name fleet-wide → no per-repo webhook secrets to maintain.

Part of getting the v0.8.0 release cut working end-to-end (pairs with #752's release-tools v1.1.0 bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration for release automation.

**Note:** This release contains no user-facing changes. The update optimizes internal infrastructure for posting release information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->