### PR TITLE
docs: refresh for feature-remediation, A2A streaming/tool-call-v1, issue close-the-loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Auto-merge captures the head SHA when you enable it. If you force-push afterward
 src/              Application entry, router, dispatcher, executors, telemetry
 src/agent-runtime/    DeepAgentExecutor wiring + agent YAML loader
 src/executor/         ExecutorRegistry, SkillDispatcher, A2A/Function/Workflow executors, extensions
-src/plugins/          CeremonyPlugin, AgentFleetHealth, alert/ceremony/pr-remediator skill executors
+src/plugins/          CeremonyPlugin, AgentFleetHealth, alert/ceremony skill executors
 src/api/              HTTP routes (per-module)
 src/router/           RouterPlugin
 lib/plugins/          Integration plugins (Discord, GitHub, Linear, Google, scheduler, HITL, etc.)

--- a/STATUS.md
+++ b/STATUS.md
@@ -10,7 +10,7 @@ That's the spine. Everything else extends it.
 
 - **In-process agents** (DeepAgent / LangGraph): Ava, protoBot, Quinn
 - **Remote agents** (A2A): protoMaker, protoPen
-- **Integration plugins**: Discord, GitHub, Linear, Google Workspace, linear-protomaker-bridge, pr-remediator
+- **Integration plugins**: Discord, GitHub, Linear, Google Workspace, linear-protomaker-bridge, feature-remediation (feature.blocked → ignore / HITL / Roxy unblock_feature), issue-closer (feature.completed → close originating GitHub issue)
 - **Scheduling**: SchedulerPlugin (yaml-defined crons), CeremonyPlugin (named, observable, hot-reloadable rituals)
 - **Observability**: AgentFleetHealth (24h rollups → health-weighted dispatch), Langfuse OTEL tracing, cost-v1 / confidence-v1 / blast-v1 / hitl-mode-v1 A2A extensions
 - **Operator routing**: OperatorRoutingPlugin abstracts the transport (Discord DM today; SMS / Signal / push future)

--- a/docs/architecture/chokepoint-invariants.md
+++ b/docs/architecture/chokepoint-invariants.md
@@ -2,7 +2,7 @@
 title: Cross-cut — Dispatcher chokepoint invariants
 ---
 
