### PR TITLE
docs(adr): ADR-0006 addendum — structured skill outputs (schema-enforced DataParts)

### DIFF
--- a/docs/decisions/0006-a2a-1.0-canonical-sdks-and-protolabs-conventions-layer.md
+++ b/docs/decisions/0006-a2a-1.0-canonical-sdks-and-protolabs-conventions-layer.md
@@ -111,3 +111,23 @@ Both layers mirror each other: same extension URIs, same card conventions, same 
 - **Risk concentrates on the hub** (alpha JS SDK); the Python fleet runs stable 1.0/1.1. Mitigation: the hub spike is already green and pinned to `1.0.0-alpha.0`; bump deliberately.
 - **Flag-day blast radius** is accepted (low-traffic fleet); the `a2a-sdk` 0.3-compat mode is a fallback if a node lags.
 - **Lock-in to canon** — if an SDK diverges from the spec, we carry it in the thin layer, not the agents.
+
+---
+
+## Addendum (2026-06-02): Structured skill outputs as schema-enforced DataParts
+
+- **Status:** Accepted. (Design: protoAgent#476; TS companion: protoWorkstacean#756.)
+
+**Problem.** A2A skills return free-form LLM text — fine for humans/agents, broken when a *program* must parse the result (protoMaker's `parseReviewXml` for jon's `market_review`; the pr-remediator reading `diagnose_pr_stuck`). "Make it structured" is attempted by *prompting*, a soft constraint the model ignores. Empirically (gateway probes, 2026-06-02) `response_format: json_schema` is **ignored by `protolabs/reasoning`→minimax-m2.7 even called directly**; LiteLLM also drops it. **Forced tool-calling works on every backend in our zoo.**
+
+**Decision.** A skill MAY declare an `output_schema` (JSON Schema) + `result_mime`. Split by the A2A spec's own boundary:
+
+- **Transport — A2A-native, shared/mirrored.** Emit the validated object as a **DataPart** (`data` + `metadata.mimeType`/`media_type` = `result_mime`), advertised via the skill's `output_modes` on the card — the *same machinery* as the four custom extensions. The shared layers (`@protolabs/a2a` TS + `protolabs_a2a` Py) add **`emitSkillResult(obj, mime)`** + the **`submit_<skill>`** tool-name convention, **mirrored byte-for-byte (wire only, no LLM dependency).**
+- **Enforcement — runtime-local, NOT mirrored.** Generation is **out of A2A's scope** (the SDK has no `output_schema`/`response_format`/`tool_choice` primitive — verified). Each runtime enforces via **forced tool-calling** (a `submit_<skill>` function whose params *are* the schema, `tool_choice` forced), validates, and **repairs once**, in its own LLM stack — `DeepAgentExecutor` (TS) here, LangChain `with_structured_output` in protoAgent. **Not** `response_format` (ignored by the reasoning backend); **not** byte-for-byte (different stacks, no A2A primitive to mirror).
+- **Declaration.** `output_schema` is **not** a card field — `AgentSkill` exposes `output_modes` (MIME) only. The schema lives in the skill definition (+ optional published schema URL via the card's `documentation_url`).
+
+**Rationale.** A2A natively defines the structured *transport* (DataPart + `output_modes`) but no *generation* primitive — so transport is shared/mirrored, enforcement is runtime-local. Tool-calling is the provider-agnostic generation lever; `response_format` is unreliable across our heterogeneous model zoo.
+
+**Consequences.** Shared layers add `emitSkillResult` + the tool-name convention (wire only); each runtime adds forced-tool-call enforcement in its executor; skills opt in per-skill (free-text default, untouched); `parseReviewXml` (and any regex-on-text consumer) → typed DataPart parsing.
+
+**TS-side rollout (#756):** (1) this addendum [done]; (2) `@protolabs/a2a` `emitSkillResult` + `submit_<skill>` convention, in lockstep with `protolabs_a2a`; (3) `DeepAgentExecutor` forced-tool-call enforcement + zod validate + 1 repair → `emitSkillResult`; (4) `diagnose_pr_stuck` declares its verdict schema → the pr-remediator reads the DataPart.


### PR DESCRIPTION
Lands the **canonical decision** for structured skill outputs (step 1 of #756) — the architecture we settled on in protoAgent#476:

- **Transport (A2A-native, shared/mirrored):** validated object → **DataPart** (`data` + `metadata.mimeType` = `result_mime`), advertised via `output_modes`; `@protolabs/a2a` + `protolabs_a2a` add `emitSkillResult` + the `submit_<skill>` convention (wire only).
- **Enforcement (runtime-local):** **forced tool-calling** (`tool_choice` → `submit_<skill>` fn whose params are the schema) + validate + 1 repair — **not** `response_format` (empirically ignored by `protolabs/reasoning`→minimax). Each runtime in its own LLM stack; not mirrored.
- **`output_schema` is not a card field** — `AgentSkill` exposes `output_modes` (MIME) only; schema lives in the skill def.

Next on #756: `@protolabs/a2a` `emitSkillResult` + `submit_<skill>` (lockstep w/ `protolabs_a2a`) → `DeepAgentExecutor` enforcement → `diagnose_pr_stuck` declares its schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added specification for skills to return schema-enforced structured outputs with validation and enforcement mechanisms. Includes data transport protocols, skill capability advertisement details, TypeScript implementation checklist, and consumer integration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->