### PR TITLE
feat: researcher agent — hybrid knowledge base + source connectors + weekly digest

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "cron-parser": "^5.5.0",
         "discord.js": "^14.0.0",
         "openai": "^4.77.0",
+        "sqlite-vec": "^0.1.9",
         "yaml": "^2.8.3",
         "zod": "^3.25.0",
       },
@@ -788,6 +789,18 @@
     "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "sqlite-vec": ["sqlite-vec@0.1.9", "", { "optionalDependencies": { "sqlite-vec-darwin-arm64": "0.1.9", "sqlite-vec-darwin-x64": "0.1.9", "sqlite-vec-linux-arm64": "0.1.9", "sqlite-vec-linux-x64": "0.1.9", "sqlite-vec-windows-x64": "0.1.9" } }, "sha512-L7XJWRIBNvR9O5+vh1FQ+IGkh/3D2AzVksW5gdtk28m78Hy8skFD0pqReKH1Yp0/BUKRGcffgKvyO/EON5JXpA=="],
+
+    "sqlite-vec-darwin-arm64": ["sqlite-vec-darwin-arm64@0.1.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jSsZpE42OfBkGL/ItyJTVCUwl6o6Ka3U5rc4j+UBDIQzC1ulSSKMEhQLthsOnF/MdAf1MuAkYhkdKmmcjaIZQg=="],
+
+    "sqlite-vec-darwin-x64": ["sqlite-vec-darwin-x64@0.1.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-KDlVyqQT7pnOhU1ymB9gs7dMbSoVmKHitT+k1/xkjarcX8bBqPxWrGlK/R+C5WmWkfvWwyq5FfXfiBYCBs6PlA=="],
+
+    "sqlite-vec-linux-arm64": ["sqlite-vec-linux-arm64@0.1.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-5wXVJ9c9kR4CHm/wVqXb/R+XUHTdpZ4nWbPHlS+gc9qQFVHs92Km4bPnCKX4rtcPMzvNis+SIzMJR1SCEwpuUw=="],
+
+    "sqlite-vec-linux-x64": ["sqlite-vec-linux-x64@0.1.9", "", { "os": "linux", "cpu": "x64" }, "sha512-w3tCH8xK2finW8fQJ/m8uqKodXUZ9KAuAar2UIhz4BHILfpE0WM/MTGCRfa7RjYbrYim5Luk3guvMOGI7T7JQA=="],
+
+    "sqlite-vec-windows-x64": ["sqlite-vec-windows-x64@0.1.9", "", { "os": "win32", "cpu": "x64" }, "sha512-y3gEIyy/17bq2QFPQOWLE68TYWcRZkBQVA2XLrTPHNTOp55xJi/BBBmOm40tVMDMjtP+Elpk6UBUXdaq+46b0Q=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "cron-parser": "^5.5.0",
     "discord.js": "^14.0.0",
     "openai": "^4.77.0",
+    "sqlite-vec": "^0.1.9",
     "yaml": "^2.8.3",
     "zod": "^3.25.0"
   },

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -32,12 +32,14 @@ import { createRoutes as humanInputRoutes } from "./human-input.ts";
 import { createRoutes as agentsCrudRoutes } from "./agents-crud.ts";
 import { createRoutes as controlPlaneRoutes } from "./control-plane.ts";
 import { createRoutes as mcpCrudRoutes } from "./mcp-crud.ts";
