### PR TITLE
feat: Ava memory flywheel + Discord context awareness (5 phases)

### DIFF
--- a/lib/plugins/discord.ts
+++ b/lib/plugins/discord.ts
@@ -21,6 +21,7 @@ import { initAgentPool, reloadAgentPool } from "./discord/agent-pool.ts";
 import { registerInboundHandlers, handleDM, setupDmAccumulator } from "./discord/inbound.ts";
 import { registerSlashCommandHandlers, registerSlashCommands } from "./discord/slash-commands.ts";
 import { registerOutboundHandlers } from "./discord/outbound.ts";
+import { registerLifecycleHandlers } from "./discord/lifecycle.ts";
 
 // Re-export for API routes (discord operations agent)
 export { pendingReplies, canSendProgress } from "./discord/outbound.ts";
@@ -112,6 +113,7 @@ export class DiscordPlugin implements Plugin {
     setupDmAccumulator(ctx);
 
     // Register event handlers
+    registerLifecycleHandlers(this.client);
     registerInboundHandlers(ctx);
     registerSlashCommandHandlers(ctx);
     registerOutboundHandlers(ctx);

--- a/lib/plugins/discord/__tests__/context.test.ts
+++ b/lib/plugins/discord/__tests__/context.test.ts
@@ -1,0 +1,91 @@
+import { describe, test, expect } from "bun:test";
+import type { Message } from "discord.js";
+import { buildMessageContext } from "../context.ts";
+
+/** Minimal structural fake of a discord.js Message for the fields context.ts reads. */
+function fakeMessage(opts: {
+  id?: string;
+  cleanContent?: string;
+  displayName?: string;
+  reference?: { messageId: string };
+  fetchReference?: () => Promise<Message>;
+  isThread?: boolean;
+  starter?: Message | null;
+  threadName?: string;
+  scrollback?: Message[];
+  attachments?: { name: string; url: string }[];
+}): Message {
+  const attachments = new Map((opts.attachments ?? []).map((a, i) => [String(i), a]));
+  const channel: Record<string, unknown> = {
+    isThread: () => !!opts.isThread,
+    name: opts.threadName,
+    fetchStarterMessage: async () => opts.starter ?? null,
+    messages: {
+      fetch: async () => new Map((opts.scrollback ?? []).map((m, i) => [String(i), m])),
+    },
+  };
+  return {
+    id: opts.id ?? "m1",
+    cleanContent: opts.cleanContent ?? "",
+    member: opts.displayName ? { displayName: opts.displayName } : null,
+    author: { username: "user", globalName: opts.displayName },
+    reference: opts.reference,
+    fetchReference: opts.fetchReference ?? (async () => { throw new Error("no ref"); }),
+    channel,
+    attachments,
+  } as unknown as Message;
+}
+
+describe("buildMessageContext", () => {
+  test("returns '' when there's no surrounding context", async () => {
+    const m = fakeMessage({ cleanContent: "just a plain message" });
+    expect(await buildMessageContext(m)).toBe("");
+  });
+
+  test("includes the replied-to message", async () => {
+    const ref = fakeMessage({ cleanContent: "the original question about deploys", displayName: "Josh" });
+    const m = fakeMessage({
+      reference: { messageId: "ref1" },
+      fetchReference: async () => ref,
+    });
+    const ctx = await buildMessageContext(m);
+    expect(ctx).toContain("[Conversation context]");
+    expect(ctx).toContain("replying to Josh");
+    expect(ctx).toContain("original question about deploys");
+  });
+
+  test("includes recent channel scrollback, oldest-first", async () => {
+    const older = fakeMessage({ cleanContent: "first message", displayName: "Alice" });
+    const newer = fakeMessage({ cleanContent: "second message", displayName: "Bob" });
+    // fetch returns newest-first (Discord order); builder reverses to chronological.
+    const m = fakeMessage({ scrollback: [newer, older] });
+    const ctx = await buildMessageContext(m);
+    expect(ctx).toContain("Recent messages in this channel");
+    expect(ctx.indexOf("first message")).toBeLessThan(ctx.indexOf("second message"));
+    expect(ctx).toContain("Alice:");
+  });
+
+  test("includes thread context", async () => {
+    const starter = fakeMessage({ cleanContent: "thread kickoff topic", displayName: "Josh" });
+    const m = fakeMessage({ isThread: true, threadName: "Memory work", starter });
+    const ctx = await buildMessageContext(m);
+    expect(ctx).toContain('Thread "Memory work"');
+    expect(ctx).toContain("thread kickoff topic");
+  });
+
+  test("lists attachments", async () => {
+    const m = fakeMessage({ attachments: [{ name: "trace.log", url: "http://x/trace.log" }] });
+    const ctx = await buildMessageContext(m);
+    expect(ctx).toContain("Attachments on this message: trace.log");
+  });
+
+  test("degrades when fetchReference throws", async () => {
+    const m = fakeMessage({
+      reference: { messageId: "gone" },
+      fetchReference: async () => { throw new Error("uncached"); },
+      cleanContent: "reply to a deleted message",
+    });
+    // No throw; reply line simply omitted.
+    expect(await buildMessageContext(m)).toBe("");
+  });
+});

--- a/lib/plugins/discord/__tests__/dedup.test.ts
+++ b/lib/plugins/discord/__tests__/dedup.test.ts
@@ -1,0 +1,20 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { alreadyHandled, _resetDedup } from "../dedup.ts";
+
+beforeEach(() => _resetDedup());
+
+describe("alreadyHandled", () => {
+  test("first sight is new, repeat within TTL is a duplicate", () => {
+    expect(alreadyHandled("msg:1")).toBe(false);
+    expect(alreadyHandled("msg:1")).toBe(true);
+    expect(alreadyHandled("msg:1")).toBe(true);
+  });
+
+  test("distinct keys are independent", () => {
+    expect(alreadyHandled("msg:a")).toBe(false);
+    expect(alreadyHandled("msg:b")).toBe(false);
+    expect(alreadyHandled("msg:a")).toBe(true);
+    expect(alreadyHandled("react:1:u:📋")).toBe(false);
+    expect(alreadyHandled("react:1:u:📋")).toBe(true);
+  });
+});

--- a/lib/plugins/discord/context.ts
+++ b/lib/plugins/discord/context.ts
@@ -1,0 +1,104 @@
+/**
+ * context.ts — assemble surrounding Discord context for an inbound message.
+ *
+ * Ava used to receive only the bare text of the message that triggered her, so
+ * she couldn't see what a reply was replying to, the recent channel scrollback,
+ * the thread she's in, or any attachments. This builds a compact context
+ * preamble from those signals and ships it alongside the message (as
+ * `contextPreamble` on the bus payload) so the executor can inject it into the
+ * turn without polluting the stored conversation history.
+ *
+ * Everything here is best-effort and defensive — a failed fetch degrades to
+ * less context, never an error.
+ */
+
+import { type Message, type TextChannel, ChannelType } from "discord.js";
+
+/** How many prior channel messages to include as scrollback. */
+const SCROLLBACK_LIMIT = 6;
+/** Per-message content cap inside the preamble (keep it bounded). */
+const SNIPPET_CHARS = 280;
+
+function snippet(text: string): string {
+  const clean = text.replace(/\s+/g, " ").trim();
+  return clean.length > SNIPPET_CHARS ? clean.slice(0, SNIPPET_CHARS) + "…" : clean;
+}
+
+function authorName(m: Message): string {
+  return m.member?.displayName ?? m.author?.globalName ?? m.author?.username ?? "someone";
+}
+
+/**
+ * Build a context preamble for `message`. Returns "" when there's nothing
+ * useful to add (keeps the LLM input clean for plain messages).
+ */
+export async function buildMessageContext(message: Message): Promise<string> {
+  const parts: string[] = [];
+
+  // 1. Replied-to message — the most direct context signal.
+  if (message.reference?.messageId) {
+    try {
+      const ref = await message.fetchReference();
+      const refText = snippet(ref.cleanContent || "(no text)");
+      parts.push(`The user is replying to ${authorName(ref)}: "${refText}"`);
+    } catch {
+      /* reference gone / uncached — skip */
+    }
+  }
+
+  // 2. Thread context — name + starter message if we're inside one.
+  const channel = message.channel;
+  if (channel.isThread()) {
+    try {
+      const starter = await channel.fetchStarterMessage().catch(() => null);
+      const threadName = channel.name ? `Thread "${channel.name}"` : "This thread";
+      parts.push(
+        starter
+          ? `${threadName}, started by ${authorName(starter)}: "${snippet(starter.cleanContent || "(no text)")}"`
+          : `${threadName}.`,
+      );
+    } catch {
+      /* skip */
+    }
+  }
+
+  // 3. Recent channel scrollback (excluding this message), oldest-first.
+  if ("messages" in channel) {
+    try {
+      const recent = await (channel as TextChannel).messages.fetch({
+        limit: SCROLLBACK_LIMIT,
+        before: message.id,
+      });
+      const lines = [...recent.values()]
+        .reverse()
+        .filter((m) => (m.cleanContent || m.attachments.size > 0))
+        .map((m) => `  ${authorName(m)}: ${snippet(m.cleanContent || "(attachment)")}`);
+      if (lines.length > 0) {
+        parts.push(`Recent messages in this channel:\n${lines.join("\n")}`);
+      }
+    } catch {
+      /* skip */
+    }
+  }
+
+  // 4. Attachments / embeds on the triggering message.
+  if (message.attachments.size > 0) {
+    const names = [...message.attachments.values()].map((a) => a.name ?? a.url).slice(0, 5);
+    parts.push(`Attachments on this message: ${names.join(", ")}`);
+  }
+
+  if (parts.length === 0) return "";
+  return `[Conversation context]\n${parts.join("\n")}`;
+}
+
+/** Whether this channel type can supply scrollback (text/thread/announcement). */
+export function channelSupportsContext(message: Message): boolean {
+  const t = message.channel.type;
+  return (
+    t === ChannelType.GuildText ||
+    t === ChannelType.PublicThread ||
+    t === ChannelType.PrivateThread ||
+    t === ChannelType.GuildAnnouncement ||
+    t === ChannelType.DM
+  );
+}

--- a/lib/plugins/discord/dedup.ts
+++ b/lib/plugins/discord/dedup.ts
@@ -1,0 +1,35 @@
+/**
+ * dedup.ts — short-TTL de-duplication for inbound Discord events.
+ *
+ * discord.js auto-reconnects and, on a gateway RESUME, replays events the
+ * client missed while disconnected. Without dedup that re-delivers a
+ * MessageCreate (or reaction) we already handled, so Ava responds twice. This
+ * keeps a small TTL map of handled event keys and reports repeats.
+ *
+ * Module-level (one shared listener set across the process); opportunistically
+ * pruned so it can't grow unbounded.
+ */
+
+const TTL_MS = 60_000;
+const MAX_ENTRIES = 2000;
+const seen = new Map<string, number>();
+
+/**
+ * Returns true if `key` was already handled within the TTL window (caller
+ * should skip it). Otherwise records it and returns false.
+ */
+export function alreadyHandled(key: string): boolean {
+  const now = Date.now();
+  if (seen.size > MAX_ENTRIES) {
+    for (const [k, t] of seen) if (now - t > TTL_MS) seen.delete(k);
+  }
+  const prev = seen.get(key);
+  if (prev !== undefined && now - prev < TTL_MS) return true;
+  seen.set(key, now);
+  return false;
+}
+
+/** Test helper — clear all recorded keys. */
+export function _resetDedup(): void {
+  seen.clear();
+}

--- a/lib/plugins/discord/inbound.ts
+++ b/lib/plugins/discord/inbound.ts
@@ -10,6 +10,7 @@ import { DmAccumulator, type AccumulatorEntry } from "../../dm/dm-accumulator.ts
 import { makeId, type DiscordContext } from "./core.ts";
 import { isRateLimited, isSpam } from "./rate-limit.ts";
 import { pendingReplies } from "./outbound.ts";
+import { buildMessageContext } from "./context.ts";
 
 // ── Admin check ───────────────────────────────────────────────────────────────
 
@@ -91,6 +92,9 @@ export async function handleDMFlush(
   } else {
     console.warn(`[discord] Could not fetch message for ${conversationId} via ${agentName ?? "main"} — reply will use unprompted push`);
   }
+
+  // Surrounding context for the DM (reply-to / scrollback / attachments).
+  const contextPreamble = discordMessage ? await buildMessageContext(discordMessage).catch(() => "") : "";
   if (agentName) ctx.pendingAgents.set(conversationId, agentName);
 
   if (isNew) {
@@ -122,6 +126,7 @@ export async function handleDMFlush(
         content: batchedContent,
         targets: [agentName],
         isDM: true,
+        ...(contextPreamble ? { contextPreamble } : {}),
       },
       source: { interface: "discord" as const, channelId, userId },
       reply: { topic: `message.outbound.discord.${channelId}` },
@@ -137,6 +142,7 @@ export async function handleDMFlush(
         channel: channelId,
         content: batchedContent,
         isDM: true,
+        ...(contextPreamble ? { contextPreamble } : {}),
       },
       source: { interface: "discord" as const, channelId, userId },
       reply: { topic: `message.outbound.discord.${channelId}` },
@@ -195,6 +201,9 @@ export function registerInboundHandlers(ctx: DiscordContext): void {
     }
 
     await message.react("👀").catch(() => {});
+
+    // Surrounding context (reply-to, scrollback, thread, attachments) — best-effort.
+    const contextPreamble = await buildMessageContext(message).catch(() => "");
 
     let correlationId: string;
     let isNewConversation = false;
@@ -255,6 +264,7 @@ export function registerInboundHandlers(ctx: DiscordContext): void {
         content,
         isThread: message.channel.isThread(),
         guildId: message.guildId,
+        ...(contextPreamble ? { contextPreamble } : {}),
         ...(channelEntry?.agent ? { agentId: channelEntry.agent } : {}),
       },
       source: { interface: "discord" as const, channelId: message.channelId, userId },

--- a/lib/plugins/discord/inbound.ts
+++ b/lib/plugins/discord/inbound.ts
@@ -11,6 +11,7 @@ import { makeId, type DiscordContext } from "./core.ts";
 import { isRateLimited, isSpam } from "./rate-limit.ts";
 import { pendingReplies } from "./outbound.ts";
 import { buildMessageContext } from "./context.ts";
+import { alreadyHandled } from "./dedup.ts";
 
 // ── Admin check ───────────────────────────────────────────────────────────────
 
@@ -166,6 +167,9 @@ export function registerInboundHandlers(ctx: DiscordContext): void {
   // ── DM and guild message handling ────────────────────────────────────────
   ctx.client.on(Events.MessageCreate, async message => {
     if (message.author.bot) return;
+    // Skip gateway RESUME replays of an already-handled message (else Ava
+    // responds twice after a reconnect).
+    if (alreadyHandled(`msg:${message.id}`)) return;
 
     if (!message.guild) {
       await handleDM(ctx, message, undefined);
@@ -276,6 +280,7 @@ export function registerInboundHandlers(ctx: DiscordContext): void {
   ctx.client.on(Events.MessageReactionAdd, async (reaction, user) => {
     if (user.bot) return;
     if (reaction.emoji.name !== "📋") return;
+    if (alreadyHandled(`react:${reaction.message.id}:${user.id}:📋`)) return;
     if (!isAdmin(ctx, user.id)) {
       console.log(`[discord] reaction from ${user.id} ignored — not in admins list`);
       return;

--- a/lib/plugins/discord/lifecycle.ts
+++ b/lib/plugins/discord/lifecycle.ts
@@ -1,0 +1,34 @@
+/**
+ * lifecycle.ts — connection-lifecycle visibility for the Discord client.
+ *
+ * discord.js handles reconnection internally, but silently — a flaky gateway
+ * connection was previously invisible until messages simply stopped arriving.
+ * These handlers log shard disconnect / reconnecting / resume / error + client
+ * error/warn so a degraded connection is observable (and greppable by the
+ * existing alert.discord_disconnected monitor).
+ */
+
+import { Events, type Client } from "discord.js";
+
+export function registerLifecycleHandlers(client: Client, label = "main"): void {
+  client.on(Events.Error, (err) => {
+    console.error(`[discord:${label}] client error:`, err instanceof Error ? err.message : err);
+  });
+  client.on(Events.Warn, (msg) => {
+    console.warn(`[discord:${label}] warn: ${msg}`);
+  });
+  client.on(Events.ShardError, (err, shardId) => {
+    console.error(`[discord:${label}] shard ${shardId} error:`, err instanceof Error ? err.message : err);
+  });
+  client.on(Events.ShardDisconnect, (event, shardId) => {
+    console.warn(
+      `[discord:${label}] shard ${shardId} disconnected (code ${event?.code ?? "?"}) — auto-reconnecting`,
+    );
+  });
+  client.on(Events.ShardReconnecting, (shardId) => {
+    console.log(`[discord:${label}] shard ${shardId} reconnecting…`);
+  });
+  client.on(Events.ShardResume, (shardId, replayed) => {
+    console.log(`[discord:${label}] shard ${shardId} resumed (${replayed} event(s) replayed)`);
+  });
+}

--- a/src/agent-runtime/agent-definition-loader.ts
+++ b/src/agent-runtime/agent-definition-loader.ts
@@ -139,6 +139,21 @@ export function parseAgentYaml(raw: RawAgentYaml, fileName: string): AgentDefini
       );
     })();
 
+  const rawMemory = (raw as Record<string, unknown>).memory;
+  const memory =
+    rawMemory && typeof rawMemory === "object" && (rawMemory as { enabled?: unknown }).enabled === true
+      ? (() => {
+          const m = rawMemory as Record<string, unknown>;
+          return {
+            enabled: true as const,
+            ...(Array.isArray(m.skills) ? { skills: m.skills.filter((s): s is string => typeof s === "string") } : {}),
+            ...(typeof m.historyTurns === "number" && m.historyTurns > 0 ? { historyTurns: m.historyTurns } : {}),
+            ...(typeof m.recallTopK === "number" && m.recallTopK > 0 ? { recallTopK: m.recallTopK } : {}),
+            ...(typeof m.harvest === "boolean" ? { harvest: m.harvest } : {}),
+          };
+        })()
+      : undefined;
+
   return {
     name: raw.name,
     role: raw.role,
@@ -151,6 +166,7 @@ export function parseAgentYaml(raw: RawAgentYaml, fileName: string): AgentDefini
     ...(canDelegate !== undefined ? { canDelegate } : {}),
     maxTurns,
     skills,
+    ...(memory ? { memory } : {}),
     ...(discordBotTokenEnvKey ? { discordBotTokenEnvKey } : {}),
   };
 }

--- a/src/agent-runtime/agent-runtime-plugin.ts
+++ b/src/agent-runtime/agent-runtime-plugin.ts
@@ -25,6 +25,9 @@ import type { ExecutorRegistry } from "../executor/executor-registry.ts";
 import type { IExecutor } from "../executor/types.ts";
 import { DeepAgentExecutor } from "../executor/executors/deep-agent-executor.ts";
 import { ProtoSdkExecutor } from "../executor/executors/proto-sdk-executor.ts";
+import { AgentMemory } from "../knowledge/agent-memory.ts";
+import { ConversationStore } from "../knowledge/conversation-store.ts";
+import { KnowledgeStore } from "../knowledge/knowledge-store.ts";
 import { loadAgentEntries, type AgentEntry } from "./agent-definition-loader.ts";
 import type { AgentDefinition } from "./types.ts";
 import { WorkspaceWatcher } from "../../lib/workspace-watcher.ts";
@@ -62,15 +65,27 @@ export class AgentRuntimePlugin implements Plugin {
   private watcher?: WorkspaceWatcher;
   /** Executor factory — injectable for tests; defaults to the real DeepAgent / ProtoSDK builder. */
   private readonly buildExecutor: (def: AgentDefinition) => IExecutor;
+  /** Shared memory flywheel for memory-enabled agents. Lazily created on first real build (or injected for tests). */
+  private memory?: AgentMemory;
 
   constructor(
     config: AgentRuntimeConfig,
     executorRegistry: ExecutorRegistry,
-    opts: { buildExecutor?: (def: AgentDefinition) => IExecutor } = {},
+    opts: { buildExecutor?: (def: AgentDefinition) => IExecutor; memory?: AgentMemory } = {},
   ) {
     this.config = config;
     this.executorRegistry = executorRegistry;
     this.buildExecutor = opts.buildExecutor ?? ((def) => this._buildExecutor(def));
+    this.memory = opts.memory;
+  }
+
+  /** The shared memory instance (lazily created), for the harvester to share. */
+  private _memory(): AgentMemory {
+    if (!this.memory) {
+      this.memory = new AgentMemory(new ConversationStore(), new KnowledgeStore());
+      this.memory.init();
+    }
+    return this.memory;
   }
 
   install(bus: EventBus): void {
@@ -235,6 +250,8 @@ export class AgentRuntimePlugin implements Plugin {
       apiBaseUrl: this.config.apiBaseUrl ?? "http://localhost:3000",
       apiKey: this.config.apiKey ?? process.env.WORKSTACEAN_API_KEY,
       onToolCall: this._publishToolCall,
+      // Share one memory instance across agents; only memory-enabled agents use it.
+      memory: def.memory?.enabled ? this._memory() : undefined,
     });
   }
 }

--- a/src/agent-runtime/agent-runtime-plugin.ts
+++ b/src/agent-runtime/agent-runtime-plugin.ts
@@ -28,6 +28,9 @@ import { ProtoSdkExecutor } from "../executor/executors/proto-sdk-executor.ts";
 import { AgentMemory } from "../knowledge/agent-memory.ts";
 import { ConversationStore } from "../knowledge/conversation-store.ts";
 import { KnowledgeStore } from "../knowledge/knowledge-store.ts";
+import { ConversationHarvester } from "../knowledge/conversation-harvester.ts";
+import { ChatOpenAI } from "@langchain/openai";
+import { SystemMessage, HumanMessage } from "@langchain/core/messages";
 import { loadAgentEntries, type AgentEntry } from "./agent-definition-loader.ts";
 import type { AgentDefinition } from "./types.ts";
 import { WorkspaceWatcher } from "../../lib/workspace-watcher.ts";
@@ -67,6 +70,8 @@ export class AgentRuntimePlugin implements Plugin {
   private readonly buildExecutor: (def: AgentDefinition) => IExecutor;
   /** Shared memory flywheel for memory-enabled agents. Lazily created on first real build (or injected for tests). */
   private memory?: AgentMemory;
+  /** Background harvester retiring aged-out conversations into the KB (Phase 3). */
+  private harvester?: ConversationHarvester;
 
   constructor(
     config: AgentRuntimeConfig,
@@ -77,7 +82,12 @@ export class AgentRuntimePlugin implements Plugin {
     this.executorRegistry = executorRegistry;
     this.buildExecutor = opts.buildExecutor ?? ((def) => this._buildExecutor(def));
     this.memory = opts.memory;
+    // Tests inject buildExecutor; the harvester (real DB + LLM) only runs under
+    // the real runtime so unit tests don't open a DB or start a sweep timer.
+    this.realRuntime = !opts.buildExecutor;
   }
+
+  private readonly realRuntime: boolean;
 
   /** The shared memory instance (lazily created), for the harvester to share. */
   private _memory(): AgentMemory {
@@ -112,6 +122,43 @@ export class AgentRuntimePlugin implements Plugin {
       onChange: () => this._applyAgentChanges(),
     });
     this.watcher.start();
+
+    // Phase 3: harvest aged-out conversations into searchable memory. Start one
+    // background sweeper when any agent opts into harvest (default on for
+    // memory-enabled agents). Skipped under an injected test executor.
+    const wantsHarvest = entries.some(e => e.def.memory?.enabled && e.def.memory.harvest !== false);
+    if (wantsHarvest && this.realRuntime && !this.harvester) {
+      this._startHarvester();
+    }
+  }
+
+  private _startHarvester(): void {
+    const memory = this._memory();
+    const gatewayUrl = this.config.gatewayUrl ?? process.env.LLM_GATEWAY_URL ?? process.env.OPENAI_BASE_URL;
+    const apiKey = this.config.gatewayApiKey ?? process.env.OPENAI_API_KEY ?? "unused";
+    const model = process.env.MEMORY_SUMMARY_MODEL ?? "protolabs/reasoning";
+    const llm = new ChatOpenAI({
+      model,
+      temperature: 0,
+      configuration: gatewayUrl ? { baseURL: gatewayUrl } : undefined,
+      apiKey,
+    });
+    const SUMMARY_PROMPT =
+      "Summarize this conversation for long-term, searchable memory. Capture the " +
+      "user's goals, the concrete facts/preferences/decisions, and outcomes — " +
+      "anything worth recalling in a future conversation. Write a concise factual " +
+      "summary (a few sentences). Omit pleasantries and meta-commentary.";
+    const maxAgeDays = Number(process.env.MEMORY_HARVEST_MAX_AGE_DAYS ?? 7);
+    const sweepHours = Number(process.env.MEMORY_HARVEST_SWEEP_HOURS ?? 6);
+    this.harvester = new ConversationHarvester(memory, {
+      summarize: async (transcript) => {
+        const resp = await llm.invoke([new SystemMessage(SUMMARY_PROMPT), new HumanMessage(transcript)]);
+        return typeof resp.content === "string" ? resp.content : String(resp.content);
+      },
+      maxAgeMs: maxAgeDays * 86_400_000,
+      sweepIntervalMs: sweepHours * 3_600_000,
+    });
+    this.harvester.start();
   }
 
   /** Build an executor for `def`, register its skills, and record it as running. */
@@ -194,6 +241,10 @@ export class AgentRuntimePlugin implements Plugin {
   uninstall(): void {
     this.watcher?.stop();
     this.watcher = undefined;
+    this.harvester?.stop();
+    this.harvester = undefined;
+    this.memory?.close();
+    this.memory = undefined;
   }
 
   /**

--- a/src/agent-runtime/types.ts
+++ b/src/agent-runtime/types.ts
@@ -6,6 +6,10 @@
  * selection, delegation rules, and bus subscription patterns.
  */
 
+import type { AgentMemoryConfig } from "../knowledge/agent-memory.ts";
+
+export type { AgentMemoryConfig };
+
 export type AgentRole =
   | "orchestrator"   // Ava — delegates to subagents, drives plans
   | "qa"             // Quinn — code review, bug triage
@@ -157,6 +161,13 @@ export interface AgentDefinition {
 
   /** Skills this agent can handle (maps skill.name → AgentSkillDefinition). */
   skills: AgentSkillDefinition[];
+
+  /**
+   * Opt-in memory flywheel (within-conversation history + cross-conversation
+   * recall + harvest). Off unless declared. Only conversational skills get it
+   * (default ["chat"]) so narrow skills like pr_review stay stateless.
+   */
+  memory?: AgentMemoryConfig;
 
   /**
    * Optional Discord bot token env var. When set, DiscordPlugin's agent

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -16,6 +16,7 @@ import { HttpClient } from "../../services/http-client.ts";
 import type { AgentDefinition } from "../../agent-runtime/types.ts";
 import type { IExecutor, SkillRequest, SkillResult } from "../types.ts";
 import { runStructuredFinalizer, type ForcedToolCaller } from "./structured-finalizer.ts";
+import { AgentMemory, memoryAppliesTo } from "../../knowledge/agent-memory.ts";
 
 const LANGFUSE_ENABLED = !!(process.env.LANGFUSE_PUBLIC_KEY && process.env.LANGFUSE_SECRET_KEY);
 
@@ -101,6 +102,13 @@ export interface DeepAgentConfig {
    * SkillDispatcher across ALL executor types and does not need this hook.
    */
   onToolCall?: (event: { agentName: string; correlationId: string; skill?: string; toolNames: string[] }) => void;
+
+  /**
+   * Shared memory flywheel. When provided AND the agent declares `memory`,
+   * conversational skills replay recent turns + recalled knowledge into each
+   * invocation and persist the turn afterward. One instance backs all agents.
+   */
+  memory?: AgentMemory;
 }
 
 // Each tool() call infers a unique DynamicStructuredTool<ZodObject<{specific fields}>, ...>.
@@ -749,6 +757,7 @@ export class DeepAgentExecutor implements IExecutor {
   private readonly onToolCall: DeepAgentConfig["onToolCall"];
   private readonly gatewayUrl: string | undefined;
   private readonly apiKey: string;
+  private readonly memory: AgentMemory | undefined;
   /**
    * Cache of ChatOpenAI instances by model name — `agentDef.model` always
    * resolves to `this.model`, but per-call overrides (`payload.model`) get
@@ -762,6 +771,7 @@ export class DeepAgentExecutor implements IExecutor {
     this.onToolCall = config.onToolCall;
     this.gatewayUrl = config.gatewayUrl ?? process.env.LLM_GATEWAY_URL ?? process.env.OPENAI_BASE_URL;
     this.apiKey = config.gatewayApiKey ?? process.env.OPENAI_API_KEY ?? "unused";
+    this.memory = config.memory;
 
     this.model = this._buildModel(agentDef.model);
     this.modelCache.set(agentDef.model, this.model);
@@ -814,6 +824,13 @@ export class DeepAgentExecutor implements IExecutor {
       ? this.agentDef.skills.find(s => s.name === req.skill)
       : undefined;
 
+    // Memory flywheel — only when the agent opts in AND this is a conversational
+    // skill. The conversation key is contextId (multi-turn chat) falling back to
+    // correlationId (a one-off, which simply has no prior history).
+    const memoryOn = !!this.memory && memoryAppliesTo(this.agentDef.memory, req.skill);
+    const memCfg = this.agentDef.memory;
+    const memCtxId = req.contextId ?? req.correlationId;
+
     // Skill-level tools override: intersect with agent.tools (a skill can't
     // grant access to tools the agent doesn't declare). When skill.tools is
     // unset, all of agent.tools are available. This is the structural way
@@ -837,7 +854,14 @@ export class DeepAgentExecutor implements IExecutor {
       // Resolve skill-level systemPromptOverride if this skill defines one.
       // Skills like diagnose_pr_stuck have narrow, structured output requirements
       // that replace the agent's general-purpose prompt.
-      const basePrompt = skillDef?.systemPromptOverride ?? this.agentDef.systemPrompt;
+      let basePrompt = skillDef?.systemPromptOverride ?? this.agentDef.systemPrompt;
+
+      // Cross-conversation recall (Phase 2): inject hot memory + BM25 hits for
+      // this turn's prompt into the system message.
+      if (memoryOn) {
+        const recall = this.memory!.recallBlock(prompt, memCfg);
+        if (recall) basePrompt += `\n\n## Recalled context\n${recall}`;
+      }
 
       // Per-call model override via payload.model — see effectiveModelFor
       // + the matching path in ProtoSdkExecutor. Lets a caller escalate to
@@ -858,8 +882,11 @@ export class DeepAgentExecutor implements IExecutor {
         : "";
       console.log(`[deep-agent:${this.agentDef.name}] invoke skill="${req.skill ?? "?"}" tools=${tools.length}/${agentTools.length} maxTurns=${effectiveMaxTurns} promptLen=${prompt.length} langfuse=${LANGFUSE_ENABLED}${usingModel}`);
 
+      // Within-conversation history (Phase 1): replay recent turns so the agent
+      // sees the conversation, not just the latest message.
+      const history = memoryOn ? this.memory!.history(memCtxId, memCfg) : [];
       const result = await agent.invoke(
-        { messages: [{ role: "user", content: prompt }] },
+        { messages: [...history.map(t => ({ role: t.role, content: t.content })), { role: "user", content: prompt }] },
         { recursionLimit: effectiveMaxTurns * 2 + 1, callbacks },
       );
 
@@ -904,6 +931,17 @@ export class DeepAgentExecutor implements IExecutor {
       }
 
       const finalText = text || "No response generated.";
+
+      // Persist the turn + extract a finding (Phases 1+2). Best-effort; the
+      // store never throws into the caller.
+      if (memoryOn) {
+        this.memory!.record(memCtxId, {
+          agent: this.agentDef.name,
+          skill: req.skill,
+          userText: prompt,
+          aiText: finalText,
+        });
+      }
 
       // Structured finalizer: when the skill declares an outputSchema, distill
       // the analysis into a schema-shaped object via a forced submit_<skill>

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -885,8 +885,16 @@ export class DeepAgentExecutor implements IExecutor {
       // Within-conversation history (Phase 1): replay recent turns so the agent
       // sees the conversation, not just the latest message.
       const history = memoryOn ? this.memory!.history(memCtxId, memCfg) : [];
+
+      // Ephemeral surrounding context (Phase 4): a trigger surface (e.g. Discord
+      // reply-chain / scrollback / thread / attachments) can attach a
+      // `contextPreamble`. Inject it into THIS turn's user message only — it is
+      // never persisted as conversation history (memory.record stores `prompt`).
+      const preamble = typeof req.payload?.contextPreamble === "string" ? req.payload.contextPreamble : "";
+      const userContent = preamble ? `${preamble}\n\n${prompt}` : prompt;
+
       const result = await agent.invoke(
-        { messages: [...history.map(t => ({ role: t.role, content: t.content })), { role: "user", content: prompt }] },
+        { messages: [...history.map(t => ({ role: t.role, content: t.content })), { role: "user", content: userContent }] },
         { recursionLimit: effectiveMaxTurns * 2 + 1, callbacks },
       );
 

--- a/src/knowledge/__tests__/agent-memory.test.ts
+++ b/src/knowledge/__tests__/agent-memory.test.ts
@@ -1,0 +1,151 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ConversationStore } from "../conversation-store.ts";
+import { KnowledgeStore } from "../knowledge-store.ts";
+import { AgentMemory, memoryAppliesTo } from "../agent-memory.ts";
+
+let dir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "mem-test-"));
+  dbPath = join(dir, "knowledge.db");
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("ConversationStore", () => {
+  test("appends turns and replays them chronologically (most-recent N)", () => {
+    const s = new ConversationStore(dbPath);
+    s.init();
+    s.appendTurn("ctx1", "user", "hello", "ava", "chat");
+    s.appendTurn("ctx1", "assistant", "hi there", "ava", "chat");
+    s.appendTurn("ctx1", "user", "what's up", "ava", "chat");
+    const turns = s.recentTurns("ctx1", 10);
+    expect(turns).toEqual([
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+      { role: "user", content: "what's up" },
+    ]);
+    // limit returns the most-recent tail, still chronological
+    expect(s.recentTurns("ctx1", 1)).toEqual([{ role: "user", content: "what's up" }]);
+    s.close();
+  });
+
+  test("isolates conversations by contextId", () => {
+    const s = new ConversationStore(dbPath);
+    s.init();
+    s.appendTurn("a", "user", "in a", "ava");
+    s.appendTurn("b", "user", "in b", "ava");
+    expect(s.recentTurns("a")).toEqual([{ role: "user", content: "in a" }]);
+    expect(s.recentTurns("b")).toEqual([{ role: "user", content: "in b" }]);
+    s.close();
+  });
+
+  test("retirable() finds conversations older than maxAge; deleteConversation clears them", () => {
+    const s = new ConversationStore(dbPath);
+    s.init();
+    s.appendTurn("old", "user", "stale", "ava");
+    s.appendTurn("fresh", "user", "recent", "ava");
+    // Everything is "now"; with maxAge 0 and now in the future, all are retirable.
+    const retirable = s.retirable(0, Date.now() + 1000);
+    expect(retirable.map(r => r.contextId).sort()).toEqual(["fresh", "old"]);
+    s.deleteConversation("old");
+    expect(s.recentTurns("old")).toEqual([]);
+    expect(s.recentTurns("fresh").length).toBe(1);
+    s.close();
+  });
+});
+
+describe("KnowledgeStore", () => {
+  test("addChunk + search returns BM25/LIKE hits", () => {
+    const k = new KnowledgeStore(dbPath);
+    k.init();
+    k.addChunk("The deploy pipeline uses watchtower to auto-pull the main image.", { domain: "finding", heading: "deploy" });
+    k.addChunk("Roxy is the portfolio manager agent on the protoMaker board.", { domain: "finding", heading: "roxy" });
+    const hits = k.search("watchtower deploy", 5);
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits[0].content).toContain("watchtower");
+    k.close();
+  });
+
+  test("getHotMemory concatenates domain=hot chunks", () => {
+    const k = new KnowledgeStore(dbPath);
+    k.init();
+    k.addChunk("Always greet the operator as Josh.", { domain: "hot" });
+    k.addChunk("Never push directly to main.", { domain: "hot" });
+    const hot = k.getHotMemory();
+    expect(hot).toContain("Josh");
+    expect(hot).toContain("main");
+    // non-hot chunk excluded
+    k.addChunk("some finding", { domain: "finding" });
+    expect(k.getHotMemory()).not.toContain("some finding");
+    k.close();
+  });
+
+  test("search scoped to a domain", () => {
+    const k = new KnowledgeStore(dbPath);
+    k.init();
+    k.addChunk("alpha bravo charlie", { domain: "conversation" });
+    k.addChunk("alpha bravo delta", { domain: "finding" });
+    const conv = k.search("alpha", 5, "conversation");
+    expect(conv.every(h => h.domain === "conversation")).toBe(true);
+    expect(conv.length).toBe(1);
+    k.close();
+  });
+});
+
+describe("AgentMemory", () => {
+  test("record persists turns and extracts a finding for substantive answers", () => {
+    const mem = new AgentMemory(new ConversationStore(dbPath), new KnowledgeStore(dbPath));
+    mem.init();
+    const longAnswer = "The release cadence stalled at v0.7.22; we cut v0.8.0 and standardized release-tools. ".repeat(2);
+    mem.record("ctx1", { agent: "ava", skill: "chat", userText: "what's our release status?", aiText: longAnswer });
+    // turn history present
+    const h = mem.history("ctx1");
+    expect(h.length).toBe(2);
+    expect(h[0]).toEqual({ role: "user", content: "what's our release status?" });
+    // finding searchable
+    const block = mem.recallBlock("release cadence v0.8.0");
+    expect(block).toContain("Relevant context");
+    expect(block).toContain("v0.8.0");
+    mem.close();
+  });
+
+  test("short answers are not stored as findings", () => {
+    const mem = new AgentMemory(new ConversationStore(dbPath), new KnowledgeStore(dbPath));
+    mem.init();
+    mem.record("ctx1", { agent: "ava", skill: "chat", userText: "hi", aiText: "hey" });
+    // history still recorded, but no finding chunk → recall finds nothing
+    expect(mem.history("ctx1").length).toBe(2);
+    expect(mem.recallBlock("hey")).toBe("");
+    mem.close();
+  });
+
+  test("recallBlock includes hot memory", () => {
+    const mem = new AgentMemory(new ConversationStore(dbPath), new KnowledgeStore(dbPath));
+    mem.init();
+    mem.knowledge.addChunk("Operator is Josh.", { domain: "hot" });
+    expect(mem.recallBlock("anything")).toContain("Always-on facts");
+    mem.close();
+  });
+});
+
+describe("memoryAppliesTo", () => {
+  test("off when disabled or undefined", () => {
+    expect(memoryAppliesTo(undefined, "chat")).toBe(false);
+    expect(memoryAppliesTo({ enabled: false }, "chat")).toBe(false);
+  });
+  test("default skill set is [chat]", () => {
+    expect(memoryAppliesTo({ enabled: true }, "chat")).toBe(true);
+    expect(memoryAppliesTo({ enabled: true }, undefined)).toBe(true); // undefined ⇒ chat
+    expect(memoryAppliesTo({ enabled: true }, "pr_review")).toBe(false);
+  });
+  test("honors explicit skills list", () => {
+    expect(memoryAppliesTo({ enabled: true, skills: ["chat", "triage"] }, "triage")).toBe(true);
+    expect(memoryAppliesTo({ enabled: true, skills: ["triage"] }, "chat")).toBe(false);
+  });
+});

--- a/src/knowledge/__tests__/conversation-harvester.test.ts
+++ b/src/knowledge/__tests__/conversation-harvester.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ConversationStore } from "../conversation-store.ts";
+import { KnowledgeStore } from "../knowledge-store.ts";
+import { AgentMemory } from "../agent-memory.ts";
+import { ConversationHarvester, renderTranscript } from "../conversation-harvester.ts";
+
+let dir: string;
+let mem: AgentMemory;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "harvest-test-"));
+  const db = join(dir, "knowledge.db");
+  mem = new AgentMemory(new ConversationStore(db), new KnowledgeStore(db));
+  mem.init();
+});
+afterEach(() => {
+  mem.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("renderTranscript", () => {
+  test("renders User/Assistant lines, skips blanks", () => {
+    const t = renderTranscript([
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "  " },
+      { role: "assistant", content: "hi there" },
+    ]);
+    expect(t).toBe("User: hello\nAssistant: hi there");
+  });
+});
+
+describe("ConversationHarvester.sweepOnce", () => {
+  test("summarizes aged conversations into the KB and reclaims the turns", async () => {
+    mem.record("old-conv", { agent: "ava", skill: "chat", userText: "what's the deploy story?", aiText: "Watchtower auto-pulls :main. Workspace config deploys via git pull." });
+
+    let summarizeCalls = 0;
+    const harvester = new ConversationHarvester(mem, {
+      summarize: async (transcript) => { summarizeCalls++; expect(transcript).toContain("deploy"); return "Summary: deploy via watchtower + git pull config."; },
+      maxAgeMs: 0,
+      now: () => Date.now() + 10_000, // everything is "aged"
+    });
+
+    const n = await harvester.sweepOnce();
+    expect(n).toBe(1);
+    expect(summarizeCalls).toBe(1);
+    // raw turns reclaimed
+    expect(mem.conversations.recentTurns("old-conv")).toEqual([]);
+    // summary searchable in the conversation domain
+    const hits = mem.knowledge.search("watchtower deploy", 5, "conversation");
+    expect(hits.length).toBe(1);
+    expect(hits[0].content).toContain("watchtower");
+  });
+
+  test("does not harvest conversations newer than maxAge", async () => {
+    mem.record("fresh", { agent: "ava", skill: "chat", userText: "hi", aiText: "a reasonably long answer ".repeat(6) });
+    const harvester = new ConversationHarvester(mem, {
+      summarize: async () => "should not be called",
+      maxAgeMs: 24 * 60 * 60_000, // 1 day
+      now: () => Date.now(), // fresh conv is well within the day
+    });
+    const n = await harvester.sweepOnce();
+    expect(n).toBe(0);
+    expect(mem.conversations.recentTurns("fresh").length).toBe(2);
+  });
+
+  test("a summarizer failure leaves the conversation in place to retry", async () => {
+    mem.record("err-conv", { agent: "ava", skill: "chat", userText: "q", aiText: "an answer long enough to be a finding ".repeat(4) });
+    const harvester = new ConversationHarvester(mem, {
+      summarize: async () => { throw new Error("LLM down"); },
+      maxAgeMs: 0,
+      now: () => Date.now() + 10_000,
+    });
+    const n = await harvester.sweepOnce();
+    expect(n).toBe(0);
+    // turns NOT reclaimed — retried next sweep
+    expect(mem.conversations.recentTurns("err-conv").length).toBe(2);
+  });
+});

--- a/src/knowledge/agent-memory.ts
+++ b/src/knowledge/agent-memory.ts
@@ -1,0 +1,104 @@
+/**
+ * AgentMemory — the in-process memory flywheel for DeepAgent agents.
+ *
+ * Bundles the two stores and exposes the three operations the executor needs,
+ * mirroring protoAgent's KnowledgeMiddleware + MemoryMiddleware:
+ *   - history(contextId)      → recent turns to replay into the next invocation
+ *   - recallBlock(query)      → hot memory + BM25 hits, formatted for the prompt
+ *   - record(...)             → persist the turn + extract a searchable finding
+ *
+ * One shared instance backs every memory-enabled agent; per-agent gating +
+ * tuning come from `AgentDefinition.memory`. All ops are best-effort and never
+ * throw into the caller — memory must not break a running skill.
+ */
+
+import { ConversationStore, type ConversationTurn } from "./conversation-store.ts";
+import { KnowledgeStore } from "./knowledge-store.ts";
+
+/** Per-agent memory config (from agent yaml). */
+export interface AgentMemoryConfig {
+  enabled: boolean;
+  /** Skills that get memory. Default: ["chat"] — narrow skills (pr_review…) stay stateless. */
+  skills?: string[];
+  /** Recent turns replayed into the next invocation. Default 10. */
+  historyTurns?: number;
+  /** Knowledge hits injected per recall. Default 5. */
+  recallTopK?: number;
+  /** Whether aged-out conversations are harvested into the KB. Default true. */
+  harvest?: boolean;
+}
+
+const DEFAULT_SKILLS = ["chat"];
+const DEFAULT_HISTORY_TURNS = 10;
+const DEFAULT_RECALL_TOP_K = 5;
+/** Min AI-answer length to be worth storing as a finding (mirrors protoAgent's 100). */
+const MIN_FINDING_CHARS = 100;
+const MAX_FINDING_CHARS = 2000;
+
+export function memoryAppliesTo(cfg: AgentMemoryConfig | undefined, skill: string | undefined): boolean {
+  if (!cfg?.enabled) return false;
+  const skills = cfg.skills ?? DEFAULT_SKILLS;
+  // skill undefined ⇒ treat as the default conversational skill.
+  return skills.includes(skill ?? "chat");
+}
+
+export class AgentMemory {
+  constructor(
+    readonly conversations: ConversationStore,
+    readonly knowledge: KnowledgeStore,
+  ) {}
+
+  /** Init both stores (idempotent — they open the same DB file). */
+  init(): void {
+    this.conversations.init();
+    this.knowledge.init();
+  }
+
+  /** Recent turns for a conversation, chronological. */
+  history(contextId: string, cfg?: AgentMemoryConfig): ConversationTurn[] {
+    return this.conversations.recentTurns(contextId, cfg?.historyTurns ?? DEFAULT_HISTORY_TURNS);
+  }
+
+  /**
+   * Build the recall context block injected into the system prompt: always-on
+   * hot memory + the top BM25 hits for the query. Returns "" when nothing
+   * relevant — callers append only when non-empty.
+   */
+  recallBlock(query: string, cfg?: AgentMemoryConfig): string {
+    const parts: string[] = [];
+    const hot = this.knowledge.getHotMemory();
+    if (hot) parts.push(`Always-on facts:\n${hot}`);
+
+    const hits = this.knowledge.search(query, cfg?.recallTopK ?? DEFAULT_RECALL_TOP_K);
+    if (hits.length > 0) {
+      const lines = hits.map((h) => `- ${h.heading ? `(${h.heading}) ` : ""}${h.preview}`);
+      parts.push(`Relevant context from earlier conversations:\n${lines.join("\n")}`);
+    }
+    return parts.join("\n\n");
+  }
+
+  /**
+   * Persist a completed turn: append the user + assistant messages, and extract
+   * the assistant answer as a searchable finding when it's substantive.
+   */
+  record(contextId: string, opts: { agent: string; skill?: string; userText: string; aiText: string }): void {
+    const { agent, skill, userText, aiText } = opts;
+    this.conversations.appendTurn(contextId, "user", userText, agent, skill);
+    if (aiText.trim()) this.conversations.appendTurn(contextId, "assistant", aiText, agent, skill);
+
+    const clean = aiText.trim();
+    if (clean.length >= MIN_FINDING_CHARS) {
+      const heading = userText.trim().slice(0, 80) || undefined;
+      this.knowledge.addChunk(clean.slice(0, MAX_FINDING_CHARS), {
+        domain: "finding",
+        heading,
+        source: `conversation:${agent}`,
+      });
+    }
+  }
+
+  close(): void {
+    this.conversations.close();
+    this.knowledge.close();
+  }
+}

--- a/src/knowledge/conversation-harvester.ts
+++ b/src/knowledge/conversation-harvester.ts
@@ -1,0 +1,114 @@
+/**
+ * ConversationHarvester — retire aged-out conversations into searchable memory.
+ *
+ * Ports protoAgent's conversation_harvest + checkpoint-pruner trigger. On a
+ * periodic sweep it finds conversations with no activity for `maxAgeMs`,
+ * summarizes each one's transcript via a cheap aux model, ingests the summary
+ * into the KnowledgeStore (domain="conversation"), then deletes the raw turns.
+ * Save space, keep the signal — the substance stays recallable via recall()
+ * while the bulky turn-by-turn history is reclaimed.
+ *
+ * The summarizer is injected so this stays testable + decoupled from the LLM
+ * client. Every step is best-effort: a failure on one conversation never blocks
+ * the others, and never throws out of the sweep.
+ */
+
+import type { AgentMemory } from "./agent-memory.ts";
+import type { ConversationTurn } from "./conversation-store.ts";
+
+export type Summarizer = (transcript: string) => Promise<string>;
+
+export interface HarvesterOptions {
+  summarize: Summarizer;
+  /** Idle age after which a conversation is harvested. Default 7 days. */
+  maxAgeMs?: number;
+  /** How often to sweep. Default 6 hours. */
+  sweepIntervalMs?: number;
+  /** Max conversations harvested per sweep. Default 25. */
+  batchLimit?: number;
+  /** Injectable clock for tests. */
+  now?: () => number;
+}
+
+const DEFAULT_MAX_AGE_MS = 7 * 24 * 60 * 60_000;
+const DEFAULT_SWEEP_MS = 6 * 60 * 60_000;
+const DEFAULT_BATCH = 25;
+const MAX_TRANSCRIPT_CHARS = 16000;
+
+/** Render a User/Assistant transcript, tail-capped (mirrors protoAgent). */
+export function renderTranscript(turns: ConversationTurn[]): string {
+  const lines = turns
+    .filter((t) => t.content.trim())
+    .map((t) => `${t.role === "assistant" ? "Assistant" : "User"}: ${t.content.trim()}`);
+  let transcript = lines.join("\n");
+  if (transcript.length > MAX_TRANSCRIPT_CHARS) {
+    transcript = "…\n" + transcript.slice(-MAX_TRANSCRIPT_CHARS);
+  }
+  return transcript;
+}
+
+export class ConversationHarvester {
+  private readonly memory: AgentMemory;
+  private readonly summarize: Summarizer;
+  private readonly maxAgeMs: number;
+  private readonly sweepIntervalMs: number;
+  private readonly batchLimit: number;
+  private readonly now: () => number;
+  private timer?: ReturnType<typeof setInterval>;
+
+  constructor(memory: AgentMemory, opts: HarvesterOptions) {
+    this.memory = memory;
+    this.summarize = opts.summarize;
+    this.maxAgeMs = opts.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+    this.sweepIntervalMs = opts.sweepIntervalMs ?? DEFAULT_SWEEP_MS;
+    this.batchLimit = opts.batchLimit ?? DEFAULT_BATCH;
+    this.now = opts.now ?? Date.now;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => { void this.sweepOnce(); }, this.sweepIntervalMs);
+    this.timer.unref?.();
+    console.log(`[harvester] started — maxAge=${Math.round(this.maxAgeMs / 86_400_000)}d sweep=${Math.round(this.sweepIntervalMs / 3_600_000)}h`);
+  }
+
+  stop(): void {
+    if (this.timer) { clearInterval(this.timer); this.timer = undefined; }
+  }
+
+  /**
+   * One harvest pass. Returns the number of conversations harvested. Safe to
+   * call directly (tests / manual trigger).
+   */
+  async sweepOnce(): Promise<number> {
+    const candidates = this.memory.conversations.retirable(this.maxAgeMs, this.now(), this.batchLimit);
+    let harvested = 0;
+    for (const conv of candidates) {
+      try {
+        const turns = this.memory.conversations.allTurns(conv.contextId);
+        const transcript = renderTranscript(turns);
+        if (!transcript.trim()) {
+          // Nothing to summarize — just reclaim it.
+          this.memory.conversations.deleteConversation(conv.contextId);
+          continue;
+        }
+        const summary = (await this.summarize(transcript)).trim();
+        if (summary) {
+          this.memory.knowledge.addChunk(summary, {
+            domain: "conversation",
+            heading: `Conversation summary${conv.agent ? ` (${conv.agent})` : ""}`,
+            source: `conversation:${conv.contextId}`,
+          });
+          harvested += 1;
+        }
+        // Reclaim raw turns regardless — the summary (or empty) is the keeper.
+        this.memory.conversations.deleteConversation(conv.contextId);
+      } catch (err) {
+        console.warn(`[harvester] failed for ${conv.contextId}: ${err instanceof Error ? err.message : String(err)}`);
+        // Leave it in place to retry next sweep.
+      }
+    }
+    if (harvested > 0) console.log(`[harvester] harvested ${harvested}/${candidates.length} conversation(s) into knowledge`);
+    return harvested;
+  }
+}

--- a/src/knowledge/conversation-store.ts
+++ b/src/knowledge/conversation-store.ts
@@ -1,0 +1,183 @@
+/**
+ * ConversationStore — durable per-conversation turn history (bun:sqlite).
+ *
+ * The in-process DeepAgent runtime invokes the LangGraph ReAct loop with a
+ * single user message and no checkpointer, so without this an agent has zero
+ * memory of prior turns — every message is handled in isolation. This store
+ * persists each (contextId, role, content) turn and lets the executor replay
+ * the recent tail into the next invocation's message list.
+ *
+ * It also tracks per-conversation last-activity in `conversation_meta`, which
+ * the harvester (Phase 3) uses to retire aged-out conversations into the
+ * searchable KnowledgeStore.
+ *
+ * Shares `data/knowledge.db` with the rest of the knowledge layer. Gracefully
+ * degrades to a no-op when the DB is unavailable — memory is best-effort and
+ * must never break a running skill.
+ */
+
+import { Database } from "bun:sqlite";
+import { mkdirSync, existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+export type TurnRole = "user" | "assistant";
+
+export interface ConversationTurn {
+  role: TurnRole;
+  content: string;
+}
+
+export interface RetirableConversation {
+  contextId: string;
+  agent: string | null;
+  lastActivity: number;
+}
+
+/** Hard cap on stored turns per conversation — prevents unbounded growth. */
+const MAX_TURNS_PER_CONVERSATION = 200;
+
+export class ConversationStore {
+  private db: Database | null = null;
+  private readonly dbPath: string;
+
+  constructor(dbPath?: string) {
+    this.dbPath = resolve(dbPath ?? "data/knowledge.db");
+  }
+
+  init(): void {
+    try {
+      const dir = dirname(this.dbPath);
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+      this.db = new Database(this.dbPath);
+      this.db.exec("PRAGMA journal_mode=WAL;");
+      this.db.exec("PRAGMA synchronous=NORMAL;");
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS conversation_turns (
+          id          INTEGER PRIMARY KEY AUTOINCREMENT,
+          context_id  TEXT    NOT NULL,
+          role        TEXT    NOT NULL,
+          content     TEXT    NOT NULL,
+          agent       TEXT,
+          skill       TEXT,
+          created_at  INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_conversation_turns_context
+          ON conversation_turns(context_id, id);
+
+        CREATE TABLE IF NOT EXISTS conversation_meta (
+          context_id    TEXT PRIMARY KEY,
+          agent         TEXT,
+          created_at    INTEGER NOT NULL,
+          last_activity INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_conversation_meta_activity
+          ON conversation_meta(last_activity);
+      `);
+      console.log(`[conversation-store] DB ready: ${this.dbPath}`);
+    } catch (err) {
+      console.error(`[conversation-store] DB init failed: ${err instanceof Error ? err.message : String(err)}`);
+      this.db = null;
+    }
+  }
+
+  /** Append one turn and bump the conversation's last-activity. Best-effort. */
+  appendTurn(contextId: string, role: TurnRole, content: string, agent?: string, skill?: string): void {
+    if (!this.db || !content.trim()) return;
+    const now = Date.now();
+    try {
+      const tx = this.db.transaction(() => {
+        this.db!
+          .query(`INSERT INTO conversation_turns (context_id, role, content, agent, skill, created_at)
+                  VALUES (?, ?, ?, ?, ?, ?)`)
+          .run(contextId, role, content, agent ?? null, skill ?? null, now);
+        // Upsert meta (created_at preserved on conflict, last_activity bumped).
+        this.db!
+          .query(`INSERT INTO conversation_meta (context_id, agent, created_at, last_activity)
+                  VALUES (?, ?, ?, ?)
+                  ON CONFLICT(context_id) DO UPDATE SET last_activity = excluded.last_activity,
+                    agent = COALESCE(conversation_meta.agent, excluded.agent)`)
+          .run(contextId, agent ?? null, now, now);
+        // Prune oldest turns beyond the cap for this conversation.
+        this.db!
+          .query(`DELETE FROM conversation_turns
+                  WHERE context_id = ? AND id NOT IN (
+                    SELECT id FROM conversation_turns WHERE context_id = ? ORDER BY id DESC LIMIT ?
+                  )`)
+          .run(contextId, contextId, MAX_TURNS_PER_CONVERSATION);
+      });
+      tx();
+    } catch (err) {
+      console.warn(`[conversation-store] appendTurn failed for ${contextId}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  /** Most recent `limit` turns for a conversation, oldest-first (chronological). */
+  recentTurns(contextId: string, limit = 10): ConversationTurn[] {
+    if (!this.db) return [];
+    try {
+      const rows = this.db
+        .query<{ role: string; content: string }, [string, number]>(
+          `SELECT role, content FROM conversation_turns
+           WHERE context_id = ? ORDER BY id DESC LIMIT ?`,
+        )
+        .all(contextId, limit);
+      return rows
+        .reverse()
+        .map((r) => ({ role: r.role === "assistant" ? "assistant" : "user", content: r.content }));
+    } catch (err) {
+      console.warn(`[conversation-store] recentTurns failed for ${contextId}: ${err instanceof Error ? err.message : String(err)}`);
+      return [];
+    }
+  }
+
+  /** All turns for a conversation, oldest-first — used by the harvester. */
+  allTurns(contextId: string): ConversationTurn[] {
+    if (!this.db) return [];
+    try {
+      const rows = this.db
+        .query<{ role: string; content: string }, [string]>(
+          `SELECT role, content FROM conversation_turns WHERE context_id = ? ORDER BY id ASC`,
+        )
+        .all(contextId);
+      return rows.map((r) => ({ role: r.role === "assistant" ? "assistant" : "user", content: r.content }));
+    } catch {
+      return [];
+    }
+  }
+
+  /** Conversations whose last activity is older than `maxAgeMs` — harvest candidates. */
+  retirable(maxAgeMs: number, now = Date.now(), limit = 50): RetirableConversation[] {
+    if (!this.db) return [];
+    try {
+      const cutoff = now - maxAgeMs;
+      const rows = this.db
+        .query<{ context_id: string; agent: string | null; last_activity: number }, [number, number]>(
+          `SELECT context_id, agent, last_activity FROM conversation_meta
+           WHERE last_activity < ? ORDER BY last_activity ASC LIMIT ?`,
+        )
+        .all(cutoff, limit);
+      return rows.map((r) => ({ contextId: r.context_id, agent: r.agent, lastActivity: r.last_activity }));
+    } catch {
+      return [];
+    }
+  }
+
+  /** Drop a conversation's turns + meta (after harvest). */
+  deleteConversation(contextId: string): void {
+    if (!this.db) return;
+    try {
+      const tx = this.db.transaction(() => {
+        this.db!.query(`DELETE FROM conversation_turns WHERE context_id = ?`).run(contextId);
+        this.db!.query(`DELETE FROM conversation_meta WHERE context_id = ?`).run(contextId);
+      });
+      tx();
+    } catch (err) {
+      console.warn(`[conversation-store] deleteConversation failed for ${contextId}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  close(): void {
+    if (this.db) { this.db.close(); this.db = null; }
+  }
+}

--- a/src/knowledge/knowledge-store.ts
+++ b/src/knowledge/knowledge-store.ts
@@ -1,0 +1,183 @@
+/**
+ * KnowledgeStore — searchable long-term memory (bun:sqlite + FTS5).
+ *
+ * Ports protoAgent's KnowledgeStore: a chunk table mirrored into an FTS5 index
+ * (BM25-ranked) so agents can recall relevant facts from prior conversations.
+ * Chunks carry a `domain` so different sources stay distinguishable:
+ *   - "conversation" — summaries of retired conversations (harvester, Phase 3)
+ *   - "finding"      — substantive answers extracted per turn (Phase 2)
+ *   - "hot"          — always-on facts injected into every recall
+ *
+ * FTS5 (lexical, BM25) is the always-on floor — no embedding service in the hot
+ * path, so recall can't be taken down by an embeddings outage. A semantic layer
+ * can be layered on later by fusing vector hits, but lexical recall ships first
+ * (this is exactly what protoAgent runs by default).
+ *
+ * Shares `data/knowledge.db`. Degrades to a no-op when the DB is unavailable.
+ */
+
+import { Database } from "bun:sqlite";
+import { mkdirSync, existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+export interface KnowledgeChunk {
+  id: number;
+  content: string;
+  domain: string;
+  heading: string | null;
+  source: string | null;
+  createdAt: number;
+}
+
+export interface KnowledgeHit {
+  id: number;
+  content: string;
+  domain: string;
+  heading: string | null;
+  /** First ~200 chars — what recall injects. */
+  preview: string;
+}
+
+const PREVIEW_CHARS = 240;
+
+export class KnowledgeStore {
+  private db: Database | null = null;
+  private ftsAvailable = false;
+  private readonly dbPath: string;
+
+  constructor(dbPath?: string) {
+    this.dbPath = resolve(dbPath ?? "data/knowledge.db");
+  }
+
+  init(): void {
+    try {
+      const dir = dirname(this.dbPath);
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+      this.db = new Database(this.dbPath);
+      this.db.exec("PRAGMA journal_mode=WAL;");
+      this.db.exec("PRAGMA synchronous=NORMAL;");
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS chunks (
+          id          INTEGER PRIMARY KEY AUTOINCREMENT,
+          content     TEXT    NOT NULL,
+          domain      TEXT    NOT NULL DEFAULT 'general',
+          heading     TEXT,
+          source      TEXT,
+          created_at  INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_chunks_domain ON chunks(domain);
+      `);
+
+      // FTS5 mirror + sync triggers. Wrapped: a SQLite build without FTS5
+      // falls back to a LIKE scan (still functional, just slower).
+      try {
+        this.db.exec(`
+          CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
+            content, heading, content='chunks', content_rowid='id'
+          );
+          CREATE TRIGGER IF NOT EXISTS chunks_ai AFTER INSERT ON chunks BEGIN
+            INSERT INTO chunks_fts(rowid, content, heading) VALUES (new.id, new.content, new.heading);
+          END;
+          CREATE TRIGGER IF NOT EXISTS chunks_ad AFTER DELETE ON chunks BEGIN
+            INSERT INTO chunks_fts(chunks_fts, rowid, content, heading) VALUES ('delete', old.id, old.content, old.heading);
+          END;
+          CREATE TRIGGER IF NOT EXISTS chunks_au AFTER UPDATE ON chunks BEGIN
+            INSERT INTO chunks_fts(chunks_fts, rowid, content, heading) VALUES ('delete', old.id, old.content, old.heading);
+            INSERT INTO chunks_fts(rowid, content, heading) VALUES (new.id, new.content, new.heading);
+          END;
+        `);
+        this.ftsAvailable = true;
+      } catch (err) {
+        console.warn(`[knowledge-store] FTS5 unavailable — using LIKE fallback: ${err instanceof Error ? err.message : String(err)}`);
+        this.ftsAvailable = false;
+      }
+      console.log(`[knowledge-store] DB ready: ${this.dbPath} (fts5=${this.ftsAvailable})`);
+    } catch (err) {
+      console.error(`[knowledge-store] DB init failed: ${err instanceof Error ? err.message : String(err)}`);
+      this.db = null;
+    }
+  }
+
+  /** Insert a chunk. Returns the new row id, or null on failure (never throws). */
+  addChunk(content: string, opts: { domain?: string; heading?: string; source?: string } = {}): number | null {
+    if (!this.db || !content.trim()) return null;
+    try {
+      const res = this.db
+        .query(`INSERT INTO chunks (content, domain, heading, source, created_at) VALUES (?, ?, ?, ?, ?)`)
+        .run(content, opts.domain ?? "general", opts.heading ?? null, opts.source ?? null, Date.now());
+      return Number(res.lastInsertRowid);
+    } catch (err) {
+      console.warn(`[knowledge-store] addChunk failed: ${err instanceof Error ? err.message : String(err)}`);
+      return null;
+    }
+  }
+
+  /** BM25-ranked (or LIKE-fallback) search. Optionally scoped to a domain. */
+  search(query: string, k = 5, domain?: string): KnowledgeHit[] {
+    if (!this.db) return [];
+    const tokens = (query.match(/[\w']+/g) ?? []).filter((t) => t.length > 1);
+    if (tokens.length === 0) return [];
+    try {
+      if (this.ftsAvailable) {
+        const match = tokens.map((t) => `"${t.replace(/"/g, '""')}"`).join(" OR ");
+        const sql = domain
+          ? `SELECT c.id, c.content, c.domain, c.heading FROM chunks_fts f
+             JOIN chunks c ON c.id = f.rowid
+             WHERE chunks_fts MATCH ? AND c.domain = ? ORDER BY rank LIMIT ?`
+          : `SELECT c.id, c.content, c.domain, c.heading FROM chunks_fts f
+             JOIN chunks c ON c.id = f.rowid
+             WHERE chunks_fts MATCH ? ORDER BY rank LIMIT ?`;
+        const rows = domain
+          ? this.db.query<{ id: number; content: string; domain: string; heading: string | null }, [string, string, number]>(sql).all(match, domain, k)
+          : this.db.query<{ id: number; content: string; domain: string; heading: string | null }, [string, number]>(sql).all(match, k);
+        return rows.map((r) => this._toHit(r));
+      }
+      return this._likeSearch(tokens, k, domain);
+    } catch (err) {
+      console.warn(`[knowledge-store] search failed: ${err instanceof Error ? err.message : String(err)}`);
+      return [];
+    }
+  }
+
+  private _likeSearch(tokens: string[], k: number, domain?: string): KnowledgeHit[] {
+    if (!this.db) return [];
+    const esc = (t: string) => `%${t.replace(/[%_\\]/g, (m) => "\\" + m)}%`;
+    const scoreExpr = tokens.map(() => `(CASE WHEN content LIKE ? ESCAPE '\\' OR heading LIKE ? ESCAPE '\\' THEN 1 ELSE 0 END)`).join(" + ");
+    const params: (string | number)[] = [];
+    for (const t of tokens) { params.push(esc(t), esc(t)); }
+    let sql = `SELECT id, content, domain, heading, (${scoreExpr}) AS score FROM chunks`;
+    if (domain) { sql += ` WHERE domain = ?`; params.push(domain); }
+    sql += ` ORDER BY score DESC, id DESC LIMIT ?`;
+    params.push(k);
+    const rows = this.db.query<{ id: number; content: string; domain: string; heading: string | null; score: number }, (string | number)[]>(sql).all(...params);
+    return rows.filter((r) => r.score > 0).map((r) => this._toHit(r));
+  }
+
+  /** All `domain="hot"` chunks concatenated, newest-first, trimmed to `maxChars`. */
+  getHotMemory(maxChars = 4000): string {
+    if (!this.db) return "";
+    try {
+      const rows = this.db
+        .query<{ content: string }, []>(`SELECT content FROM chunks WHERE domain = 'hot' ORDER BY id DESC`)
+        .all();
+      let out = "";
+      for (const r of rows) {
+        if (out.length + r.content.length + 1 > maxChars) break;
+        out += (out ? "\n" : "") + r.content;
+      }
+      return out;
+    } catch {
+      return "";
+    }
+  }
+
+  private _toHit(r: { id: number; content: string; domain: string; heading: string | null }): KnowledgeHit {
+    const preview = r.content.length > PREVIEW_CHARS ? r.content.slice(0, PREVIEW_CHARS) + "…" : r.content;
+    return { id: r.id, content: r.content, domain: r.domain, heading: r.heading, preview };
+  }
+
+  close(): void {
+    if (this.db) { this.db.close(); this.db = null; }
+  }
+}

--- a/src/schemas/yaml-schemas.ts
+++ b/src/schemas/yaml-schemas.ts
@@ -42,6 +42,15 @@ export const AgentDefinitionSchema = z.object({
     "maxTurns must be -1 (unlimited) or a positive integer",
   ).default(10),
   skills: z.array(AgentSkillDefinitionSchema).default([]),
+  memory: z
+    .object({
+      enabled: z.boolean(),
+      skills: z.array(z.string()).optional(),
+      historyTurns: z.number().int().positive().optional(),
+      recallTopK: z.number().int().positive().optional(),
+      harvest: z.boolean().optional(),
+    })
+    .optional(),
 });
 
 export type AgentDefinitionInput = z.input<typeof AgentDefinitionSchema>;

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -216,6 +216,16 @@ tools:
 
 maxTurns: 25
 
+# Memory flywheel — Ava remembers within a conversation, recalls relevant facts
+# from past ones, and harvests aged-out conversations into searchable memory.
+# Scoped to the conversational `chat` skill; narrow skills stay stateless.
+memory:
+  enabled: true
+  skills: [chat]
+  historyTurns: 12
+  recallTopK: 5
+  harvest: true
+
 discordBotTokenEnvKey: DISCORD_BOT_TOKEN_AVA
 
 skills:


### PR DESCRIPTION
Makes Ava context-aware and robust, porting protoAgent's Python memory flywheel onto workstacean's existing bun:sqlite + gateway rails. Five phases, each its own commit.

## The gap
Ava's DeepAgent ran every turn with a single user message and **no checkpointer** — no within-conversation history, no cross-conversation recall — and the Discord boundary fed her only the bare text of the triggering message (no reply-chain, scrollback, thread, or attachments).

## Phases
1. **Within-conversation memory** — `ConversationStore` (bun:sqlite) persists per-`contextId` turns; the executor replays the recent tail into each invocation.
2. **Cross-conversation recall** — `KnowledgeStore` (FTS5/BM25, LIKE fallback) + `AgentMemory`. Pre-model recall injects a "Recalled context" block (hot memory + BM25 hits); substantive answers are extracted as searchable findings. Mirrors protoAgent's KnowledgeMiddleware + MemoryMiddleware.
3. **Conversation harvest** — a background sweeper retires idle conversations (default 7d), summarizes each via a cheap aux model, ingests the summary (`domain=conversation`), and reclaims the raw turns. Ports `conversation_harvest` + pruner trigger.
4. **Discord context enrichment** — `buildMessageContext` assembles replied-to message, thread name+starter, recent scrollback, and attachments into a `contextPreamble` shipped on the bus payload; the executor injects it into the turn **without** persisting it as history.
5. **Robustness** — connection-lifecycle logging (reconnect/resume/disconnect visibility) + inbound event dedup (guards gateway-RESUME replay double-responses).

## Design notes
- **Opt-in per agent** via a `memory` block on the agent yaml (type + zod schema + loader); scoped to conversational skills (default `[chat]`) so narrow skills (pr_review…) stay stateless. Enabled on `ava.yaml`.
- **Reuses existing infra**: one shared `data/knowledge.db`, the gateway for summarization. FTS5 is the always-on recall floor — no embedding service in the hot path (a semantic layer can fuse in later without touching callers).
- **Best-effort everywhere**: every store/memory op degrades to a no-op and never throws into a running skill.

## Tests
30 new tests (conversation store, knowledge store, agent memory, harvester, Discord context builder, dedup). `tsc` clean; **full suite green — 1013 pass / 0 fail**.

## Deploy note
The CODE deploys via the image (watchtower); `ava.yaml`'s new `memory` block is **workspace config** (host bind-mount) and must be synced to the live mount + hot-reloaded, per the config-vs-code split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agents now support optional conversational memory with automatic harvesting of aged conversations into a searchable knowledge base
  * Discord messages include contextual information (previous channel messages, thread details, attachments)
  * Improved handling of duplicate Discord events via deduplication

* **Tests**
  * Added comprehensive test coverage for memory and conversation systems
  * Added test coverage for Discord context building and deduplication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->