### PR TITLE
feat(reliability): graceful shutdown + crash handlers (#792)

### DIFF
--- a/docs/guides/deploy-with-docker.md
+++ b/docs/guides/deploy-with-docker.md
@@ -24,6 +24,10 @@ Config reload behaviour by surface:
 
 So the operational model is: **code lands via watchtower automatically; config lands via `git pull` on the host; ceremonies and in-process agents apply live, and only `workspace/agents.yaml` (A2A) edits need a restart.**
 
+### Graceful shutdown
+
+On `SIGTERM` / `SIGINT` (every watchtower redeploy) the process drains before exiting: it stops the HTTP server, calls `uninstall()` on every plugin (closing webhook listeners, scheduler timers, Discord/Linear clients), flushes the Langfuse tracer, and closes the sqlite stores **checkpointing the WAL** so the last commits aren't lost. An `unhandledRejection` is logged loudly but kept alive (one bad async handler shouldn't take down the switchboard); an `uncaughtException` is logged and the process exits non-zero so the orchestrator restarts cleanly.
+
 ## Docker Compose
 
 A `docker-compose.yml` is provided at the project root. Adjust it for your environment:

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ parseEnv();
 // Without this, @langfuse/langchain's CallbackHandler (used by
 // DeepAgentExecutor) falls through to the no-op OTEL tracer and nothing
 // is captured. Gated on LANGFUSE_PUBLIC_KEY + LANGFUSE_SECRET_KEY.
-import { initLangfuseTracer } from "./telemetry/langfuse-tracer.ts";
+import { initLangfuseTracer, shutdownLangfuseTracer } from "./telemetry/langfuse-tracer.ts";
 const langfuseEnabled = initLangfuseTracer();
 console.log(`[langfuse] OTEL tracer ${langfuseEnabled ? "registered" : "skipped (no credentials)"}`);
 // --- Workspace config ---
@@ -698,7 +698,7 @@ async function serveDashboardAsset(pathname: string): Promise<Response | null> {
   return null;
 }
 
-Bun.serve<BusSubscribeWsData>({
+const httpServer = Bun.serve<BusSubscribeWsData>({
   port: HTTP_PORT,
   fetch: async (req, server) => {
     const url = new URL(req.url);
@@ -782,3 +782,43 @@ console.log(`HTTP API listening on port ${HTTP_PORT}`);
     executorRegistry.setHealthGetter(() => fleetPlugin.getFleetHealth().agents);
   }
 }
+
+// ── Graceful shutdown + crash handlers (#792) ───────────────────────────────
+// The container is restarted several times a day (watchtower auto-pull). Without
+// this, each restart kills in-flight runs, drops un-flushed Langfuse spans, and
+// never checkpoints the sqlite WAL. Drain on SIGTERM/SIGINT; close db-backed
+// stores (each checkpoints WAL first).
+let shuttingDown = false;
+async function gracefulShutdown(signal: string): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`[shutdown] ${signal} received — draining…`);
+  try { httpServer.stop(); } catch (e) { console.warn("[shutdown] server.stop threw:", e); }
+  for (const plugin of allPlugins) {
+    try { plugin.uninstall?.(); } catch (e) { console.warn(`[shutdown] ${plugin.name} uninstall threw:`, e); }
+  }
+  await shutdownLangfuseTracer();
+  for (const [name, closer] of [
+    ["telemetry", () => telemetry.close()],
+    ["fleet-state", () => fleetStateRepo.close()],
+    ["research-store", () => researchStore.close()],
+  ] as const) {
+    try { closer(); } catch (e) { console.warn(`[shutdown] ${name} close threw:`, e); }
+  }
+  console.log("[shutdown] complete");
+  process.exit(0);
+}
+process.on("SIGTERM", () => void gracefulShutdown("SIGTERM"));
+process.on("SIGINT", () => void gracefulShutdown("SIGINT"));
+
+// An unhandled rejection in a fire-and-forget bus handler must not silently take
+// down the whole switchboard — log loud and stay up. An uncaughtException leaves
+// the process in an undefined state — log loud and exit non-zero so the
+// orchestrator restarts cleanly.
+process.on("unhandledRejection", (reason) => {
+  console.error("[fatal] unhandledRejection (process kept alive):", reason);
+});
+process.on("uncaughtException", (err) => {
+  console.error("[fatal] uncaughtException — exiting for a clean restart:", err);
+  process.exit(1);
+});

--- a/src/knowledge/fleet-state.ts
+++ b/src/knowledge/fleet-state.ts
@@ -181,9 +181,10 @@ export class FleetStateRepository {
     }
   }
 
