### PR TITLE
feat(github): close the originating issue when its feature ships (close-the-loop)

### DIFF
--- a/lib/__tests__/github-issues.test.ts
+++ b/lib/__tests__/github-issues.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { closeIssue } from "../github-issues.ts";
+
+/** A fetch stub recording calls and returning canned responses. */
+function stubFetch(responses: Array<{ ok: boolean; status?: number; text?: string }>) {
+  const calls: Array<{ url: string; method?: string; body?: unknown }> = [];
+  let i = 0;
+  const fetchImpl = (async (url: string, init?: { method?: string; body?: string }) => {
+    calls.push({ url, method: init?.method, body: init?.body ? JSON.parse(init.body) : undefined });
+    const r = responses[i++] ?? { ok: true, status: 200 };
+    return { ok: r.ok, status: r.status ?? (r.ok ? 200 : 500), text: async () => r.text ?? "" } as Response;
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+const auth = async () => "tok";
+
+describe("closeIssue", () => {
+  test("comments then PATCHes the issue closed with state_reason=completed", async () => {
+    const { fetchImpl, calls } = stubFetch([{ ok: true }, { ok: true }]);
+    await closeIssue("o", "r", 7, { comment: "shipped", authGetter: auth, fetchImpl });
+    expect(calls).toHaveLength(2);
+    expect(calls[0].url).toBe("https://api.github.com/repos/o/r/issues/7/comments");
+    expect(calls[0].body).toEqual({ body: "shipped" });
+    expect(calls[1].url).toBe("https://api.github.com/repos/o/r/issues/7");
+    expect(calls[1].method).toBe("PATCH");
+    expect(calls[1].body).toEqual({ state: "closed", state_reason: "completed" });
+  });
+
+  test("skips the comment call when no comment is given", async () => {
+    const { fetchImpl, calls } = stubFetch([{ ok: true }]);
+    await closeIssue("o", "r", 8, { authGetter: auth, fetchImpl });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://api.github.com/repos/o/r/issues/8");
+  });
+
+  test("honors reason=not_planned", async () => {
+    const { fetchImpl, calls } = stubFetch([{ ok: true }]);
+    await closeIssue("o", "r", 9, { reason: "not_planned", authGetter: auth, fetchImpl });
+    expect(calls[0].body).toEqual({ state: "closed", state_reason: "not_planned" });
+  });
+
+  test("a failed comment is non-fatal — the close still happens", async () => {
+    const { fetchImpl, calls } = stubFetch([{ ok: false, status: 403 }, { ok: true }]);
+    await closeIssue("o", "r", 10, { comment: "x", authGetter: auth, fetchImpl });
+    expect(calls).toHaveLength(2);
+    expect(calls[1].method).toBe("PATCH");
+  });
+
+  test("throws (fail-loud) when the PATCH fails", async () => {
+    const { fetchImpl } = stubFetch([{ ok: false, status: 422, text: "nope" }]);
+    await expect(closeIssue("o", "r", 11, { authGetter: auth, fetchImpl })).rejects.toThrow(/422/);
+  });
+});

--- a/lib/github-issues.ts
+++ b/lib/github-issues.ts
@@ -1,0 +1,82 @@
+/**
+ * GitHub issue close helper — the issues-endpoint counterpart to pr-inspector's
+ * PR-close (`setPrState`, which targets `/pulls/{n}`). Closes an issue with an
+ * optional comment, authenticating as the Quinn GitHub App (or GITHUB_TOKEN PAT)
+ * via the shared `makeGitHubAuth`.
+ *
+ * Used by IssueCloserPlugin to close the originating GitHub issue when its
+ * feature ships (the close-the-loop), and reusable by a future
+ * `pr_inspector close_issue` action. `authGetter` / `fetchImpl` are injectable
+ * so unit tests never touch the network or `process.env`.
+ */
+
+import { makeGitHubAuth } from "./github-auth.ts";
+
+export interface CloseIssueOpts {
+  /** Comment posted before the close so observers see the rationale first. Best-effort. */
+  comment?: string;
+  /** GitHub close motive. "completed" (resolved) vs "not_planned" (won't do). */
+  reason?: "completed" | "not_planned";
+  /** Injected for tests; defaults to the shared makeGitHubAuth resolution. */
+  authGetter?: (owner: string, repo: string) => Promise<string>;
+  /** Injected for tests; defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+function ghHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "User-Agent": "protoWorkstacean/1.0",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "Content-Type": "application/json",
+  };
+}
+
+/**
+ * Close `owner/name#issueNumber`. Throws (fail-loud) on missing auth or a
+ * non-OK PATCH so the caller can surface it; a failed comment is non-fatal
+ * (logged, then the close proceeds).
+ */
+export async function closeIssue(
+  owner: string,
+  name: string,
+  issueNumber: number,
+  opts: CloseIssueOpts = {},
+): Promise<void> {
+  const auth = opts.authGetter ?? makeGitHubAuth();
+  if (!auth) {
+    throw new Error(
+      `[github-issues] no GitHub auth configured (set QUINN_APP_ID+QUINN_APP_PRIVATE_KEY or GITHUB_TOKEN) — cannot close ${owner}/${name}#${issueNumber}`,
+    );
+  }
+  const doFetch = opts.fetchImpl ?? fetch;
+  const token = await auth(owner, name);
+  const headers = ghHeaders(token);
+
+  if (opts.comment && opts.comment.trim()) {
+    try {
+      const c = await doFetch(`https://api.github.com/repos/${owner}/${name}/issues/${issueNumber}/comments`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ body: opts.comment }),
+      });
+      if (!c.ok) {
+        console.warn(`[github-issues] comment on ${owner}/${name}#${issueNumber} failed (proceeding to close): ${c.status}`);
+      }
+    } catch (e) {
+      console.warn(`[github-issues] comment on ${owner}/${name}#${issueNumber} threw (proceeding to close): ${String(e).slice(0, 200)}`);
+    }
+  }
+
+  const resp = await doFetch(`https://api.github.com/repos/${owner}/${name}/issues/${issueNumber}`, {
+    method: "PATCH",
+    headers,
+    body: JSON.stringify({ state: "closed", state_reason: opts.reason ?? "completed" }),
+  });
+  if (!resp.ok) {
+    throw new Error(
+      `[github-issues] closing ${owner}/${name}#${issueNumber} failed: ${resp.status} ${await resp.text().catch(() => "")}`.slice(0, 400),
+    );
+  }
+}

--- a/lib/plugins/__tests__/issue-closer.test.ts
+++ b/lib/plugins/__tests__/issue-closer.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { InMemoryEventBus } from "../../bus.ts";
+import { IssueCloserPlugin } from "../issue-closer.ts";
+
+function publishCompleted(bus: InMemoryEventBus, payload: Record<string, unknown>) {
+  bus.publish("feature.completed", {
+    id: crypto.randomUUID(),
+    correlationId: crypto.randomUUID(),
+    topic: "feature.completed",
+    timestamp: 0,
+    payload,
+  });
+  // The handler is async (await closeFn); let the microtask queue drain.
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+function spyCloser() {
+  const calls: Array<{ owner: string; name: string; n: number; opts: { comment?: string; reason?: string } }> = [];
+  const closeFn = async (owner: string, name: string, n: number, opts: { comment?: string; reason?: "completed" | "not_planned" }) => {
+    calls.push({ owner, name, n, opts });
+  };
+  return { closeFn, calls };
+}
+
+describe("IssueCloserPlugin", () => {
+  test("closes the originating issue with a shipped-in-PR comment", async () => {
+    const bus = new InMemoryEventBus();
+    const { closeFn, calls } = spyCloser();
+    const plugin = new IssueCloserPlugin({ closeFn });
+    plugin.install(bus);
+
+    await publishCompleted(bus, { featureId: "F1", featureTitle: "Do X", repo: "acme/widgets", githubIssueNumber: 42, prNumber: 99 });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ owner: "acme", name: "widgets", n: 42 });
+    expect(calls[0].opts.reason).toBe("completed");
+    expect(calls[0].opts.comment).toContain("PR #99");
+    expect(calls[0].opts.comment).toContain("Do X");
+    plugin.uninstall();
+  });
+
+  test("does nothing when the feature carries no originating issue", async () => {
+    const bus = new InMemoryEventBus();
+    const { closeFn, calls } = spyCloser();
+    const plugin = new IssueCloserPlugin({ closeFn });
+    plugin.install(bus);
+
+    await publishCompleted(bus, { featureId: "F2", repo: "acme/widgets" }); // no githubIssueNumber
+    await publishCompleted(bus, { featureId: "F3", githubIssueNumber: 7 }); // no repo
+
+    expect(calls).toHaveLength(0);
+    plugin.uninstall();
+  });
+
+  test("skips a malformed repo without throwing", async () => {
+    const bus = new InMemoryEventBus();
+    const { closeFn, calls } = spyCloser();
+    const plugin = new IssueCloserPlugin({ closeFn });
+    plugin.install(bus);
+
+    await publishCompleted(bus, { featureId: "F4", repo: "not-a-slug", githubIssueNumber: 5 });
+
+    expect(calls).toHaveLength(0);
+    plugin.uninstall();
+  });
+
+  test("a close failure is swallowed (other consumers unaffected)", async () => {
+    const bus = new InMemoryEventBus();
+    const closeFn = async () => {
+      throw new Error("GitHub 500");
+    };
+    const plugin = new IssueCloserPlugin({ closeFn });
+    plugin.install(bus);
+
+    // Must not throw out of the bus publish.
+    await expect(
+      publishCompleted(bus, { featureId: "F5", repo: "acme/widgets", githubIssueNumber: 8 }),
+    ).resolves.toBeUndefined();
+    plugin.uninstall();
+  });
+
+  test("does not act on feature.failed", async () => {
+    const bus = new InMemoryEventBus();
+    const { closeFn, calls } = spyCloser();
+    const plugin = new IssueCloserPlugin({ closeFn });
+    plugin.install(bus);
+
+    bus.publish("feature.failed", {
+      id: crypto.randomUUID(),
+      correlationId: crypto.randomUUID(),
+      topic: "feature.failed",
+      timestamp: 0,
+      payload: { featureId: "F6", repo: "acme/widgets", githubIssueNumber: 9 },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(calls).toHaveLength(0);
+    plugin.uninstall();
+  });
+});

--- a/lib/plugins/issue-closer.ts
+++ b/lib/plugins/issue-closer.ts
@@ -1,0 +1,91 @@
+/**
+ * IssueCloserPlugin — closes the originating GitHub issue when its feature ships.
+ *
+ * The portfolio pipeline files GitHub issues as the spine (Ava fans out per-repo
+ * issues → protoMaker ingests them as features → execution). protoMaker emits
+ * `feature.completed` on `done`, echoing the originating `githubIssueNumber` +
+ * `repo` (protoMaker PR for that field). Without this consumer the work ships
+ * but the issue stays open forever — issues created on an event, never cleared
+ * on resolve, the exact stale-pile-up shape behind this P1.
+ *
+ * This is the GitHub analog of the Linear close-the-loop. It subscribes to
+ * `feature.completed` and closes `repo#githubIssueNumber` with a comment linking
+ * the shipped PR. Best-effort: a close failure is logged loudly but never
+ * disturbs other consumers (e.g. the Discord feature-notifier on the same event).
+ *
+ * `feature.failed` is intentionally NOT handled — a failed/escalated feature's
+ * issue must stay open for attention.
+ */
+
+import type { Plugin, EventBus, BusMessage } from "../types.ts";
+import { closeIssue as defaultCloseIssue } from "../github-issues.ts";
+
+interface FeatureCompletedPayload {
+  featureId?: string;
+  featureTitle?: string;
+  githubIssueNumber?: number;
+  repo?: string; // "owner/name"
+  prNumber?: number;
+}
+
+type CloseFn = (
+  owner: string,
+  name: string,
+  issueNumber: number,
+  opts: { comment?: string; reason?: "completed" | "not_planned" },
+) => Promise<void>;
+
+export class IssueCloserPlugin implements Plugin {
+  readonly name = "issue-closer";
+  readonly description = "Closes the originating GitHub issue when its feature ships (feature.completed close-the-loop)";
+  readonly capabilities = ["feature.completed", "github-issue-close"];
+
+  private bus?: EventBus;
+  private readonly subscriptionIds: string[] = [];
+  private readonly closeFn: CloseFn;
+
+  constructor(opts: { closeFn?: CloseFn } = {}) {
+    this.closeFn = opts.closeFn ?? ((owner, name, n, o) => defaultCloseIssue(owner, name, n, o));
+  }
+
+  install(bus: EventBus): void {
+    this.bus = bus;
+    this.subscriptionIds.push(
+      bus.subscribe("feature.completed", this.name, (msg) => {
+        void this._onCompleted(msg);
+      }),
+    );
+    console.log("[issue-closer] installed — closing originating GitHub issues on feature.completed");
+  }
+
+  uninstall(): void {
+    for (const id of this.subscriptionIds) this.bus?.unsubscribe(id);
+    this.subscriptionIds.length = 0;
+  }
+
+  private async _onCompleted(msg: BusMessage): Promise<void> {
+    const p = (msg.payload ?? {}) as FeatureCompletedPayload;
+    if (!p.githubIssueNumber || !p.repo) {
+      // Not every completed feature originated from a GitHub issue — nothing to close.
+      return;
+    }
+    const [owner, name] = p.repo.split("/");
+    if (!owner || !name) {
+      console.warn(`[issue-closer] feature.completed has malformed repo "${p.repo}" — cannot close #${p.githubIssueNumber}`);
+      return;
+    }
+    const comment = [
+      `✅ Resolved by protoMaker${p.prNumber ? ` — shipped in PR #${p.prNumber}` : ""}.`,
+      p.featureTitle ? `Feature: ${p.featureTitle}` : "",
+    ]
+      .filter(Boolean)
+      .join("\n");
+    try {
+      await this.closeFn(owner, name, p.githubIssueNumber, { comment, reason: "completed" });
+      console.log(`[issue-closer] closed ${p.repo}#${p.githubIssueNumber} (feature ${p.featureId ?? "?"} shipped)`);
+    } catch (err) {
+      // Loud, but never breaks the bus / other feature.completed consumers.
+      console.warn(`[issue-closer] failed to close ${p.repo}#${p.githubIssueNumber}: ${String(err).slice(0, 300)}`);
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,6 +195,19 @@ const pluginRegistry: PluginRegistryEntry[] = [
     },
   },
   {
+    // IssueCloserPlugin closes the originating GitHub issue when its feature
+    // ships (feature.completed with githubIssueNumber + repo) — the GitHub
+    // close-the-loop, so portfolio-pipeline issues don't pile up open forever.
+    // Needs GitHub auth (Quinn App or PAT) to act; without it closeIssue throws
+    // and the plugin logs it, so gate on auth being present.
+    name: "issue-closer",
+    condition: () => !!(process.env.QUINN_APP_ID || process.env.GITHUB_TOKEN),
+    factory: async () => {
+      const { IssueCloserPlugin } = await import("../lib/plugins/issue-closer");
+      return new IssueCloserPlugin();
+    },
+  },
+  {
     name: "discord",
     condition: () => !!process.env.DISCORD_BOT_TOKEN,
     factory: async () => {


### PR DESCRIPTION
Addresses the "no issue-close path" P1 (the stale-issue pile-up). Pairs with protoMaker#4072.

## The gap

The portfolio pipeline files **GitHub issues** as the spine — Ava fans out per-repo issues → protoMaker ingests them as features → execution → `feature.completed`. But nothing ever **closes** the originating issue when the work ships. ws had a PR-close path (`pr-inspector` `setPrState` → `/pulls/{n}`) but **no issue-close path** at all. Classic shape of every finding in the backstop review: *state created on an event, never cleared when the thing resolves.*

## What

- **`lib/github-issues.ts`** — `closeIssue(owner, name, n, { comment, reason })`, the `/issues/{n}` counterpart to `setPrState`. Comments first (best-effort), then PATCHes `state=closed` + `state_reason`. Auths via the shared `makeGitHubAuth` (Quinn App or PAT). `authGetter`/`fetchImpl` injected in tests — no network, no `process.env`.
- **`IssueCloserPlugin`** — subscribes `feature.completed`; when the payload carries `githubIssueNumber` + `repo`, closes the issue with a `✅ shipped in PR #N` comment. Best-effort: a close failure is logged loudly but never disturbs other consumers (e.g. the Discord `feature-notifier` on the same event). `feature.failed` is intentionally left **open** (needs attention).
- Registered in `src/index.ts`, gated on GitHub auth being present.

## Safe to merge independently

Degrades gracefully: until protoMaker echoes `githubIssueNumber` (**protoMaker#4072**), the payload lacks it and the plugin simply skips. No flag-day hold — it activates automatically once #4072 deploys. This is the GitHub analog of the Linear close-the-loop (roadmap A3/B2 shape).

## Tests

`closeIssue`: comment-then-PATCH, no-comment skip, `not_planned`, non-fatal comment failure, fail-loud on PATCH error. `IssueCloserPlugin`: closes with PR comment, skips when no originating issue, skips malformed repo, swallows close failures, ignores `feature.failed`. **1051 green, tsc clean, lint clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)