### PR TITLE
fix(a2a): record cost/confidence extension samples on async (poll) completion

### DIFF
--- a/src/executor/__tests__/a2a-async-extension-recording.test.ts
+++ b/src/executor/__tests__/a2a-async-extension-recording.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { A2AExecutor } from "../executors/a2a-executor.ts";
+import { CostStore, registerCostExtension } from "../extensions/cost.ts";
+import { ConfidenceStore, registerConfidenceExtension } from "../extensions/confidence.ts";
+
+// Regression for the async-completion telemetry gap (follow-up to #763/#764):
+// when a streaming agent hands off to TaskTracker polling, execute() returns
+// non-terminal and SKIPS its after-hooks, so the cost-v1/confidence-v1 samples
+// must be recorded on the async terminal completion instead. TaskTracker calls
+// A2AExecutor.recordTerminalExtensions for exactly that.
+
+describe("A2AExecutor.recordTerminalExtensions — async completion path", () => {
+  let bus: InMemoryEventBus;
+  let costStore: CostStore;
+  let confStore: ConfidenceStore;
+  let exec: A2AExecutor;
+
+  beforeEach(() => {
+    bus = new InMemoryEventBus();
+    costStore = new CostStore();
+    confStore = new ConfidenceStore();
+    registerCostExtension(bus, costStore);
+    registerConfidenceExtension(bus, confStore);
+    exec = new A2AExecutor({ name: "roxy", url: "http://roxy:7870/a2a", streaming: true, pushNotifications: false });
+  });
+
+  test("records real cost + confidence from a terminal result.data", async () => {
+    const costEvents: unknown[] = [];
+    const confEvents: unknown[] = [];
+    bus.subscribe("autonomous.cost.#", "t", (m) => { costEvents.push(m); });
+    bus.subscribe("autonomous.confidence.#", "t", (m) => { confEvents.push(m); });
+
+    await exec.recordTerminalExtensions("portfolio_sitrep", "corr-async", {
+      usage: { input_tokens: 54339, output_tokens: 1969 },
+      costUsd: 0.006221,
+      success: true,
+      confidence: 0.92,
+      confidenceExplanation: "consistent across sources",
+    });
+
+    const cost = costStore.summary("roxy", "portfolio_sitrep");
+    expect(cost?.sampleCount).toBe(1);
+    expect(cost?.avgTokensIn).toBe(54339);
+    expect(cost?.avgTokensOut).toBe(1969);
+    expect(cost?.avgCostUsd).toBe(0.006221);
+
+    const conf = confStore.summary("roxy", "portfolio_sitrep");
+    expect(conf?.sampleCount).toBe(1);
+    expect(conf?.avgConfidenceOnSuccess).toBe(0.92);
+
+    expect(costEvents).toHaveLength(1);
+    expect(confEvents).toHaveLength(1);
+  });
+
+  test("no-ops on undefined data (nothing recorded)", async () => {
+    await exec.recordTerminalExtensions("portfolio_sitrep", "corr-x", undefined);
+    expect(costStore.size).toBe(0);
+    expect(confStore.size).toBe(0);
+  });
+
+  test("records cost but not confidence when only cost is present", async () => {
+    await exec.recordTerminalExtensions("board_sweep", "corr-y", {
+      usage: { input_tokens: 100, output_tokens: 50 },
+      costUsd: 0.001,
+      success: true,
+    });
+    expect(costStore.summary("roxy", "board_sweep")?.sampleCount).toBe(1);
+    expect(confStore.summary("roxy", "board_sweep")).toBeUndefined();
+  });
+});

