### PR TITLE
feat(a2a): emit tool-call-v1 frames on the streaming channel (#781)

### DIFF
--- a/packages/a2a/src/index.ts
+++ b/packages/a2a/src/index.ts
@@ -16,7 +16,7 @@
  */
 
 // Part builders + readers (1.0 member-discriminated Part)
-export { textPart, textArtifact, dataPart, partText, partData, partsToText } from "./parts.ts";
+export { textPart, textArtifact, dataArtifact, dataPart, partText, partData, partsToText } from "./parts.ts";
 
 // Structured skill results (output_schema → forced-finalizer DataPart)
 export {

--- a/packages/a2a/src/parts.ts
+++ b/packages/a2a/src/parts.ts
@@ -41,6 +41,23 @@ export function textArtifact(text: string, opts: { artifactId?: string; name?: s
 }
 
 /**
+ * Wrap one or more Parts into an Artifact — the generic counterpart to
+ * `textArtifact`, for streaming structured (DataPart) artifact-updates such as
+ * tool-call-v1 progress frames. Defaults give each frame a fresh artifactId so
+ * consumers treat them as distinct streamed artifacts rather than appends.
+ */
+export function dataArtifact(parts: Part[], opts: { artifactId?: string; name?: string } = {}): Artifact {
+  return {
+    artifactId: opts.artifactId ?? crypto.randomUUID(),
+    name: opts.name ?? "data",
+    description: "",
+    parts,
+    metadata: undefined,
+    extensions: [],
+  };
+}
+
+/**
  * Build a structured data Part: `{ content: { $case: "data", value } }`.
  *
  * The protoLabs convention carries the application-level discriminator in

--- a/src/agent-runtime/agent-runtime-plugin.ts
+++ b/src/agent-runtime/agent-runtime-plugin.ts
@@ -23,6 +23,7 @@
 import type { Plugin, EventBus } from "../../lib/types.ts";
 import type { ExecutorRegistry } from "../executor/executor-registry.ts";
 import type { IExecutor } from "../executor/types.ts";
+import type { ToolCallArtifactData } from "@protolabs/a2a";
 import { DeepAgentExecutor } from "../executor/executors/deep-agent-executor.ts";
 import { ProtoSdkExecutor } from "../executor/executors/proto-sdk-executor.ts";
 import { AgentMemory } from "../knowledge/agent-memory.ts";
@@ -378,6 +379,32 @@ export class AgentRuntimePlugin implements Plugin {
     }
   };
 
+  /**
+   * Structured tool-call frame hook (tool-call-v1) — bridges each tool
+   * lifecycle frame to `agent.skill.toolframe.{correlationId}` so the a2a-server
+   * can emit it as a streamed artifact-update DataPart. Best-effort.
+   */
+  private _publishToolFrame = (event: {
+    agentName: string;
+    correlationId: string;
+    skill?: string;
+    frame: ToolCallArtifactData;
+  }): void => {
+    if (!this.bus) return;
+    const topic = `agent.skill.toolframe.${event.correlationId}`;
+    try {
+      this.bus.publish(topic, {
+        id: crypto.randomUUID(),
+        correlationId: event.correlationId,
+        topic,
+        timestamp: Date.now(),
+        payload: { frame: event.frame },
+      });
+    } catch (err) {
+      console.warn(`[agent-runtime] toolframe publish failed for ${event.agentName}:`, err);
+    }
+  };
+
   private _buildExecutor(def: AgentDefinition): IExecutor {
     const runtime = def.runtime ?? "deep-agent";
     if (runtime === "proto-sdk") {
@@ -398,6 +425,7 @@ export class AgentRuntimePlugin implements Plugin {
       apiKey: this.config.apiKey ?? process.env.WORKSTACEAN_API_KEY,
       onToolCall: this._publishToolCall,
       onProgress: this._publishProgress,
+      onToolFrame: this._publishToolFrame,
       // Share one memory instance across agents; only memory-enabled agents use it.
       memory: def.memory?.enabled ? this._memory() : undefined,
     });

--- a/src/api/__tests__/a2a-server.test.ts
+++ b/src/api/__tests__/a2a-server.test.ts
@@ -16,6 +16,7 @@ import { InMemoryEventBus } from "../../../lib/bus.ts";
 import { ExecutorRegistry } from "../../executor/executor-registry.ts";
 import { BusAgentExecutor } from "../a2a-server.ts";
 import type { ApiContext } from "../types.ts";
+import { parseToolCall } from "@protolabs/a2a";
 
 function makeUserMessage(text: string, metadata: Record<string, unknown> = {}): Message {
   return {
@@ -431,6 +432,55 @@ describe("BusAgentExecutor (Phase 7)", () => {
     );
     expect(completedEvt).toBeDefined();
     expect(completedEvt!.data.status?.state).toBe(TaskState.TASK_STATE_COMPLETED);
+  });
+
+  test("tool-call-v1 frames stream as artifact-update DataParts (#781)", async () => {
+    const bus = new InMemoryEventBus();
+    const ctx: ApiContext = {
+      workspaceDir: "/tmp",
+      bus,
+      plugins: [],
+      executorRegistry: new ExecutorRegistry(),
+    };
+
+    bus.subscribe("agent.skill.request", "test", (msg) => {
+      const cid = msg.correlationId!;
+      const frameTopic = `agent.skill.toolframe.${cid}`;
+      const replyTopic = msg.reply!.topic!;
+      setTimeout(() => bus.publish(frameTopic, {
+        id: crypto.randomUUID(), correlationId: cid, topic: frameTopic, timestamp: Date.now(),
+        payload: { frame: { toolCallId: "c1", name: "get_ci_health", phase: "started", args: { repo: "x" } } },
+      }), 0);
+      setTimeout(() => bus.publish(frameTopic, {
+        id: crypto.randomUUID(), correlationId: cid, topic: frameTopic, timestamp: Date.now(),
+        payload: { frame: { toolCallId: "c1", name: "get_ci_health", phase: "completed", result: "green" } },
+      }), 5);
+      setTimeout(() => bus.publish(replyTopic, {
+        id: crypto.randomUUID(), correlationId: cid, topic: replyTopic, timestamp: Date.now(),
+        payload: { content: "done", correlationId: cid },
+      }), 10);
+    });
+
+    const adapter = new BusAgentExecutor(ctx);
+    const eventBus = new DefaultExecutionEventBus();
+    const collected: AgentExecutionEvent[] = [];
+    eventBus.on("event", (e) => collected.push(e));
+    const done = new Promise<void>(resolve => eventBus.on("finished", () => resolve()));
+
+    await adapter.execute(makeRequestContext("Tool task"), eventBus);
+    await done;
+
+    type ArtifactUpdate = Extract<AgentExecutionEvent, { kind: "artifactUpdate" }>;
+    const frames = collected
+      .filter((e): e is ArtifactUpdate => e.kind === "artifactUpdate")
+      .map(e => parseToolCall(e.data.artifact?.parts ?? []))
+      .filter((f): f is NonNullable<typeof f> => Boolean(f));
+
+    // Two tool-call frames (started → completed); the terminal text answer is a
+    // separate artifact and carries no tool-call DataPart.
+    expect(frames).toHaveLength(2);
+    expect(frames[0]).toMatchObject({ toolCallId: "c1", name: "get_ci_health", phase: "started" });
+    expect(frames[1]).toMatchObject({ toolCallId: "c1", phase: "completed", result: "green" });
   });
 
   test("progress events arriving after terminal are silently dropped (no extra status-update)", async () => {

--- a/src/api/a2a-server.ts
+++ b/src/api/a2a-server.ts
@@ -37,7 +37,7 @@ import {
 } from "@a2a-js/sdk/server";
 import { join } from "node:path";
 import { Role, TaskState, type Message } from "@a2a-js/sdk";
-import { textPart, partText, textArtifact } from "@protolabs/a2a";
+import { textPart, partText, textArtifact, dataArtifact, emitToolCall, type ToolCallArtifactData } from "@protolabs/a2a";
 import type { Route, ApiContext } from "./types.ts";
 import type { BusMessage } from "../../lib/types.ts";
 import { buildAgentCard } from "./agent-card.ts";
@@ -208,6 +208,26 @@ class BusAgentExecutor implements AgentExecutor {
         }));
       });
 
+      // Tool-call-v1 frame subscriber — structured per-tool lifecycle frames
+      // (started → completed/failed) streamed as artifact-update DataParts for
+      // rich clients that render a tool timeline. Plain-text narration still
+      // rides status.message via the progress subscriber above; this is the
+      // structured channel the AgentCard's tool-call-v1 extension advertises.
+      const toolFrameTopic = `agent.skill.toolframe.${correlationId}`;
+      const toolFrameSubId = this.ctx.bus.subscribe(toolFrameTopic, "a2a-server-toolframe", (msg: BusMessage) => {
+        if (settled) return;
+        const frame = (msg.payload as { frame?: ToolCallArtifactData } | undefined)?.frame;
+        if (!frame) return;
+        eventBus.publish(AgentEvent.artifactUpdate({
+          taskId,
+          contextId,
+          artifact: dataArtifact([emitToolCall(frame)], { name: "tool-call" }),
+          append: false,
+          lastChunk: false,
+          metadata: undefined,
+        }));
+      });
+
       // Input-required subscriber — when the in-process agent's `ask_human`
       // tool announces it needs an answer (agent.input.request.{cid}), surface
       // an `input-required` status-update carrying the question + requestId so
@@ -241,6 +261,7 @@ class BusAgentExecutor implements AgentExecutor {
         this.ctx.bus.unsubscribe(subId);
         this.ctx.bus.unsubscribe(progressSubId);
         this.ctx.bus.unsubscribe(inputReqSubId);
+        this.ctx.bus.unsubscribe(toolFrameSubId);
         this.activeCancels.delete(taskId);
 
         const payload = (msg.payload ?? {}) as { content?: string; error?: string };
@@ -313,6 +334,7 @@ class BusAgentExecutor implements AgentExecutor {
         this.ctx.bus.unsubscribe(subId);
         this.ctx.bus.unsubscribe(progressSubId);
         this.ctx.bus.unsubscribe(inputReqSubId);
+        this.ctx.bus.unsubscribe(toolFrameSubId);
         this.activeCancels.delete(taskId);
         eventBus.publish(AgentEvent.statusUpdate({
           taskId,

--- a/src/event-bus/all-topics.ts
+++ b/src/event-bus/all-topics.ts
@@ -52,6 +52,16 @@ export const ACTION_TOPICS = {
   AGENT_SKILL_PROGRESS_PREFIX: "agent.skill.progress",
 
   /**
+   * Prefix for structured tool-call-v1 frames. Full topic is
+   * `agent.skill.toolframe.{correlationId}`. The in-process runtime publishes
+   * one frame per tool lifecycle event (started → completed/failed); the
+   * a2a-server emits each as a streamed artifact-update DataPart for clients
+   * that render a structured tool timeline. Sibling to the plain-text
+   * narration on AGENT_SKILL_PROGRESS_PREFIX. Opt-in.
+   */
+  AGENT_SKILL_TOOLFRAME_PREFIX: "agent.skill.toolframe",
+
+  /**
    * Prefix for human-input requests. Full topic is
    * `agent.input.request.{correlationId}`. An in-process agent's `ask_human`
    * tool (via POST /api/agent/ask-human) publishes here when it needs an answer

--- a/src/executor/__tests__/deep-agent-tool-call-narrations.test.ts
+++ b/src/executor/__tests__/deep-agent-tool-call-narrations.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { extractToolCallNarrations } from "../executors/deep-agent-executor.ts";
+import { extractToolCallNarrations, extractToolFrames } from "../executors/deep-agent-executor.ts";
 
 /** Minimal stand-ins for LangChain message objects. */
 const ai = (toolCalls?: Array<{ name: string; args?: unknown }>) => ({
@@ -65,5 +65,51 @@ describe("extractToolCallNarrations", () => {
     const out = extractToolCallNarrations([ai([{ name: "" }, { name: "real" }])], 0);
     expect(out).toHaveLength(1);
     expect(out[0].toolNames).toEqual(["real"]);
+  });
+});
+
+/** AI message with id'd tool calls + a tool-result message. */
+const aiIds = (toolCalls: Array<{ name: string; args?: unknown; id?: string }>) => ({ _getType: () => "ai", tool_calls: toolCalls });
+const toolResult = (opts: { tool_call_id?: string; name?: string; content?: unknown; status?: string }) => ({ _getType: () => "tool", ...opts });
+
+describe("extractToolFrames (tool-call-v1)", () => {
+  test("emits a 'started' frame per tool call, keyed by call id", () => {
+    const frames = extractToolFrames([aiIds([{ name: "get_ci_health", args: { repo: "x" }, id: "call_1" }])], 0);
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toEqual({ toolCallId: "call_1", name: "get_ci_health", phase: "started", args: { repo: "x" } });
+  });
+
+  test("emits a 'completed' frame from a tool-result message, correlated by tool_call_id", () => {
+    const msgs = [aiIds([{ name: "get_ci_health", id: "call_1" }]), toolResult({ tool_call_id: "call_1", name: "get_ci_health", content: "all green" })];
+    const frames = extractToolFrames(msgs, 0);
+    expect(frames).toHaveLength(2);
+    expect(frames[0].phase).toBe("started");
+    expect(frames[1]).toEqual({ toolCallId: "call_1", name: "get_ci_health", phase: "completed", result: "all green" });
+  });
+
+  test("emits a 'failed' frame when the tool result is an error", () => {
+    const frames = extractToolFrames([toolResult({ tool_call_id: "c", name: "boom", content: "kaboom", status: "error" })], 0);
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toEqual({ toolCallId: "c", name: "boom", phase: "failed", error: "kaboom" });
+  });
+
+  test("the cursor emits each frame exactly once across re-yielded accumulated state", () => {
+    const step1 = [aiIds([{ name: "search", id: "c1" }])];
+    const step2 = [...step1, toolResult({ tool_call_id: "c1", name: "search", content: "hits" })];
+    const step3 = [...step2, aiIds([])]; // final answer
+
+    let cursor = 0;
+    const phases: string[] = [];
+    for (const state of [step1, step2, step3]) {
+      for (const f of extractToolFrames(state, cursor)) phases.push(`${f.name}:${f.phase}`);
+      cursor = state.length;
+    }
+    expect(phases).toEqual(["search:started", "search:completed"]);
+  });
+
+  test("synthesizes a stable toolCallId when the provider omits ids", () => {
+    const frames = extractToolFrames([aiIds([{ name: "t" }])], 0);
+    expect(frames[0].toolCallId).toBe("t#0.0");
+    expect(frames[0].phase).toBe("started");
   });
 });

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -17,6 +17,7 @@ import type { AgentDefinition } from "../../agent-runtime/types.ts";
 import type { IExecutor, SkillRequest, SkillResult } from "../types.ts";
 import { runStructuredFinalizer, type ForcedToolCaller } from "./structured-finalizer.ts";
 import { AgentMemory, memoryAppliesTo } from "../../knowledge/agent-memory.ts";
+import type { ToolCallArtifactData } from "@protolabs/a2a";
 
 const LANGFUSE_ENABLED = !!(process.env.LANGFUSE_PUBLIC_KEY && process.env.LANGFUSE_SECRET_KEY);
 
@@ -118,6 +119,48 @@ export function extractToolCallNarrations(messages: unknown[], fromIndex: number
   return out;
 }
 
+/**
+ * Scan `messages[fromIndex..]` for structured tool-call lifecycle frames
+ * (tool-call-v1): a `started` frame per tool call on each new AI message (keyed
+ * by the call's `id` so a later result correlates), and a `completed` / `failed`
+ * frame per tool-result message. Cursor-driven the same way as
+ * `extractToolCallNarrations` — each message contributes its frames exactly once.
+ * These ride the streaming artifact-update channel for rich clients; the plain
+ * `status.message` narration is unaffected.
+ */
+export function extractToolFrames(messages: unknown[], fromIndex: number): ToolCallArtifactData[] {
+  const out: ToolCallArtifactData[] = [];
+  for (let i = Math.max(0, fromIndex); i < messages.length; i++) {
+    const msg = messages[i] as {
+      _getType?: () => string;
+      constructor?: { name?: string };
+      tool_calls?: unknown;
+      tool_call_id?: string;
+      name?: string;
+      content?: unknown;
+      status?: string;
+    };
+    const type = msg?._getType?.() ?? msg?.constructor?.name ?? "";
+    if (type === "ai" || type === "AIMessage") {
+      const tc = msg?.tool_calls;
+      if (!Array.isArray(tc)) continue;
+      tc.forEach((t: { name?: string; args?: unknown; id?: string }, idx: number) => {
+        if (!t?.name) return;
+        out.push({ toolCallId: t.id ?? `${t.name}#${i}.${idx}`, name: t.name, phase: "started", args: t.args });
+      });
+    } else if (type === "tool" || type === "ToolMessage") {
+      const name = typeof msg?.name === "string" ? msg.name : "";
+      const toolCallId = typeof msg?.tool_call_id === "string" ? msg.tool_call_id : `${name}#${i}`;
+      if (msg?.status === "error") {
+        out.push({ toolCallId, name, phase: "failed", error: typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content) });
+      } else {
+        out.push({ toolCallId, name, phase: "completed", result: msg?.content });
+      }
+    }
+  }
+  return out;
+}
+
 export interface DeepAgentConfig {
   gatewayUrl?: string;
   gatewayApiKey?: string;
@@ -144,6 +187,15 @@ export interface DeepAgentConfig {
    * a byte-silent run. Errors inside the callback are swallowed.
    */
   onProgress?: (event: { agentName: string; correlationId: string; skill?: string; text: string; step?: string }) => void;
+
+  /**
+   * Best-effort structured tool-call frame hook (tool-call-v1). Fires per tool
+   * lifecycle event (started → completed/failed) as the graph streams. Wired by
+   * `AgentRuntimePlugin` to publish `agent.skill.toolframe.{cid}` so the
+   * a2a-server can emit them as streamed artifact-update DataParts for rich
+   * clients. Errors inside the callback are swallowed.
+   */
+  onToolFrame?: (event: { agentName: string; correlationId: string; skill?: string; frame: ToolCallArtifactData }) => void;
 
   /**
    * Shared memory flywheel. When provided AND the agent declares `memory`,
@@ -907,6 +959,7 @@ export class DeepAgentExecutor implements IExecutor {
   private readonly http: HttpClient;
   private readonly onToolCall: DeepAgentConfig["onToolCall"];
   private readonly onProgress: DeepAgentConfig["onProgress"];
+  private readonly onToolFrame: DeepAgentConfig["onToolFrame"];
   private readonly gatewayUrl: string | undefined;
   private readonly apiKey: string;
   private readonly memory: AgentMemory | undefined;
@@ -922,6 +975,7 @@ export class DeepAgentExecutor implements IExecutor {
     this.agentDef = agentDef;
     this.onToolCall = config.onToolCall;
     this.onProgress = config.onProgress;
+    this.onToolFrame = config.onToolFrame;
     this.gatewayUrl = config.gatewayUrl ?? process.env.LLM_GATEWAY_URL ?? process.env.OPENAI_BASE_URL;
     this.apiKey = config.gatewayApiKey ?? process.env.OPENAI_API_KEY ?? "unused";
     this.memory = config.memory;
@@ -1085,6 +1139,17 @@ export class DeepAgentExecutor implements IExecutor {
             } catch (cbErr) {
               // Telemetry must never break a running skill.
               console.warn(`[deep-agent:${this.agentDef.name}] onToolCall callback threw:`, cbErr);
+            }
+          }
+        }
+        // Structured tool-call-v1 frames (started → completed/failed) for rich
+        // clients, on the streaming artifact-update channel.
+        if (this.onToolFrame) {
+          for (const frame of extractToolFrames(msgs, narrated)) {
+            try {
+              this.onToolFrame({ agentName: this.agentDef.name, correlationId: req.correlationId, skill: req.skill, frame });
+            } catch (cbErr) {
+              console.warn(`[deep-agent:${this.agentDef.name}] onToolFrame callback threw:`, cbErr);
             }
           }
         }


### PR DESCRIPTION
Closes #781. Follow-up to #780 (live streaming).

## Why

Ava's AgentCard advertises the **tool-call-v1** extension (structured per-tool progress frames), but the hub only emitted structured DataParts on the **terminal artifact** — mid-task it sent plain `status.message` text. The card promised a streaming capability that didn't exist. This makes it true (option 1 from #781), rather than tempering the card.

## What

As the DeepAgent graph streams, emit one tool-call-v1 frame per tool lifecycle event:

| phase | source | payload |
|---|---|---|
| `started` | each AI message's `tool_calls` (keyed by call `id`) | `args` |
| `completed` | tool-result message (correlated by `tool_call_id`) | `result` |
| `failed` | tool-result message with `status: "error"` | `error` |

**Path:** `DeepAgentExecutor.onToolFrame` → `AgentRuntimePlugin` publishes `agent.skill.toolframe.{cid}` → a2a-server emits each as an `artifact-update` DataPart via `emitToolCall()`. Subscriptions torn down on settle/cancel alongside the existing progress/input subs.

**Plain-text narration is untouched.** `status.message` (via `onToolCall`/`onProgress` from #780) still carries the human-readable line — the progress pill and other simple consumers keep working exactly as before. tool-call-v1 is purely additive, for clients that render a structured tool timeline.

## Alignment outcome

This closes the card-vs-reality gap flagged during ORBIS streaming work: consumers can stay on `status.message` (canonical, simple) **or** opt into structured `tool-call-v1` artifact frames. Both are now real on the live stream.

## Tests

- `extractToolFrames` pure helper: started/completed/failed derivation, cursor-narrates-once across re-yielded state, id synthesis when the provider omits ids.
- a2a-server: `agent.skill.toolframe.{cid}` → two artifact-update DataParts (`started` → `completed`), parsed back with `parseToolCall`.

**1041 green, tsc clean, no new lint.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured tool-call lifecycle frame streaming with detailed visibility into tool execution phases: started, completed, and failed states
  * New data artifact wrapper utility enabling simplified artifact construction and consistency

* **Tests**
  * Added comprehensive tests for tool-call frame extraction, lifecycle event emission, and artifact data integration

* **Chores**
  * Added event bus topic namespace for tool-call lifecycle frames
  * Integrated tool-frame telemetry hook into agent runtime plugin

<!-- end of auto-generated comment: release notes by coderabbit.ai -->