### PR TITLE
fix(github): deterministic approve-on-terminal-green — open the merge gate (#748)

### DIFF
--- a/lib/plugins/__tests__/github-approve-on-green.test.ts
+++ b/lib/plugins/__tests__/github-approve-on-green.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Deterministic approve-on-terminal-green (#748).
+ *
+ * Quinn never reliably chooses review_approve on the CI-completion re-dispatch,
+ * so the merge-on-green gate never opens. `_handleCiCompletion` now posts a
+ * formal APPROVE programmatically when CI is terminal-GREEN and Quinn's latest
+ * review is a held COMMENT. These tests cover the pure decision gates plus the
+ * orchestration's fire / fall-through behavior with a stubbed GitHub API.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { allChecksGreen, quinnLatestReviewState, GitHubPlugin } from "../github.ts";
+import { InMemoryEventBus } from "../../bus.ts";
+import { ProjectRegistry } from "../../../src/plugins/project-registry.ts";
+
+// ── Pure gates ────────────────────────────────────────────────────────────────
+
+describe("allChecksGreen", () => {
+  test("all completed + benign conclusions → green", () => {
+    expect(allChecksGreen([
+      { status: "completed", conclusion: "success" },
+      { status: "completed", conclusion: "neutral" },
+      { status: "completed", conclusion: "skipped" },
+    ])).toBe(true);
+  });
+  test("any failing conclusion → NOT green", () => {
+    expect(allChecksGreen([
+      { status: "completed", conclusion: "success" },
+      { status: "completed", conclusion: "failure" },
+    ])).toBe(false);
+    for (const bad of ["cancelled", "timed_out", "action_required", "stale", null]) {
+      expect(allChecksGreen([{ status: "completed", conclusion: bad }])).toBe(false);
+    }
+  });
+  test("any non-terminal check → NOT green (terminal is necessary but not sufficient)", () => {
+    expect(allChecksGreen([
+      { status: "completed", conclusion: "success" },
+      { status: "in_progress" },
+    ])).toBe(false);
+    expect(allChecksGreen([{ status: "queued" }])).toBe(false);
+  });
+  test("fail closed: empty / undefined check set is NOT green (no positive signal)", () => {
+    expect(allChecksGreen(undefined)).toBe(false);
+    expect(allChecksGreen([])).toBe(false);
+  });
+});
+
+describe("quinnLatestReviewState", () => {
+  test("returns the LATEST protoquinn review state (case-normalized)", () => {
+    expect(quinnLatestReviewState([
+      { user: { login: "protoquinn[bot]" }, state: "COMMENTED" },
+    ])).toBe("COMMENTED");
+    expect(quinnLatestReviewState([
+      { user: { login: "ProtoQuinn" }, state: "commented" },
+      { user: { login: "protoquinn[bot]" }, state: "approved" },
+    ])).toBe("APPROVED");
+  });
+  test("ignores non-Quinn reviews when picking the latest", () => {
+    expect(quinnLatestReviewState([
+      { user: { login: "protoquinn[bot]" }, state: "COMMENTED" },
+      { user: { login: "mabry1985" }, state: "CHANGES_REQUESTED" },
+    ])).toBe("COMMENTED");
+  });
+  test("undefined when Quinn has no review", () => {
+    expect(quinnLatestReviewState([])).toBeUndefined();
+    expect(quinnLatestReviewState(undefined)).toBeUndefined();
+    expect(quinnLatestReviewState([{ user: { login: "coderabbitai[bot]" }, state: "COMMENTED" }])).toBeUndefined();
+  });
+});
+
+// ── Orchestration: _handleCiCompletion ─────────────────────────────────────────
+
+const OWNER = "protoLabsAI";
+const REPO = "widget";
+const PR = 42;
+const SHA = "deadbeefcafe";
+
+interface StubOpts {
+  reviews: Array<Record<string, unknown>>;
+  /** Returns the check-runs body, or a 403 Response to simulate the CiAccessError path. */
+  checkRuns?: Array<Record<string, unknown>>;
+  checkRunsStatus?: number; // default 200
+}
+
+/** Records every POST .../reviews submission so a test can assert the APPROVE. */
+interface Captured {
+  approvePosts: Array<Record<string, unknown>>;
+}
+
+function ciCompletionPayload(): Record<string, unknown> {
+  return {
+    action: "completed",
+    workflow_run: { head_sha: SHA },
+    repository: { name: REPO, owner: { login: OWNER } },
+  };
+}
+
+function stubFetch(opts: StubOpts): Captured {
+  const captured: Captured = { approvePosts: [] };
+  const json = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+
+  globalThis.fetch = (async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init?.method ?? "GET").toUpperCase();
+
+    // _handleCiCompletion: resolve PRs for the SHA
+    if (url.includes(`/commits/${SHA}/pulls`)) {
+      return json([{ number: PR, state: "open", draft: false, head: { sha: SHA }, title: "t", html_url: "u", user: { login: "dev" } }]);
+    }
+    // reviews list (GET)
+    if (url.includes(`/pulls/${PR}/reviews`) && method === "GET") {
+      return json(opts.reviews);
+    }
+    // check-runs (both _ciTerminal and _ciGreen)
+    if (url.includes(`/commits/${SHA}/check-runs`)) {
+      const status = opts.checkRunsStatus ?? 200;
+      if (status !== 200) return json({ message: "Forbidden" }, status);
+      return json({ check_runs: opts.checkRuns ?? [] });
+    }
+    // APPROVE submission (POST .../reviews) via GitHubReviewSubmitter
+    if (url.includes(`/pulls/${PR}/reviews`) && method === "POST") {
+      captured.approvePosts.push(JSON.parse(String(init?.body ?? "{}")));
+      return json({ id: 999 });
+    }
+    throw new Error(`unexpected fetch in test: ${method} ${url}`);
+  }) as typeof fetch;
+
+  return captured;
+}
+
+async function runCiCompletion(opts: StubOpts): Promise<Captured> {
+  const captured = stubFetch(opts);
+  const bus = new InMemoryEventBus();
+  const plugin = new GitHubPlugin("/tmp/nonexistent-ws", new ProjectRegistry());
+  const getToken = async () => "fake-token";
+  // _handleCiCompletion is private orchestration; drive it directly.
+  await (plugin as unknown as {
+    _handleCiCompletion: (e: string, p: Record<string, unknown>, b: InMemoryEventBus, g: () => Promise<string>) => Promise<void>;
+  })._handleCiCompletion("workflow_run", ciCompletionPayload(), bus, getToken);
+  return captured;
+}
+
+const origFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = origFetch; });
+
+describe("_handleCiCompletion — deterministic approve-on-green", () => {
+  test("(a) terminal-green + prior COMMENTED → posts formal APPROVE", async () => {
+    const captured = await runCiCompletion({
+      reviews: [{ user: { login: "protoquinn[bot]" }, state: "COMMENTED" }],
+      checkRuns: [{ status: "completed", conclusion: "success" }],
+    });
+    expect(captured.approvePosts.length).toBe(1);
+    expect(captured.approvePosts[0]!.event).toBe("APPROVE");
+    expect(captured.approvePosts[0]!.commit_id).toBe(SHA);
+  });
+
+  test("(b) terminal-green + prior CHANGES_REQUESTED → no approve (falls through)", async () => {
+    const captured = await runCiCompletion({
+      reviews: [{ user: { login: "protoquinn[bot]" }, state: "CHANGES_REQUESTED" }],
+      checkRuns: [{ status: "completed", conclusion: "success" }],
+    });
+    expect(captured.approvePosts.length).toBe(0);
+  });
+
+  test("(c) terminal-green + no prior Quinn review → no blind approve (falls through)", async () => {
+    const captured = await runCiCompletion({
+      reviews: [{ user: { login: "mabry1985" }, state: "COMMENTED" }],
+      checkRuns: [{ status: "completed", conclusion: "success" }],
+    });
+    expect(captured.approvePosts.length).toBe(0);
+  });
+
+  test("(d) terminal but RED + prior COMMENTED → no approve (falls through)", async () => {
+    const captured = await runCiCompletion({
+      reviews: [{ user: { login: "protoquinn[bot]" }, state: "COMMENTED" }],
+      checkRuns: [
+        { status: "completed", conclusion: "success" },
+        { status: "completed", conclusion: "failure" },
+      ],
+    });
+    expect(captured.approvePosts.length).toBe(0);
+  });
+
+  test("(e) CI inaccessible (403) + prior COMMENTED → no approve (fail closed)", async () => {
+    const captured = await runCiCompletion({
+      reviews: [{ user: { login: "protoquinn[bot]" }, state: "COMMENTED" }],
+      checkRunsStatus: 403,
+    });
+    expect(captured.approvePosts.length).toBe(0);
+  });
+
+  test("already APPROVED → no duplicate approve (latest state gate)", async () => {
+    const captured = await runCiCompletion({
+      reviews: [
+        { user: { login: "protoquinn[bot]" }, state: "COMMENTED" },
+        { user: { login: "protoquinn[bot]" }, state: "APPROVED" },
+      ],
+      checkRuns: [{ status: "completed", conclusion: "success" }],
+    });
+    expect(captured.approvePosts.length).toBe(0);
+  });
+});

