### PR TITLE
feat(ceremony): explicit notifyWebhookEnv → wire research-digest to DISCORD_RESEARCH_WEBHOOK

### DIFF
--- a/src/integrations/discord/CeremonyNotifier.ts
+++ b/src/integrations/discord/CeremonyNotifier.ts
@@ -33,8 +33,8 @@ export class CeremonyNotifier {
    * If notifyChannel is provided, attempts to resolve a channel-specific webhook.
    * Returns true on success, false on fallback.
    */
-  async notify(outcome: CeremonyOutcome, ceremonyName: string, notifyChannel?: string): Promise<boolean> {
-    const webhookUrl = this._resolveWebhook(notifyChannel);
+  async notify(outcome: CeremonyOutcome, ceremonyName: string, notifyChannel?: string, webhookEnv?: string): Promise<boolean> {
+    const webhookUrl = this._resolveWebhook(notifyChannel, webhookEnv);
 
     if (!webhookUrl) {
       this._logFallback(outcome, ceremonyName);
@@ -64,9 +64,11 @@ export class CeremonyNotifier {
     }
   }
 
-  private _resolveWebhook(channelSlug?: string): string | null {
+  private _resolveWebhook(channelSlug?: string, webhookEnv?: string): string | null {
+    // Explicit env var override (e.g. DISCORD_RESEARCH_WEBHOOK) wins.
+    if (webhookEnv && process.env[webhookEnv]) return process.env[webhookEnv]!;
     if (channelSlug) {
-      // Try channel-specific webhook env var
+      // Channel-specific webhook env var: DISCORD_WEBHOOK_<SLUG>.
       const envKey = `DISCORD_WEBHOOK_${channelSlug.toUpperCase().replace(/-/g, "_")}`;
       const channelUrl = process.env[envKey];
       if (channelUrl) return channelUrl;

--- a/src/integrations/discord/__tests__/CeremonyNotifier.test.ts
+++ b/src/integrations/discord/__tests__/CeremonyNotifier.test.ts
@@ -92,4 +92,20 @@ describe("Discord ceremony notifications", () => {
 
     delete process.env.DISCORD_WEBHOOK_GENERAL;
   });
+
+  test("Discord notify: explicit webhookEnv overrides the channel-derived env", async () => {
+    process.env.DISCORD_WEBHOOK_RESEARCH = "http://localhost:0/derived";
+    process.env.DISCORD_RESEARCH_WEBHOOK = "http://localhost:0/explicit-override";
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(new Response("", { status: 204 }));
+
+    const notifier = new CeremonyNotifier(undefined);
+    const ok = await notifier.notify(makeOutcome(), "Research Digest", "research", "DISCORD_RESEARCH_WEBHOOK");
+
+    expect(ok).toBe(true);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe("http://localhost:0/explicit-override");
+
+    fetchSpy.mockRestore();
+    delete process.env.DISCORD_WEBHOOK_RESEARCH;
+    delete process.env.DISCORD_RESEARCH_WEBHOOK;
+  });
 });

--- a/src/loaders/ceremonyYamlLoader.ts
+++ b/src/loaders/ceremonyYamlLoader.ts
@@ -153,6 +153,7 @@ export class CeremonyYamlLoader {
       skill: c.skill,
       targets: c.targets as string[],
       notifyChannel: typeof c.notifyChannel === "string" ? c.notifyChannel : undefined,
+      notifyWebhookEnv: typeof c.notifyWebhookEnv === "string" ? c.notifyWebhookEnv : undefined,
       enabled: c.enabled !== false,
       timeoutMs: typeof c.timeoutMs === "number" && c.timeoutMs > 0 ? c.timeoutMs : undefined,
     };

--- a/src/plugins/CeremonyPlugin.ts
+++ b/src/plugins/CeremonyPlugin.ts
@@ -474,7 +474,7 @@ export class CeremonyPlugin implements Plugin {
     // Send Discord notification (non-blocking)
     if (ceremony) {
       this.notifier
-        .notify(outcome, ceremony.name, ceremony.notifyChannel)
+        .notify(outcome, ceremony.name, ceremony.notifyChannel, ceremony.notifyWebhookEnv)
         .catch((err) => {
           console.error("[ceremony] Discord notification error:", err);
         });

--- a/src/plugins/CeremonyPlugin.types.ts
+++ b/src/plugins/CeremonyPlugin.types.ts
@@ -16,8 +16,14 @@ export interface Ceremony {
   skill: string;
   /** Project paths to target, or ['all'] for all projects */
   targets: string[];
-  /** Optional Discord channel slug for outcome notifications */
+  /** Optional Discord channel slug for outcome notifications (→ DISCORD_WEBHOOK_<SLUG>) */
   notifyChannel?: string;
+  /**
+   * Optional explicit env var holding the notification webhook URL — takes
+   * precedence over notifyChannel's derived DISCORD_WEBHOOK_<SLUG>. Use when the
+   * webhook secret follows a different naming pattern (e.g. DISCORD_RESEARCH_WEBHOOK).
+   */
+  notifyWebhookEnv?: string;
   /** Whether this ceremony is active */
   enabled: boolean;
   /** Optional per-ceremony timeout in milliseconds. Defaults to no timeout. */

--- a/src/schemas/yaml-schemas.ts
+++ b/src/schemas/yaml-schemas.ts
@@ -185,6 +185,7 @@ export const CeremonySchema = z.object({
   skill: z.string().min(1, "Ceremony skill must not be empty"),
   targets: z.array(z.string()).min(1, "Ceremony targets must be a non-empty array"),
   notifyChannel: z.string().optional(),
+  notifyWebhookEnv: z.string().optional(),
   enabled: z.boolean().default(true),
 });
 

--- a/workspace/ceremonies/research-digest.yaml
+++ b/workspace/ceremonies/research-digest.yaml
@@ -13,11 +13,12 @@ schedule: "0 9 * * 1"
 skill: research_digest
 targets:
   - researcher
-# Posts the digest to the research channel via DISCORD_WEBHOOK_RESEARCH.
-# NOTE: set that webhook env (Discord webhook → Infisical secret) for the post
-# to land; until then the digest still runs + is stored in the KB, the publish
-# step just no-ops. Switch to "updates" to reuse the existing fleet channel.
+# Posts the digest to the research channel. Uses the explicit webhook env
+# DISCORD_RESEARCH_WEBHOOK (set as an Infisical secret in workstacean's prod env).
+# Until that env is injected the digest still runs + is stored in the KB; the
+# publish step just no-ops. notifyChannel is the fallback derivation.
 notifyChannel: "research"
+notifyWebhookEnv: "DISCORD_RESEARCH_WEBHOOK"
 # Research scans multiple sources + synthesizes — give it room.
 timeoutMs: 600000
 enabled: true


### PR DESCRIPTION
The operator provisioned the research webhook as **`DISCORD_RESEARCH_WEBHOOK`** (the `DISCORD_RELEASE_WEBHOOK` pattern), but CeremonyNotifier only derived `DISCORD_WEBHOOK_<SLUG>` from notifyChannel. Adds an optional per-ceremony `notifyWebhookEnv` that names the webhook env explicitly and takes precedence — so the secret works under its given name without a rename. Threaded through the Ceremony type, zod schema, yaml loader, notifier, and plugin call site; research-digest.yaml points at `DISCORD_RESEARCH_WEBHOOK`. Graceful fallback preserved. +1 test; suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for explicit Discord webhook environment variable configuration in ceremony definitions, allowing users to specify custom webhook environment variables that take precedence over default channel-derived variables.

* **Tests**
  * Added test coverage for webhook environment variable override behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->