### PR TITLE
fix(a2a): TaskTracker reads 1.0 part shape on poll + push paths (#765)

### DIFF
--- a/src/executor/__tests__/task-tracker-part-shape.test.ts
+++ b/src/executor/__tests__/task-tracker-part-shape.test.ts
@@ -1,0 +1,77 @@
+import { describe, test, expect } from "bun:test";
+import { Part } from "@a2a-js/sdk";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import type { BusMessage } from "../../../lib/types.ts";
+import { TaskTracker } from "../task-tracker.ts";
+import { emitWorldStateDelta, textPart } from "@protolabs/a2a";
+import type { A2AExecutor } from "../executors/a2a-executor.ts";
+
+// Regression for #765: TaskTracker's webhook-callback path used to read the
+// legacy 0.3 part shape ({kind,text,data}). A 1.0 push body is RAW proto3-JSON
+// (text part = {text}, data part = {data,metadata,mediaType} — no `kind`), so
+// text came back empty and worldstate-delta never published. The fix normalizes
+// via Part.fromJSON and uses the @protolabs/a2a helpers.
+
+/** Serialize a part to the proto3-JSON wire shape an agent's push body carries. */
+const wire = (p: Part) => Part.toJSON(p) as unknown;
+
+function makeTracker() {
+  const bus = new InMemoryEventBus();
+  const tracker = new TaskTracker({ bus });
+  tracker.track({
+    correlationId: "corr-765",
+    taskId: "task-765",
+    agentName: "roxy",
+    replyTopic: "agent.skill.response.corr-765",
+    executor: {} as unknown as A2AExecutor,
+  });
+  return { bus, tracker };
+}
+
+describe("TaskTracker handleCallback — 1.0 raw-wire parts (#765)", () => {
+  test("extracts answer text + publishes worldstate-delta from a raw-wire callback body", () => {
+    const { bus, tracker } = makeTracker();
+    const replies: BusMessage[] = [];
+    const deltas: BusMessage[] = [];
+    bus.subscribe("agent.skill.response.corr-765", "t", (m) => { replies.push(m); });
+    bus.subscribe("world.state.delta", "t", (m) => { deltas.push(m); });
+
+    tracker.handleCallback("corr-765", {
+      status: { state: "completed" },
+      artifacts: [
+        { parts: [
+          wire(textPart("Portfolio is healthy — 0 blocked PRs.")),
+          wire(emitWorldStateDelta({ deltas: [{ domain: "ci", path: "data.blockedPRs", op: "set", value: 0 }] })),
+        ] },
+      ],
+    });
+
+    // text extracted from the raw-wire text part (was empty under the 0.3 filter)
+    expect(replies).toHaveLength(1);
+    const reply = replies[0].payload as Record<string, unknown>;
+    expect(reply.content).toBe("Portfolio is healthy — 0 blocked PRs.");
+    expect(reply.taskState).toBe("completed");
+
+    // worldstate-delta published from the raw-wire data part (was dropped)
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0].payload as Record<string, unknown>).toMatchObject({
+      domain: "ci", path: "data.blockedPRs", op: "set", value: 0,
+      sourceAgent: "roxy", sourceTaskId: "task-765",
+    });
+    tracker.destroy();
+  });
+
+  test("input-required text reads from raw-wire status.message parts", () => {
+    const { bus, tracker } = makeTracker();
+    const replies: BusMessage[] = [];
+    bus.subscribe("agent.skill.response.corr-765", "t", (m) => { replies.push(m); });
+
+    tracker.handleCallback("corr-765", {
+      status: { state: "input-required", message: { parts: [wire(textPart("Approve shell command?"))] } },
+    });
+
+    expect(replies).toHaveLength(1);
+    expect((replies[0].payload as Record<string, unknown>).error).toContain("Approve shell command?");
+    tracker.destroy();
+  });
+});

--- a/src/executor/task-tracker.ts
+++ b/src/executor/task-tracker.ts
@@ -15,11 +15,29 @@
 import type { EventBus } from "../../lib/types.ts";
 import type { A2AExecutor } from "./executors/a2a-executor.ts";
 import type { AgentSkillResponsePayload } from "../event-bus/payloads.ts";
