### PR TITLE
fix(a2a): pin transport to configured agents.d URL, not card's self-advertised interface (#760)

### DIFF
--- a/src/executor/__tests__/a2a-pin-url.test.ts
+++ b/src/executor/__tests__/a2a-pin-url.test.ts
@@ -1,0 +1,50 @@
+import { describe, test, expect } from "bun:test";
+import { pinCardTransportUrl } from "../executors/a2a-executor.ts";
+import type { AgentCard } from "@a2a-js/sdk";
+
+// The #760 regression: an agent self-advertised http://127.0.0.1:7870/a2a in its
+// card, so the hub's A2A client dialed loopback (itself) instead of the agent.
+// pinCardTransportUrl makes the configured (reachable) agents.d URL authoritative
+// for the connection while leaving the card intact for discovery.
+
+const CONFIGURED = "http://roxy:7870/a2a";
+
+function cardWithIfaceUrl(url: string): AgentCard {
+  return {
+    name: "roxy",
+    supportedInterfaces: [
+      { url, protocolBinding: "JSONRPC", protocolVersion: "1.0", tenant: "" },
+    ],
+  } as unknown as AgentCard;
+}
+
+describe("pinCardTransportUrl (#760)", () => {
+  test("rewrites a loopback interface URL to the configured URL", () => {
+    const pinned = pinCardTransportUrl(cardWithIfaceUrl("http://127.0.0.1:7870/a2a"), CONFIGURED);
+    expect(pinned.supportedInterfaces?.[0]?.url).toBe(CONFIGURED);
+  });
+
+  test("preserves the other interface fields (binding/version)", () => {
+    const pinned = pinCardTransportUrl(cardWithIfaceUrl("http://127.0.0.1:7870/a2a"), CONFIGURED);
+    expect(pinned.supportedInterfaces?.[0]?.protocolBinding).toBe("JSONRPC");
+    expect(pinned.supportedInterfaces?.[0]?.protocolVersion).toBe("1.0");
+    expect(pinned.name).toBe("roxy");
+  });
+
+  test("does NOT mutate the input card", () => {
+    const card = cardWithIfaceUrl("http://127.0.0.1:7870/a2a");
+    pinCardTransportUrl(card, CONFIGURED);
+    expect(card.supportedInterfaces?.[0]?.url).toBe("http://127.0.0.1:7870/a2a");
+  });
+
+  test("pins the legacy top-level url field if present", () => {
+    const card = { name: "x", url: "http://127.0.0.1:7870/a2a" } as unknown as AgentCard;
+    const pinned = pinCardTransportUrl(card, CONFIGURED) as { url?: string };
+    expect(pinned.url).toBe(CONFIGURED);
+  });
+
+  test("no supportedInterfaces → returns a copy, no throw", () => {
+    const card = { name: "x" } as unknown as AgentCard;
+    expect(() => pinCardTransportUrl(card, CONFIGURED)).not.toThrow();
+  });
+});

--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -12,6 +12,7 @@
  */
 
 import { ClientFactory, JsonRpcTransportFactory, type Client } from "@a2a-js/sdk/client";