--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -35,6 +35,7 @@ import { withCircuitBreaker } from "./circuit-breaker.ts";
 import type { ProjectRegistry } from "../../src/plugins/project-registry.ts";
 import type { ReleasePublishedPayload } from "../../src/event-bus/payloads.ts";
 import { handlePRMerge, parsePRMergePayload } from "../../src/webhooks/github-pr-merge.ts";
+import { GitHubReviewSubmitter } from "../../src/github/reviewSubmitter.ts";
 import {
   handleCommentResponse,
   handleReviewDismissal,
@@ -176,6 +177,54 @@ export function quinnHasReviewed(reviews: Array<Record<string, unknown>> | undef
     const login = (r.user as Record<string, unknown> | undefined)?.login;
     return typeof login === "string" && login.toLowerCase().startsWith("protoquinn");
   });
+}
+
+/**
+ * Terminal-GREEN gate for the deterministic approve-on-green path (#748).
+ *
+ * A formal APPROVE enables auto-merge, so it must only fire when CI is not
+ * merely terminal but actually PASSING — every check completed with a benign
+ * conclusion (`success` / `neutral` / `skipped`), none failed/cancelled/
+ * timed_out/stale, and nothing still in flight.
+ *
+ * FAIL CLOSED: an empty / unknown check set is NOT green. `guardTerminalCi`
+ * treats no-checks as terminal (nothing to wait for), but "no checks" gives us
+ * no positive green signal to auto-approve on, so the deterministic path
+ * declines and the LLM re-dispatch handles it. A 403 / network failure on the
+ * fetch surfaces as `undefined` here → not green.
+ */
+const GREEN_CONCLUSIONS = new Set(["success", "neutral", "skipped"]);
+export function allChecksGreen(checkRuns: Array<Record<string, unknown>> | undefined): boolean {
+  if (!Array.isArray(checkRuns) || checkRuns.length === 0) return false;
+  return checkRuns.every((r) => {
+    if (r.status !== "completed") return false;
+    return typeof r.conclusion === "string" && GREEN_CONCLUSIONS.has(r.conclusion);
+  });
+}
+
+/**
+ * The state of @protoquinn[bot]'s LATEST review (by submission order), or
+ * `undefined` when she has not reviewed. Drives the deterministic approve gate
+ * (#748): only a latest `COMMENTED` review — Quinn reviewed, found no blockers,
+ * and was held by guardTerminalCi while CI ran — is eligible for auto-approve.
+ * A latest `CHANGES_REQUESTED` means blockers exist (never auto-approve); a
+ * latest `APPROVED` means we are already done.
+ *
+ * GitHub returns reviews oldest-first, so the last protoquinn review wins.
+ */
+export function quinnLatestReviewState(
+  reviews: Array<Record<string, unknown>> | undefined,
+): string | undefined {
+  if (!Array.isArray(reviews)) return undefined;
+  let state: string | undefined;
+  for (const r of reviews) {
+    const login = (r.user as Record<string, unknown> | undefined)?.login;
+    if (typeof login === "string" && login.toLowerCase().startsWith("protoquinn")) {
+      const s = r.state;
+      if (typeof s === "string") state = s.toUpperCase();
+    }
+  }
+  return state;
 }
 
 /**
@@ -893,9 +942,48 @@ export class GitHubPlugin implements Plugin {
       const number = pr.number as number;
       if (!prEligibleForCiReview(pr, headSha)) continue;
 
-      if (!(await this._quinnHasReviewed(getToken, owner, repo, number))) continue;
+      const reviews = (await this._ghGet(getToken, owner, repo, `/repos/${owner}/${repo}/pulls/${number}/reviews`)) as
+        | Array<Record<string, unknown>>
+        | null;
+      if (!quinnHasReviewed(reviews ?? undefined)) continue;
       if (!(await this._ciTerminal(getToken, owner, repo, headSha))) {
         console.log(`[github] CI-completion (${event}): ${owner}/${repo}#${number} — checks not all terminal yet, deferring`);
+        continue;
+      }
+
+      // ── Deterministic approve-on-terminal-green (#748) ───────────────────────
+      // Quinn reliably re-COMMENTs instead of choosing review_approve, so the
+      // merge-on-green gate never opens (approvedCount stays 0). When CI is
+      // terminal-GREEN and Quinn's latest review is a held COMMENT (no blockers),
+      // post the formal APPROVE programmatically rather than re-prompting the LLM.
+      //
+      // Fail closed: only the COMMENTED-latest + all-green case auto-approves.
+      // CHANGES_REQUESTED (blockers), an already-APPROVED PR, no prior Quinn
+      // review, or any non-green / unverifiable CI state falls through to the
+      // unchanged LLM re-dispatch below.
+      const latestState = quinnLatestReviewState(reviews ?? undefined);
+      if (latestState === "COMMENTED" && (await this._ciGreen(getToken, owner, repo, headSha))) {
+        try {
+          const submitter = new GitHubReviewSubmitter(getToken);
+          await submitter.submitReview(
+            owner,
+            repo,
+            number,
+            headSha,
+            "APPROVE",
+            "CI terminal-green, no blockers on prior review — auto-approving on green (#748).",
+            [],
+          );
+          console.log(
+            `[github] CI-completion (${event}): auto-approved ${owner}/${repo}#${number} @${headSha.slice(0, 7)} ` +
+              `(terminal-green, prior Quinn review COMMENTED) — #748`,
+          );
+        } catch (err) {
+          console.error(
+            `[github] CI-completion (${event}): auto-approve failed for ${owner}/${repo}#${number}: ` +
+              `${err instanceof Error ? err.message : err}`,
+          );
+        }
         continue;
       }
 
@@ -951,19 +1039,6 @@ export class GitHubPlugin implements Plugin {
     }
   }
 
-  /** True iff @protoquinn[bot] has already left a review on this PR. */
-  private async _quinnHasReviewed(
-    getToken: (owner: string, repo: string) => Promise<string>,
-    owner: string,
-    repo: string,
-    number: number,
-  ): Promise<boolean> {
-    const reviews = (await this._ghGet(getToken, owner, repo, `/repos/${owner}/${repo}/pulls/${number}/reviews`)) as
-      | Array<Record<string, unknown>>
-      | null;
-    return quinnHasReviewed(reviews ?? undefined);
-  }
-
   /**
    * True when every check-run for the SHA is terminal, so guardTerminalCi will
    * permit a formal verdict.
@@ -978,6 +1053,24 @@ export class GitHubPlugin implements Plugin {
       | { check_runs?: Array<Record<string, unknown>> }
       | null;
     return allChecksTerminal(data?.check_runs);
+  }
+
+  /**
+   * True only when every check-run for the SHA is terminal AND green (#748).
+   * Fail closed: `_ghGet` returns null on a 403 / network failure, and
+   * `allChecksGreen(undefined)` is false — an unverifiable or empty CI state
+   * never reads as green, so the deterministic auto-approve declines.
+   */
+  private async _ciGreen(
+    getToken: (owner: string, repo: string) => Promise<string>,
+    owner: string,
+    repo: string,
+    headSha: string,
+  ): Promise<boolean> {
+    const data = (await this._ghGet(getToken, owner, repo, `/repos/${owner}/${repo}/commits/${headSha}/check-runs`)) as
+      | { check_runs?: Array<Record<string, unknown>> }
+      | null;
+    return allChecksGreen(data?.check_runs);
   }
 
   /**


### PR DESCRIPTION
## Problem (#748)
Quinn never posts a formal `APPROVED` review, so the autonomous merge-on-green gate never opens (`approvedCount` stays 0).

Root cause: on PR-open CI is PENDING, so `guardTerminalCi` correctly holds Quinn's APPROVE and she posts `COMMENTED`. `github.ts` `_handleCiCompletion` re-dispatches `pr_review` when CI completes, but it relies on the **LLM to choose** `review_approve` — and she reliably re-COMMENTs instead.

## Fix — deterministic approve-on-terminal-green
In `_handleCiCompletion`, after the existing eligibility / Quinn-reviewed / all-terminal filters and **before** the LLM re-dispatch, add a deterministic branch:

Post a formal `APPROVE` programmatically (via `GitHubReviewSubmitter`, `commit_id = headSha`, empty comments) when **both**:
1. **CI is terminal-GREEN** — every check completed with `success`/`neutral`/`skipped`, none failing/cancelled/timed_out/stale, nothing in flight (`allChecksGreen`).
2. **Quinn's latest review is `COMMENTED`** — she reviewed, found no blockers, was held for CI (`quinnLatestReviewState`).

On fire: submit APPROVE, log, `continue` (skip the LLM re-dispatch for that PR). Otherwise fall through unchanged.

### Fail closed
- A latest `CHANGES_REQUESTED` (blockers), an already-`APPROVED` PR, or **no prior Quinn review** → fall through (never blind-approve an unreviewed PR).
- CI inaccessible (403 → `_ghGet` returns null) or any non-green/unverifiable state → `allChecksGreen(undefined)` is false → fall through. A wrong approve would auto-merge a bad PR.

### Reuse
`_ghGet`, `ciCompletionHeadSha`, `prEligibleForCiReview`, `_ciTerminal`/`allChecksTerminal`, `quinnHasReviewed`, and `GitHubReviewSubmitter.submitReview` — no duplicated GitHub-API logic. (Replaced the now-redundant private `_quinnHasReviewed` with an inline reviews fetch so the same `reviews` array feeds `quinnHasReviewed` + `quinnLatestReviewState`.)

## Tests
`bunx tsc --noEmit` → 0 errors. `bun test` → 961 pass / 0 fail.

New `github-approve-on-green.test.ts`:
- Pure gates `allChecksGreen` / `quinnLatestReviewState` (green/red/non-terminal/empty; latest-wins, non-Quinn-ignored, none).
- Orchestration with stubbed GitHub API: (a) green + COMMENTED → APPROVE; (b) green + CHANGES_REQUESTED → no approve; (c) green + no prior review → no approve; (d) terminal-RED → no approve; (e) 403 → no approve (fail closed); plus already-APPROVED → no duplicate.

## Note on "all-green" strength
The green determination reads the **check-runs** API for the head SHA (same source `guardTerminalCi`/`_ciTerminal` use). It does not consult the legacy commit-**statuses** API or branch-protection required-checks config — a repo that gates merge on a status-only context would be evaluated solely on its check-runs. In practice the fleet's CI emits check-runs; flagged for awareness. Fail-closed posture means the worst case is a missed auto-approve (falls through to LLM), not a wrong one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub pull requests now automatically receive approval when all continuous integration checks complete successfully with terminal status and prior review conditions are satisfied.

* **Tests**
  * Added comprehensive test suite validating automatic PR approval behavior, with coverage for check state verification, review conditions, API failures, state normalization, and duplicate approval prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->