--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -287,11 +287,19 @@ export class A2AExecutor implements IExecutor {
 
       // Run extension after-hooks — they read result.data (usage, confidence,
       // worldstate-delta) and emit observability events or record samples.
-      for (const i of interceptors) {
-        try {
-          await i.after?.(extCtx, { text: result.text, data: result.data });
-        } catch (err) {
-          console.debug(`[a2a-executor] extension after-hook error:`, err);
+      // Only on TERMINAL results: when the stream breaks to TaskTracker polling
+      // the result here is non-terminal ("working"/"submitted") with no cost/
+      // confidence yet — recording it would log a premature zero sample. The
+      // real terminal result is recorded by TaskTracker on async completion.
+      const ts = result.data?.taskState;
+      const nonTerminal = ts === "working" || ts === "submitted" || ts === "input-required";
+      if (!nonTerminal) {
+        for (const i of interceptors) {
+          try {
+            await i.after?.(extCtx, { text: result.text, data: result.data });
+          } catch (err) {
+            console.debug(`[a2a-executor] extension after-hook error:`, err);
+          }
         }
       }
 
@@ -302,6 +310,39 @@ export class A2AExecutor implements IExecutor {
         isError: true,
         correlationId: req.correlationId,
       };
+    }
+  }
+
+  /**
+   * Run the extension after-hooks (cost-v1/confidence-v1/worldstate-delta
+   * recording + observability events) for a result that completed
+   * ASYNCHRONOUSLY — i.e. execute() returned non-terminal and TaskTracker
+   * later polled/received the terminal Task. execute()'s own after-hook pass
+   * skips non-terminal returns, so without this the async-completion path
+   * (which most real tasks take) never records its extension samples.
+   * Builds the same ExtensionContext shape as the sync pass.
+   */
+  async recordTerminalExtensions(
+    skill: string,
+    correlationId: string,
+    data: Record<string, unknown> | undefined,
+  ): Promise<void> {
+    if (!data) return;
+    const ctx: ExtensionContext = {
+      agentName: this.config.name,
+      skill,
+      correlationId,
+      metadata: {},
+    };
+    const interceptors = defaultExtensionRegistry.list()
+      .map(d => d.interceptor)
+      .filter((i): i is ExtensionInterceptor => !!i);
+    for (const i of interceptors) {
+      try {
+        await i.after?.(ctx, { text: "", data });
+      } catch (err) {
+        console.debug(`[a2a-executor] extension after-hook error (async):`, err);
+      }
     }
   }
 

--- a/src/executor/task-tracker.ts
+++ b/src/executor/task-tracker.ts
@@ -240,6 +240,10 @@ export class TaskTracker {
         if (state && TERMINAL_STATES.has(state)) {
           const rawArtifacts = (result.data?.artifacts ?? []) as Array<{ extensions?: string[]; parts?: Array<{ kind?: string; text?: string; data?: Record<string, unknown> }> }>;
           this._extractAndPublishDeltas(task.taskId, task.agentName, rawArtifacts);
+          // Record cost-v1/confidence-v1 samples here: execute() returned
+          // non-terminal (it handed off to us) so it skipped its after-hooks.
+          // result.data carries the extension payloads pollTask extracted.
+          await task.executor.recordTerminalExtensions(task.skillName ?? "unknown", task.correlationId, result.data);
           this._publishResponse(task, result.text, result.isError ? result.text : undefined, state, result.data);
           this.tasks.delete(task.correlationId);
           console.log(


### PR DESCRIPTION
Follow-up to #764 (and the second half of the #763 telemetry fix). **Verified live that #764 alone still recorded all-zeros**, so this completes it.

## Why #764 wasn't enough
#764 made `pollTask` put cost/confidence into `result.data`. But the samples that feed `/api/cost-summaries` are recorded by the **extension after-hooks**, which run in `A2AExecutor.execute()` on the value `execute()` *returns*. For a streaming agent the SSE loop **breaks to TaskTracker polling on the first non-terminal `task` event**, so `execute()` returns the `working` result (no cost) — the after-hooks recorded a **premature zero sample**, and the real terminal result delivered later by TaskTracker never ran them.

Live proof after #764 deployed (store reset by the redeploy → clean): `roxy/portfolio_sitrep` still `avgCostUsd:0`, confidence-summaries empty.

## Fix (both halves)
1. **`execute()` skips after-hooks on non-terminal returns** (`working`/`submitted`/`input-required`) — kills the premature zero sample.
2. **New `A2AExecutor.recordTerminalExtensions(skill, correlationId, data)`** runs the same after-hook pass with an identical `ExtensionContext` (same `agentName`, empty metadata → `systemActor` defaults to `"user"`, matching the sync path). **TaskTracker calls it on terminal async completion** (poll-sweep path), where `result.data` now carries the cost-v1/confidence-v1 payloads from #764.

Net: **exactly one recording per task** — sync-terminal tasks record in `execute()` as before; async tasks (the common case) record in TaskTracker. No double-count (TaskTracker only runs for tasks `execute()` returned non-terminal).

## Tests
3 new tests over `recordTerminalExtensions` (real cost+confidence recorded + `autonomous.*` events emitted; no-op on undefined; cost-without-confidence). `tsc` clean; full `src/executor/` suite green (185).

## Note
The webhook-callback completion path still parses the raw-wire body with the legacy 0.3 `{kind}` shape and doesn't surface cost/confidence — tracked in #765; recording wires in there once that extraction is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)