+import { createRoutes as researchRoutes } from "./research.ts";
 
 export { matchPath } from "./types.ts";
 export type { Route, ApiContext } from "./types.ts";
 
 export function createAllRoutes(ctx: ApiContext): Route[] {
   return [
+    ...researchRoutes(ctx),
     ...operationRoutes(ctx),
     ...githubRoutes(ctx),
     ...incidentRoutes(ctx),

--- a/src/api/research.ts
+++ b/src/api/research.ts
@@ -1,0 +1,81 @@
+/**
+ * research.ts — HTTP surface over the ResearchStore.
+ *
+ * Backs the researcher agent's `research_search` / `research_ingest` /
+ * `research_stats` DeepAgent tools (tool → http → here → store), mirroring how
+ * every other in-process tool reaches server state. Also reused by the
+ * automated research ceremony (R4). Auth: admin X-API-Key / Bearer, matching
+ * the rest of the agent-facing API.
+ */
+
+import type { ApiContext } from "./types.ts";
+import type { Route } from "./types.ts";
+import type { ResearchKind } from "../knowledge/research-store.ts";
+
+function authed(ctx: ApiContext, req: Request): boolean {
+  if (!ctx.apiKey) return true; // open in dev / no key configured
+  const key = ctx.apiKey;
+  return req.headers.get("x-api-key") === key || req.headers.get("authorization") === `Bearer ${key}`;
+}
+
+const KINDS: ResearchKind[] = ["paper", "finding", "digest", "model_release"];
+
+export function createRoutes(ctx: ApiContext): Route[] {
+  const unavailable = () =>
+    Response.json({ success: false, error: "Research store not configured" }, { status: 503 });
+
+  return [
+    {
+      method: "POST",
+      path: "/api/research/search",
+      handler: async (req) => {
+        if (!authed(ctx, req)) return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+        if (!ctx.researchStore) return unavailable();
+        let body: Record<string, unknown>;
+        try { body = (await req.json()) as Record<string, unknown>; }
+        catch { return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 }); }
+        const query = typeof body.query === "string" ? body.query : "";
+        if (!query.trim()) return Response.json({ success: false, error: "query is required" }, { status: 400 });
+        const k = typeof body.k === "number" && body.k > 0 ? Math.min(body.k, 25) : 5;
+        const kind = KINDS.includes(body.kind as ResearchKind) ? (body.kind as ResearchKind) : undefined;
+        const hits = await ctx.researchStore.hybridSearch(query, k, kind);
+        return Response.json({ success: true, data: { hits } });
+      },
+    },
+    {
+      method: "POST",
+      path: "/api/research/ingest",
+      handler: async (req) => {
+        if (!authed(ctx, req)) return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+        if (!ctx.researchStore) return unavailable();
+        let body: Record<string, unknown>;
+        try { body = (await req.json()) as Record<string, unknown>; }
+        catch { return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 }); }
+        const kind = body.kind as ResearchKind;
+        const content = typeof body.content === "string" ? body.content : "";
+        if (!KINDS.includes(kind)) return Response.json({ success: false, error: `kind must be one of ${KINDS.join(", ")}` }, { status: 400 });
+        if (!content.trim()) return Response.json({ success: false, error: "content is required" }, { status: 400 });
+        const id = await ctx.researchStore.addChunk({
+          kind,
+          content,
+          title: typeof body.title === "string" ? body.title : undefined,
+          source: typeof body.source === "string" ? body.source : undefined,
+          sourceType: typeof body.sourceType === "string" ? body.sourceType : undefined,
+          url: typeof body.url === "string" ? body.url : undefined,
+          metadata: body.metadata && typeof body.metadata === "object" ? (body.metadata as Record<string, unknown>) : undefined,
+        });
+        if (id === null) return Response.json({ success: false, error: "ingest failed" }, { status: 500 });
+        return Response.json({ success: true, data: { id } });
+      },
+    },
+    {
+      method: "GET",
+      path: "/api/research/stats",
+      handler: async (req) => {
+        if (!authed(ctx, req)) return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+        if (!ctx.researchStore) return unavailable();
+        return Response.json({ success: true, data: ctx.researchStore.stats() });
+      },
+    },
+  ];
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -18,6 +18,7 @@ import type { BusHistoryRecorder } from "../event-bus/history-recorder.ts";
 import type { SkillResponseCache } from "../event-bus/skill-response-cache.ts";
 import type { ChannelRegistry } from "../../lib/channels/channel-registry.ts";
 import type { ProjectRegistry } from "../plugins/project-registry.ts";
+import type { ResearchStore } from "../knowledge/research-store.ts";
 
 export type Params = Record<string, string>;
 export type RouteHandler = (req: Request, params: Params) => Response | Promise<Response>;
@@ -73,6 +74,8 @@ export interface ApiContext {
   projectRegistry?: ProjectRegistry;
   /** Channels registry — used by routes that need per-project channel lookups. */
   channelRegistry?: ChannelRegistry;
+  /** Researcher agent's hybrid knowledge base — backs /api/research/*. */
+  researchStore?: ResearchStore;
 }
 
 /** Match a path against a pattern like "/api/foo/:id/run". Returns params or null. */

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -424,6 +424,115 @@ export function createLangChainTools(toolNames: string[], http: HttpClient, corr
         }),
       },
     ),