-_The "four invariants" pattern referred to elsewhere in the codebase. This doc audits what is actually in source vs. what was planned. Three of the four are implemented; one is not generalized; one fleet-side filter lives outside the dispatcher entirely._
+_The "dispatcher invariants" pattern referred to elsewhere in the codebase. This doc audits what is actually in source vs. what was planned. Two are true dispatcher invariants; one fleet-side filter lives outside the dispatcher entirely. (A fourth — the #465 destructive-verdict guard — lived in the now-deleted `pr-remediator.ts` and is no longer in the codebase; see the historical note below.)_
 
 ---
 
@@ -17,9 +17,9 @@ Audit reality:
 | #437 | Cooldown | `src/executor/skill-dispatcher-plugin.ts:216-230` | ✅ yes |
 | #444 | Target-registry guard | `src/executor/executor-registry.ts:93-97` (inside `resolve()`) | ✅ effectively — dispatcher drops on null resolve |
 | #459 | Synthetic actor filter | `src/plugins/agent-fleet-health-plugin.ts:281-334` | ❌ **outside** the dispatcher (fleet-health aggregation site) |
-| #465 | Destructive verdict guard | `lib/plugins/pr-remediator.ts:1516-1546` | ❌ **specific to pr-remediator**, not a general dispatcher invariant |
+| #465 | Destructive verdict guard | _retired — lived in `pr-remediator.ts`, deleted #776_ | ❌ **no longer in the codebase** |
 
-Treat #437 and #444 as the actual dispatcher invariants. #459 and #465 are the same architectural *pattern* (single chokepoint for an invariant) applied at *different* chokepoints — outcome-aggregation and verdict-handling respectively.
+Treat #437 and #444 as the actual dispatcher invariants. #459 is the same architectural *pattern* (single chokepoint for an invariant) applied at a *different* chokepoint — the outcome-aggregation site. #465 was that pattern applied at the PR-remediator verdict-handling site; it was removed when `pr-remediator.ts` was deleted (the PR-pipeline-violation derivation it guarded moved to protoMaker — see [flow-alert-remediator](flow-alert-remediator.md)).
 
 ---
 
@@ -114,21 +114,21 @@ on autonomous.outcome.{actor}.{skill}:
         → logged once-per-distinct-actor at warn level
 ```
 
-**Known synthetic actors:** `pr-remediator`, `goap`, `user`.
+**Known synthetic actors:** `feature-remediation`, `user`.
 
 **On trip:** one-time `console.warn` per actor, no escalation. The point is bucketing, not blocking.
 
 ---
 
-## #465 — Destructive verdict guard (only in pr-remediator)
+## #465 — Destructive verdict guard (RETIRED — no longer in code)
 
-**Where:** [pr-remediator.ts:1516–1546](../../lib/plugins/pr-remediator.ts), specifically the promotion-PR check inside `diagnose_pr_stuck` verdict handling.
+**Status:** removed. This invariant lived in `lib/plugins/pr-remediator.ts`, which was **deleted in #776**. It is documented here only as history — there is no destructive-verdict guard in the current codebase, because the LLM-driven PR-close verdict it guarded no longer exists in workstacean.
 
-**What it actually does:** when Ava's LLM verdict on a stuck PR is `decomposable` (i.e. "close this and re-cut as smaller PRs"), the handler checks whether the PR is a promotion PR (`head ∈ {dev, staging}` OR `base ∈ {main, staging}` OR title starts with "Promote"). If so, the close is suppressed and an HITL escalation is emitted instead.
+**What it did:** inside the old pr-remediator's `diagnose_pr_stuck` verdict handling, when an LLM verdict on a stuck PR was `decomposable` (i.e. "close this and re-cut as smaller PRs"), the handler checked whether the PR was a promotion PR (`head ∈ {dev, staging}` OR `base ∈ {main, staging}` OR title starts with "Promote"). If so, the close was suppressed and an HITL escalation emitted instead.
 
-**Why it's not generalized:** there is no other destructive verb in the codebase today that an LLM can issue. Closing a PR is the only one. If `delete issue` or `force-update ref` become LLM-driven, *then* generalizing this to a dispatcher invariant becomes worth the abstraction cost. For now, the guard lives next to the only verb that needs it.
+**Why it's gone:** workstacean no longer re-derives PR-pipeline violations or issues destructive PR verdicts. protoMaker now detects stuck PRs as blocked features and emits a single canonical `feature.blocked` signal; `FeatureRemediationPlugin` routes that to Roxy's `unblock_feature` skill or to HITL (see [flow-alert-remediator](flow-alert-remediator.md)). Roxy may take unblocking actions, but the promotion-PR destructive-close path that #465 guarded no longer exists on the workstacean side.
 
-**On trip:** `console.warn` + intended HITL escalation. See [flow-hitl](flow-hitl.md) for the gap that the HITL bus topic is *not actually published* — only logged.
+If a new LLM-driven destructive verb appears later (e.g. `delete issue`, `force-update ref`), the right pattern is the same one #465 used — guard it next to the verb's consumer, and only promote it to a dispatcher invariant if it generalizes across skills.
 
 ---
 
@@ -157,13 +157,12 @@ If you find yourself adding a check that:
 
 …then add it to `_dispatch()` in the same sequence (after registry resolve, before cooldown is fine — the order between these is semantic, see [#437 above](#437--cooldown)).
 
-If the check is **specific to one skill or one verb** (like #465's PR close), put it next to the consumer, not at the dispatcher. The dispatcher is for invariants every skill must respect.
+If the check is **specific to one skill or one verb** (as #465's now-retired PR-close guard was), put it next to the consumer, not at the dispatcher. The dispatcher is for invariants every skill must respect.
 
 ---
 
 ## Related
 
 - [flow-inbound-message](flow-inbound-message.md) — full dispatcher sequence with these invariants in context
-- [flow-alert-remediator](flow-alert-remediator.md) — #459's downstream consumer
-- [flow-pr-review](flow-pr-review.md) — #465's home today
-- [flow-hitl](flow-hitl.md) — the (gap) destination for #465 escalations
+- [flow-alert-remediator](flow-alert-remediator.md) — #459's downstream consumer; also where the retired #465 guard's responsibility moved (protoMaker + feature-remediation)
+- [flow-hitl](flow-hitl.md) — the operator-escalation path

--- a/docs/architecture/flow-agent-runtime-telemetry.md
+++ b/docs/architecture/flow-agent-runtime-telemetry.md
@@ -205,7 +205,7 @@ The `_publishToolCall` callback is wired uniformly in `AgentRuntimePlugin.instal
 - **Progress topics are silent today** — no executor publishes `agent.skill.progress.*`. Dashboard tiles relying on them show nothing.
 - **TaskTracker outcome publish is the canonical path for long-running A2A** — if you're debugging "outcome never fires", check whether the task is parked in TaskTracker (likely) or actually never completed (unlikely).
 - **Latency is `durationMs` on outcomes + structured `agent.skill.latency` on success** — `autonomous.outcome.*.durationMs` is wall-clock; `agent.skill.latency` adds queueMs/executeMs split + optional GitHub PR context. Aggregate at the consumer for p50/p95 ([flow-alert-remediator](flow-alert-remediator.md) does this from outcomes).
-- **`systemActor` is whatever the dispatcher writes** — it's not validated by the bus. Synthetic actors (`pr-remediator`, `goap`, `user`) coexist with real agents. The synthetic-actor filter at FleetHealth ([#459](chokepoint-invariants.md)) is the source of truth for "is this a real agent."
+- **`systemActor` is whatever the dispatcher writes** — it's not validated by the bus. Synthetic actors (`feature-remediation`, `user`) coexist with real agents. The synthetic-actor filter at FleetHealth ([#459](chokepoint-invariants.md)) is the source of truth for "is this a real agent."
 
 ---
 

--- a/docs/architecture/flow-alert-remediator.md
+++ b/docs/architecture/flow-alert-remediator.md
@@ -1,19 +1,21 @@
 ---
-title: Flow — Alert / PR remediator
+title: Flow — Alerts & feature remediation
 ---
 
-_The fleet self-healing path: AgentFleetHealth aggregates outcomes into a snapshot; the `fleet_alerts` ceremony polls thresholds every minute and dispatches `alert.*` skills on violation; pr-remediator handles `pr.remediate.*` topics that propose code mutations._
+_The fleet self-healing path has two halves. **Alerts**: AgentFleetHealth aggregates outcomes into a snapshot; the `fleet_alerts` ceremony polls thresholds every minute and dispatches `alert.*` skills on violation. **Feature remediation**: protoMaker detects blocked features and emits a kinded `feature.blocked` event; `FeatureRemediationPlugin` routes it (ignore / HITL / Roxy `unblock_feature`) with bounded retries._
+
+> **Note on filename.** This doc was historically "alert / PR remediator." The PR-remediator half is gone — `pr-remediator.ts` was deleted (#776) and replaced by `FeatureRemediationPlugin`, which consumes a single canonical `feature.blocked` signal from protoMaker instead of re-deriving PR-pipeline violations in workstacean. The filename is kept stable to avoid breaking links.
 
 ---
 
 ## What & why
 
-The fleet is a distributed system; agents fail, PRs get stuck, costs spike. Two related paths handle the response:
+The fleet is a distributed system; agents fail, features get stuck, costs spike. Two related paths handle the response:
 
-- **Alerts** — declarative skill executors (20 of them) that turn a `alert.fleet_*` skill dispatch into a Discord message. Fire-and-forget, no LLM.
-- **PR remediator** — five `pr.remediate.*` topics (`update_branch`, `merge_ready`, `fix_ci`, `address_feedback`, `pr.backmerge.dispatch`) that consume an action dispatch and mutate the PR via GitHub API.
+- **Alerts** — declarative skill executors (20 of them) that turn an `alert.fleet_*` skill dispatch into a Discord message. Fire-and-forget, no LLM.
+- **Feature remediation** — a single auto-remediation loop. protoMaker's automode raises `feature.blocked` (via the workstacean `/publish` ingress) whenever a feature transitions to blocked, carrying a `kind`. `FeatureRemediationPlugin` routes by kind: ignore the kinds protoMaker self-heals, escalate the kinds no auto-action can fix straight to HITL, and dispatch Roxy's `unblock_feature` for everything else.
 
-Both are `FunctionExecutor`-backed (no LLM at the executor itself; LLM lives one layer deeper in `pr-remediator` for `diagnose_pr_stuck`).
+Alerts are `FunctionExecutor`-backed (no LLM at the executor). Feature remediation does no work itself — it routes a kinded event to either an operator DM or a Roxy DeepAgent skill that holds the LLM.
 
 ---
 
@@ -46,29 +48,52 @@ Both are `FunctionExecutor`-backed (no LLM at the executor itself; LLM lives one
    └──────────────┬───────────┘
                   │
                   ▼
-   ┌──────────────────────────┐  ┌──────────────────────────┐
-   │ alert.fleet_agent_stuck  │  │ action.pr_update_branch  │
-   │ alert.fleet_skill_       │  │ action.pr_fix_ci         │
-   │   orphaned               │  │ action.pr_address_       │
-   │ alert.fleet_cost_over_   │  │   feedback               │
-   │   budget                 │  │ action.pr_merge_ready    │
-   │ … (20 alert skills)      │  │ action.pr_backmerge      │
-   └──────────────┬───────────┘  └──────────────┬───────────┘
-                  │                              │
-                  ▼  SkillDispatcher              ▼  SkillDispatcher
-   ┌──────────────────────────┐  ┌──────────────────────────┐
-   │ AlertSkillExecutorPlugin │  │ PrRemediatorSkillExec.   │
-   │  → message.outbound.     │  │  → pr.remediate.{action} │
-   │      discord.alert       │  │                          │
-   └──────────────────────────┘  └──────────────┬───────────┘
-                                                 │
-                                                 ▼
-                                  ┌──────────────────────────┐
-                                  │ PrRemediatorPlugin       │
-                                  │  in-memory inFlight Map  │
-                                  │  publishes GitHub mut.   │
-                                  │  or HITL escalation      │
-                                  └──────────────────────────┘
+   ┌──────────────────────────┐
+   │ alert.fleet_agent_stuck  │
+   │ alert.fleet_skill_       │
+   │   orphaned               │
+   │ alert.fleet_cost_over_   │
+   │   budget                 │
+   │ … (20 alert skills)      │
+   └──────────────┬───────────┘
+                  │
+                  ▼  SkillDispatcher
+   ┌──────────────────────────┐
+   │ AlertSkillExecutorPlugin │
+   │  → message.outbound.     │
+   │      discord.alert       │
+   └──────────────────────────┘
+
+
+   protoMaker automode (feature blocked)
+        │  POST /publish
+        ▼
+   ┌──────────────────────────┐
+   │ feature.blocked          │  { featureId, kind, projectSlug,
+   │   (kinded)               │    prNumber?, reason?, … }
+   └──────────────┬───────────┘
+                  ▼
+   ┌──────────────────────────┐
+   │ FeatureRemediationPlugin │  per-feature tracker
+   │   _onBlocked()           │  (attempts, cooldown, escalated)
+   │                          │
+   │   route by kind:         │
+   │   • IGNORE_KINDS  ─► drop (protoMaker self-heals)
+   │   • HITL_KINDS    ─► operator.message.request
+   │   • else          ─► dispatch Roxy unblock_feature
+   │                       (bounded: ≤3 attempts, 5min cooldown)
+   │                       on exhaustion ─► escalate ONCE to operator
+   └──────────────┬───────────┘
+                  │
+        ┌─────────┴──────────┐
+        ▼                    ▼
+   agent.skill.request   operator.message.request
+   {skill:unblock_feature,   (HITL — see flow-hitl)
+    targets:["roxy"]}
+        │
+        ▼  SkillDispatcher → A2AExecutor (Roxy)
+
+   feature.unblocked ─► clears the per-feature tracker (fresh budget)
 ```
 
 ---
@@ -101,38 +126,45 @@ sequenceDiagram
     DP->>DP: post to alert webhook channel
 ```
 
-## Sequence (PR remediator path)
+## Sequence (feature remediation path)
 
 ```mermaid
 sequenceDiagram
     autonumber
-    participant TE as Threshold/policy<br/>(external)
+    participant PM as protoMaker automode
     participant Bus as Bus
+    participant FR as FeatureRemediationPlugin
     participant SD as SkillDispatcher
-    participant PRE as PrRemediatorSkillExec
-    participant PR as PrRemediatorPlugin
-    participant GH as GitHub API
+    participant RX as Roxy (A2A)
+    participant OR as OperatorRouting
 
-    TE->>Bus: agent.skill.request<br/>(skill=action.pr_update_branch)
-    Bus->>SD: deliver
-    SD->>PRE: execute (FunctionExecutor)
-    PRE->>Bus: pr.remediate.update_branch
-    Bus->>PR: deliver
+    PM->>Bus: feature.blocked (via POST /publish)<br/>{ featureId, kind, projectSlug, … }
+    Bus->>FR: deliver
+    FR->>FR: _onBlocked(): route by kind
 
-    PR->>PR: look up / create inFlight entry
-    PR->>GH: PATCH /repos/{o}/{r}/pulls/{n}/branch
-    GH-->>PR: response
-
-    alt success
-        PR->>Bus: flow.item.updated / completed
-    else 422 conflict (2+ attempts)
-        PR->>PR: dispatch diagnose_pr_stuck (LLM verdict)
-        alt decomposable + promotion PR
-            Note over PR: #465 destructive guard:<br/>suppress close, escalate HITL
-        else genuine conflict
-            PR->>PR: escalate HITL (console.warn only)
+    alt kind ∈ IGNORE_KINDS (dependency_unsatisfied, …)
+        Note over FR: protoMaker self-heals — ignore
+    else kind ∈ HITL_KINDS (cost_exceeded, quota, …)
+        FR->>Bus: operator.message.request (urgency=high)
+        Bus->>OR: deliver → Discord DM
+    else everything else (ci_failure, merge_conflict, …)
+        alt attempts < MAX_ATTEMPTS (3) and outside cooldown
+            FR->>FR: attempts += 1, lastAttemptAt = now
+            FR->>Bus: agent.skill.request<br/>{ skill: unblock_feature, targets: ["roxy"] }
+            Bus->>SD: deliver
+            SD->>RX: execute (A2AExecutor)
+            RX-->>RX: investigate + smallest unblocking action / crisp ask
+        else attempts ≥ MAX_ATTEMPTS
+            FR->>Bus: operator.message.request (escalate ONCE)
+            Bus->>OR: deliver → Discord DM
+        else within COOLDOWN_MS (5min)
+            Note over FR: skip — too soon since last attempt
         end
     end
+
+    Note over PM,FR: later, when the feature recovers
+    PM->>Bus: feature.unblocked
+    Bus->>FR: clears per-feature tracker (fresh budget on re-block)
 ```
 
 ---
@@ -156,17 +188,16 @@ sequenceDiagram
 
 All 20 are `FunctionExecutor` registrations with priority=5, fire-and-forget, no LLM.
 
-### PR remediator
+### Feature remediation
 
-| Skill | Topic published | Handler in `pr-remediator.ts` |
-|---|---|---|
-| `action.pr_update_branch` | `pr.remediate.update_branch` | line 1006+ |
-| `action.pr_merge_ready` | `pr.remediate.merge_ready` | line 985+ |
-| `action.pr_fix_ci` | `pr.remediate.fix_ci` | line 750+ |
-| `action.pr_address_feedback` | `pr.remediate.address_feedback` | line 750+ |
-| `action.pr_backmerge` | `pr.backmerge.dispatch` | line 6+ |
+| Topic | Published by | Subscribed by | File |
+|---|---|---|---|
+| `feature.blocked` | protoMaker automode (via `POST /publish`) | FeatureRemediationPlugin | `lib/plugins/feature-remediation.ts:80` |
+| `feature.unblocked` | protoMaker automode (via `POST /publish`) | FeatureRemediationPlugin | `lib/plugins/feature-remediation.ts:82` |
+| `agent.skill.request` (`skill: unblock_feature`, `targets: ["roxy"]`) | FeatureRemediationPlugin | SkillDispatcher → Roxy A2AExecutor | `lib/plugins/feature-remediation.ts:150` |
+| `operator.message.request` | FeatureRemediationPlugin (HITL_KINDS + exhaustion) | OperatorRoutingPlugin | `lib/plugins/feature-remediation.ts:185` |
 
-PrRemediatorSkillExecutorPlugin maps skill→topic; PrRemediatorPlugin subscribes to all five.
+`feature.blocked` payload (`FeatureBlockedPayload`): `{ featureId, projectSlug?, projectPath?, featureTitle?, kind?, reason?, prNumber?, branchName?, retryCount?, retryable?, failureCategory?, detail? }`. `featureId` is required; `kind` drives the routing.
 
 ---
 
@@ -174,7 +205,7 @@ PrRemediatorSkillExecutorPlugin maps skill→topic; PrRemediatorPlugin subscribe
 
 Lives at [AgentFleetHealthPlugin._record:281–334](../../src/plugins/agent-fleet-health-plugin.ts). Detail in [chokepoint-invariants](chokepoint-invariants.md).
 
-Summary: `pr-remediator`, `goap`, `user` are recognized synthetic actors. Their outcomes go into `systemActors[]` bucket (not `agents[]`) so they don't inflate `agentCount` or skew `maxFailureRate1h`.
+Summary: synthetic actors like `feature-remediation`, `user` are recognized and their outcomes go into the `systemActors[]` bucket (not `agents[]`) so they don't inflate `agentCount` or skew `maxFailureRate1h`.
 
 ---
 
@@ -209,32 +240,39 @@ src/plugins/fleet-alerts-evaluator-plugin.ts
 
 ---
 
-## PR remediator state machine
+## Feature-remediation state machine
 
-PrRemediatorPlugin (`lib/plugins/pr-remediator.ts`) maintains in-memory `inFlight` Map per PR:
+`FeatureRemediationPlugin` (`lib/plugins/feature-remediation.ts`) maintains an in-memory `tracked` Map keyed by `{projectSlug|projectPath}::{featureId}`:
 
 ```
-InFlightEntry {
-  attemptCount,
-  escalated,
-  diagnostics?,
-  …
+Tracked {
+  attempts,        // auto-remediations dispatched so far
+  lastAttemptAt,   // for cooldown
+  lastSeenAt,      // for the TTL sweep
+  escalated,       // one-shot HITL flag
 }
 ```
 
-Key transitions ([pr-remediator.ts:604+](../../lib/plugins/pr-remediator.ts)):
-- Fresh PR → enter inFlight, attempt = 0
-- Each `pr.remediate.*` consume → attempt += 1, try GitHub mutation
-- Attempt count ≥ `MAX_ATTEMPTS_PER_PR` (3) → mark escalated, emit HITL (see gap in [flow-hitl](flow-hitl.md))
-- 422 conflict on `update_branch` after 2 attempts → dispatch `diagnose_pr_stuck` for LLM verdict
-- Verdict `genuine` → immediate HITL
-- Verdict `decomposable` + promotion PR → suppress close, HITL (defense-in-depth #465)
+Constants: `MAX_ATTEMPTS = 3`, `COOLDOWN_MS = 5min`, `ENTRY_TTL_MS = 1h` (sweep interval that drops stale trackers).
+
+Routing on `feature.blocked` ([feature-remediation.ts:101](../../lib/plugins/feature-remediation.ts)):
+
+- **`kind` ∈ IGNORE_KINDS** (`dependency_unsatisfied`, `external_dependency_unsatisfied`) → ignored; protoMaker self-heals on stale deps. No tracker entry created.
+- **`kind` ∈ HITL_KINDS** (`cost_exceeded`, `runtime_exceeded`, `quota`, `rate_limit`, `worktree_safety`) → escalate directly to the operator (`urgency: high`); no auto-action can help.
+- **everything else** (`ci_failure`, `merge_conflict`, `changes_requested`, `retries_exhausted`, unknown):
+  - `attempts ≥ MAX_ATTEMPTS (3)` → escalate ONCE to the operator, then stay quiet.
+  - within `COOLDOWN_MS (5min)` of the last attempt → skip.
+  - otherwise → `attempts += 1`, dispatch Roxy `unblock_feature` with the blocked-feature context (`targets: ["roxy"]`, `systemActor: "feature-remediation"`).
+- **`feature.unblocked`** → delete the tracker, so a feature that recovers and later re-blocks gets a fresh budget.
+- The escalation is one-shot per tracker (`escalated` flag) — bottlenecks-are-growth: a stuck loop becomes a single HITL signal, never silent infinite retry.
 
 ---
 
 ## Failure modes & gotchas
 
-- **Live CI re-check before fix_ci escalation** ([line 821–830](../../lib/plugins/pr-remediator.ts)) — before emitting HITL for "stuck on CI", pr-remediator hits GitHub live API to confirm CI is still red. If it flipped green between snapshot and escalation, the escalation is silently dropped. Prevents stale-snapshot false alarms.
+- **One escalation per blocked feature** — `Tracked.escalated` is a one-shot flag. Once a feature escalates (either via HITL_KINDS or exhaustion), no further operator DMs fire for it until `feature.unblocked` clears the tracker. Acceptable today; revisit if HITL becomes a queue.
+- **Trackers are in-memory** — a restart drops all per-feature attempt counts. A feature blocked across a restart starts fresh at `attempts = 0`. The `ENTRY_TTL_MS` sweep also drops trackers idle for >1h, intentionally granting a fresh budget on a much-later re-block.
+- **`feature.blocked` without `featureId` is dropped** ([feature-remediation.ts:103](../../lib/plugins/feature-remediation.ts)) with a `console.warn`. protoMaker must always include it.
 - **Alert thresholds are hard-coded in source** — `WINDOW_MS = 24h`, `MAX_RECENT_FAILURES = 10`. No env override. Changing these requires a rebuild.
 - **Cost calculation depends on `MODEL_RATES`** ([lib/types/budget.ts](../../lib/types/budget.ts)) — hard-coded model price table. When LiteLLM gateway adds a new model, this table must be updated or `costUsd` is zero for that model.
 - **Outcome attribution is write-time, not read-time** ([line 281](../../src/plugins/agent-fleet-health-plugin.ts)) — `systemActor` is bucketed *as outcomes arrive*. If `ExecutorRegistry` enrolls a new agent later, prior outcomes for that name stay in `systemActors[]`. Restart required to re-bucket.
@@ -243,7 +281,7 @@ Key transitions ([pr-remediator.ts:604+](../../lib/plugins/pr-remediator.ts)):
 
 ## Related
 
-- [chokepoint-invariants](chokepoint-invariants.md) — #459 synthetic actor filter, #465 destructive verdict guard
-- [flow-hitl](flow-hitl.md) — the escalation path (with the wire-incomplete gap)
+- [chokepoint-invariants](chokepoint-invariants.md) — #459 synthetic actor filter
+- [flow-hitl](flow-hitl.md) — the escalation path (feature-remediation + dispatch-drop-escalator)
 - [flow-agent-runtime-telemetry](flow-agent-runtime-telemetry.md) — what feeds the snapshot
 - [flow-dashboard](flow-dashboard.md) — how the snapshot is rendered

--- a/docs/architecture/flow-hitl.md
+++ b/docs/architecture/flow-hitl.md
@@ -2,7 +2,7 @@
 title: Flow — HITL escalation
 ---
 
-_When an autonomous loop gets stuck, escalation sites publish `operator.message.request` which `OperatorRoutingPlugin` routes to a Discord DM. **Phase 1 outbound is shipped** (#619, #622); the operator-reply path back into the bus (Phase 2) is still open design — text commands vs. buttons vs. CLI/dashboard, decision pending real usage data._
+_When an autonomous loop gets stuck, escalation sites publish `operator.message.request` which `OperatorRoutingPlugin` routes to a Discord DM. **Phase 1 outbound is shipped** (#622, #776); the operator-reply path back into the bus (Phase 2) is still open design — text commands vs. buttons vs. CLI/dashboard, decision pending real usage data._
 
 ---
 
@@ -14,28 +14,30 @@ Two production-wired escalation sources today, both pushing to the same `operato
 
 | Source | What it escalates | Source | Shipped in |
 |---|---|---|---|
-| **pr-remediator** | Stuck PRs (budget exhausted, genuine semantic conflict, promotion-PR destructive-verdict guard) | `lib/plugins/pr-remediator.ts:_emitStuckHitlEscalation` | #619 |
+| **feature-remediation** | Blocked features — directly for HITL_KINDS (cost / runtime / quota / rate-limit / worktree-safety) and once on auto-remediation exhaustion (≥3 Roxy `unblock_feature` attempts) | `lib/plugins/feature-remediation.ts:_escalate` | #776 |
 | **dispatch-drop-escalator** | Drop storms (N drops on same key in M min — cooldown trips, target-unresolved, no-skill) | `src/plugins/dispatch-drop-escalator-plugin.ts` | #622 |
-| **Operator routing** | Subscriber that takes any `operator.message.request` and routes to the admin Discord DM via `users.yaml` identity | `lib/plugins/operator-routing.ts:75–127` | pre-existing |
+| **Operator routing** | Subscriber that takes any `operator.message.request` and routes to the admin Discord DM via `users.yaml` identity | `lib/plugins/operator-routing.ts` | pre-existing |
 
-The previous `lib/plugins/hitl.ts` was ripped in commit `f658744` (2026-05-23) because it violated bus-is-the-contract — DiscordPlugin held a direct reference to `hitlPlugin.registerRenderer()`. The rip commit explicitly anticipated this reconnect: "If approval gates are needed later they'll be implemented as pure bus pub/sub with no registrar pattern." Phase 1 honors that — both #619 and #622 are pure publish-only.
+The previous `lib/plugins/hitl.ts` was ripped in commit `f658744` (2026-05-23) because it violated bus-is-the-contract — DiscordPlugin held a direct reference to `hitlPlugin.registerRenderer()`. The rip commit explicitly anticipated this reconnect: "If approval gates are needed later they'll be implemented as pure bus pub/sub with no registrar pattern." Phase 1 honors that — both feature-remediation and dispatch-drop-escalator are pure publish-only.
 
 ---
 
 ## ASCII spine
 
 ```
-   stuck PR (3 attempts)    drop storm (N drops in M min)    [future sources]
-        │                          │                              │
-        ▼                          ▼                              ▼
-   ┌────────────┐         ┌────────────────────┐
-   │ pr-        │         │ dispatch-drop-     │
-   │ remediator │         │ escalator          │
-   │            │         │                    │
-   │ #619       │         │ #622               │
-   └─────┬──────┘         └─────────┬──────────┘
-         │                          │
-         └──────────────┬───────────┘
+   blocked feature              drop storm (N drops in M min)    [future sources]
+   (HITL kind, or                    │                              │
+    ≥3 Roxy attempts)                │                              │
+        │                           │                              │
+        ▼                           ▼                              ▼
+   ┌──────────────┐         ┌────────────────────┐
+   │ feature-     │         │ dispatch-drop-     │
+   │ remediation  │         │ escalator          │
+   │              │         │                    │
+   │ #776         │         │ #622               │
+   └─────┬────────┘         └─────────┬──────────┘
+         │                            │
+         └──────────────┬─────────────┘
                         ▼
    ┌──────────────────────────┐
    │  operator.message.       │  topic shape OperatorMessageRequest
@@ -66,7 +68,7 @@ The previous `lib/plugins/hitl.ts` was ripped in commit `f658744` (2026-05-23) b
 ```mermaid
 sequenceDiagram
     autonumber
-    participant Source as Escalation source<br/>(pr-remediator OR<br/>dispatch-drop-escalator)
+    participant Source as Escalation source<br/>(feature-remediation OR<br/>dispatch-drop-escalator)
     participant Bus as Bus
     participant OR as OperatorRoutingPlugin
     participant DP as DiscordPlugin
@@ -89,10 +91,10 @@ sequenceDiagram
 
 | Topic | Publisher(s) | Subscriber | Status |
 |---|---|---|---|
-| `operator.message.request` | pr-remediator (#619), dispatch-drop-escalator (#622) | OperatorRoutingPlugin | ✅ wired |
+| `operator.message.request` | feature-remediation (#776), dispatch-drop-escalator (#622) | OperatorRoutingPlugin | ✅ wired |
 | `operator.message.failed.{correlationId}` | OperatorRoutingPlugin (when no transport available) | _(no subscriber yet — for future HTTP callers)_ | ✅ wired publisher side |
 | `message.outbound.discord.dm.user.{userId}` | OperatorRoutingPlugin | DiscordPlugin DM sink | ✅ wired |
-| `operator.message.response` | _Phase 2 — not yet implemented_ | _Phase 2 — pr-remediator would consume_ | ❌ aspirational |
+| `operator.message.response` | _Phase 2 — not yet implemented_ | _Phase 2 — an escalation source would consume_ | ❌ aspirational |
 
 ---
 
@@ -100,13 +102,14 @@ sequenceDiagram
 
 All sites publish `operator.message.request` AND keep their `console.warn` (log-tail visibility is independent of the bus path).
 
-### pr-remediator ([pr-remediator.ts](../../lib/plugins/pr-remediator.ts), all flow through `_emitStuckHitlEscalation`):
+### feature-remediation ([feature-remediation.ts](../../lib/plugins/feature-remediation.ts), all flow through `_escalate`):
 
 | Site | Condition | Urgency |
 |---|---|---|
-| Budget exhaustion (line 770, 744) | `attempts ≥ MAX_ATTEMPTS_PER_PR (3)` | `normal` |
-| diagnose verdict "genuine" (line 1598) | LLM judges semantic conflict | `high` |
-| diagnose verdict "decomposable" on promotion PR (line 1536) | #465 destructive verdict guard | `high` |
+| HITL kind | `kind ∈ {cost_exceeded, runtime_exceeded, quota, rate_limit, worktree_safety}` — no auto-action helps | `high` |
+| Auto-remediation exhausted | `attempts ≥ MAX_ATTEMPTS (3)` after repeated Roxy `unblock_feature` dispatches | `medium` |
+
+`_escalate` is one-shot per blocked feature (`Tracked.escalated`); subsequent triggers stay quiet until `feature.unblocked` clears the tracker. The urgency is `high` for HITL kinds, `medium` otherwise.
 
 ### dispatch-drop-escalator ([dispatch-drop-escalator-plugin.ts](../../src/plugins/dispatch-drop-escalator-plugin.ts)):
 
@@ -125,14 +128,18 @@ All thresholds + windows + cooldowns env-tunable. Per-key escalation cooldown (d
 [operator-routing.ts](../../lib/plugins/operator-routing.ts):
 
 ```
-on operator.message.request:
-    payload: { message, urgency, topic, from }
-    look up operator userId from workspace/users.yaml
-    publish message.outbound.discord.dm.user.{userId}
-        with payload.content = formatted message
+on operator.message.request (payload.type === "operator_message_request"):
+    payload: { message, urgency, topic, from, correlationId }
+    look up the first admin Discord ID via IdentityRegistry (workspace/users.yaml)
+    if found:
+        publish message.outbound.discord.dm.user.{userId}
+            with payload.content = urgency badge + [topic] prefix + message + "— {from}" attribution
+    else:
+        throw OperatorUnreachableError → caught in install(), published as
+        operator.message.failed.{correlationId} (no silent drop)
 ```
 
-[`workspace/users.yaml`](../../workspace/users.yaml) — operator list with Discord user IDs. The plugin reads this at install and routes by `urgency` field (could escalate to multiple operators in future; today it picks the first).
+`IdentityRegistry` is the single source of truth for operator identity, backed by [`workspace/users.yaml`](../../workspace/users.yaml). The first admin user with a Discord identity is the DM recipient; there is no env-var fallback. Multi-channel / presence-based routing is a designed-for branch, not yet implemented — today it's a single Discord DM.
 
 ---
 
@@ -140,7 +147,7 @@ on operator.message.request:
 
 The outbound path is shipped. The inbound path — operator's Discord DM reply re-entering the bus as a structured `operator.message.response` — is undecided. Three viable shapes:
 
-1. **Text commands** in DM (`pr-remediator: merge #123`) → parsed by DiscordPlugin DM handler, published as `operator.message.response`. Pure bus, no Discord UI dependencies.
+1. **Text commands** in DM (`feature-remediation: retry JOSH-123`) → parsed by DiscordPlugin DM handler, published as `operator.message.response`. Pure bus, no Discord UI dependencies.
 2. **Discord buttons / interaction handlers** — richer UX, but the old HITL plugin used a registrar pattern for buttons that was the explicit reason for the f658744 rip. Reintroducing buttons requires designing a bus-pure rendering protocol.
 3. **CLI / dashboard action** — separate surface entirely; operator runs `wsk operator reply <correlationId> <decision>` or clicks in the dashboard.
 
@@ -150,16 +157,15 @@ Decision deferred until ~1 week of Phase 1 escalation data informs which shape f
 
 ## Failure modes & gotchas
 
-- **Promotion-PR destructive guard now escalates loudly** (`#465`) — the LLM-decomposable verdict on a release PR suppresses the close AND fires an operator DM at `urgency: high` (since Phase 1 shipped in #619). Previously this was the most-visible "wire-incomplete" surface; now it's the most-visible "wired" surface.
-- **Live CI re-check before escalating `fix_ci`** (line 821–830) — prevents spurious "stuck on CI" escalation if CI flipped green. Good. But also masks the case where CI flipped green *because* something else fixed it, not because the original issue was resolved.
-- **`InFlightEntry.escalated` is a one-shot flag** ([line 196](../../lib/plugins/pr-remediator.ts)) — once set, no further escalations on the same PR. If a real new failure mode appears, it's not re-escalated. Acceptable today (we don't have multiple operators); revisit if HITL becomes a queue.
-- **`operator.message.request` is fire-and-forget** ([line 76](../../lib/plugins/operator-routing.ts)) — no acknowledgment topic. If the DM send fails, the publisher doesn't know. The OperatorRoutingPlugin logs failures but doesn't notify upstream.
+- **`Tracked.escalated` is a one-shot flag** ([feature-remediation.ts:172](../../lib/plugins/feature-remediation.ts)) — once a blocked feature escalates, no further operator DMs fire for it until `feature.unblocked` clears the tracker. If a different failure mode appears on the same feature before it unblocks, it's not re-escalated. Acceptable today (single operator); revisit if HITL becomes a queue.
+- **In-memory trackers don't survive restart** — a feature blocked across a workstacean restart loses its attempt count and escalation flag, starting fresh at `attempts = 0`. The 1h TTL sweep likewise grants a fresh budget on a much-later re-block. Intentional, but means escalation state is not durable.
+- **`operator.message.request` failure is observable but async** — if no admin Discord identity is configured, `_route()` throws `OperatorUnreachableError`, which `install()` catches and republishes as `operator.message.failed.{correlationId}`. Bus subscribers (like feature-remediation) don't subscribe to that failure topic — only synchronous HTTP callers do — so a feature-remediation escalation that fails to deliver is logged at `console.error` but not retried.
 
 ---
 
 ## Related
 
-- [chokepoint-invariants](chokepoint-invariants.md) — #465 is the most well-formed HITL escalation site
-- [flow-alert-remediator](flow-alert-remediator.md) — pr-remediator hosts most escalation sites
+- [chokepoint-invariants](chokepoint-invariants.md) — the dispatcher-invariant pattern (and the retired #465 destructive-verdict guard)
+- [flow-alert-remediator](flow-alert-remediator.md) — feature-remediation hosts the feature-blocked escalation sites
 - [flow-dashboard](flow-dashboard.md) — once escalations are bussed, the dashboard can count them
 - **Bottlenecks are growth** — the design principle behind this flow: every escalation is a feature-request for the next layer of autonomy

--- a/docs/architecture/flow-pr-review.md
+++ b/docs/architecture/flow-pr-review.md
@@ -199,6 +199,6 @@ Note this is separate from #437 cooldown (which is per-skill-per-repo and 30s) �
 ## Related
 
 - [flow-inbound-message](flow-inbound-message.md) — the underlying transport
-- [chokepoint-invariants](chokepoint-invariants.md) — #465 destructive-verdict guard, which sits inside `pr-remediator` (not Quinn), but related to the verdict pattern
-- [flow-alert-remediator](flow-alert-remediator.md) — PR remediator handles `update_branch` / `fix_ci` / `address_feedback` actions that follow up on review verdicts
+- [chokepoint-invariants](chokepoint-invariants.md) — #465 destructive-verdict guard (retired; it lived in the deleted pr-remediator), kept as history of the verdict-guard pattern
+- [flow-alert-remediator](flow-alert-remediator.md) — feature remediation: protoMaker detects stuck PRs as blocked features (`feature.blocked`) and `FeatureRemediationPlugin` routes them to Roxy `unblock_feature` / HITL
 - [flow-dashboard](flow-dashboard.md) — PR-1/-2/-3 tiles

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -37,7 +37,7 @@ Nine flows + one cross-cut. Each doc has the same shape:
    │ Google       │                         │          │                        │ • outcome    │
    │ Scheduler    │ ── cron.* ──────────────┴──────────┘                        │   publish    │
    │ Ceremonies   │ ── ceremony.{id}.execute ───────────────────────────────────┤              │
-   │ Alerts/PR-R  │ ── action.*, pr.remediate.* ────────────────────────────────┘              │
+   │ Alerts       │ ── action.* ───────────────────────────────────────────────┘              │
    └──────────────┘                                                              └──────┬───────┘
                                                                                         │ dispatch
                                                                                         ▼
@@ -50,8 +50,8 @@ Nine flows + one cross-cut. Each doc has the same shape:
                                                               ▼                                       ▼
                                                   ┌────────────────────┐                  ┌──────────────────┐
                                                   │  DeepAgentExecutor │                  │ FunctionExecutor │
-                                                  │   A2AExecutor      │                  │  (alert/ceremony │
-                                                  │                    │                  │   /pr-remediator)│
+                                                  │   A2AExecutor      │                  │  (alert/ceremony)│
+                                                  │                    │                  │                  │
                                                   └─────────┬──────────┘                  └────────┬─────────┘
                                                             │ message.outbound.*                   │
                                                             │ linear.reply.{id}                    │
@@ -76,8 +76,8 @@ Everything else — telemetry, dashboard, HITL, fleet health — observes this s
 | 2 | [flow-linear-bridges](flow-linear-bridges.md) | `message.inbound.linear.issue.created` (`proto-task` label → `code.execute`@`proto`) | `linear.reply.{issueId}` |
 | 3 | [flow-ceremonies](flow-ceremonies.md) | cron tick / external trigger | `ceremony.{id}.completed` + `autonomous.outcome.ceremony.{id}.{skill}` |
 | 4 | [flow-pr-review](flow-pr-review.md) | `message.inbound.github.{owner}.{repo}.pull_request.{n}` | GitHub review (APPROVED / COMMENTED / CHANGES_REQUESTED) |
-| 5 | [flow-alert-remediator](flow-alert-remediator.md) | fleet-health threshold trip → `action.*` / `pr.remediate.*` | `message.outbound.discord.alert` / GitHub mutation |
-| 6 | [flow-hitl](flow-hitl.md) | escalation site (stuck PR, destructive verdict) | `operator.message.request` → Discord DM |
+| 5 | [flow-alert-remediator](flow-alert-remediator.md) | fleet-health threshold trip → `action.*`; `feature.blocked` (from protoMaker) | `message.outbound.discord.alert` / Roxy `unblock_feature` / HITL |
+| 6 | [flow-hitl](flow-hitl.md) | escalation site (stuck feature, exhausted remediation) | `operator.message.request` → Discord DM |
 | 7 | [flow-agent-runtime-telemetry](flow-agent-runtime-telemetry.md) | executor lifecycle | `agent.runtime.activity.*`, `agent.skill.progress.*`, `agent.skill.latency`, `autonomous.outcome.*` |
 | 8 | [flow-a2a-discovery](flow-a2a-discovery.md) | process startup | ExecutorRegistry enrollment |
 | 9 | [flow-dashboard](flow-dashboard.md) | BusHistoryRecorder + API routes | dashboard tiles |

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -204,7 +204,6 @@ src/
     agent-fleet-health-plugin.ts
     alert-skill-executor-plugin.ts
     ceremony-skill-executor-plugin.ts
-    pr-remediator-skill-executor-plugin.ts
     skill-broker-plugin.ts
   agent-runtime/
     agent-runtime-plugin.ts    # Registrar for in-process agents
@@ -228,7 +227,8 @@ lib/
     github.ts
     linear.ts
     google.ts
-    pr-remediator.ts
+    feature-remediation.ts       # feature.blocked → ignore / HITL / Roxy unblock_feature
+    issue-closer.ts              # feature.completed → close the originating GitHub issue
     scheduler.ts
     a2a-delivery.ts
     operator-routing.ts

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -10,7 +10,7 @@ Contributions to protoWorkstacean are welcome. This section covers how to get st
 |-----------------|------------|
 | `src/index.ts` | Application bootstrap — wires all plugins, starts the HTTP server |
 | `src/executor/` | Executor layer: `IExecutor`, `ExecutorRegistry`, `SkillDispatcherPlugin`, executor implementations |
-| `src/plugins/` | Built-in plugins (CeremonyPlugin, AgentFleetHealth, alert/ceremony/pr-remediator skill executors) |
+| `src/plugins/` | Built-in plugins (CeremonyPlugin, AgentFleetHealth, alert/ceremony skill executors). Feature remediation + issue close-the-loop live in `lib/plugins/` (`feature-remediation.ts`, `issue-closer.ts`) |
 | `src/router/` | `RouterPlugin` + `SkillResolver` + `ProjectEnricher` |
 | `src/agent-runtime/` | `AgentRuntimePlugin`, `AgentDefinitionLoader` (registers `DeepAgentExecutor` instances) |
 | `src/api/` | HTTP route modules (one per concern) |

--- a/docs/explanation/agent-identity.md
+++ b/docs/explanation/agent-identity.md
@@ -29,10 +29,10 @@ Two important splits:
 
 ## GitHub App identities
 
-Quinn and the protoMaker team each have their own GitHub App installation. Each app has an App ID and a private key (PKCS#1 PEM). The pr-remediator and A2A plugins generate short-lived installation tokens from those credentials so comments and reviews post with the right attribution.
+Quinn and the protoMaker team each have their own GitHub App installation. Each app has an App ID and a private key (PKCS#1 PEM). The GitHub-acting code paths (the GitHub plugin, `pr-inspector`, the `issue-closer`) mint short-lived installation tokens from those credentials via the shared `makeGitHubAuth` helper, so comments, reviews, and issue closes post with the right attribution.
 
 When a PR review response lands for Quinn:
-1. pr-remediator looks up the GitHub context from the inbound `correlationId` (owner, repo, number)
+1. The GitHub context is resolved from the inbound `correlationId` (owner, repo, number)
 2. The Quinn container mints a JWT using `QUINN_APP_ID` + `QUINN_APP_PRIVATE_KEY`
 3. Exchanges it for a GitHub installation token (refreshed every 45 min by an entrypoint daemon)
 4. Submits the formal review via the GitHub API — shows as `@protoquinn[bot]`

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -46,13 +46,16 @@ flowchart TD
         SKB["SkillBrokerPlugin\nworkspace/agents.yaml\n→ A2AExecutor"]
         ASE["AlertSkillExecutorPlugin\n→ FunctionExecutor for alert.*"]
         CSE["CeremonySkillExecutorPlugin\n→ FunctionExecutor for ceremony.*"]
-        PSE["PrRemediatorSkillExecutorPlugin\n→ FunctionExecutor for action.pr_*"]
+    end
+
+    subgraph Remediation["Auto-remediation (bus subscriber)"]
+        FR["FeatureRemediationPlugin\nfeature.blocked → ignore / HITL /\nRoxy unblock_feature (bounded)"]
     end
 
     subgraph Executors["Executor implementations"]
         DAE["DeepAgentExecutor\nLangGraph createReactAgent\nin-process (Ava, protoBot)"]
-        A2AE["A2AExecutor\nHTTP JSON-RPC 2.0 + SSE\n(Quinn, protoMaker, Researcher, Jon, protoPen)"]
-        FE["FunctionExecutor\ninline function\n(alert.*, ceremony.*, action.pr_*)"]
+        A2AE["A2AExecutor\nHTTP JSON-RPC 2.0 + SSE\n(Quinn, protoMaker, Researcher, Jon, protoPen, Roxy)"]
+        FE["FunctionExecutor\ninline function\n(alert.*, ceremony.*)"]
     end
 
     GH --> GHP
@@ -74,7 +77,10 @@ flowchart TD
 
     ART -- "register DeepAgentExecutor" --> REG
     SKB -- "register A2AExecutor" --> REG
-    ASE & CSE & PSE -- "register FunctionExecutor" --> REG
+    ASE & CSE -- "register FunctionExecutor" --> REG
+
+    BUS -- "feature.blocked / feature.unblocked\n(from protoMaker via /publish)" --> FR
+    FR -- "agent.skill.request\n(unblock_feature → Roxy)" --> BUS
 ```
 
 ---
@@ -91,14 +97,14 @@ This constraint is what makes the system composable. Adding Discord support does
 
 The executor layer is the unified dispatch path for all agent skill calls. It separates registration from dispatch:
 
-- **Registrars** (`AgentRuntimePlugin`, `SkillBrokerPlugin`, plus the function-executor registrars for `alert.*` / `ceremony.*` / `action.pr_*`) — register executors into `ExecutorRegistry` at `install()` time. No bus subscriptions.
+- **Registrars** (`AgentRuntimePlugin`, `SkillBrokerPlugin`, plus the function-executor registrars for `alert.*` / `ceremony.*`) — register executors into `ExecutorRegistry` at `install()` time. No bus subscriptions.
 - **Dispatcher** (`SkillDispatcherPlugin`) — sole subscriber to `agent.skill.request`, delegates to the registry.
 
 ```
 agent.skill.request
   → SkillDispatcherPlugin
-    ├── chokepoint invariants (cooldown, target-registry guard,
-    │   synthetic-actor filter, destructive-verdict guard)
+    ├── chokepoint invariants (cooldown, target-registry guard;
+    │   synthetic-actor filter lives downstream at fleet-health)
     └── ExecutorRegistry.resolve(skill, targets?)
        1. Named target: any registration whose agentName ∈ targets[]
        2. Skill match: highest priority registration where skill matches

--- a/docs/explanation/operator-flows.md
+++ b/docs/explanation/operator-flows.md
@@ -51,6 +51,18 @@ Linear issue (trigger label)
 
 The net effect: a Linear ticket gets an automatic outcome comment when the board feature it spawned completes — closing the loop that filing alone couldn't.
 
+## Flow 2b — When a feature gets stuck (auto-remediation)
+
+A feature doesn't always march straight to done. When protoMaker's automode detects one is *blocked* — CI failing, a merge conflict, changes requested, retries exhausted, a cost/quota ceiling hit — it emits a **kinded** `feature.blocked` event by `POST`ing to workstacean's `/publish` (same ingress as `feature.completed`). **`FeatureRemediationPlugin`** (`lib/plugins/feature-remediation.ts`) is the single auto-remediation loop and routes by `kind`:
+
+- **Ignore** — `dependency_unsatisfied` / `external_dependency_unsatisfied`: protoMaker self-heals these on its own (stale-dep resolution), so workstacean does nothing.
+- **Escalate to HITL** — `cost_exceeded`, `runtime_exceeded`, `quota`, `rate_limit`, `worktree_safety`: no auto-action can help, so it publishes `operator.message.request` (`urgency: high`) straight to the operator's Discord DM (see [HITL flow](../architecture/flow-hitl)).
+- **Dispatch Roxy** — everything else (`ci_failure`, `merge_conflict`, `changes_requested`, `retries_exhausted`, unknown): it dispatches Roxy's `unblock_feature` skill with the blocked-feature context, asking her to investigate and take the smallest unblocking action (rebase, dispatch a fix, re-queue) or escalate with a crisp ask.
+
+The Roxy path is **bounded**: at most 3 auto-remediation attempts per feature, with a 5-minute cooldown between them. On exhaustion it escalates **once** to the operator and goes quiet — a stuck loop becomes a single HITL signal, never silent infinite retry. A later `feature.unblocked` clears the per-feature tracker, so a feature that recovers and re-blocks gets a fresh budget.
+
+This subsumes the old PR-remediator: instead of workstacean re-deriving PR-pipeline violations and dispatching ad-hoc fixes, protoMaker now detects stuck PRs (and any other block) as blocked features and emits one canonical signal. Non-feature PRs (dependabot / renovate) use GitHub-native auto-merge, not this loop.
+
 ## Flow 3 — PR review with Quinn
 
 1. A PR is opened or synchronized (auto-review), **or** a maintainer comments **`@protoquinn review`** on the PR — a top-level PR comment routes to the `pr_review` skill (not triage).
@@ -73,3 +85,4 @@ The net effect: a Linear ticket gets an automatic outcome comment when the board
 | Label a Linear issue | File the board feature, then comment the outcome back when it completes |
 | `@protoquinn review` (or just open a PR) | Gather CI + diff + structural findings, verify cross-repo refs, post a CI-terminal verdict |
 | Nothing | Notify the project dev channel on feature done/fail; gate the merge on protoMaker's eligibility check |
+| Nothing | On a blocked feature: ignore self-healing kinds, dispatch Roxy to unblock (bounded), or escalate to HITL — only pinging you when auto-remediation can't help or is exhausted |

--- a/docs/extensions/tool-call-v1.md
+++ b/docs/extensions/tool-call-v1.md
@@ -1,0 +1,125 @@
+---
+title: "Extension: x-protolabs/tool-call-v1"
+---
+
+`x-protolabs/tool-call-v1` is a **streaming progress construct**: per-tool lifecycle frames (`started → completed/failed`) emitted on the live A2A stream as `artifact-update` DataParts, so a rich client can render which tool an agent is running mid-task and how each invocation resolves.
+
+**Extension URI**: `https://proto-labs.ai/a2a/ext/tool-call-v1`
+**MIME type** (DataPart discriminator): `application/vnd.protolabs.tool-call-v1+json`
+
+---
+
+## What makes it different from the other extensions
+
+The other four extensions ([cost-v1](cost-v1), [confidence-v1](confidence-v1), [blast-v1](blast-v1), [hitl-mode-v1](hitl-mode-v1)) are **interceptors**: they hook the `A2AExecutor` dispatch pipeline with `before` / `after` hooks, and gate on whether an agent declared the URI in its card. They observe or stamp a single terminal exchange.
+
+tool-call-v1 is **not** an interceptor. It is not declared with `before` / `after` hooks, and it is not a terminal-artifact telemetry payload. It rides the **live SSE stream** while the task is still `working`: each frame is its own `artifact-update` event, emitted the moment a tool turn streams out of the agent's reasoning loop. There is no dispatch-pipeline registration for it — the frames originate inside the in-process runtime and flow over the bus to the A2A server, which emits them on the wire.
+
+Think of it as the structured sibling of the plain-text `status.message` narration described in [A2A Streaming](../guides/a2a-streaming): same live stream, but a machine-readable tool timeline instead of a humanized sentence.
+
+---
+
+## Payload shape
+
+A single frame describes one tool invocation. The payload is a discriminated union on `phase`, so each phase carries only its relevant field. Multiple frames sharing a `toolCallId` describe that invocation's lifecycle.
+
+```ts
+interface ToolCallFrameBase {
+  toolCallId: string;   // stable id correlating frames of the same invocation
+  name: string;         // tool name (e.g. "github_create_issue")
+}
+
+type ToolCallArtifactData =
+  | (ToolCallFrameBase & { phase: "started";   args?: unknown })
+  | (ToolCallFrameBase & { phase: "completed"; result?: unknown })
+  | (ToolCallFrameBase & { phase: "failed";    error?: string });
+```
+
+- **`started`** — the agent's reasoning step requested this tool; `args` carries the parsed call arguments.
+- **`completed`** — the tool returned; `result` carries its output.
+- **`failed`** — the tool errored; `error` carries the message.
+
+A consumer keys on `toolCallId` to stitch `started` to its later `completed` / `failed`, rendering a per-tool spinner that resolves to a check or an X.
+
+---
+
+## Emit / parse helpers
+
+The contract lives in `packages/a2a/src/extensions.ts` (the TypeScript source of truth; the Python `protolabs-a2a` layer mirrors it):
+
+```ts
+import { emitToolCall, parseToolCall, TOOL_CALL_V1_MIME_TYPE } from "@protolabs/a2a";
+
+// Build a DataPart for a streamed artifact-update.
+const part = emitToolCall({ toolCallId, name: "pr_inspector", phase: "started", args });
+
+// Extract the first tool-call-v1 payload from a parts array, or undefined.
+const frame = parseToolCall(parts);
+```
+
+`emitToolCall` builds a spec-correct A2A 1.0 DataPart: the structured payload lives in `content.value`, and the discriminator rides on `metadata.mimeType` (not the SDK's transport-level `mediaType`, which stays `application/json`). `parseToolCall` scans a parts array for the first part whose `metadata.mimeType` matches the MIME constant and returns its payload.
+
+---
+
+## How a frame reaches the wire
+
+The frames are produced by the in-process `DeepAgentExecutor` and bridged to the A2A server over the bus. The path:
+
+1. **Emit (executor).** `DeepAgentExecutor` streams the LangGraph agent with `agent.stream(..., { streamMode: "values" })` rather than `invoke()`-ing it, so tool turns surface live as they stream in. `extractToolFrames` scans each newly-streamed message: a `started` frame per tool call on an AI message (keyed by the call's `id`), and a `completed` / `failed` frame per tool-result message. Each frame fires the executor's `onToolFrame` callback.
+
+2. **Bridge (runtime plugin).** `AgentRuntimePlugin` wires `onToolFrame` to publish on the bus topic:
+
+   ```
+   agent.skill.toolframe.{correlationId}
+   ```
+
+   with payload `{ frame: ToolCallArtifactData }`.
+
+3. **Emit on the stream (A2A server).** `BusAgentExecutor` (`src/api/a2a-server.ts`) subscribes to `agent.skill.toolframe.{correlationId}` for the duration of an inbound `message/send` / `message/stream` call. Each frame becomes an `artifact-update` event whose artifact (named `tool-call`) carries `emitToolCall(frame)`:
+
+   ```ts
+   eventBus.publish(AgentEvent.artifactUpdate({
+     taskId, contextId,
+     artifact: dataArtifact([emitToolCall(frame)], { name: "tool-call" }),
+     append: false,
+     lastChunk: false,
+   }));
+   ```
+
+   The subscription is torn down together with the reply / progress / input subscriptions on terminal or cancel, so frames never leak across overlapping task ids, and late frames after settle are dropped.
+
+---
+
+## Two parallel channels — pick by client capability
+
+A single in-process run feeds **two** streaming channels off the same tool turns:
+
+| Channel | Topic | A2A surface | Reader |
+|---|---|---|---|
+| **Text narration** | `agent.skill.progress.{cid}` | `status-update` (state=`working`, `status.message`) | Simple clients |
+| **Structured frames** | `agent.skill.toolframe.{cid}` | `artifact-update` DataPart (this extension) | Rich tool-timeline clients |
+
+The narration channel carries a humanized one-liner (`routing to quinn`, `searching the web`) plus an initial `thinking` frame emitted the instant the graph starts — before the first LLM turn produces any tool call, so the caller sees motion during the model-latency window. The tool-call-v1 channel carries the machine-readable `started/completed/failed` frames in parallel.
+
+A simple client reads `status.message` and ignores the artifact frames. A rich client reads the tool-call-v1 artifact frames to draw a live tool timeline. Neither blocks the other.
+
+---
+
+## Reference implementations
+
+| Side | Where | Notes |
+|---|---|---|
+| **Contract** | [`packages/a2a/src/extensions.ts`](https://github.com/protoLabsAI/protoWorkstacean/blob/main/packages/a2a/src/extensions.ts) | MIME + URI constants, `ToolCallArtifactData` union, `emitToolCall` / `parseToolCall` |
+| **Frame extraction** | [`src/executor/executors/deep-agent-executor.ts`](https://github.com/protoLabsAI/protoWorkstacean/blob/main/src/executor/executors/deep-agent-executor.ts) — `extractToolFrames` | Cursor-driven scan over streamed messages; fires `onToolFrame` per lifecycle event |
+| **Bus bridge** | [`src/agent-runtime/agent-runtime-plugin.ts`](https://github.com/protoLabsAI/protoWorkstacean/blob/main/src/agent-runtime/agent-runtime-plugin.ts) — `_publishToolFrame` | Publishes `agent.skill.toolframe.{cid}` |
+| **Wire emission** | [`src/api/a2a-server.ts`](https://github.com/protoLabsAI/protoWorkstacean/blob/main/src/api/a2a-server.ts) — `BusAgentExecutor` | Subscribes to the toolframe topic, emits `artifact-update` DataParts |
+
+This channel is specific to the **in-process** runtime (DeepAgent). Remote A2A agents emit their own streaming frames over their own `/a2a` SSE response; this bus bridge is how workstacean's in-process agents reach parity with that on their own `/a2a` endpoint.
+
+---
+
+## Related
+
+- [A2A Streaming (SSE)](../guides/a2a-streaming) — the streaming pipeline this rides on, including the `agent.skill.progress.{cid}` text-narration channel
+- [Extend an A2A Agent](../guides/extend-an-a2a-agent) — the interceptor-style extensions (cost / confidence / blast / hitl-mode)
+- [`cost-v1`](cost-v1) — terminal-task telemetry, by contrast a `before`/`after` interceptor

--- a/docs/guides/a2a-streaming.md
+++ b/docs/guides/a2a-streaming.md
@@ -261,6 +261,46 @@ submitted → working → working (text="...") → working (percent=40, step="..
 
 Same task lifecycle, real-time visibility into what the agent is doing.
 
+## Structured tool-call frames (tool-call-v1)
+
+The `agent.skill.progress.{correlationId}` channel above carries **humanized text** — a one-liner like `routing to quinn` or `searching the web` on `status.message`, which simple clients render as-is. Alongside it, the in-process runtime emits a **structured** tool timeline on a parallel channel for rich clients that want to draw a per-tool spinner with `started → completed/failed` state.
+
+### Topic contract
+
+```
+agent.skill.toolframe.{correlationId}
+```
+
+`BusAgentExecutor` subscribes to this topic on every inbound `message/send` / `message/stream` call, alongside the reply and progress topics. Each event payload is `{ frame: ToolCallArtifactData }`, and each frame becomes its own A2A `artifact-update` event whose artifact (named `tool-call`) carries a [tool-call-v1](../extensions/tool-call-v1) DataPart:
+
+```ts
+eventBus.publish(AgentEvent.artifactUpdate({
+  taskId, contextId,
+  artifact: dataArtifact([emitToolCall(frame)], { name: "tool-call" }),
+  append: false,
+  lastChunk: false,
+}));
+```
+
+The frame is a discriminated union on `phase` — `{ toolCallId, name, phase: "started", args? }`, `{ ..., phase: "completed", result? }`, or `{ ..., phase: "failed", error? }`. A client keys on `toolCallId` to stitch each `started` to its later `completed` / `failed`. See the [tool-call-v1 extension reference](../extensions/tool-call-v1) for the full payload shape and emit/parse helpers.
+
+### Where the frames come from
+
+`DeepAgentExecutor` streams its LangGraph agent (`streamMode: "values"`) and, as each tool turn streams in, fires an `onToolFrame` callback (a `started` frame per AI-message tool call keyed by the call id; a `completed` / `failed` frame per tool-result message). `AgentRuntimePlugin` bridges that callback to `agent.skill.toolframe.{correlationId}`, and `BusAgentExecutor` emits each as the `artifact-update` above.
+
+### The initial "thinking" frame
+
+The first LLM turn can take 15–20s before it produces any tool call, so the runtime also emits an immediate `thinking` progress frame the instant the graph starts — published on the **text** channel (`agent.skill.progress.{cid}`, `step: "thinking"`) so even a simple client sees motion before any tool runs, instead of a byte-silent stream broken only by keepalive heartbeats.
+
+### Two channels, pick by client
+
+| Channel | Topic | A2A surface | Reader |
+|---|---|---|---|
+| Text narration | `agent.skill.progress.{cid}` | `status-update` (`status.message`) | Simple clients |
+| Structured frames | `agent.skill.toolframe.{cid}` | `artifact-update` DataPart | Rich tool-timeline clients |
+
+Both ride the same SSE stream and both are torn down together with the reply subscription on terminal / cancel; late frames after settle are dropped. A simple client reads `status.message` and ignores the artifact frames; a rich client reads the frames to render a live tool timeline.
+
 ## Push-notification configs survive restart
 
 Inbound A2A clients can register a webhook callback via `tasks/pushNotificationConfig/set` so workstacean POSTs them when long-running work terminates. Those configs are persisted to `${DATA_DIR}/push-notifications.db` (SQLite, WAL journal) so they survive container restarts — important on `:main` where watchtower auto-pulls multiple times per day. Each config carries a 24-hour TTL by default; expired rows are filtered from `load()` and opportunistically purged on subsequent `save()` calls. Falls back to the SDK's in-memory store when `DATA_DIR` is unset (tests + ephemeral setups).

--- a/docs/guides/create-a-ceremony.md
+++ b/docs/guides/create-a-ceremony.md
@@ -4,7 +4,7 @@ title: Create a Ceremony
 
 A **ceremony** is a scheduled skill invocation — a recurring fleet ritual defined in YAML, fired by a cron expression, and dispatched through the standard skill routing pipeline.
 
-Ceremonies are distinct from actions. Actions react to world-state violations. Ceremonies run on a fixed schedule regardless of world state, like a daily standup or a weekly retrospective.
+A ceremony is a recurring fleet ritual: a cron schedule, an observable outcome (persisted to `knowledge.db` and surfaced on `/api/ceremonies`), and an on-demand trigger. Unlike event-driven routing — where an inbound Discord/GitHub/Linear message is routed to an agent the moment it arrives — a ceremony fires on its own fixed schedule, like a daily standup or a weekly retrospective, and can also be run on demand.
 
 ## How ceremonies work
 

--- a/docs/guides/extend-an-a2a-agent.md
+++ b/docs/guides/extend-an-a2a-agent.md
@@ -14,6 +14,8 @@ Once you've built the A2A spec surface ([Build an A2A Agent](./build-an-a2a-agen
 
 You don't have to implement any of them. You keep working as a plain A2A agent. But each extension unlocks behavior on the workstacean side that only fires when you opt in.
 
+A sixth extension — [tool-call-v1](../extensions/tool-call-v1) — also exists, but it is **not** part of this interceptor pack. It is a streaming-only construct (live `started → completed/failed` tool frames emitted as `artifact-update` DataParts), not a card-declared `before`/`after` interceptor. See [its own subsection below](#tool-call-v1-—-a-streaming-only-extension-not-an-interceptor).
+
 ## How workstacean picks them up
 
 All five interceptors are **registered unconditionally** at workstacean startup (`src/index.ts`). They run on every outbound A2A call, but **self-gate** on whether you advertised the URI in your agent card. Workstacean never forces behavior on agents that don't opt in.
@@ -184,7 +186,20 @@ All five interceptors live in `defaultExtensionRegistry` and fire on every `A2AE
 
 Each step is independently useful. The pack composes — e.g. blast-v1 + hitl-mode-v1 together let you say "anything `fleet` or `public` radius is `gated`, reviewer: operator."
 
+## tool-call-v1 — a streaming-only extension, not an interceptor
+
+[tool-call-v1](../extensions/tool-call-v1) is the odd one out: it is **not** one of the five interceptors above and **not** something you declare on your card with `before` / `after` hooks. It is a live streaming construct — per-tool lifecycle frames (`started → completed/failed`) emitted on the SSE stream as `artifact-update` DataParts (MIME `application/vnd.protolabs.tool-call-v1+json`) while the task is still `working`.
+
+Key differences from the interceptor pack:
+
+- **No card declaration, no self-gating.** The five interceptors register on the `A2AExecutor` dispatch pipeline and fire (then no-op) based on whether you advertised the URI. tool-call-v1 has no dispatch-pipeline registration at all — the frames originate inside the in-process runtime and ride the live stream.
+- **Streaming, not terminal telemetry.** cost-v1 / confidence-v1 read the terminal task's `data`; tool-call-v1 frames arrive mid-task, one `artifact-update` per tool turn, keyed by `toolCallId` so a client can stitch a `started` to its later `completed` / `failed`.
+- **It's the structured sibling of `status.message` narration.** Workstacean's in-process agents emit both a humanized text line (on `status.message`) and these structured frames in parallel. Simple clients read the text; rich clients read the frames to draw a tool timeline. See [A2A Streaming → Structured tool-call frames](./a2a-streaming#structured-tool-call-frames-tool-call-v1).
+
+You don't opt into it from your card. Workstacean's own `/a2a` endpoint emits it for its in-process agents; a remote A2A agent that wants to offer the same rich timeline streams equivalent `artifact-update` DataParts (built with `emitToolCall`) on its own SSE response.
+
 ## Related
 
 - [Build an A2A Agent](./build-an-a2a-agent) — the spec-side recipe (task store, webhooks, health)
-- Extension reference pages — [cost-v1](../extensions/cost-v1), [confidence-v1](../extensions/confidence-v1), [effect-domain-v1](../extensions/effect-domain-v1), [blast-v1](../extensions/blast-v1), [hitl-mode-v1](../extensions/hitl-mode-v1)
+- Extension reference pages — [cost-v1](../extensions/cost-v1), [confidence-v1](../extensions/confidence-v1), [effect-domain-v1](../extensions/effect-domain-v1), [blast-v1](../extensions/blast-v1), [hitl-mode-v1](../extensions/hitl-mode-v1), [tool-call-v1](../extensions/tool-call-v1)
+- [A2A Streaming (SSE)](./a2a-streaming) — the streaming pipeline tool-call-v1 frames ride on

--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -23,11 +23,15 @@ Receives GitHub webhook events and routes `@mention` comments to the agent fleet
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `GITHUB_TOKEN` | Yes | PAT used to post comment replies (enables the plugin) |
+| `GITHUB_TOKEN` | Yes* | PAT used to post comment replies (enables the plugin) |
+| `QUINN_APP_ID` | No | GitHub App ID — preferred over the PAT for write operations (comments, PR ops, issue closure) so they author as `@protoquinn[bot]` |
+| `QUINN_APP_PRIVATE_KEY` | No | GitHub App PEM private key (newlines as `\n`). Must be set together with `QUINN_APP_ID` |
 | `GITHUB_WEBHOOK_SECRET` | Recommended | Validates `X-Hub-Signature-256` on inbound payloads |
 | `GITHUB_WEBHOOK_PORT` | No | Port for the webhook HTTP server (default: `8082`) |
 
 The plugin is automatically skipped if `GITHUB_TOKEN` is not set.
+
+\* Write operations resolve auth via the shared `makeGitHubAuth` (`lib/github-auth.ts`): the Quinn GitHub App when both `QUINN_APP_ID` and `QUINN_APP_PRIVATE_KEY` are set, otherwise the `GITHUB_TOKEN` PAT. Setting exactly one of the App pair is a misconfiguration and fails loud rather than silently writing as the operator's PAT identity.
 
 ### 2. github.yaml
 
@@ -68,6 +72,8 @@ Fine-grained PAT scoped to the target repo:
 | Pull requests | Read & Write |
 | Actions | Read |
 | Contents | Read |
+
+Issues **Write** covers both comment replies and the close-the-loop (`IssueCloserPlugin` commenting on then closing an issue). The same permissions apply to the Quinn GitHub App installation when used instead of a PAT.
 
 ## Bus Topics
 
@@ -134,6 +140,18 @@ Independent of the @mention triage path, every opened or reopened issue is forwa
 | `AUTOMAKER_API_KEY` | Value sent as the `X-API-Key` header | (none — if unset, the bridge logs a warning and skips forwarding) |
 
 **Dedup.** protoMaker's `SignalIntakeService.submitSignal` dedups on `github:{repository}#{issueNumber}`, so a reopened or redelivered issue does not double-create a board idea.
+
+## GitHub issue close-the-loop
+
+The portfolio pipeline files GitHub issues as the spine (Ava fans out per-repo issues → protoMaker ingests them as features → execution). Without a consumer to clear them, the work ships but the issues pile up open forever. `IssueCloserPlugin` (`lib/plugins/issue-closer.ts`) closes the loop — the GitHub analog of the Linear close-the-loop.
+
+**Subscribe.** The plugin subscribes to `feature.completed`. protoMaker emits this when a feature reaches `done`, echoing the originating `githubIssueNumber` and `repo` (`"owner/name"`). When both are present, the plugin closes the originating issue; completed features that did not originate from a GitHub issue are ignored.
+
+**Close.** It calls `closeIssue(owner, name, issueNumber, { comment, reason })` from `lib/github-issues.ts`, which POSTs a comment (`✅ Resolved by protoMaker — shipped in PR #N`) then PATCHes `/issues/{n}` to `state=closed` with `state_reason` (`completed` by default, or `not_planned`). Issue-closing — not just PR operations — is now supported on this auth path.
+
+**Best-effort.** A close failure is logged loudly but never disturbs other `feature.completed` consumers (e.g. the Discord feature-notifier on the same event). `feature.failed` is intentionally **not** handled — a failed or escalated feature's issue must stay open for attention.
+
+**Auth.** Like PR operations, `closeIssue` authenticates via the shared `makeGitHubAuth` (`lib/github-auth.ts`): the Quinn GitHub App when `QUINN_APP_ID` + `QUINN_APP_PRIVATE_KEY` are set, otherwise the `GITHUB_TOKEN` PAT fallback. The plugin is registered in `src/index.ts` only when GitHub auth is present. A missing comment is non-fatal (logged, then the close proceeds); a failed PATCH throws so the caller surfaces it.
 
 ## Org Webhook: repository.created
 

--- a/docs/integrations/runtimes/deep-agent.md
+++ b/docs/integrations/runtimes/deep-agent.md
@@ -15,7 +15,7 @@ title: DeepAgent Runtime (LangGraph)
 3. When `SkillDispatcherPlugin` routes a `SkillRequest` to this executor, it:
    - Creates a LangGraph ReAct agent with `ChatOpenAI` pointed at the LiteLLM gateway
    - Resolves the system prompt: if the matched skill has `systemPromptOverride`, uses that; otherwise uses the agent's `systemPrompt`
-   - Appends a cached world state snapshot for instant situational awareness
+   - Replays recent conversation history when per-agent memory is enabled (`this.memory.history(...)`), so the agent sees the conversation rather than only the latest message
    - Provides LangChain tools matching the `tools` whitelist from the agent YAML
    - Runs the agent loop with `recursionLimit` derived from `maxTurns`
    - Returns the final AI message as `SkillResult.text`
@@ -75,6 +75,20 @@ skills:
 When a skill declares `systemPromptOverride`, the executor uses it instead of the agent's main `systemPrompt` for that specific invocation. This allows structured-output skills (like `diagnose_pr_stuck`) to use narrow, format-enforcing prompts while operational skills use the full conversational prompt.
 
 See [Agent Skills Reference](../../reference/agent-skills) for the full YAML schema and available tools.
+
+## Streaming & live tool narration
+
+The executor **streams** the LangGraph run rather than calling `invoke()`. It iterates `agent.stream({ messages }, { streamMode: "values" })`, which yields the full accumulated state after each node; the final yield is exactly what `invoke()` would have returned, so all downstream extraction (final text, memory, structured output) is unchanged.
+
+Streaming exists so progress reaches the caller **live** — the moment each turn streams in — instead of being replayed in a tight loop after the whole run settles. The executor fires three hooks during the run, all wired by `AgentRuntimePlugin` onto the bus:
+
+| Hook | When | Bus topic | Payload |
+|------|------|-----------|---------|
+| `onProgress` | An initial `"thinking"` frame, emitted before the first LLM turn (which can take 15–20s) so the stream is not byte-silent | `agent.skill.progress.{correlationId}` | Humanized progress text |
+| `onToolCall` | Each tool-call turn as it streams in, before its tools execute | `agent.skill.progress.{correlationId}` | Humanized tool-call narration (`toolNames`, `toolCalls`) |
+| `onToolFrame` | A structured tool-call-v1 lifecycle frame (`started` → `completed`/`failed`) per tool call as the graph streams | `agent.skill.toolframe.{correlationId}` | Structured `ToolCallArtifactData` frame |
+
+The progress topics carry humanized narration for plain clients; the toolframe topic carries structured frames that the a2a-server emits as streamed artifact-update DataParts for rich clients. All three hooks are best-effort — a throwing callback is logged and never aborts the run.
 
 ## Available tools
 

--- a/docs/reference/bus-topics.md
+++ b/docs/reference/bus-topics.md
@@ -6,9 +6,9 @@ title: Bus Topics
 
 ## Summary
 
-- **88** distinct topics seen across the codebase
-- **20** declared in `src/event-bus/all-topics.ts` (TOPICS constant)
-- **68** raw-string / template topics not in TOPICS (candidates to register)
+- **85** distinct topics seen across the codebase
+- **23** declared in `src/event-bus/all-topics.ts` (TOPICS constant)
+- **62** raw-string / template topics not in TOPICS (candidates to register)
 - **18** topics that couldn't be statically resolved (computed at runtime)
 - **100** publish call sites, **59** subscribe call sites
 
@@ -30,9 +30,10 @@ Each row links to the original call site as `path:line` so jumping from this ind
 | `agent.input.response` | ✅ `AGENT_INPUT_RESPONSE_PREFIX` (`ACTION_TOPICS`) | — | _(none)_ | _(none)_ |
 | `agent.skill.latency` | ✅ `AGENT_SKILL_LATENCY` (`ACTION_TOPICS`) | — | `src/executor/skill-dispatcher-plugin.ts:518` | _(none)_ |
 | `agent.skill.progress` | ✅ `AGENT_SKILL_PROGRESS_PREFIX` (`ACTION_TOPICS`) | — | _(none)_ | _(none)_ |
-| `agent.skill.request` | ✅ `AGENT_SKILL_REQUEST` (`ACTION_TOPICS`) | — | `src/router/router-plugin.ts:295`<br>`src/router/router-plugin.ts:342`<br>`src/executor/skill-dispatcher-plugin.ts:665`<br>`src/api/openai-compat.ts:171`<br>`src/api/ava-tools.ts:132`<br>`src/api/ava-tools.ts:323`<br>`src/api/a2a-server.ts:354`<br>`src/plugins/fleet-alerts-evaluator-plugin.ts:188`<br>`lib/plugins/pr-remediator.ts:1350`<br>`lib/plugins/pr-remediator.ts:1616`<br>`lib/plugins/linear-proto-bridge.ts:105`<br>`lib/plugins/discord/inbound.ts:115` | `src/executor/skill-dispatcher-plugin.ts:183` |
-| `agent.skill.response.{correlationId}` | — | — | _(none)_ | `src/api/ava-tools.ts:51`<br>`lib/plugins/pr-remediator.ts:1335` |
-| `agent.skill.response.#` | — | — | _(none)_ | `lib/plugins/pr-remediator.ts:632` |
+| `agent.skill.toolframe.{correlationId}` | ✅ `AGENT_SKILL_TOOLFRAME_PREFIX` (`ACTION_TOPICS`) | `ToolCallArtifactData` (tool-call-v1) | `src/agent-runtime/agent-runtime-plugin.ts:394` | `src/api/a2a-server.ts:217` |
+| `agent.skill.request` | ✅ `AGENT_SKILL_REQUEST` (`ACTION_TOPICS`) | — | `src/router/router-plugin.ts:295`<br>`src/router/router-plugin.ts:342`<br>`src/executor/skill-dispatcher-plugin.ts:667`<br>`src/api/openai-compat.ts:171`<br>`src/api/ava-tools.ts:132`<br>`src/api/ava-tools.ts:323`<br>`src/api/a2a-server.ts:390`<br>`src/plugins/fleet-alerts-evaluator-plugin.ts:188`<br>`lib/plugins/feature-remediation.ts:150`<br>`lib/plugins/linear-proto-bridge.ts:105`<br>`lib/plugins/discord/inbound.ts:45` | `src/executor/skill-dispatcher-plugin.ts:183` |
+| `agent.skill.response.{correlationId}` | — | — | _(none)_ | `src/api/ava-tools.ts:52` |
+| `agent.skill.response.#` | — | — | _(none)_ | `src/event-bus/skill-response-cache.ts:96` |
 
 **`agent.input.request`** — Prefix for human-input requests. Full topic is `agent.input.request.{correlationId}`. An in-process agent's `ask_human` tool (via POST /api/agent/ask-human) publishes here when it needs an answer from the A2A caller; BusAgentExecutor turns it into an `input-required` status-update on the caller's stream. See src/api/human-input.ts.
 
@@ -41,6 +42,8 @@ Each row links to the original call site as `path:line` so jumping from this ind
 **`agent.skill.latency`** — Published by SkillDispatcherPlugin after every successful skill completion that came from a webhook-stamped dispatch (today: github's `_handleAutoReview`). Structured form of the existing `[skill-latency]` log line — dashboard tiles + downstream alerting can subscribe and accumulate without parsing stdout. Payload shape: { skill, totalMs, queueMs, executeMs, github? }. - totalMs   = webhook arrival → done - queueMs   = webhook arrival → dispatch start (bus hops + routing) - executeMs = dispatch start → done (LLM + tools) - github    = { owner, repo, number } when the original payload carried it (PR reviews, etc.); absent otherwise.
 
 **`agent.skill.progress`** — Prefix for skill-progress events. Full topic is `agent.skill.progress.{correlationId}`. Skill executors that want to stream intermediate progress to a long-running A2A caller publish to this topic; BusAgentExecutor translates each event into a `status-update` (state=working, final=false) on the A2A `message/stream` channel. Opt-in — executors that don't publish lose nothing. See AgentSkillProgressPayload in src/event-bus/payloads.ts.
+
+**`agent.skill.toolframe`** — Prefix for structured tool-call-v1 frames. Full topic is `agent.skill.toolframe.{correlationId}`. AgentRuntimePlugin publishes one frame per tool lifecycle event (started → completed/failed), sourced from DeepAgentExecutor's `onToolFrame` callback; the a2a-server subscribes and emits each frame as a streamed artifact-update DataPart for clients that render a structured tool timeline. Sibling to the plain-text narration on `agent.skill.progress.{correlationId}`. Opt-in.
 
 **`agent.skill.request`** — Published to invoke an agent skill (unified dispatch).
 
@@ -114,18 +117,22 @@ Each row links to the original call site as `path:line` so jumping from this ind
 
 **`dispatch.dropped`** — Prefix for dispatcher drop events. Full topic is `dispatch.dropped.{reason}` where reason ∈ {no_skill, target_unresolved, cooldown}. Published by SkillDispatcherPlugin at each chokepoint drop site so subscribers (dashboard, drop-rate alerts) can count + filter by reason without scraping stdout. Payload shape: see `DispatchDroppedPayload` in src/event-bus/payloads.ts.
 
-## `entry.*`
-
-| Topic | Declared | Payload | Publishers | Subscribers |
-|---|---|---|---|---|
-| `entry.topic` | — | — | `src/plugins/pr-remediator-skill-executor-plugin.ts:111` | _(none)_ |
-
 ## `feature.*`
 
 | Topic | Declared | Payload | Publishers | Subscribers |
 |---|---|---|---|---|
-| `feature.completed` | — | — | _(none)_ | `lib/plugins/feature-notifier.ts:62` |
-| `feature.failed` | — | — | _(none)_ | `lib/plugins/feature-notifier.ts:65` |
+| `feature.blocked` | ✅ `FEATURE_BLOCKED` (`FEATURE_TOPICS`) | `FeatureBlockedPayload` | _(protoMaker via POST /publish)_ | `lib/plugins/feature-remediation.ts:80` |
+| `feature.unblocked` | ✅ `FEATURE_UNBLOCKED` (`FEATURE_TOPICS`) | `{ projectSlug?, featureId }` | _(protoMaker via POST /publish)_ | `lib/plugins/feature-remediation.ts:82` |
+| `feature.completed` | — | `{ projectSlug, featureId, featureTitle?, branchName?, prNumber?, githubIssueNumber?, repo? }` | _(protoMaker via POST /publish)_ | `lib/plugins/feature-notifier.ts:62`<br>`lib/plugins/issue-closer.ts:54` |
+| `feature.failed` | — | `{ projectSlug, featureId, featureTitle?, error? }` | _(protoMaker via POST /publish)_ | `lib/plugins/feature-notifier.ts:65` |
+
+**`feature.blocked`** — Declared in `FEATURE_TOPICS` (not yet in the `TOPICS` barrel). Published when a protoMaker feature transitions to blocked — the canonical auto-remediation signal. Raised by protoMaker's automode via the workstacean `POST /publish` ingress; consumed by FeatureRemediationPlugin, which routes by `kind` to Roxy `unblock_feature` or operator HITL (bounded + escalating). Payload shape: `FeatureBlockedPayload` `{ projectSlug?, projectPath?, featureId, featureTitle?, kind?, reason?, prNumber?, branchName?, retryCount?, retryable?, failureCategory?, detail? }`.
+
+**`feature.unblocked`** — Declared in `FEATURE_TOPICS` (not yet in the `TOPICS` barrel). protoMaker recovery signal published when a feature recovers; FeatureRemediationPlugin clears its remediation tracker so a later re-block gets a fresh retry budget.
+
+**`feature.completed`** — Published by protoMaker (via `POST /publish`) when a feature ships. FeatureNotifierPlugin posts a ✅ message to the project's dev channel; IssueCloserPlugin closes the originating `repo#githubIssueNumber` with a comment when both `githubIssueNumber` and `repo` are present (close-the-loop).
+
+**`feature.failed`** — Published by protoMaker (via `POST /publish`) when a feature fails/escalates. FeatureNotifierPlugin posts a ❌ message with the error; IssueCloserPlugin intentionally does not act on it (a failed feature's issue stays open).
 
 ## `flow.*`
 
@@ -179,7 +186,7 @@ Each row links to the original call site as `path:line` so jumping from this ind
 | `message.inbound.onboard` | — | — | _(none)_ | `lib/plugins/onboarding.ts:142` |
 | `message.outbound.cli` | — | — | _(none)_ | `lib/plugins/cli.ts:18` |
 | `message.outbound.discord.#` | — | — | _(none)_ | `lib/plugins/discord/outbound.ts:43` |
-| `message.outbound.discord.alert` | ✅ `MESSAGE_OUTBOUND_DISCORD_ALERT` (`MESSAGE_TOPICS`) | — | `src/plugins/quinn-review-notifier-plugin.ts:113`<br>`src/plugins/alert-skill-executor-plugin.ts:135`<br>`lib/plugins/pr-remediator.ts:1241`<br>`lib/plugins/pr-remediator.ts:1638` | _(none)_ |
+| `message.outbound.discord.alert` | ✅ `MESSAGE_OUTBOUND_DISCORD_ALERT` (`MESSAGE_TOPICS`) | — | `src/plugins/quinn-review-notifier-plugin.ts:113`<br>`src/plugins/alert-skill-executor-plugin.ts:135` | _(none)_ |
 | `message.outbound.discord.dm.user.#` | — | — | _(none)_ | `lib/plugins/discord/outbound.ts:129` |
 | `message.outbound.discord.push.{AGENT_OPS_CHANNEL}` | — | — | `src/api/ava-tools.ts:117`<br>`src/api/ava-tools.ts:181` | _(none)_ |
 | `message.outbound.discord.push.{opsChannel}` | — | — | `src/plugins/skill-broker-plugin.ts:178` | _(none)_ |
@@ -208,17 +215,7 @@ Each row links to the original call site as `path:line` so jumping from this ind
 | Topic | Declared | Payload | Publishers | Subscribers |
 |---|---|---|---|---|
 | `operator.message.failed.{correlationId}` | — | — | `lib/plugins/operator-routing.ts:90` | _(none)_ |
-| `operator.message.request` | — | — | `src/api/operator.ts:69`<br>`src/plugins/dispatch-drop-escalator-plugin.ts:144`<br>`lib/plugins/pr-remediator.ts:827` | `lib/plugins/operator-routing.ts:76` |
-
-## `pr.*`
-
-| Topic | Declared | Payload | Publishers | Subscribers |
-|---|---|---|---|---|
-| `pr.backmerge.dispatch` | — | — | _(none)_ | `lib/plugins/pr-remediator.ts:649` |
-| `pr.remediate.address_feedback` | — | — | _(none)_ | `lib/plugins/pr-remediator.ts:643` |
-| `pr.remediate.fix_ci` | — | — | _(none)_ | `lib/plugins/pr-remediator.ts:640` |
-| `pr.remediate.merge_ready` | — | — | _(none)_ | `lib/plugins/pr-remediator.ts:637` |
-| `pr.remediate.update_branch` | — | — | _(none)_ | `lib/plugins/pr-remediator.ts:646` |
+| `operator.message.request` | — | — | `src/api/operator.ts:69`<br>`src/plugins/dispatch-drop-escalator-plugin.ts:144`<br>`lib/plugins/feature-remediation.ts:185` | `lib/plugins/operator-routing.ts:76` |
 
 ## `quinn.*`
 
@@ -274,12 +271,6 @@ Each row links to the original call site as `path:line` so jumping from this ind
 | Topic | Declared | Payload | Publishers | Subscribers |
 |---|---|---|---|---|
 | `task.replyTopic` | — | — | `src/executor/task-tracker.ts:330` | _(none)_ |
-
-## `world.*`
-
-| Topic | Declared | Payload | Publishers | Subscribers |
-|---|---|---|---|---|
-| `world.state.updated` | — | — | _(none)_ | `lib/plugins/pr-remediator.ts:592` |
 
 ## `{RESPONSE_TOPIC_WILDCARD}.*`
 
@@ -452,6 +443,5 @@ These sites pass a non-literal topic that the static scan couldn't resolve to a 
 | `src/plugins/CeremonyPlugin.ts:372` | subscribe | `replyTopic` |
 | `src/plugins/CeremonyPlugin.ts:399` | publish | `skillRequestTopic` |
 | `src/plugins/CeremonyPlugin.ts:453` | publish | `completedTopic` |
-| `src/plugins/pr-remediator-skill-executor-plugin.ts:111` | publish | `entry.topic` |
 | `src/world/extensions/CeremonyStateExtension.ts:120` | publish | `topic` |
 

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -145,8 +145,6 @@ These variables are read via `process.env` somewhere in `src/` or `lib/` but are
 | `A2A_INPUT_REQUIRED_TTL_MS` | `src/api/human-input.ts` |
 | `A2A_STREAM_HEARTBEAT_MS` | `src/api/a2a-server.ts` |
 | `AUTOMAKER_API_KEY` | `lib/plugins/protomaker-board-bridge.ts`, `src/plugins/project-registry.ts` |
-| `BACKMERGE_WORKFLOW_FILE` | `lib/plugins/pr-remediator.ts` |
-| `BACKMERGE_WORKFLOW_REF` | `lib/plugins/pr-remediator.ts` |
 | `CLAWPATCH_CHECKOUT_ROOT` | `lib/checkout-cache.ts` |
 | `CLAWPATCH_REPO_PATH_MAP` | `src/api/clawpatch.ts` |
 | `CLAWPATCH_STATE_ROOT` | `src/api/clawpatch.ts` |

--- a/docs/roadmap/2026-06.md
+++ b/docs/roadmap/2026-06.md
@@ -15,6 +15,10 @@ calibrated to ~10–15 points/week of capacity for one engineer.
 | --- | --- | --- |
 | **A. Close the Linear loop** | 3 PRs | 8 |
 | **B. Quinn PR autonomy** (close_pr / close_issue) | 2 PRs | 5 |
+<!-- Status convention: items completed since this roadmap was written are
+     marked **✅ SHIPPED (PR #…)** in their heading and keep their original body
+     for history. Don't delete shipped items — mark them. -->
+
 | **C. Clawpatch on any repo** (worktree checkouts) | 4 PRs | 13 |
 | **D. Dashboard phase 3** (trace view + layout + drawer) | 3 PRs | 13 |
 | **E. Cleanup + release hygiene** | 4 small PRs | 5 |
@@ -38,7 +42,7 @@ herself. Add it.
 * Auth: same `@protoquinn[bot]` App identity already in use for reviews
 * Test plan: smoke a self-PR close on a draft test PR
 
-### B2 — `pr_inspector close_issue` action (2 pts)
+### B2 — `pr_inspector close_issue` action — ✅ SHIPPED (PR #787)
 
 Same shape as B1, but for issues. Quinn's `bug_triage` skill was filing
 issues asking for issue closure because she couldn't close them herself.
@@ -46,6 +50,12 @@ issues asking for issue closure because she couldn't close them herself.
 * Files: extend the route from B1 + tool schema
 * Actions: `close_issue`, `close_issue_as_not_planned`, `reopen_issue`, `comment_on_issue`
 * Prompt update: `bug_triage` resolves "already_fixed" / "duplicate" / "stale" by closing directly with a linking comment instead of filing a meta-issue
+
+> **Shipped as `lib/github-issues.ts` `closeIssue()` + `IssueCloserPlugin`.** The
+> close-the-loop landed as an event-driven consumer (`feature.completed` →
+> close `repo#githubIssueNumber` with a linking comment) rather than a Quinn-driven
+> `pr_inspector` action. The underlying `closeIssue()` helper is reusable for the
+> agent-driven `bug_triage` resolution path described above.
 
 ### A1 — Wire `linear.*` inbound to Ava (2 pts)
 
@@ -96,7 +106,7 @@ on `git tag`.
 
 ## Week 2 (~10 pts) — Linear close-the-loop + release hygiene cleanup
 
-### A3 — protoMaker `done` → Linear comment (3 pts)
+### A3 — protoMaker `done` → Linear comment (3 pts) — GitHub analog ✅ SHIPPED (PR #787)
 
 Reverse direction of the Linear bridge. When protoMaker reports a
 feature complete (probably via `feature.completed` bus event), the
@@ -106,6 +116,13 @@ a comment with the result.
 * Files: `lib/plugins/linear-protomaker-bridge.ts` (currently unidirectional Linear → protoMaker)
 * Lookup: bridge already keeps the issue ↔ feature mapping at dispatch time; reuse
 * Reply via existing `linear.reply.{issueId}` topic
+
+> **GitHub close-the-loop shipped (`IssueCloserPlugin`, PR #787).** The portfolio
+> pipeline now uses GitHub issues as the spine, so the completed-feature analog
+> landed there first: `feature.completed` → close the originating
+> `repo#githubIssueNumber` with a comment linking the shipped PR. The
+> **Linear-specific side described here is still open** — `feature.completed` → comment
+> back on the originating Linear issue via `linear-protomaker-bridge` is not yet wired.
 
 ### E4 — Trusted Publishing migration for protoPatch (2 pts)
 

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -238,7 +238,9 @@ skills:
     keywords: [diagnose, conflict, stuck, merge, rebase, pr, dirty]
     # Structured output: after the analysis loop, a forced submit_diagnose_pr_stuck
     # tool call distills the verdict into this schema, validated + emitted as a
-    # typed DataPart (resultMime) the pr-remediator reads directly — no prose parsing.
+    # typed DataPart (resultMime) a remediation consumer reads directly — no prose
+    # parsing. (PR-pipeline remediation now flows through feature.blocked →
+    # FeatureRemediationPlugin → Roxy unblock_feature; the old pr-remediator is gone.)
     resultMime: application/vnd.protolabs.pr-diagnosis-v1+json
     outputSchema:
       type: object

--- a/workspace/agents/quinn.yaml
+++ b/workspace/agents/quinn.yaml
@@ -9,7 +9,8 @@
 #   pr_review        — Formal review of a single PR. Posts an
 #                      APPROVED / COMMENTED / CHANGES_REQUESTED
 #                      review via the GitHub Review API. Feeds the
-#                      autonomous merge loop in pr-remediator.
+#                      autonomous merge-on-green loop (deterministic
+#                      approve-on-terminal-green in github.ts).
 #   bug_triage       — Triage open GitHub issues / blocked board
 #                      features and report patterns.
 #   security_triage  — Classify a CVE / dependabot / vuln report,

--- a/workspace/channels.yaml
+++ b/workspace/channels.yaml
@@ -65,7 +65,7 @@ channels:
 
   # ── Per-project bindings ──────────────────────────────────────────────────
   # Bind a Discord channel to a (projectSlug, kind) pair so feature-notifier,
-  # pr-remediator, and slash-commands can resolve "the dev channel for
+  # feature-remediation, and slash-commands can resolve "the dev channel for
   # protomaker" without any project-level config file. Lookup:
   # ChannelRegistry.getProjectChannel(slug, kind).
   #


### PR DESCRIPTION
Audit + full sweep of `docs/` against current `main`. Nearly all staleness traced to **this session's merges**: pr-remediator deleted (#779), the `feature.blocked` router, live A2A streaming (#780), tool-call-v1 frames (#782), and the GitHub issue close-the-loop (#787). Audited all ~75 docs; **25 files changed, 1 new**.

## 🔴 Stale → fixed
- **architecture/flow-alert-remediator.md** — rewritten end-to-end: the deleted pr-remediator flow (ASCII spine, sequence diagrams, `pr.remediate.*` topic table, `InFlightEntry` state machine) → `FeatureRemediationPlugin` (`feature.blocked` → ignore / HITL / Roxy `unblock_feature`, bounded + one-shot escalation).
- **reference/bus-topics.md** — removed 6 dead topics (`pr.remediate.*`, `pr.backmerge.dispatch`, `world.state.updated`, `entry.*`); added `feature.blocked`, `feature.unblocked`, `agent.skill.toolframe`; fixed deleted-file refs + declared-topic count (20 → 23).
- **architecture/** {chokepoint-invariants (#465 marked retired), flow-hitl (escalation sources → feature-remediation), flow-pr-review, index (flow table + ASCII diagram), flow-agent-runtime-telemetry (synthetic actors)}.
- **explanation/** {architecture (mermaid node), operator-flows (new feature-blocked remediation flow), agent-identity (GitHub-auth narrative)}.
- **guides/create-a-ceremony.md** — dropped the GOAP "world-state violations" framing.
- **roadmap/2026-06.md** — B2 + A3 (GitHub close-the-loop) marked shipped.
- **contributing/{index,development}.md, CLAUDE.md, STATUS.md** — plugin rosters drop pr-remediator, add feature-remediation + issue-closer.
- **workspace/{agents/ava,agents/quinn,channels}.yaml** — comments only (no config touched).

## 🟡 Missing → added
- **extensions/tool-call-v1.md** (new) — documents the live tool-call-v1 streaming extension (started/completed/failed frames as artifact-update DataParts), clarifying it's a streaming construct, not an interceptor.
- **guides/{a2a-streaming, extend-an-a2a-agent}.md** — tool-call-v1 frames + the initial "thinking" frame.
- **integrations/github.md** — issue close-the-loop + Quinn-App-for-issues auth.
- **integrations/runtimes/deep-agent.md** — streaming + `onToolCall`/`onProgress`/`onToolFrame` hooks; **fixed** the inaccurate "cached world-state snapshot" claim (it's conversation-history replay).

## Verification
VitePress build is clean — every internal link + anchor resolves (the new page included). Residual sweep for `pr-remediator`/`pr.remediate`/`world.state.updated`/`action.pr_*` comes back clean except intentionally-retired history notes and ADR-0006 (a point-in-time decision record, left as-is).

## Follow-up (not a doc change)
`workspace/agents/quinn.yaml` `systemPrompt`/`description` (lines ~174, 316, 318) still name pr-remediator in **functional prompt text**. Left out of this docs PR — it's a behavior/prompt change that deserves its own PR, not bundling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic GitHub issue closure when features complete
  * Enhanced feature remediation with bounded retry attempts and operator escalation for unresolved issues
  * Structured tool-call frames (`tool-call-v1`) in A2A streaming for richer client UI integration

* **Documentation**
  * Updated architecture guides to reflect feature remediation flow and updated integration patterns
  * Added comprehensive A2A streaming extension reference and guides
  * Enhanced GitHub integration documentation with issue close-the-loop details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->