### PR TITLE
chore(quinn): correct prompt refs to the deleted pr-remediator merge loop

### DIFF
--- a/workspace/agents/quinn.yaml
+++ b/workspace/agents/quinn.yaml
@@ -171,7 +171,7 @@ skills:
       Formal review of a single GitHub PR. Gathers CI status, unresolved
       review threads, and the diff; produces a verdict; submits an
       APPROVED / COMMENTED / CHANGES_REQUESTED review via the GitHub
-      Review API. Feeds the autonomous merge loop in pr-remediator.
+      Review API. Feeds the autonomous merge-on-green loop.
     keywords: [pr_review, review, pull request, audit, formal review]
     # Scoped toolbelt: pr_inspector covers all GitHub-side review IO;
     # clawpatch_review adds a structural code-review pass via the gateway
@@ -313,9 +313,9 @@ skills:
 
       | VERDICT | pr_inspector action | GitHub state | When |
       |---------|---------------------|--------------|------|
-      | **PASS** | `review_approve` | APPROVED | All critical checks pass, no blocking issues, no HIGH/CRITICAL findings. Triggers auto-merge in pr-remediator. |
+      | **PASS** | `review_approve` | APPROVED | All critical checks pass, no blocking issues, no HIGH/CRITICAL findings. Clears the merge-on-green gate — the PR auto-merges once CI is terminal-green. |
       | **WARN** | `review_comment` | COMMENTED | Critical checks pass but medium/low concerns worth flagging, or confidence below the 80% threshold. Does NOT block merge. |
-      | **FAIL** | `review_request_changes` | CHANGES_REQUESTED | One or more CRITICAL or HIGH findings, broken CI, verified defect. Triggers `pr_address_feedback` in pr-remediator. |
+      | **FAIL** | `review_request_changes` | CHANGES_REQUESTED | One or more CRITICAL or HIGH findings, broken CI, verified defect. protoMaker's automode then iterates on the feedback and re-requests review. |
 
       **Never skip this step.** Narrative summary without a formal review
       = PR stuck forever.


### PR DESCRIPTION
The functional-prompt follow-up I flagged on #788. Quinn's `pr_review` description and the VERDICT→action table named `pr-remediator` / `pr_address_feedback` as the downstream of her verdicts — that plugin was deleted (#779).

**Quinn's behavior is unchanged** — she still emits `review_approve` / `review_comment` / `review_request_changes`. Only the now-wrong downstream descriptions are corrected, in positive framing:

| line | was | now |
|---|---|---|
| pr_review description | "merge loop in pr-remediator" | "merge-on-green loop" |
| PASS → `review_approve` | "Triggers auto-merge in pr-remediator" | "Clears the merge-on-green gate — the PR auto-merges once CI is terminal-green" |
| FAIL → `review_request_changes` | "Triggers `pr_address_feedback` in pr-remediator" | "protoMaker's automode then iterates on the feedback and re-requests review" |

The merge-on-green path is now the deterministic approve-on-terminal-green in `github.ts` (#757) → protoMaker's MergeProcessor. YAML parses, 3 skills intact. Workspace agent yaml → hot-reloads on deploy, no restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)