### PR TITLE
fix(a2a): emit final answer as a terminal Artifact (#773)

### DIFF
--- a/packages/a2a/src/index.ts
+++ b/packages/a2a/src/index.ts
@@ -16,7 +16,7 @@
  */
 
 // Part builders + readers (1.0 member-discriminated Part)
-export { textPart, dataPart, partText, partData, partsToText } from "./parts.ts";
+export { textPart, textArtifact, dataPart, partText, partData, partsToText } from "./parts.ts";
 
 // Structured skill results (output_schema → forced-finalizer DataPart)
 export {

--- a/packages/a2a/src/parts.ts
+++ b/packages/a2a/src/parts.ts
@@ -8,7 +8,7 @@
  * discrimination in one place so callers never hand-assemble a Part.
  */
 
-import type { Part } from "@a2a-js/sdk";
+import type { Part, Artifact } from "@a2a-js/sdk";
 
 /** Build a text Part: `{ content: { $case: "text", value } }`. */
 export function textPart(text: string): Part {
@@ -17,6 +17,26 @@ export function textPart(text: string): Part {
     metadata: undefined,
     filename: "",
     mediaType: "text/plain",
+  };
+}
+
+/**
+ * Build a terminal text Artifact carrying an agent's final answer.
+ *
+ * A2A clients read a task's result from `task.artifacts[].parts[].text` — the
+ * canonical "agent output" location. Emitting the answer as an artifact (in
+ * addition to the completion `status.message`) is the fleet-canonical placement
+ * so every A2A consumer gets the answer the same way, matching the Python
+ * `protolabs-a2a` executor. (#773)
+ */
+export function textArtifact(text: string, opts: { artifactId?: string; name?: string } = {}): Artifact {
+  return {
+    artifactId: opts.artifactId ?? crypto.randomUUID(),
+    name: opts.name ?? "answer",
+    description: "",
+    parts: [textPart(text)],
+    metadata: undefined,
+    extensions: [],
   };
 }
 

--- a/src/api/__tests__/a2a-server.test.ts
+++ b/src/api/__tests__/a2a-server.test.ts
@@ -109,6 +109,16 @@ describe("BusAgentExecutor (Phase 7)", () => {
     expect(completedEvt.data.status?.state).toBe(TaskState.TASK_STATE_COMPLETED);
     const terminalText = (completedEvt.data.status?.message?.parts ?? []).map(partText).join("");
     expect(terminalText).toBe("42");
+
+    // #773: the answer is ALSO emitted as a terminal Artifact (the A2A-canonical
+    // result location) so clients reading task.artifacts get it, not only
+    // status.message.
+    const artifactEvt = collected.find(e => e.kind === "artifactUpdate");
+    expect(artifactEvt).toBeDefined();
+    if (artifactEvt?.kind !== "artifactUpdate") throw new Error("expected artifactUpdate");
+    expect(artifactEvt.data.lastChunk).toBe(true);
+    const artifactText = (artifactEvt.data.artifact?.parts ?? []).map(partText).join("");
+    expect(artifactText).toBe("42");
   });
 
   test("error response maps to failed status-update", async () => {

--- a/src/api/a2a-server.ts
+++ b/src/api/a2a-server.ts
@@ -37,7 +37,7 @@ import {
 } from "@a2a-js/sdk/server";
 import { join } from "node:path";
 import { Role, TaskState, type Message } from "@a2a-js/sdk";
-import { textPart, partText } from "@protolabs/a2a";
+import { textPart, partText, textArtifact } from "@protolabs/a2a";
 import type { Route, ApiContext } from "./types.ts";
 import type { BusMessage } from "../../lib/types.ts";
 import { buildAgentCard } from "./agent-card.ts";
@@ -273,6 +273,22 @@ class BusAgentExecutor implements AgentExecutor {
         // together close the stream.
         const finalState = errorText ? TaskState.TASK_STATE_FAILED : TaskState.TASK_STATE_COMPLETED;
         const finalText = errorText || contentText || "";
+
+        // Emit the answer as a terminal Artifact — the A2A-canonical result
+        // location clients read from `task.artifacts`. Without this, clients
+        // that don't fall back to `status.message` get an empty answer. Matches
+        // protolabs-a2a (Python). Only on success with real text; failures carry
+        // the error on status.message below. (#773)
+        if (finalState === TaskState.TASK_STATE_COMPLETED && finalText) {
+          eventBus.publish(AgentEvent.artifactUpdate({
+            taskId,
+            contextId,
+            artifact: textArtifact(finalText),
+            append: false,
+            lastChunk: true,
+            metadata: undefined,
+          }));
+        }
 
         eventBus.publish(AgentEvent.statusUpdate({
           taskId,


### PR DESCRIPTION
Closes #773.

WorkStacean's A2A server placed an agent's final answer only on `status.message` (+ history), leaving `task.artifacts: []`. A standard A2A client reading the result from `task.artifacts` (the canonical agent-output location) got an **empty answer** — ORBIS hit this (voice delegation → `"ava says — "`).

**Fix:** on successful completion, publish an `artifact-update` (via `AgentEvent.artifactUpdate`) carrying the final text **before** the terminal completed status, so the completed Task has ≥1 artifact whose text part is the answer. `status.message` is kept (status + `input-required` prompts); failures still carry the error on `status.message` only.

- New shared helper **`@protolabs/a2a textArtifact(text)`** — builds the terminal text Artifact so the placement is consistent for **every** WorkStacean-routed agent, matching the Python `protolabs-a2a` / `OrbisAgentExecutor` convention.

**Acceptance** (from the issue): completed Task has ≥1 artifact with the answer; a client reading `task.artifacts[].parts[].text` gets it without falling back to `status.message`; TS + Python convention layers agree (artifacts). Test asserts the `artifactUpdate` (lastChunk) text == the answer. tsc clean; full suite green (1024).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added helper function for creating text-based artifacts representing agent final answers, supporting custom artifact identifiers and names with automatic ID generation
* Agent completion now emits artifact updates containing the terminal answer, making final results accessible through task artifacts in addition to status messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->