### PR TITLE
fix(a2a): emit real streaming progress on routed tasks (#777)

### DIFF
--- a/src/agent-runtime/__tests__/humanize-tool-progress.test.ts
+++ b/src/agent-runtime/__tests__/humanize-tool-progress.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect } from "bun:test";
+import { humanizeToolProgress } from "../agent-runtime-plugin.ts";
+
+// #777: tool calls become a human progress line that a2a-server surfaces on
+// streaming `working` updates (status.message), so A2A clients narrate real
+// steps instead of bare heartbeats.
+
+describe("humanizeToolProgress", () => {
+  test("chat_with_agent names the target → 'routing to <agent>'", () => {
+    expect(humanizeToolProgress([{ name: "chat_with_agent", args: { agent: "quinn" } }])).toBe("routing to quinn");
+    expect(humanizeToolProgress([{ name: "delegate_task", args: { target: "roxy" } }])).toBe("routing to roxy");
+  });
+
+  test("chat_with_agent without a target falls back", () => {
+    expect(humanizeToolProgress([{ name: "chat_with_agent", args: {} }])).toBe("delegating to an agent");
+  });
+
+  test("known tools map to readable phrases", () => {
+    expect(humanizeToolProgress([{ name: "searxng_search" }])).toBe("searching the web");
+    expect(humanizeToolProgress([{ name: "huggingface_search" }])).toBe("searching HuggingFace");
+    expect(humanizeToolProgress([{ name: "research_search" }])).toBe("searching the research knowledge base");
+    expect(humanizeToolProgress([{ name: "linear_get_issue" }])).toBe("working with Linear");
+  });
+
+  test("unknown tool → 'running <name>'", () => {
+    expect(humanizeToolProgress([{ name: "frobnicate" }])).toBe("running frobnicate");
+  });
+
+  test("self-narrating tools produce no progress text (no double-narration)", () => {
+    expect(humanizeToolProgress([{ name: "send_update" }])).toBe("");
+    expect(humanizeToolProgress([{ name: "msg_operator" }])).toBe("");
+  });
+
+  test("dedupes repeated phrases, preserves order", () => {
+    expect(humanizeToolProgress([
+      { name: "chat_with_agent", args: { agent: "quinn" } },
+      { name: "searxng_search" },
+      { name: "searxng_search" },
+    ])).toBe("routing to quinn; searching the web");
+  });
+
+  test("empty calls → empty string", () => {
+    expect(humanizeToolProgress([])).toBe("");
+  });
+});

--- a/src/agent-runtime/agent-runtime-plugin.ts
+++ b/src/agent-runtime/agent-runtime-plugin.ts
@@ -46,6 +46,41 @@ export interface AgentRuntimeConfig {
   apiKey?: string;
 }
 