+import type { AgentCard } from "@a2a-js/sdk";
 import {
   Role,
   TaskState,
@@ -164,6 +165,24 @@ function buildFetch(
  */
 function isTask(result: Message | Task): result is Task {
   return "id" in result && "status" in result;
+}
+
+/**
+ * Pin an agent card's transport URL(s) to `url`. Agents — especially
+ * containerized / NAT'd ones — sometimes self-advertise an unreachable
+ * interface URL in their card (e.g. `http://127.0.0.1:7870/a2a`). The
+ * operator-configured `agents.d` URL is authoritative for reachability, so we
+ * use the card for discovery (skills/extensions/capabilities) but connect to
+ * the configured URL. Returns a shallow copy; does not mutate the input. (#760)
+ */
+export function pinCardTransportUrl(card: AgentCard, url: string): AgentCard {
+  const pinned: AgentCard = { ...card };
+  if (Array.isArray(card.supportedInterfaces)) {
+    pinned.supportedInterfaces = card.supportedInterfaces.map(iface => ({ ...iface, url }));
+  }
+  // Legacy 0.3 top-level `url`, if a server still emits it.
+  if ((card as { url?: string }).url) (pinned as { url?: string }).url = url;
+  return pinned;
 }
 
 export class A2AExecutor implements IExecutor {
@@ -691,17 +710,35 @@ export class A2AExecutor implements IExecutor {
       transports: [new JsonRpcTransportFactory({ fetchImpl: customFetch })],
     });
 
-    try {
-      return await factory.createFromUrl(baseUrl);
-    } catch (err) {
-      // Fallback to legacy path — some servers still serve /.well-known/agent.json
-      // instead of the newer /.well-known/agent-card.json
+    // Resolve the card for discovery, then PIN the transport URL to the
+    // configured `url`. createFromUrl would connect to the card's self-advertised
+    // interface URL, which containerized/NAT'd agents often set to loopback
+    // (e.g. http://127.0.0.1:7870/a2a) — unreachable from here, and a single
+    // point of failure for the whole edge (#760). The agents.d URL is
+    // authoritative for reachability; the card stays the source for skills/extensions.
+    const card = await this._fetchAgentCard(baseUrl, customFetch);
+    return await factory.createFromAgentCard(pinCardTransportUrl(card, this.config.url));
+  }
+
+  /** Fetch the agent card from `baseUrl`, trying the 1.0 path then the legacy 0.3 path. */
+  private async _fetchAgentCard(
+    baseUrl: string,
+    fetchImpl: (url: string, init?: RequestInit) => Promise<Response>,
+  ): Promise<AgentCard> {
+    let lastErr: unknown;
+    for (const path of ["/.well-known/agent-card.json", "/.well-known/agent.json"]) {
       try {
-        return await factory.createFromUrl(baseUrl, "/.well-known/agent.json");
-      } catch {
-        throw err;
+        const res = await fetchImpl(`${baseUrl}${path}`);
+        if (res.ok) return (await res.json()) as AgentCard;
+        lastErr = new Error(`HTTP ${res.status} from ${path}`);
+      } catch (err) {
+        lastErr = err;
       }
     }
+    throw new Error(
+      `[a2a] could not resolve agent card for ${baseUrl} (tried agent-card.json + agent.json): ` +
+      (lastErr instanceof Error ? lastErr.message : String(lastErr)),
+    );
   }
 
   /**


### PR DESCRIPTION
Closes #760.

## Problem
`A2AExecutor._buildClient` built its client via `factory.createFromUrl(baseUrl)`, which connects to whatever URL the agent advertises in its card (`supportedInterfaces[].url`). Containerized / NAT'd agents routinely self-advertise a **loopback** URL — e.g. roxy's card returns `http://127.0.0.1:7870/a2a`. The hub then dials localhost (itself), so `message:send` fails with *"Unable to connect"* even though the agent is healthy and reachable at its configured address. This just broke hub→roxy after roxy's redeploy (roxy#26).

The operator already tells the hub the reachable address in `agents.d/*.yaml` (`url: http://roxy:7870/a2a`). That URL should be authoritative for the connection — the card's self-report should not be.

## Fix
Use the card for **discovery** (skills, extensions, capabilities) exactly as today, but **pin** the transport URL to the configured `agents.d` `url` before connecting:

- **`pinCardTransportUrl(card, url)`** — pure, exported, non-mutating. Rewrites every `supportedInterfaces[].url` (and the legacy top-level `url`) to the configured URL.
- **`_fetchAgentCard(baseUrl, fetchImpl)`** — fetches the card via the configured/reachable host, trying `/.well-known/agent-card.json` (1.0) then `/.well-known/agent.json` (legacy 0.3); throws loudly with both attempts named if neither resolves.
- `_buildClient` now: fetch card → `createFromAgentCard(pinCardTransportUrl(card, this.config.url))`.

Fail-soft: if the card omits `supportedInterfaces`, the helper returns a copy unchanged (no throw).

## Tests
- 5 unit tests over `pinCardTransportUrl` (loopback→configured rewrite, field preservation, no-mutation, legacy `url`, empty-interfaces).
- `bunx tsc --noEmit` clean; full `src/executor/` suite green (180 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transport URL pinning for agent card configuration to ensure correct network routing
  * Improved agent card discovery with enhanced fallback handling and comprehensive error reporting

* **Tests**
  * Added test coverage for transport URL pinning functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->