### PR TITLE
fix(a2a): extract cost/confidence/worldstate DataParts on the tasks/get poll path (#763)

### DIFF
--- a/src/executor/__tests__/a2a-executor-cost-confidence.test.ts
+++ b/src/executor/__tests__/a2a-executor-cost-confidence.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from "bun:test";
+import { TaskState } from "@a2a-js/sdk";
 import { A2AExecutor } from "../executors/a2a-executor.ts";
 import { COST_V1_MIME_TYPE, CONFIDENCE_V1_MIME_TYPE } from "@protolabs/a2a";
 
@@ -104,5 +105,71 @@ describe("A2AExecutor cost-v1 / confidence-v1 extraction", () => {
   test("_flattenExtensionData returns {} when neither payload present", () => {
     const exec = makeExec();
     expect(exec._flattenExtensionData(undefined, undefined, "completed")).toEqual({});
+  });
+});
+
+// Regression for #763: the tasks/get poll path (taken whenever a streaming
+// agent emits a non-terminal task event first — i.e. virtually every real task)
+// used to surface only text + state, silently dropping cost-v1/confidence-v1.
+describe("A2AExecutor.pollTask surfaces extension DataParts (#763)", () => {
+  function execWithTask(task: unknown): A2AExecutor {
+    const exec = new A2AExecutor({
+      name: "roxy",
+      url: "http://roxy:7870/a2a",
+      streaming: true,
+      pushNotifications: false,
+    });
+    // Stub the client build so no network/card fetch happens.
+    (exec as unknown as { _buildClient: () => Promise<unknown> })._buildClient =
+      async () => ({ getTask: async () => task });
+    return exec;
+  }
+
+  const terminalTask = {
+    id: "t-763",
+    contextId: "ctx-763",
+    status: { state: TaskState.TASK_STATE_COMPLETED },
+    artifacts: [
+      {
+        artifactId: "a1",
+        parts: [
+          { content: { $case: "text", value: "portfolio sitrep…" } },
+          {
+            content: {
+              $case: "data",
+              value: { usage: { input_tokens: 54339, output_tokens: 1969 }, costUsd: 0.006221, success: true },
+            },
+            metadata: { mimeType: COST_V1_MIME_TYPE },
+          },
+          {
+            content: { $case: "data", value: { confidence: 0.92, explanation: "consistent across sources", success: true } },
+            metadata: { mimeType: CONFIDENCE_V1_MIME_TYPE },
+          },
+        ],
+      },
+    ],
+  };
+
+  test("poll result.data carries costUsd + usage + confidence (not just text)", async () => {
+    const exec = execWithTask(terminalTask);
+    const res = await exec.pollTask("t-763", "corr-763");
+    expect(res.text).toBe("portfolio sitrep…");
+    expect(res.data?.costUsd).toBe(0.006221);
+    expect(res.data?.usage).toEqual({ input_tokens: 54339, output_tokens: 1969 });
+    expect(res.data?.confidence).toBe(0.92);
+    expect(res.data?.confidenceExplanation).toBe("consistent across sources");
+  });
+
+  test("poll result omits cost/confidence cleanly when the task emits no such parts", async () => {
+    const exec = execWithTask({
+      id: "t2",
+      contextId: "ctx2",
+      status: { state: TaskState.TASK_STATE_COMPLETED },
+      artifacts: [{ artifactId: "a1", parts: [{ content: { $case: "text", value: "pong" } }] }],
+    });
+    const res = await exec.pollTask("t2", "corr2");
+    expect(res.text).toBe("pong");
+    expect(res.data?.costUsd).toBeUndefined();
+    expect(res.data?.confidence).toBeUndefined();
   });
 });

--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -365,8 +365,18 @@ export class A2AExecutor implements IExecutor {
       const client = await this._buildClient(correlationId, parentId);
       const task = await client.getTask({ tenant: "", id: taskId });
       const state = task.status?.state ?? TaskState.TASK_STATE_UNSPECIFIED;
-      const artifactText = this._textFromParts((task.artifacts ?? []).flatMap(a => a.parts));
+      const allParts = (task.artifacts ?? []).flatMap(a => a.parts);
+      const artifactText = this._textFromParts(allParts);
       const statusText = task.status?.message ? this._textFromParts(task.status.message.parts) : "";
+      // Extract extension DataParts here too — most real tasks complete via this
+      // poll path (the stream loop breaks to tasks/get on the first non-terminal
+      // task event), so without this the cost-v1/confidence-v1/worldstate-delta
+      // parts an agent emits never reach result.data and are silently dropped.
+      // Mirrors the blocking + stream-to-terminal paths.
+      const taskState = stateToLegacyString(state);
+      const worldStateDelta = this._extractWorldStateDelta(task);
+      const cost = this._costFromParts(allParts);
+      const confidence = this._confidenceFromParts(allParts);
       return {
         text: artifactText || statusText || "",
         isError: isErrorState(state),
@@ -374,8 +384,10 @@ export class A2AExecutor implements IExecutor {
         data: {
           taskId: task.id,
           contextId: task.contextId,
-          taskState: stateToLegacyString(state),
+          taskState,
           artifacts: task.artifacts ?? [],
+          ...(worldStateDelta ? { [WORLDSTATE_DELTA_MIME_TYPE]: worldStateDelta } : {}),
+          ...this._flattenExtensionData(cost, confidence, taskState),
         },
       };
     } catch (err) {


### PR DESCRIPTION
Closes #763. Resolves the telemetry side of roxy#22 (the emit was correct).

## TL;DR
The hub drops `cost-v1`/`confidence-v1` (and worldstate-delta) DataParts because **the `tasks/get` poll-completion path never extracts them** — and that's the path virtually every real A2A task takes. Not a version skew, not an SDK deserialization bug, not an agent emit gap.

## The chain (all verified live, 2026-06-03)
1. roxy is `streaming:true` → executor uses `sendMessageStream`. A2A's normal lifecycle opens with a non-terminal `task` event (`submitted`/`working`), and the SSE loop **intentionally breaks** on the first non-terminal task event to hand off to `TaskTracker` `tasks/get` polling (so slow agents don't hold the stream open). Log proof: `Tracking roxy task… → reached terminal state "completed" after 45s`.
2. **`A2AExecutor.pollTask` surfaced only `text` + `state`** — it returned `data:{taskId,contextId,taskState,artifacts}` and never called `_costFromParts`/`_confidenceFromParts`/`_flattenExtensionData`, unlike the blocking path and the stream-to-terminal path which do.
3. So `result.data.costUsd`/`confidence` were undefined → `_publishResponse` forwarded nothing → the cost interceptor recorded its **default all-zeros** sample; confidence recorded nothing.

## Proof it's not the agent/SDK/parse layer
Captured roxy's wire response directly (`SendMessage`, `A2A-Version: 1.0`):
- `cost-v1`: `{usage:{input_tokens:54339, output_tokens:1969}, costUsd:0.006221, success:true}`
- `confidence-v1`: `{confidence:0.92, explanation:"…", success:true}`

Both deserialize cleanly through the hub's `@a2a-js/sdk@1.0.0-alpha.0` `Part.fromJSON` (→ `content.$case==="data"`, `metadata.mimeType` preserved), and `parseCost`/`parseConfidence` return the real values. The parts were just never extracted on the poll path.

## Fix
`pollTask` now extracts extensions via the existing `_costFromParts`/`_confidenceFromParts`/`_extractWorldStateDelta` + `_flattenExtensionData`, mirroring the blocking and stream-to-terminal paths. No agent or SDK change.

## Tests
2 regression tests stub `_buildClient` so the poll path runs offline: one asserts `costUsd`/`usage`/`confidence` now land on `result.data`, one asserts a clean omission when no such parts exist. `tsc` clean; full `src/executor/` suite green (182 pass).

## Follow-up (separate, filed)
`TaskTracker._extractAndPublishDeltas` + the webhook-callback text extraction still read the legacy 0.3 `{kind}` part shape (the push-callback body is raw wire, a distinct deserialization concern), so worldstate-delta publishing drops on the poll/push paths too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Task polling responses now include enriched artifact data: cost metrics (costUsd, usage, duration, success status) and confidence metrics (score and explanation) extracted from task artifacts when available.

* **Tests**
  * Added regression test suite covering task polling with various artifact types, validating proper extraction and population of cost and confidence data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->