+/**
+ * Turn a turn's tool calls into a short human progress line for A2A streaming
+ * (#777) — e.g. chat_with_agent(agent="quinn") → "routing to quinn". Returns ""
+ * when there's nothing worth narrating (tools that surface their own text).
+ */
+export function humanizeToolProgress(calls: Array<{ name: string; args?: unknown }>): string {
+  const phrases: string[] = [];
+  for (const c of calls) {
+    const args = (c.args ?? {}) as Record<string, unknown>;
+    const name = c.name;
+    if (name === "chat_with_agent" || name === "delegate_task") {
+      const target = typeof args.agent === "string" ? args.agent
+        : typeof args.target === "string" ? args.target : undefined;
+      phrases.push(target ? `routing to ${target}` : "delegating to an agent");
+    } else if (name === "searxng_search" || name === "web_search") {
+      phrases.push("searching the web");
+    } else if (name === "huggingface_search") {
+      phrases.push("searching HuggingFace");
+    } else if (name === "github_trending") {
+      phrases.push("scanning GitHub");
+    } else if (name.startsWith("research_")) {
+      phrases.push("searching the research knowledge base");
+    } else if (name.startsWith("github_") || name === "create_github_issue") {
+      phrases.push("working with GitHub");
+    } else if (name.startsWith("linear_")) {
+      phrases.push("working with Linear");
+    } else if (name === "send_update" || name === "msg_operator" || name === "ask_human") {
+      // These surface their own user-facing text — don't double-narrate.
+    } else {
+      phrases.push(`running ${name}`);
+    }
+  }
+  return [...new Set(phrases)].join("; ");
+}
+
 /** A running agent: its executor, the skills it's registered for, content hash, and source file. */
 interface RegisteredAgent {
   executor: IExecutor;
@@ -272,6 +307,7 @@ export class AgentRuntimePlugin implements Plugin {
     correlationId: string;
     skill?: string;
     toolNames: string[];
+    toolCalls?: Array<{ name: string; args?: unknown }>;
   }): void => {
     if (!this.bus) return;
     const topic = "agent.runtime.activity.tool.call";
@@ -292,6 +328,25 @@ export class AgentRuntimePlugin implements Plugin {
       });
     } catch (err) {
       console.warn(`[agent-runtime] tool.call publish failed for ${event.agentName}:`, err);
+    }
+
+    // Also emit real streaming progress: a2a-server translates
+    // agent.skill.progress.{correlationId} {text} into a `working` status-update
+    // with status.message, so A2A clients narrate actual steps instead of bare
+    // heartbeats. (#777) Best-effort — never breaks a running skill.
+    const text = humanizeToolProgress(event.toolCalls ?? event.toolNames.map(name => ({ name })));
+    if (!text) return;
+    const progressTopic = `agent.skill.progress.${event.correlationId}`;
+    try {
+      this.bus.publish(progressTopic, {
+        id: crypto.randomUUID(),
+        correlationId: event.correlationId,
+        topic: progressTopic,
+        timestamp: Date.now(),
+        payload: { text, step: "tool_call", meta: { tools: event.toolNames } },
+      });
+    } catch (err) {
+      console.warn(`[agent-runtime] progress publish failed for ${event.agentName}:`, err);
     }
   };
 

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -101,7 +101,7 @@ export interface DeepAgentConfig {
    * Skill-level lifecycle (start / complete / error) is emitted by the
    * SkillDispatcher across ALL executor types and does not need this hook.
    */
-  onToolCall?: (event: { agentName: string; correlationId: string; skill?: string; toolNames: string[] }) => void;
+  onToolCall?: (event: { agentName: string; correlationId: string; skill?: string; toolNames: string[]; toolCalls?: Array<{ name: string; args?: unknown }> }) => void;
 
   /**
    * Shared memory flywheel. When provided AND the agent declares `memory`,
@@ -1016,7 +1016,9 @@ export class DeepAgentExecutor implements IExecutor {
         if (type === "ai" || type === "AIMessage") {
           const tc = (msg as unknown as Record<string, unknown>).tool_calls;
           if (Array.isArray(tc) && tc.length > 0) {
-            const toolNames = tc.map((t: { name?: string }) => t.name).filter((n): n is string => !!n);
+            const calls = tc.map((t: { name?: string; args?: unknown }) => ({ name: t.name ?? "", args: t.args }))
+              .filter((c) => c.name);
+            const toolNames = calls.map((c) => c.name);
             console.log(`[deep-agent:${this.agentDef.name}] tool calls: ${toolNames.join(", ")}`);
             if (this.onToolCall && toolNames.length > 0) {
               try {
@@ -1025,6 +1027,7 @@ export class DeepAgentExecutor implements IExecutor {
                   correlationId: req.correlationId,
                   skill: req.skill,
                   toolNames,
+                  toolCalls: calls,
                 });
               } catch (cbErr) {
                 // Telemetry must never break a running skill.


### PR DESCRIPTION
Closes #777 — the third ORBIS voice-testing interop item.

Ava's streaming task emitted only **bare WORKING keepalives** (`{state,timestamp}`) — no `status.message`, no progress — so A2A clients had nothing real to narrate during a routed task. The progress→stream pipe already existed (a2a-server turns `agent.skill.progress.{cid}` into a `working` status-update with `status.message`); Ava just **never auto-emitted** — only the explicit `send_update` tool did.

**Fix:** auto-emit a progress line per tool-call turn. `onToolCall` now carries the calls (name + args); `AgentRuntimePlugin` humanizes them (`chat_with_agent(agent="quinn")` → "routing to quinn", `searxng_search` → "searching the web", …) and publishes `agent.skill.progress.{cid}` `{text}`, which a2a-server surfaces as `status.message` on the working update. Self-narrating tools (`send_update`/`msg_operator`/`ask_human`) skipped to avoid double-narration. Applies to **every** in-process DeepAgent (fleet-wide), best-effort.

**Acceptance** (issue): intermediate `status_update`s now carry non-empty `status.message` text reflecting actual progress; a client can narrate real steps. (Richer `tool-call-v1` DataPart frames noted as a follow-up — acceptance is "and/or".) 7 tests; tsc clean; full suite green (1033).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved tool call progress reporting with human-readable descriptions that intelligently handle different tool types, deduplicate repeated phrases, and stream progress updates in real-time for better visibility into agent execution.

* **Tests**
  * Added comprehensive test suite validating progress humanization for various tool categories and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->