+    // ── Research: knowledge base + source connectors (researcher agent) ───────
+    research_search: tool(
+      async (input) => JSON.stringify(await http.post("/api/research/search", input)),
+      {
+        name: "research_search",
+        description: "Hybrid (semantic + keyword) search over the research knowledge base — prior papers, findings, digests, and model releases. Use this BEFORE external searches to reuse what's already been gathered.",
+        schema: z.object({
+          query: z.string().describe("What to look for."),
+          k: z.number().optional().describe("Max results (default 5)."),
+          kind: z.enum(["paper", "finding", "digest", "model_release"]).optional().describe("Restrict to one kind."),
+        }),
+      },
+    ),
+    research_ingest: tool(
+      async (input) => JSON.stringify(await http.post("/api/research/ingest", input)),
+      {
+        name: "research_ingest",
+        description: "Store a research item (paper, finding, digest, or model_release) into the searchable knowledge base so it's recallable in future research.",
+        schema: z.object({
+          kind: z.enum(["paper", "finding", "digest", "model_release"]).describe("What this item is."),
+          content: z.string().describe("The substance — abstract, finding text, digest body, or model summary."),
+          title: z.string().optional(),
+          source: z.string().optional().describe("Where it came from (e.g. arxiv, huggingface, github, discord)."),
+          url: z.string().optional(),
+          metadata: z.record(z.unknown()).optional(),
+        }),
+      },
+    ),
+    research_stats: tool(
+      async () => JSON.stringify(await http.get("/api/research/stats")),
+      { name: "research_stats", description: "Counts of stored research items per kind.", schema: z.object({}) },
+    ),
+    huggingface_search: tool(
+      async (input) => {
+        const type = input.type ?? "models";
+        const params = new URLSearchParams({ search: input.query, limit: String(input.limit ?? 10), full: "false" });
+        if (input.sort) params.set("sort", input.sort);
+        try {
+          const res = await fetch(`https://huggingface.co/api/${type}?${params}`, { headers: { Accept: "application/json" } });
+          if (!res.ok) return JSON.stringify({ error: `HuggingFace ${res.status}` });
+          const data = (await res.json()) as Array<Record<string, unknown>>;
+          return JSON.stringify({ results: data.slice(0, input.limit ?? 10).map(d => ({ id: d.id ?? d.modelId, downloads: d.downloads, likes: d.likes, pipeline_tag: d.pipeline_tag, updated: d.lastModified })) });
+        } catch (e) { return JSON.stringify({ error: e instanceof Error ? e.message : String(e) }); }
+      },
+      {
+        name: "huggingface_search",
+        description: "Search HuggingFace Hub for models or datasets (trending / by downloads / likes). Public — no auth.",
+        schema: z.object({
+          query: z.string().describe("Search terms."),
+          type: z.enum(["models", "datasets"]).optional().describe("Default: models."),
+          sort: z.enum(["downloads", "likes", "lastModified"]).optional().describe("Sort order."),
+          limit: z.number().optional().describe("Max results (default 10)."),
+        }),
+      },
+    ),
+    github_trending: tool(
+      async (input) => {
+        const q = [input.query, input.language ? `language:${input.language}` : ""].filter(Boolean).join(" ");
+        const params = new URLSearchParams({ q: q || "stars:>1000", sort: input.sort ?? "stars", order: "desc", per_page: String(input.limit ?? 10) });
+        const headers: Record<string, string> = { Accept: "application/vnd.github+json" };
+        if (process.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+        try {
+          const res = await fetch(`https://api.github.com/search/repositories?${params}`, { headers });
+          if (!res.ok) return JSON.stringify({ error: `GitHub ${res.status}` });
+          const data = (await res.json()) as { items?: Array<Record<string, unknown>> };
+          return JSON.stringify({ results: (data.items ?? []).slice(0, input.limit ?? 10).map(r => ({ full_name: r.full_name, stars: r.stargazers_count, description: r.description, url: r.html_url, language: r.language, pushed_at: r.pushed_at })) });
+        } catch (e) { return JSON.stringify({ error: e instanceof Error ? e.message : String(e) }); }
+      },
+      {
+        name: "github_trending",
+        description: "Search GitHub repositories by topic/language sorted by stars or recent activity — find trending AI/ML projects and releases.",
+        schema: z.object({
+          query: z.string().describe("Search terms (e.g. 'llm inference', 'diffusion')."),
+          language: z.string().optional().describe("Restrict to a language (e.g. python, rust)."),
+          sort: z.enum(["stars", "updated"]).optional().describe("Default: stars."),
+          limit: z.number().optional().describe("Max results (default 10)."),
+        }),
+      },
+    ),
+    discord_scan_feed: tool(
+      async (input) => {
+        const token = process.env.DISCORD_BOT_TOKEN;
+        if (!token) return JSON.stringify({ error: "DISCORD_BOT_TOKEN not set" });
+        try {
+          const res = await fetch(`https://discord.com/api/v10/channels/${input.channelId}/messages?limit=${input.limit ?? 30}`, {
+            headers: { Authorization: `Bot ${token}` },
+          });
+          if (!res.ok) return JSON.stringify({ error: `Discord ${res.status}` });
+          const msgs = (await res.json()) as Array<{ content?: string; embeds?: Array<{ url?: string; title?: string }>; author?: { username?: string } }>;
+          const urlRe = /https?:\/\/[^\s<>")]+/g;
+          const classify = (u: string): string =>
+            /arxiv\.org/.test(u) ? "arxiv" : /huggingface\.co/.test(u) ? "huggingface" : /github\.com/.test(u) ? "github" : /(youtube|youtu\.be)/.test(u) ? "video" : "web";
+          const links: Array<{ url: string; type: string; from?: string }> = [];
+          for (const m of msgs) {
+            for (const u of (m.content ?? "").match(urlRe) ?? []) links.push({ url: u, type: classify(u), from: m.author?.username });
+            for (const e of m.embeds ?? []) if (e.url) links.push({ url: e.url, type: classify(e.url), from: m.author?.username });
+          }
+          return JSON.stringify({ scanned: msgs.length, links: links.slice(0, 50) });
+        } catch (e) { return JSON.stringify({ error: e instanceof Error ? e.message : String(e) }); }
+      },
+      {
+        name: "discord_scan_feed",
+        description: "Scan a Discord channel's recent messages and extract + classify shared links (arxiv, huggingface, github, video, web) — the team's research feed.",
+        schema: z.object({
+          channelId: z.string().describe("Discord channel ID to scan."),
+          limit: z.number().optional().describe("Messages to scan (default 30, max 100)."),
+        }),
+      },
+    ),
     // ── Discord operations (protoBot agent) ──────────────────────────────────
     discord_server_stats: tool(
       async () => JSON.stringify(await http.get("/api/discord/server-stats")),

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,11 @@ import { FleetStateRepository } from "./knowledge/fleet-state.js";
 const fleetStateRepo = new FleetStateRepository(`${dataDir}/knowledge.db`);
 fleetStateRepo.init();
 
+// Researcher agent's hybrid knowledge base (sqlite-vec + FTS5). Backs /api/research/*.
+import { ResearchStore } from "./knowledge/research-store.ts";
+const researchStore = new ResearchStore(`${dataDir}/knowledge.db`);
+researchStore.init();
+
 // Core plugins — always loaded, statically imported (no dynamic overhead needed)
 const debugPlugin = new DebugPlugin();
 debugPlugin.install(bus);
@@ -592,6 +597,7 @@ const apiContext: ApiContext = {
   activeDispatchCheck: (correlationId: string) => skillDispatcher?.isActive(correlationId) ?? false,
   projectRegistry,
   channelRegistry,
+  researchStore,
 };
 
 const routes = createAllRoutes(apiContext);

--- a/src/knowledge/__tests__/research-store.test.ts
+++ b/src/knowledge/__tests__/research-store.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ResearchStore } from "../research-store.ts";
+
+// Ollama isn't reachable in tests, so embed() returns null → the store runs in
+// keyword-only (FTS5/BM25 + RRF) mode. That also exercises the graceful
+// degradation path. (The vector/KNN path is validated separately against a
+// live embedding service.)
+
+let dir: string;
+let store: ResearchStore;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "research-test-"));
+  store = new ResearchStore(join(dir, "knowledge.db"));
+  store.init();
+});
+afterEach(() => {
+  store.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("ResearchStore", () => {
+  test("ingests chunks and finds them via hybrid (keyword) search", async () => {
+    await store.addChunk({ kind: "paper", title: "FlashAttention-3", content: "Faster exact attention with asynchrony and low-precision on Hopper GPUs.", source: "arxiv", url: "https://arxiv.org/abs/2407.08608" });
+    await store.addChunk({ kind: "model_release", title: "Qwen3", content: "New open-weight LLM family from Alibaba with strong reasoning.", source: "huggingface" });
+    const hits = await store.hybridSearch("attention Hopper GPU", 5);
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits[0].title).toBe("FlashAttention-3");
+    expect(hits[0].url).toBe("https://arxiv.org/abs/2407.08608");
+    expect(hits[0].kind).toBe("paper");
+  });
+
+  test("hybridSearch can scope to a kind", async () => {
+    await store.addChunk({ kind: "paper", title: "alpha paper", content: "shared keyword bravo charlie" });
+    await store.addChunk({ kind: "finding", title: "alpha finding", content: "shared keyword bravo delta" });
+    const papers = await store.hybridSearch("bravo", 5, "paper");
+    expect(papers.length).toBe(1);
+    expect(papers[0].kind).toBe("paper");
+  });
+
+  test("returns [] for empty / stopword-only query", async () => {
+    await store.addChunk({ kind: "finding", content: "some content here" });
+    expect(await store.hybridSearch("", 5)).toEqual([]);
+  });
+
+  test("stats counts per kind", async () => {
+    await store.addChunk({ kind: "paper", content: "p1 about transformers" });
+    await store.addChunk({ kind: "paper", content: "p2 about diffusion" });
+    await store.addChunk({ kind: "finding", content: "f1 insight" });
+    const s = store.stats();
+    expect(s.paper).toBe(2);
+    expect(s.finding).toBe(1);
+    expect(s.total).toBe(3);
+  });
+
+  test("preview is truncated; metadata round-trips via ingestion", async () => {
+    const long = "lorem ipsum ".repeat(60);
+    await store.addChunk({ kind: "digest", title: "weekly", content: long, metadata: { topic: "llm" } });
+    const hits = await store.hybridSearch("lorem ipsum", 5);
+    expect(hits[0].preview.endsWith("…")).toBe(true);
+    expect(hits[0].preview.length).toBeLessThanOrEqual(281);
+  });
+});

--- a/src/knowledge/research-store.ts
+++ b/src/knowledge/research-store.ts
@@ -1,0 +1,238 @@
+/**
+ * ResearchStore — the researcher agent's hybrid knowledge base (bun:sqlite).
+ *
+ * Ports protoResearcher's storage layer onto workstacean's rails: a unified
+ * `research_chunks` table mirrored into both an FTS5 index (BM25, lexical) and
+ * a sqlite-vec virtual table (cosine KNN, semantic). `hybridSearch` fuses the
+ * two ranked lists with Reciprocal Rank Fusion — the combination that, per
+ * protoResearcher, fixes the failure modes of either signal alone.
+ *
+ * Embeddings come from the existing Ollama client. The vector half is
+ * best-effort: if the embedding service is down (embed returns null) we simply
+ * store the chunk without a vector and degrade to keyword-only search, never
+ * blocking ingestion. Same file as the rest of the knowledge layer.
+ *
+ * Distinct from KnowledgeStore (Ava's conversation memory) — different domain
+ * (papers/findings/digests/model releases), different agent (researcher).
+ */
+
+import { Database } from "bun:sqlite";
+import { mkdirSync, existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import * as sqliteVec from "sqlite-vec";
+import { embed } from "../services/embeddings/ollama-client.ts";
+
+/** What a chunk represents — drives filtering + how the agent reads it back. */
+export type ResearchKind = "paper" | "finding" | "digest" | "model_release";
+
+export interface ResearchChunkInput {
+  kind: ResearchKind;
+  content: string;
+  title?: string;
+  source?: string;
+  sourceType?: string;
+  url?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ResearchHit {
+  id: number;
+  kind: ResearchKind;
+  title: string | null;
+  preview: string;
+  source: string | null;
+  url: string | null;
+  /** RRF score (hybrid) or single-signal rank score. Higher = better. */
+  score: number;
+}
+
+/** nomic-embed-text is 768-dim; override if pointing OLLAMA_EMBED_MODEL elsewhere. */
+const EMBED_DIM = Number(process.env.RESEARCH_EMBED_DIM ?? 768);
+const RRF_K = 60;
+const PREVIEW_CHARS = 280;
+
+export class ResearchStore {
+  private db: Database | null = null;
+  private vecAvailable = false;
+  private readonly dbPath: string;
+
+  constructor(dbPath?: string) {
+    this.dbPath = resolve(dbPath ?? "data/knowledge.db");
+  }
+
+  init(): void {
+    try {
+      const dir = dirname(this.dbPath);
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+      this.db = new Database(this.dbPath);
+      this.db.exec("PRAGMA journal_mode=WAL;");
+      this.db.exec("PRAGMA synchronous=NORMAL;");
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS research_chunks (
+          id          INTEGER PRIMARY KEY AUTOINCREMENT,
+          kind        TEXT    NOT NULL,
+          title       TEXT,
+          content     TEXT    NOT NULL,
+          source      TEXT,
+          source_type TEXT,
+          url         TEXT,
+          metadata    TEXT,
+          created_at  INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_research_chunks_kind ON research_chunks(kind);
+      `);
+      try {
+        this.db.exec(`
+          CREATE VIRTUAL TABLE IF NOT EXISTS research_fts USING fts5(
+            title, content, content='research_chunks', content_rowid='id'
+          );
+          CREATE TRIGGER IF NOT EXISTS research_ai AFTER INSERT ON research_chunks BEGIN
+            INSERT INTO research_fts(rowid, title, content) VALUES (new.id, new.title, new.content);
+          END;
+          CREATE TRIGGER IF NOT EXISTS research_ad AFTER DELETE ON research_chunks BEGIN
+            INSERT INTO research_fts(research_fts, rowid, title, content) VALUES ('delete', old.id, old.title, old.content);
+          END;
+        `);
+      } catch (err) {
+        console.warn(`[research-store] FTS5 unavailable: ${err instanceof Error ? err.message : String(err)}`);
+      }
+
+      // sqlite-vec — the semantic half. If the extension won't load, we run
+      // keyword-only (still fully functional).
+      try {
+        sqliteVec.load(this.db);
+        this.db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS research_vec USING vec0(embedding float[${EMBED_DIM}])`);
+        this.vecAvailable = true;
+      } catch (err) {
+        console.warn(`[research-store] sqlite-vec unavailable — keyword-only: ${err instanceof Error ? err.message : String(err)}`);
+        this.vecAvailable = false;
+      }
+      console.log(`[research-store] DB ready: ${this.dbPath} (vec=${this.vecAvailable}, dim=${EMBED_DIM})`);
+    } catch (err) {
+      console.error(`[research-store] DB init failed: ${err instanceof Error ? err.message : String(err)}`);
+      this.db = null;
+    }
+  }
+
+  /** Ingest a chunk: row + FTS + (best-effort) embedding. Returns the id or null. */
+  async addChunk(input: ResearchChunkInput): Promise<number | null> {
+    if (!this.db || !input.content.trim()) return null;
+    try {
+      const res = this.db
+        .query(`INSERT INTO research_chunks (kind, title, content, source, source_type, url, metadata, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+        .run(
+          input.kind,
+          input.title ?? null,
+          input.content,
+          input.source ?? null,
+          input.sourceType ?? null,
+          input.url ?? null,
+          input.metadata ? JSON.stringify(input.metadata) : null,
+          Date.now(),
+        );
+      const id = Number(res.lastInsertRowid);
+      if (this.vecAvailable) await this._embedInto(id, `${input.title ?? ""}\n${input.content}`.trim());
+      return id;
+    } catch (err) {
+      console.warn(`[research-store] addChunk failed: ${err instanceof Error ? err.message : String(err)}`);
+      return null;
+    }
+  }
+
+  private async _embedInto(id: number, text: string): Promise<void> {
+    const vec = await embed(text).catch(() => null);
+    if (!vec || vec.length !== EMBED_DIM) return; // embeddings down or dim mismatch → keyword-only for this chunk
+    try {
+      const blob = new Uint8Array(new Float32Array(vec).buffer);
+      this.db!.query(`INSERT INTO research_vec(rowid, embedding) VALUES (?, ?)`).run(id, blob);
+    } catch (err) {
+      console.warn(`[research-store] vector insert failed for ${id}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  /** Lexical BM25 ranks: [{id, rank}], best first. */
+  private _keywordRanked(query: string, k: number, kind?: ResearchKind): Array<{ id: number }> {
+    if (!this.db) return [];
+    const tokens = (query.match(/[\w']+/g) ?? []).filter((t) => t.length > 1);
+    if (tokens.length === 0) return [];
+    const match = tokens.map((t) => `"${t.replace(/"/g, '""')}"`).join(" OR ");
+    try {
+      const sql = kind
+        ? `SELECT c.id FROM research_fts f JOIN research_chunks c ON c.id=f.rowid WHERE research_fts MATCH ? AND c.kind=? ORDER BY rank LIMIT ?`
+        : `SELECT c.id FROM research_fts f JOIN research_chunks c ON c.id=f.rowid WHERE research_fts MATCH ? ORDER BY rank LIMIT ?`;
+      return kind
+        ? this.db.query<{ id: number }, [string, string, number]>(sql).all(match, kind, k)
+        : this.db.query<{ id: number }, [string, number]>(sql).all(match, k);
+    } catch {
+      return [];
+    }
+  }
+
+  /** Semantic KNN ranks: [{id}], nearest first. */
+  private async _vectorRanked(query: string, k: number): Promise<Array<{ id: number }>> {
+    if (!this.db || !this.vecAvailable) return [];
+    const vec = await embed(query).catch(() => null);
+    if (!vec || vec.length !== EMBED_DIM) return [];
+    try {
+      const blob = new Uint8Array(new Float32Array(vec).buffer);
+      return this.db
+        .query<{ id: number }, [Uint8Array, number]>(
+          `SELECT rowid AS id FROM research_vec WHERE embedding MATCH ? ORDER BY distance LIMIT ?`,
+        )
+        .all(blob, k);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Reciprocal Rank Fusion of lexical + semantic results. Falls back cleanly to
+   * whichever signal is available (keyword-only when vectors are off).
+   */
+  async hybridSearch(query: string, k = 5, kind?: ResearchKind): Promise<ResearchHit[]> {
+    if (!this.db) return [];
+    const pool = Math.max(k * 4, 20);
+    const [kw, vec] = await Promise.all([
+      Promise.resolve(this._keywordRanked(query, pool, kind)),
+      this._vectorRanked(query, pool),
+    ]);
+    const scores = new Map<number, number>();
+    kw.forEach((r, i) => scores.set(r.id, (scores.get(r.id) ?? 0) + 1 / (RRF_K + i)));
+    vec.forEach((r, i) => scores.set(r.id, (scores.get(r.id) ?? 0) + 1 / (RRF_K + i)));
+    const topIds = [...scores.entries()].sort((a, b) => b[1] - a[1]).slice(0, k);
+    return topIds.map(([id, score]) => this._hydrate(id, score)).filter((h): h is ResearchHit => h !== null);
+  }
+
+  private _hydrate(id: number, score: number): ResearchHit | null {
+    if (!this.db) return null;
+    const row = this.db
+      .query<{ id: number; kind: string; title: string | null; content: string; source: string | null; url: string | null }, [number]>(
+        `SELECT id, kind, title, content, source, url FROM research_chunks WHERE id = ?`,
+      )
+      .get(id);
+    if (!row) return null;
+    const preview = row.content.length > PREVIEW_CHARS ? row.content.slice(0, PREVIEW_CHARS) + "…" : row.content;
+    return { id: row.id, kind: row.kind as ResearchKind, title: row.title, preview, source: row.source, url: row.url, score };
+  }
+
+  /** Row counts per kind — for the research_memory `stats` action. */
+  stats(): Record<string, number> {
+    if (!this.db) return {};
+    try {
+      const rows = this.db.query<{ kind: string; n: number }, []>(`SELECT kind, count(*) n FROM research_chunks GROUP BY kind`).all();
+      const out: Record<string, number> = {};
+      let total = 0;
+      for (const r of rows) { out[r.kind] = r.n; total += r.n; }
+      out.total = total;
+      return out;
+    } catch {
+      return {};
+    }
+  }
+
+  close(): void {
+    if (this.db) { this.db.close(); this.db = null; }
+  }
+}

--- a/workspace/agents/researcher.yaml
+++ b/workspace/agents/researcher.yaml
@@ -1,0 +1,71 @@
+# Researcher — deep context retrieval + research synthesis.
+#
+# In-process DeepAgent. Gathers AI/ML developments from distributed sources
+# (HuggingFace, GitHub, the team's Discord feed, the web), reasons over them,
+# and accumulates findings into a hybrid (semantic + keyword) knowledge base
+# that the whole fleet can recall. Ava delegates research to it via
+# chat_with_agent(agent="researcher", skill="deep_research").
+name: researcher
+role: research
+
+model: protolabs/reasoning
+
+systemPrompt: |
+  You are the protoLabs researcher — the fleet's deep-context retrieval and
+  synthesis agent. Your job is to turn a question or topic into grounded,
+  cited understanding, and to grow a durable research knowledge base.
+
+  Your loop for any research request:
+  1. Start with `research_search` to reuse what's already known — prior papers,
+     findings, digests, and model releases live there. Build on them.
+  2. Gather fresh signal from the right sources:
+     - `huggingface_search` for models and datasets,
+     - `github_trending` for projects, releases, and activity,
+     - `discord_scan_feed` for links the team is already sharing,
+     - `searxng_search` for the open web (use `!scholar`, `!arxiv` bangs for papers).
+  3. Synthesize: weigh the sources, note agreement and tension, and ground every
+     claim in a source. Prefer primary sources (papers, repos, model cards).
+  4. Persist what's worth keeping with `research_ingest` — store distinct
+     findings (kind: finding), notable papers (kind: paper), and model releases
+     (kind: model_release) with their source URLs, so future research recalls them.
+  5. Answer with a concise, cited synthesis. Lead with the takeaway, then the
+     evidence. Link sources inline.
+
+  Keep findings atomic and factual — one insight per ingested finding, with its
+  source. When the request is a digest, summarize the period's developments and
+  store it with `research_ingest` (kind: digest).
+
+tools:
+  - research_search
+  - research_ingest
+  - research_stats
+  - huggingface_search
+  - github_trending
+  - discord_scan_feed
+  - searxng_search
+
+maxTurns: 30
+
+# Multi-turn research sessions retain their own thread context + recall prior
+# research conversations. Scoped to the research skills.
+memory:
+  enabled: true
+  skills: [deep_research, research_digest]
+  historyTurns: 12
+  recallTopK: 6
+  harvest: true
+
+skills:
+  - name: deep_research
+    description: >
+      Research a topic or question end-to-end: recall prior knowledge, gather
+      from HuggingFace / GitHub / Discord feed / web, synthesize with citations,
+      and persist findings to the knowledge base. Returns a grounded summary.
+    keywords: [deep_research, research, investigate, look into, gather context, what's new, state of the art, sota]
+
+  - name: research_digest
+    description: >
+      Produce a digest of recent AI/ML developments — scan the sources, pull the
+      notable papers/models/releases, synthesize the highlights, and store the
+      digest (kind: digest) for recall + publishing.
+    keywords: [research_digest, digest, weekly research, research report, roundup]

--- a/workspace/ceremonies/research-digest.yaml
+++ b/workspace/ceremonies/research-digest.yaml
@@ -1,0 +1,23 @@
+id: research-digest
+name: "Research Digest"
+description: >
+  Weekly AI/ML research roundup. The researcher agent scans its sources
+  (HuggingFace, GitHub, the team's Discord feed, the web), pulls the notable
+  papers / models / releases, synthesizes the highlights, stores the digest in
+  the research knowledge base, and the outcome is posted to the research channel.
+# Monday 09:00 — start of the week. Cron: min hour dom mon dow.
+schedule: "0 9 * * 1"
+# research_digest lives on the researcher agent. The skill owns producing +
+# storing the digest (kind: digest); the ceremony only triggers it — no content
+# injection (the agent owns its response).
+skill: research_digest
+targets:
+  - researcher
+# Posts the digest to the research channel via DISCORD_WEBHOOK_RESEARCH.
+# NOTE: set that webhook env (Discord webhook → Infisical secret) for the post
+# to land; until then the digest still runs + is stored in the KB, the publish
+# step just no-ops. Switch to "updates" to reuse the existing fleet channel.
+notifyChannel: "research"
+# Research scans multiple sources + synthesizes — give it room.
+timeoutMs: 600000
+enabled: true


### PR DESCRIPTION
Folds protoResearcher's capabilities into workstacean as an in-process DeepAgent (the standalone A2A service is sunset). Builds directly on this session's KnowledgeStore work — the storage layer was ~70% there already. Four phases, each its own commit.

## Decisions (confirmed with operator)
- **Dedicated researcher agent** (not a skill on Ava) — `researcher.yaml`, role `research`; Ava delegates via `chat_with_agent`.
- **sqlite-vec in `knowledge.db`** for the vector half (verified loadable + KNN-correct under Bun) — keeps the "scoped store in workstacean" literal, no extra service.

## Phases
- **R1 — hybrid `ResearchStore`**: unified `research_chunks` (kind = paper/finding/digest/model_release) mirrored into FTS5 (BM25) + sqlite-vec (cosine KNN over Ollama nomic-embed-text), fused via RRF. Vector half is best-effort — degrades to keyword-only if embeddings/extension are unavailable.
- **R2 — tools**: `/api/research/{search,ingest,stats}` over the store; DeepAgent tools `research_search` / `research_ingest` / `research_stats` + source connectors `huggingface_search`, `github_trending` (opt `GITHUB_TOKEN`), `discord_scan_feed` (extracts + classifies links from the team's feed). All defensive.
- **R3 — `researcher.yaml`**: in-process DeepAgent with the research toolbelt + `searxng_search`, `deep_research` + `research_digest` skills, memory flywheel scoped to those skills. All 7 declared tools resolve (no phantoms).
- **R4 — weekly `research-digest` ceremony**: Mon 09:00 → researcher synthesizes + stores a digest → posts to the research channel (CeremonyNotifier). No content injection.

## Tests
12 new (research-store + the keyword-only fallback path); `tsc` clean; **full suite green — 1018 pass / 0 fail**.

## Deploy notes
- New dep `sqlite-vec` ships in the image. `researcher.yaml` + `research-digest.yaml` are **workspace config** (bind-mount) — sync to the live mount + hot-reload, per the config-vs-code split.
- Set `DISCORD_WEBHOOK_RESEARCH` for the digest to publish (else it runs + stores, publish no-ops).

## Follow-ups (noted, not blocking)
- `pdf_read` tool (needs a PDF lib — PyMuPDF equivalent).
- rabbit-hole knowledge-graph bridge (optional, from the audit).
- Live smoke once deployed (Ollama embeddings populate the vector half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a research knowledge base system with hybrid search and ingestion capabilities.
  * Added API endpoints for researching, storing, and retrieving statistics.
  * Introduced discovery tools for agents to search HuggingFace, GitHub trending, and Discord feeds.
  * Added a researcher agent for research synthesis and digest generation.
  * Enabled weekly automated research digest generation and publishing via Discord.

* **Chores**
  * Added sqlite-vec dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->