### PR TITLE
fix(research): embed via the LiteLLM gateway (lights up the semantic half)

### DIFF
--- a/src/knowledge/research-store.ts
+++ b/src/knowledge/research-store.ts
@@ -20,7 +20,7 @@ import { Database } from "bun:sqlite";
 import { mkdirSync, existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import * as sqliteVec from "sqlite-vec";
-import { embed } from "../services/embeddings/ollama-client.ts";
+import { gatewayEmbed as embed } from "../services/embeddings/gateway-embed.ts";
 
 /** What a chunk represents — drives filtering + how the agent reads it back. */
 export type ResearchKind = "paper" | "finding" | "digest" | "model_release";
@@ -46,8 +46,8 @@ export interface ResearchHit {
   score: number;
 }
 
-/** nomic-embed-text is 768-dim; override if pointing OLLAMA_EMBED_MODEL elsewhere. */
-const EMBED_DIM = Number(process.env.RESEARCH_EMBED_DIM ?? 768);
+/** Gateway text-embedding-3-small is 1024-dim as served; override via env if RESEARCH_EMBED_MODEL changes. */
+const EMBED_DIM = Number(process.env.RESEARCH_EMBED_DIM ?? 1024);
 const RRF_K = 60;
 const PREVIEW_CHARS = 280;
 
@@ -102,6 +102,15 @@ export class ResearchStore {
       // keyword-only (still fully functional).
       try {
         sqliteVec.load(this.db);
+        // Rebuild the vec table if its declared dimension changed (e.g. the
+        // embedding model was swapped). Vectors are regenerable, so dropping a
+        // stale-dim table is safe — and we only do it on a real mismatch, so
+        // vectors survive ordinary restarts.
+        const existing = this.db.query<{ sql: string }, []>(`SELECT sql FROM sqlite_master WHERE name='research_vec'`).get();
+        if (existing && !existing.sql.includes(`float[${EMBED_DIM}]`)) {
+          console.warn(`[research-store] research_vec dimension changed → rebuilding as float[${EMBED_DIM}]`);
+          this.db.exec(`DROP TABLE research_vec`);
+        }
         this.db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS research_vec USING vec0(embedding float[${EMBED_DIM}])`);
         this.vecAvailable = true;
       } catch (err) {

--- a/src/services/embeddings/gateway-embed.ts
+++ b/src/services/embeddings/gateway-embed.ts
@@ -1,0 +1,54 @@
+/**
+ * gateway-embed.ts — embeddings via the LiteLLM gateway (OpenAI-compatible).
+ *
+ * The researcher's hybrid store embeds through the fleet gateway rather than a
+ * direct Ollama connection, so it uses the same provisioned, auth'd, observable
+ * model surface as every other LLM call. POSTs to `${gateway}/embeddings` with
+ * the OpenAI shape ({model, input}) and reads `data[0].embedding`.
+ *
+ * Default model `text-embedding-3-small` (1024-dim as the gateway serves it).
+ * Best-effort: any failure returns null so the caller degrades to keyword-only
+ * search rather than blocking ingestion.
+ */
+
+const GATEWAY_URL = process.env.LLM_GATEWAY_URL ?? process.env.OPENAI_BASE_URL ?? "http://gateway:4000/v1";
+const API_KEY = process.env.OPENAI_API_KEY ?? "";
+const EMBED_MODEL = process.env.RESEARCH_EMBED_MODEL ?? "text-embedding-3-small";
+const TIMEOUT_MS = 15_000;
+
+interface EmbeddingsResponse {
+  data?: Array<{ embedding?: number[] }>;
+}
+
+/** Embed one text through the gateway. Returns the vector, or null on failure. */
+export async function gatewayEmbed(text: string): Promise<number[] | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(`${GATEWAY_URL.replace(/\/$/, "")}/embeddings`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(API_KEY ? { Authorization: `Bearer ${API_KEY}` } : {}),
+      },
+      body: JSON.stringify({ model: EMBED_MODEL, input: text }),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      console.error(`[gateway-embed] failed ${res.status}: ${(await res.text()).slice(0, 200)}`);
+      return null;
+    }
+    const data = (await res.json()) as EmbeddingsResponse;
+    const vec = data.data?.[0]?.embedding;
+    if (!Array.isArray(vec) || vec.length === 0) {
+      console.error("[gateway-embed] empty embedding in response");
+      return null;
+    }
+    return vec;
+  } catch (err) {
+    console.error("[gateway-embed] error:", err instanceof Error ? err.message : String(err));
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
Follow-up to #769. The researcher's vector/semantic half was dark in prod: `OLLAMA_URL` is unset and there's no Ollama on the hub network, so `embed()` failed and the hybrid store ran keyword-only. Route embeddings through the **LiteLLM gateway** instead (OpenAI-compatible `/embeddings`, model `text-embedding-3-small`, 1024-dim as the gateway serves it) — same provisioned/auth'd/observable surface as every other LLM call.

- `src/services/embeddings/gateway-embed.ts` — `gatewayEmbed(text)`; best-effort (null on failure → keyword-only fallback preserved).
- `ResearchStore` switches to it; `EMBED_DIM` 768→1024 + a safe dim-migration that rebuilds `research_vec` only on a real dimension change (handles the live switch; vectors regenerable, survive ordinary restarts).

Verified the gateway `/embeddings` endpoint returns 1024-dim live. tsc clean; tests green. After deploy I'll re-run the ingest + a purely-semantic query to confirm the vector half now hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated embedding service integration and enhanced database compatibility checks for improved system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->