+import { Part } from "@a2a-js/sdk";
+import { partText, parseWorldStateDelta } from "@protolabs/a2a";
 
 const TERMINAL_STATES = new Set(["completed", "failed", "canceled", "rejected"]);
 
-/** Extension URI for worldstate-delta-v1 artifacts. */
-const WORLDSTATE_DELTA_URI = "https://proto-labs.ai/a2a/ext/worldstate-delta-v1";
+/**
+ * Normalize parts that may arrive raw (proto3-JSON wire, from a push-notification
+ * callback body) OR already SDK-deserialized (`content.$case`, from the poll
+ * path) into a uniform SDK Part[] so the `@protolabs/a2a` helpers work on both.
+ * Defensive: a malformed part is dropped, never thrown. (#765)
+ */
+function normalizeParts(raw: unknown): Part[] {
+  if (!Array.isArray(raw)) return [];
+  const out: Part[] = [];
+  for (const p of raw) {
+    try {
+      out.push((p as { content?: unknown })?.content ? (p as Part) : Part.fromJSON(p));
+    } catch { /* skip malformed */ }
+  }
+  return out;
+}
+
+const textOf = (parts: Part[]): string => parts.map(partText).filter((t): t is string => !!t).join("");
 
 export interface TrackedTask {
   correlationId: string;
@@ -139,15 +157,13 @@ export class TaskTracker {
     const task = this.tasks.get(correlationId);
     if (!task) return;
 
-    const status = (body.status ?? {}) as { state?: string; message?: { parts?: Array<{ kind?: string; text?: string }> } };
+    const status = (body.status ?? {}) as { state?: string; message?: { parts?: unknown[] } };
     const state = typeof status.state === "string" ? status.state : undefined;
 
     task.lastPolledAt = Date.now();
 
     if (state === "input-required") {
-      const statusText = status.message?.parts
-        ? status.message.parts.filter(p => p.kind === "text").map(p => p.text ?? "").join("")
-        : "";
+      const statusText = textOf(normalizeParts(status.message?.parts));
       console.warn(
         `[task-tracker] ${task.agentName} task ${task.taskId.slice(0, 8)}… is input-required ` +
         `but no approval gate is wired — terminating with failure. Question: ${statusText || "(none)"}`,
@@ -162,16 +178,13 @@ export class TaskTracker {
       return;
     }
 
-    // Extract text from artifacts (primary) or status.message (fallback)
-    const artifacts = (body.artifacts ?? []) as Array<{ extensions?: string[]; parts?: Array<{ kind?: string; text?: string; data?: Record<string, unknown> }> }>;
-    const artifactText = artifacts
-      .flatMap(a => a.parts ?? [])
-      .filter((p): p is { kind: "text"; text: string } => p.kind === "text" && typeof p.text === "string")
-      .map(p => p.text)
-      .join("\n");
-    const statusText = status.message?.parts
-      ? status.message.parts.filter(p => p.kind === "text").map(p => p.text ?? "").join("")
-      : "";
+    // Extract text from artifacts (primary) or status.message (fallback).
+    // The callback body is RAW wire proto3-JSON, so normalize parts to SDK
+    // shape (content.$case) before reading them. (#765)
+    const rawArtifacts = (body.artifacts ?? []) as Array<{ parts?: unknown }>;
+    const artifacts = rawArtifacts.map(a => ({ parts: normalizeParts(a.parts) }));
+    const artifactText = artifacts.flatMap(a => a.parts).map(partText).filter((t): t is string => !!t).join("\n");
+    const statusText = textOf(normalizeParts(status.message?.parts));
     const content = artifactText || statusText;
     const isError = state === "failed" || state === "rejected";
 
@@ -238,8 +251,11 @@ export class TaskTracker {
         }
 
         if (state && TERMINAL_STATES.has(state)) {
-          const rawArtifacts = (result.data?.artifacts ?? []) as Array<{ extensions?: string[]; parts?: Array<{ kind?: string; text?: string; data?: Record<string, unknown> }> }>;
-          this._extractAndPublishDeltas(task.taskId, task.agentName, rawArtifacts);
+          // pollTask returns SDK-deserialized (content.$case) artifacts; normalize
+          // is a no-op for those but keeps _extractAndPublishDeltas shape-uniform.
+          const polledArtifacts = (result.data?.artifacts ?? []) as Array<{ parts?: unknown }>;
+          const artifacts = polledArtifacts.map(a => ({ parts: normalizeParts(a.parts) }));
+          this._extractAndPublishDeltas(task.taskId, task.agentName, artifacts);
           // Record cost-v1/confidence-v1 samples here: execute() returned
           // non-terminal (it handed off to us) so it skipped its after-hooks.
           // result.data carries the extension payloads pollTask extracted.
@@ -260,26 +276,24 @@ export class TaskTracker {
   }
 
   /**
-   * Scan terminal task artifacts for worldstate-delta-v1 data parts and publish
-   * a `world.state.delta` event for each one. Idempotent: a given taskId is
-   * processed at most once even if both the callback and sweep paths fire.
+   * Scan terminal task artifacts for a worldstate-delta-v1 DataPart and publish
+   * a `world.state.delta` event per delta entry. Parts are SDK-shaped
+   * (content.$case) — callers normalize raw-wire bodies first. Idempotent: a
+   * given taskId is processed at most once even if both the callback and sweep
+   * paths fire. (#765 — was reading the legacy 0.3 `kind`/`data` shape.)
    */
   private _extractAndPublishDeltas(
     taskId: string,
     agentName: string,
-    artifacts: Array<{
-      extensions?: string[];
-      parts?: Array<{ kind?: string; text?: string; data?: Record<string, unknown> }>;
-    }>,
+    artifacts: Array<{ parts?: Part[] }>,
   ): void {
     if (this.publishedDeltaTaskIds.has(taskId)) return;
     this.publishedDeltaTaskIds.add(taskId);
 
     for (const artifact of artifacts) {
-      if (!artifact.extensions?.includes(WORLDSTATE_DELTA_URI)) continue;
-      for (const part of artifact.parts ?? []) {
-        if (part.kind !== "data" || !part.data) continue;
-        const { domain, path, op, value } = part.data;
+      const delta = parseWorldStateDelta(artifact.parts ?? []);
+      for (const entry of delta?.deltas ?? []) {
+        const { domain, path, op, value } = entry;
         if (typeof domain !== "string" || typeof path !== "string" || typeof op !== "string") continue;
 
         const topic = "world.state.delta";
@@ -288,14 +302,7 @@ export class TaskTracker {
           correlationId: taskId,
           topic,
           timestamp: Date.now(),
-          payload: {
-            domain,
-            path,
-            op,
-            value,
-            sourceTaskId: taskId,
-            sourceAgent: agentName,
-          },
+          payload: { domain, path, op, value, sourceTaskId: taskId, sourceAgent: agentName },
         });
         console.log(
           `[task-tracker] world.state.delta: ${domain}.${path} op=${op} from ${agentName} (task ${taskId.slice(0, 8)}…)`,


### PR DESCRIPTION
Closes #765 — the final follow-up to the #763/#764/#766 A2A telemetry fixes.

`TaskTracker` still read the legacy 0.3 part shape (`{kind,text,data}`) in two spots, so on the **poll + push-callback completion paths**:
1. **worldstate-delta events never published** — gated on `part.kind==="data"`, which 1.0 parts don't have.
2. **webhook-callback text came back empty** — filtered on `p.kind==="text"`; a 1.0 push body is **raw proto3-JSON** where a text part is `{text}` (no `kind`).

**Fix** — unify on the 1.0 shape via the `@protolabs/a2a` helpers:
- `normalizeParts()` coerces to SDK `content.$case` (`Part.fromJSON` for raw-wire push bodies; pass-through for already-deserialized poll parts) — handles the shape asymmetry the issue called out.
- callback text via `partText`; deltas via `parseWorldStateDelta` → `{deltas}`, publishing one `world.state.delta` per entry. (Also corrects the payload shape — the old code read a flat `{domain,path,op,value}` off `part.data`, but worldstate-delta-v1 is `{deltas:[...]}`.)

2 regression tests drive a raw-wire callback body (`Part.toJSON` round-trip) and assert text extraction + delta publish. tsc clean; full suite green (1026).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved task tracking to properly handle raw-wire part formats with more robust data normalization
  * Enhanced state delta publishing reliability
* **Tests**
  * Added test coverage for task tracker callback handling with raw-wire part shapes
* **Refactor**
  * Refactored task part normalization and state delta extraction logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->