### PR TITLE
fix(security): lock /publish + fail-closed auth + webhook-secret-in-prod (#791)

### DIFF
--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -10,7 +10,7 @@ Every variable recognised by protoWorkstacean is declared in the zod `EnvSchema`
 
 - **63** variables declared in `EnvSchema`
 - **0** required (no `.optional()`); the rest are optional
-- **28** variable(s) read via `process.env` at runtime but **not** in `EnvSchema` (see [Read directly (not in EnvSchema)](#read-directly-not-in-envschema))
+- **29** variable(s) read via `process.env` at runtime but **not** in `EnvSchema` (see [Read directly (not in EnvSchema)](#read-directly-not-in-envschema))
 
 ## Core / runtime
 
@@ -147,6 +147,7 @@ These variables are read via `process.env` somewhere in `src/` or `lib/` but are
 | `AUTOMAKER_API_KEY` | `lib/plugins/protomaker-board-bridge.ts`, `src/plugins/project-registry.ts` |
 | `CLAWPATCH_CHECKOUT_ROOT` | `lib/checkout-cache.ts` |
 | `CLAWPATCH_REPO_PATH_MAP` | `src/api/clawpatch.ts` |
+| `WORKSTACEAN_PUBLISH_TOPIC_DENYLIST` | `lib/runtime-env.ts` — CSV of topic prefixes rejected at `POST /publish` (overrides the control-plane default). |
 | `CLAWPATCH_STATE_ROOT` | `src/api/clawpatch.ts` |
 | `CREATE_ISSUE_DEDUP_DISABLED` | `src/api/github.ts` |
 | `CREATE_ISSUE_DEDUP_WINDOW_MS` | `src/api/github.ts` |

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -253,7 +253,9 @@ Each row links to the route definition as `path:line` so jumping from this index
 
 | Method | Path | Source | Description |
 |---|---|---|---|
-| `POST` | `/publish` | `src/api/operations.ts:247` | — |
+| `POST` | `/publish` | `src/api/operations.ts` | Inject an `{ topic, payload }` event onto the bus. **Admin-key required**, an explicit `topic` is mandatory (no `"#"` default), and internal **control-plane topics are rejected (403)**. |
+
+`/publish` is the external lifecycle/event ingress (protoMaker's `feature.*` / `hitl.request.*`, agents' board/incident events). It refuses to inject internal control-plane topics — `agent.skill.request`, `agent.skill.response.*`, `operator.message.request`, `message.inbound.*`, `cron.*`, `command.*`, `autonomous.*`, `ceremony.*`, `dispatch.*`, `agent.input.*` — so a caller can't forge skill dispatches, spoof the operator, fake inbound user messages, or trigger scheduled work. The denied set is `WORKSTACEAN_PUBLISH_TOPIC_DENYLIST` (CSV override). The whole HTTP/A2A surface **fails closed in production-like envs**: the process refuses to start when `WORKSTACEAN_API_KEY` is unset and `NODE_ENV=production` (or `WORKSTACEAN_PUBLIC_BASE_URL` is set).
 
 ### `/v1`
 

--- a/lib/__tests__/runtime-env.test.ts
+++ b/lib/__tests__/runtime-env.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isProductionLike,
+  safeKeyEqual,
+  isPublishTopicDenied,
+  publishDenylistFromEnv,
+  PUBLISH_TOPIC_DENYLIST_DEFAULT,
+} from "../runtime-env.ts";
+
+describe("isProductionLike", () => {
+  test("true when NODE_ENV=production", () => {
+    expect(isProductionLike({ NODE_ENV: "production" } as NodeJS.ProcessEnv)).toBe(true);
+  });
+  test("true when WORKSTACEAN_PUBLIC_BASE_URL is set", () => {
+    expect(isProductionLike({ WORKSTACEAN_PUBLIC_BASE_URL: "https://x" } as NodeJS.ProcessEnv)).toBe(true);
+  });
+  test("false in a bare dev env", () => {
+    expect(isProductionLike({} as NodeJS.ProcessEnv)).toBe(false);
+  });
+});
+
+describe("safeKeyEqual", () => {
+  test("true for equal non-empty strings", () => {
+    expect(safeKeyEqual("secret-key", "secret-key")).toBe(true);
+  });
+  test("false for differing strings (incl. length mismatch)", () => {
+    expect(safeKeyEqual("secret-key", "secret-keys")).toBe(false);
+    expect(safeKeyEqual("a", "b")).toBe(false);
+  });
+  test("false for null/undefined/empty (no open on missing key)", () => {
+    expect(safeKeyEqual(null, "x")).toBe(false);
+    expect(safeKeyEqual("x", undefined)).toBe(false);
+    expect(safeKeyEqual("", "")).toBe(false);
+    expect(safeKeyEqual(undefined, undefined)).toBe(false);
+  });
+});
+
+describe("isPublishTopicDenied", () => {
+  test("blocks the internal control-plane topics", () => {
+    for (const t of [
+      "agent.skill.request",
+      "agent.skill.response.abc",
+      "operator.message.request",
+      "message.inbound.discord.dm.123",
+      "cron.tick",
+      "ceremony.foo.execute",
+      "command.agent.create",
+      "autonomous.outcome.ava.chat",
+      "agent.input.request.x",
+      "dispatch.dropped.y",
+    ]) {
+      expect(isPublishTopicDenied(t), t).toBe(true);
+    }
+  });
+  test("allows legitimate external lifecycle/event topics", () => {
+    for (const t of [
+      "feature.completed",
+      "feature.blocked",
+      "hitl.request.gate-hold",
+      "release.published",
+      "board.intake",
+      "incident.reported",
+    ]) {
+      expect(isPublishTopicDenied(t), t).toBe(false);
+    }
+  });
+  test("env override replaces the default denylist", () => {
+    const dl = publishDenylistFromEnv({ WORKSTACEAN_PUBLISH_TOPIC_DENYLIST: "foo.,bar." } as NodeJS.ProcessEnv);
+    expect(dl).toEqual(["foo.", "bar."]);
+    expect(isPublishTopicDenied("foo.x", dl)).toBe(true);
+    expect(isPublishTopicDenied("agent.skill.request", dl)).toBe(false); // not in override
+  });
+  test("default is used when override unset/blank", () => {
+    expect(publishDenylistFromEnv({} as NodeJS.ProcessEnv)).toBe(PUBLISH_TOPIC_DENYLIST_DEFAULT);
+  });
+});

--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -31,6 +31,7 @@ import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
 import type { EventBus, BusMessage, Plugin } from "../types.ts";
 import { makeGitHubAuth } from "../github-auth.ts";
+import { isProductionLike } from "../runtime-env.ts";
 import { withCircuitBreaker } from "./circuit-breaker.ts";
 import type { ProjectRegistry } from "../../src/plugins/project-registry.ts";
 import type { ReleasePublishedPayload } from "../../src/event-bus/payloads.ts";
@@ -396,6 +397,19 @@ export class GitHubPlugin implements Plugin {
     this.config = loadConfig(this.workspaceDir);
     const webhookSecret = process.env.GITHUB_WEBHOOK_SECRET ?? "";
     const port = parseInt(process.env.GITHUB_WEBHOOK_PORT ?? "8082", 10);
+
+    if (!webhookSecret) {
+      if (isProductionLike()) {
+        // Fail loud rather than silently accepting forged GitHub webhooks (→ bus
+        // → triage/skill routing) in a production-like env. Mirrors LinearPlugin. (#791)
+        throw new Error(
+          "[github] GITHUB_WEBHOOK_SECRET is required when NODE_ENV=production or " +
+            "WORKSTACEAN_PUBLIC_BASE_URL is set. Refusing to start an unauthenticated " +
+            "webhook receiver in production.",
+        );
+      }
+      console.warn("[github] GITHUB_WEBHOOK_SECRET not set — signature verification disabled (dev only)");
+    }
 
     // ── Hot-reload github.yaml ────────────────────────────────────────────────
     // Project list lives in protoMaker and is refreshed by the registry's own

--- a/lib/plugins/linear.ts
+++ b/lib/plugins/linear.ts
@@ -42,6 +42,7 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import { join } from "node:path";
 import { z } from "zod";
 import type { EventBus, BusMessage, Plugin } from "../types.ts";
+import { isProductionLike } from "../runtime-env.ts";
 import { LinearClient, type LinearPriority } from "../linear-client.ts";
 import { getLinearAvaTokenManager } from "../linear/ava-oauth-token-manager.ts";
 import { LinearAgentActivityClient } from "../linear/agent-activity-client.ts";
@@ -197,11 +198,6 @@ function priorityToString(p?: number): LinearPriority {
  * a webhook secret — an unauthenticated public-facing webhook receiver is a
  * footgun that lets anyone inject `message.inbound.linear.*` events.
  */
-function isProductionLike(): boolean {
-  if (process.env.NODE_ENV === "production") return true;
-  if (process.env.WORKSTACEAN_PUBLIC_BASE_URL) return true;
-  return false;
-}
 
 // ── Plugin ────────────────────────────────────────────────────────────────────
 

--- a/lib/runtime-env.ts
+++ b/lib/runtime-env.ts
@@ -1,0 +1,65 @@
+/**
+ * Runtime-environment helpers shared across plugins + the HTTP layer.
+ *
+ * Centralizes (a) the "are we production-like?" check used to fail-closed on
+ * missing secrets, (b) a constant-time key comparison, and (c) the `/publish`
+ * topic denylist that stops the external bus-injection ingress from forging
+ * internal control-plane events. Lives in `lib/` so both `lib/` plugins and
+ * `src/` can import it.
+ */
+
+import { timingSafeEqual } from "node:crypto";
+
+/**
+ * True when the process is running in (or pointed at) a production deployment.
+ * Used to refuse to start with auth/webhook secrets unset rather than silently
+ * exposing an open surface.
+ */
+export function isProductionLike(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (env.NODE_ENV === "production") return true;
+  if (env.WORKSTACEAN_PUBLIC_BASE_URL) return true;
+  return false;
+}
+
+/** Constant-time string compare. Returns false on null/length-mismatch (no early-out leak). */
+export function safeKeyEqual(a: string | null | undefined, b: string | null | undefined): boolean {
+  if (!a || !b) return false;
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+/**
+ * Topic prefixes that may NOT be injected through the external `/publish`
+ * ingress. These are internal control-plane topics — forging them would let a
+ * caller drive executors, spoof the operator, fake inbound user messages, or
+ * trigger scheduled work. Legitimate external publishers (protoMaker's
+ * `feature.*` / `hitl.request.*`, and agents' board/incident events) are
+ * unaffected. Overridable via `WORKSTACEAN_PUBLISH_TOPIC_DENYLIST` (CSV).
+ */
+export const PUBLISH_TOPIC_DENYLIST_DEFAULT: readonly string[] = [
+  "agent.skill.request",
+  "agent.skill.response",
+  "agent.input.",
+  "operator.message.request",
+  "message.inbound.",
+  "cron.",
+  "command.",
+  "autonomous.",
+  "ceremony.",
+  "dispatch.",
+];
+
+export function publishDenylistFromEnv(env: NodeJS.ProcessEnv = process.env): readonly string[] {
+  const override = env.WORKSTACEAN_PUBLISH_TOPIC_DENYLIST;
+  if (override && override.trim()) {
+    return override.split(",").map((s) => s.trim()).filter(Boolean);
+  }
+  return PUBLISH_TOPIC_DENYLIST_DEFAULT;
+}
+
+/** True if `topic` matches a denied prefix and must be rejected at `/publish`. */
+export function isPublishTopicDenied(topic: string, denylist: readonly string[] = publishDenylistFromEnv()): boolean {
+  return denylist.some((p) => topic === p || topic.startsWith(p));
+}

--- a/src/api/__tests__/operations-publish.test.ts
+++ b/src/api/__tests__/operations-publish.test.ts
@@ -1,0 +1,60 @@
+/**
+ * /publish hardening (#791) — admin auth, explicit topic, control-plane denylist.
+ */
+import { describe, test, expect } from "bun:test";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { ExecutorRegistry } from "../../executor/executor-registry.ts";
+import { createRoutes } from "../operations.ts";
+import type { ApiContext, Route } from "../types.ts";
+
+const KEY = "test-admin-key";
+
+function ctxWithKey(bus: InMemoryEventBus): ApiContext {
+  return { workspaceDir: "/tmp", bus, plugins: [], executorRegistry: new ExecutorRegistry(), apiKey: KEY };
+}
+function publishRoute(ctx: ApiContext): Route {
+  const r = createRoutes(ctx).find((x) => x.method === "POST" && x.path === "/publish");
+  if (!r) throw new Error("no /publish route");
+  return r;
+}
+function req(body: unknown, key?: string): Request {
+  return new Request("http://x/publish", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...(key ? { "X-API-Key": key } : {}) },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/publish hardening", () => {
+  test("401 without the admin key (fails closed when key is configured)", async () => {
+    const bus = new InMemoryEventBus();
+    const res = await publishRoute(ctxWithKey(bus)).handler(req({ topic: "feature.completed" }), {});
+    expect(res.status).toBe(401);
+  });
+
+  test("403 on a denied control-plane topic even with the key", async () => {
+    const bus = new InMemoryEventBus();
+    let saw = false;
+    bus.subscribe("agent.skill.request", "t", () => { saw = true; });
+    const res = await publishRoute(ctxWithKey(bus)).handler(req({ topic: "agent.skill.request", payload: {} }, KEY), {});
+    expect(res.status).toBe(403);
+    expect(saw).toBe(false); // never reached the bus
+  });
+
+  test("400 when topic is missing (no silent '#' publish)", async () => {
+    const bus = new InMemoryEventBus();
+    const res = await publishRoute(ctxWithKey(bus)).handler(req({ payload: { x: 1 } }, KEY), {});
+    expect(res.status).toBe(400);
+  });
+
+  test("publishes an allowed topic with the key", async () => {
+    const bus = new InMemoryEventBus();
+    const got: unknown[] = [];
+    bus.subscribe("feature.completed", "t", (m) => got.push(m.payload));
+    const res = await publishRoute(ctxWithKey(bus)).handler(
+      req({ topic: "feature.completed", payload: { featureId: "f1" } }, KEY), {},
+    );
+    expect(res.status).toBe(200);
+    expect(got).toEqual([{ featureId: "f1" }]);
+  });
+});

--- a/src/api/__tests__/operations-publish.test.ts
+++ b/src/api/__tests__/operations-publish.test.ts
@@ -50,7 +50,7 @@ describe("/publish hardening", () => {
   test("publishes an allowed topic with the key", async () => {
     const bus = new InMemoryEventBus();
     const got: unknown[] = [];
-    bus.subscribe("feature.completed", "t", (m) => got.push(m.payload));
+    bus.subscribe("feature.completed", "t", (m) => { got.push(m.payload); });
     const res = await publishRoute(ctxWithKey(bus)).handler(
       req({ topic: "feature.completed", payload: { featureId: "f1" } }, KEY), {},
     );

--- a/src/api/clawpatch.ts
+++ b/src/api/clawpatch.ts
@@ -37,6 +37,7 @@ import { CheckoutCache } from "../../lib/checkout-cache.ts";
 import { makeGitHubAuth } from "../../lib/github-auth.ts";
 import type { Route, ApiContext } from "./types.ts";
 import type { ProjectRegistry } from "../plugins/project-registry.ts";
+import { safeKeyEqual } from "../../lib/runtime-env.ts";
 
 /**
  * Where clawpatch persists `.clawpatch/` (features, findings, runs, reports,
@@ -246,6 +247,16 @@ export function createRoutes(ctx: ApiContext): Route[] {
       method: "POST",
       path: "/api/clawpatch/review",
       handler: async (req) => {
+        // Auth: this spawns an LLM-backed review (cost + compute). Gate it like
+        // the other write routes — admin key required (fail-closed in prod via
+        // the startup guard). (#791)
+        if (ctx.apiKey) {
+          const bearer = req.headers.get("Authorization");
+          const provided = req.headers.get("X-API-Key") ?? (bearer?.startsWith("Bearer ") ? bearer.slice(7) : null);
+          if (!safeKeyEqual(provided, ctx.apiKey)) {
+            return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+          }
+        }
         let payload: ReviewRequest;
         try {
           payload = (await req.json()) as ReviewRequest;

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -9,6 +9,7 @@ import type { Route, ApiContext } from "./types.ts";
 import { serveWorkspaceYaml } from "./types.ts";
 import type { CallerIdentity } from "../../lib/auth/agent-keys.ts";
 import { getPendingHumanInput } from "./human-input.ts";
+import { safeKeyEqual, isPublishTopicDenied } from "../../lib/runtime-env.ts";
 
 export function createRoutes(ctx: ApiContext): Route[] {
 
@@ -30,8 +31,8 @@ export function createRoutes(ctx: ApiContext): Route[] {
       if (resolved) return resolved;
     }
     // Fallback: ctx.apiKey direct comparison (single-key legacy mode when
-    // agentKeys isn't configured).
-    if (apiKey === ctx.apiKey) return { isAdmin: true };
+    // agentKeys isn't configured). Constant-time to avoid a timing oracle.
+    if (safeKeyEqual(apiKey, ctx.apiKey)) return { isAdmin: true };
     return null;
   }
 
@@ -105,13 +106,28 @@ export function createRoutes(ctx: ApiContext): Route[] {
   }
 
   async function handlePublish(req: Request): Promise<Response> {
-    if (ctx.apiKey && req.headers.get("X-API-Key") !== ctx.apiKey) {
-      return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
-    }
+    // Admin-only — `/publish` injects directly onto the internal bus.
+    const caller = authenticateCaller(req);
+    if (!caller?.isAdmin) return unauthorized();
     let body: Record<string, unknown>;
     try { body = (await req.json()) as Record<string, unknown>; }
     catch { return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 }); }
-    const topic = (body.topic as string) ?? "#";
+    // Require an explicit topic — no silent `"#"` wildcard publish.
+    const topic = typeof body.topic === "string" ? body.topic.trim() : "";
+    if (!topic) {
+      return Response.json({ success: false, error: "Missing 'topic'" }, { status: 400 });
+    }
+    // Reject internal control-plane topics — `/publish` is for external
+    // lifecycle/event injection (feature.*, hitl.request.*, board/incident),
+    // never for forging agent.skill.request / operator.message.request /
+    // inbound messages / scheduled triggers.
+    if (isPublishTopicDenied(topic)) {
+      console.warn(`[publish] rejected denied topic "${topic}" from ${caller.agentName ?? "admin"}`);
+      return Response.json(
+        { success: false, error: `Topic "${topic}" may not be published via /publish (internal control-plane topic)` },
+        { status: 403 },
+      );
+    }
     ctx.bus.publish(topic, {
       id: crypto.randomUUID(),
       correlationId: (body.correlationId as string) ?? crypto.randomUUID(),
@@ -123,9 +139,8 @@ export function createRoutes(ctx: ApiContext): Route[] {
   }
 
   async function handleOnboard(req: Request): Promise<Response> {
-    if (ctx.apiKey && req.headers.get("X-API-Key") !== ctx.apiKey) {
-      return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
-    }
+    const caller = authenticateCaller(req);
+    if (!caller?.isAdmin) return unauthorized();
     let body: Record<string, unknown>;
     try { body = (await req.json()) as Record<string, unknown>; }
     catch { return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 }); }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { A2ADeliveryPlugin } from "../lib/plugins/a2a-delivery";
 import { ControlPlaneRegistrarPlugin } from "./plugins/control-plane-registrar-plugin.ts";
 import type { Plugin, } from "../lib/types";
 import { parseEnv } from "./config/env.ts";
+import { isProductionLike, safeKeyEqual } from "../lib/runtime-env.ts";
 // Fail-fast env validation — exits immediately on misconfiguration.
 parseEnv();
 
@@ -580,6 +581,19 @@ cli?.showPrompt();
 const HTTP_PORT = parseInt(process.env.WORKSTACEAN_HTTP_PORT || "3000", 10);
 const API_KEY = process.env.WORKSTACEAN_API_KEY;
 
+// Fail closed: refuse to start an unauthenticated HTTP/A2A surface in a
+// production-like env. Without WORKSTACEAN_API_KEY every route's
+// `if (ctx.apiKey && …)` check short-circuits open — fine for local dev, a
+// wide-open control surface in prod. (#791)
+if (isProductionLike() && !API_KEY) {
+  console.error(
+    "[startup] WORKSTACEAN_API_KEY is required when NODE_ENV=production or " +
+      "WORKSTACEAN_PUBLIC_BASE_URL is set. Refusing to start an unauthenticated " +
+      "HTTP/A2A surface in production. Set the key (Infisical) and redeploy.",
+  );
+  process.exit(1);
+}
+
 // ── API routes (modular) ──────────────────────────────────────────────────────
 import { createAllRoutes, matchPath } from "./api/index.ts";
 import type { ApiContext } from "./api/index.ts";
@@ -695,7 +709,7 @@ Bun.serve<BusSubscribeWsData>({
         const headerKey = req.headers.get("X-API-Key");
         const queryKey = url.searchParams.get("apiKey");
         const provided = headerKey ?? queryKey;
-        if (provided !== API_KEY) {
+        if (!safeKeyEqual(provided, API_KEY)) {
           return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
         }
       }


### PR DESCRIPTION
Closes #791 (P0 from the audit epic #790). The top security finding.

## Holes closed
1. **`/publish` bus-injection** — republished any `{topic,payload}` onto the bus. Now: admin-key required, explicit `topic` mandatory (no `"#"` default), and internal **control-plane topics rejected (403)** — can no longer forge `agent.skill.request`, `operator.message.request`, `message.inbound.*`, `cron.*`, `ceremony.*`, etc.
2. **Auth fails open when `WORKSTACEAN_API_KEY` unset** — the process now **refuses to boot** in production-like envs (`NODE_ENV=production` or `WORKSTACEAN_PUBLIC_BASE_URL` set) without the key, instead of silently serving an open surface.
3. **`/api/clawpatch/review` had no auth** — added admin auth (was a free LLM-cost/DoS lever).
4. **GitHub webhook fails open without secret** — refuses to start the receiver in prod without `GITHUB_WEBHOOK_SECRET` (mirrors LinearPlugin).
5. Key compares now **constant-time** (`safeKeyEqual`).

## How
New `lib/runtime-env.ts` centralizes `isProductionLike()`, `safeKeyEqual()`, and the denylist (`WORKSTACEAN_PUBLISH_TOPIC_DENYLIST` override). The denylist (not an allowlist) is deliberate: agents legitimately use the `publish_event` tool for open-ended board/incident topics, and protoMaker publishes `feature.*`/`hitl.request.*` — a default-deny allowlist would break those, while the control-plane denylist still closes every audited escalation path.

## Tests
`runtime-env` helpers (isProductionLike / safeKeyEqual / denylist + env override) + `/publish` hardening (401 no key · 403 denied topic · 400 missing topic · 200 allowed). **1065 green, tsc clean, no new lint.** Docs: `http-api.md` + `env-vars.md`.

## Noted follow-up (not in scope)
A centralized default-deny auth gate in the Bun.serve fetch loop (defense against a *future* route forgetting auth) needs a careful public-route allowlist (card, OAuth callback, dashboard, /health) + its own tests — left for a hardening pass. This PR closes every *known* open route.

Part of #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)