-  /** Close the database connection. */
+  /** Close the database connection (checkpoints WAL first so commits survive). */
   close(): void {
     if (this.db) {
+      try { this.db.exec("PRAGMA wal_checkpoint(TRUNCATE);"); } catch { /* ignore */ }
       this.db.close();
       this.db = null;
     }

--- a/src/knowledge/research-store.ts
+++ b/src/knowledge/research-store.ts
@@ -242,6 +242,10 @@ export class ResearchStore {
   }
 
   close(): void {
-    if (this.db) { this.db.close(); this.db = null; }
+    if (this.db) {
+      try { this.db.exec("PRAGMA wal_checkpoint(TRUNCATE);"); } catch { /* ignore */ }
+      this.db.close();
+      this.db = null;
+    }
   }
 }

--- a/src/telemetry/__tests__/langfuse-shutdown.test.ts
+++ b/src/telemetry/__tests__/langfuse-shutdown.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { shutdownLangfuseTracer } from "../langfuse-tracer.ts";
+
+describe("shutdownLangfuseTracer", () => {
+  test("resolves and is idempotent when no provider was registered (no-creds path)", async () => {
+    // In the test env LANGFUSE_* keys are unset, so initLangfuseTracer never
+    // installed a provider. Shutdown must be a safe no-op, callable repeatedly
+    // (e.g. SIGTERM then SIGINT) without throwing.
+    await expect(shutdownLangfuseTracer()).resolves.toBeUndefined();
+    await expect(shutdownLangfuseTracer()).resolves.toBeUndefined();
+  });
+});

--- a/src/telemetry/langfuse-tracer.ts
+++ b/src/telemetry/langfuse-tracer.ts
@@ -21,6 +21,7 @@ import { LangfuseSpanProcessor } from "@langfuse/otel";
 import { setLangfuseTracerProvider } from "@langfuse/tracing";
 
 let initialized = false;
+let activeProvider: NodeTracerProvider | null = null;
 
 /**
  * Register the Langfuse OTEL tracer provider. Returns true when a live
@@ -40,6 +41,23 @@ export function initLangfuseTracer(): boolean {
     spanProcessors: [new LangfuseSpanProcessor()],
   });
   setLangfuseTracerProvider(provider);
+  activeProvider = provider;
   initialized = true;
   return true;
+}
+
+/**
+ * Flush + shut down the tracer provider so batched spans aren't lost on a
+ * graceful redeploy. No-op when no provider was registered. (#792)
+ */
+export async function shutdownLangfuseTracer(): Promise<void> {
+  if (!activeProvider) return;
+  try {
+    await activeProvider.shutdown();
+  } catch (err) {
+    console.warn("[langfuse] tracer shutdown/flush failed:", err);
+  } finally {
+    activeProvider = null;
+    initialized = false;
+  }
 }

--- a/src/telemetry/telemetry-service.ts
+++ b/src/telemetry/telemetry-service.ts
@@ -205,6 +205,7 @@ export class TelemetryService {
 
   close(): void {
     try {
+      this.db?.exec("PRAGMA wal_checkpoint(TRUNCATE);");
       this.db?.close();
     } catch {
       /* ignore */


### PR DESCRIPTION
Closes #792 (P0, epic #790).

The container restarts several times a day (watchtower) but had **no SIGTERM handler and no crash handlers**. Each restart killed in-flight runs, dropped un-flushed Langfuse spans, never checkpointed the WAL; an unhandled rejection in a fire-and-forget bus handler could crash the whole single-node process.

## Changes
- **SIGTERM/SIGINT → `gracefulShutdown`** (`src/index.ts`): stop HTTP server → `uninstall()` every plugin (webhook listeners, scheduler timers, Discord/Linear clients) → flush Langfuse → close db-backed stores. Idempotent.
- **`unhandledRejection`** → loud log, stay up. **`uncaughtException`** → loud log + `exit(1)` for a clean restart. (Explicit crash-vs-continue policy.)
- **WAL checkpoint on close** — `telemetry` / `fleet-state` / `research-store` `close()` now `PRAGMA wal_checkpoint(TRUNCATE)` first.
- **`shutdownLangfuseTracer()`** — flush + shut the OTEL provider; safe idempotent no-op when no provider registered.

## Tests
Langfuse-shutdown no-op/idempotent. **1066 green, tsc clean, no new lint.** Docs: `deploy-with-docker.md`.

Part of #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)