### PR TITLE
feat(reliability): persist TaskTracker — restarts don't drop in-flight A2A replies (#793)

### DIFF
--- a/docs/architecture/flow-agent-runtime-telemetry.md
+++ b/docs/architecture/flow-agent-runtime-telemetry.md
@@ -162,6 +162,8 @@ When an executor returns `taskState ∈ {submitted, working}`, the dispatcher ha
 
 This means **autonomous.outcome is sometimes published by TaskTracker, not the dispatcher**. Subscribers don't need to care (same payload shape), but if you're tracing a missing outcome, check both.
 
+**Durability (#793).** Tracked tasks are persisted to `${dataDir}/tasks.db` (`TaskTrackerStore`), so a restart (watchtower auto-pulls several times a day) doesn't silently drop an owed reply. On boot the tracker rehydrates in-flight tasks and parks them until the agent's executor re-registers (A2A card discovery); once resolvable it resumes polling, and if the executor never returns within the grace window it escalates a failure to the reply topic rather than leaving the caller hanging. A push callback for a task whose poll loop was lost is recovered the same way (the callback token is persisted). The rehydration path can't restore the in-memory `onTerminal` outcome callback, so a rehydrated task still publishes its reply but may not emit the outcome-telemetry event.
+
 ---
 
 ## Runtime activity + skill latency topics

--- a/src/executor/__tests__/task-tracker-persistence.test.ts
+++ b/src/executor/__tests__/task-tracker-persistence.test.ts
@@ -1,0 +1,93 @@
+/**
+ * #793 — TaskTracker durability: persist on track, delete on terminal,
+ * rehydrate-and-resume after restart, escalate the unresolvable.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import type { BusMessage } from "../../../lib/types.ts";
+import { TaskTracker } from "../task-tracker.ts";
+import { TaskTrackerStore } from "../task-tracker-store.ts";
+import type { A2AExecutor } from "../executors/a2a-executor.ts";
+
+let dir: string;
+let dbPath: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "tasktracker-")); dbPath = join(dir, "tasks.db"); });
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+/** Fake A2A executor whose poll returns a terminal completed result. */
+function fakeExecutor(): A2AExecutor {
+  return {
+    pollTask: async () => ({ data: { taskState: "completed", artifacts: [] }, text: "done!", isError: false }),
+    recordTerminalExtensions: async () => {},
+  } as unknown as A2AExecutor;
+}
+
+describe("TaskTrackerStore round-trip", () => {
+  test("upsert → loadAll → delete", () => {
+    const store = new TaskTrackerStore(dbPath);
+    store.upsert({ correlationId: "c1", taskId: "t1", agentName: "roxy", replyTopic: "r1", registeredAt: 100, pollIntervalMs: 30000, callbackToken: "tok" });
+    const rows = store.loadAll();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ correlationId: "c1", taskId: "t1", agentName: "roxy", replyTopic: "r1", callbackToken: "tok" });
+    store.delete("c1");
+    expect(store.loadAll()).toHaveLength(0);
+    store.close();
+  });
+});
+
+describe("TaskTracker persistence", () => {
+  test("track() persists; a terminal callback removes it from the store", () => {
+    const store = new TaskTrackerStore(dbPath);
+    const tracker = new TaskTracker({ bus: new InMemoryEventBus(), store });
+    tracker.track({ correlationId: "c2", taskId: "t2", agentName: "roxy", replyTopic: "agent.skill.response.c2", executor: {} as unknown as A2AExecutor });
+    expect(store.loadAll().map((r) => r.correlationId)).toEqual(["c2"]);
+    tracker.handleCallback("c2", { status: { state: "completed" }, artifacts: [] });
+    expect(store.loadAll()).toHaveLength(0);
+    store.close();
+  });
+
+  test("rehydrates a persisted task after restart and resumes polling to completion", async () => {
+    // Pre-seed the store as if a prior process tracked a task then died.
+    const seed = new TaskTrackerStore(dbPath);
+    seed.upsert({ correlationId: "c3", taskId: "t3", agentName: "roxy", skillName: "unblock_feature", replyTopic: "agent.skill.response.c3", registeredAt: Date.now(), pollIntervalMs: 30000 });
+    seed.close();
+
+    const bus = new InMemoryEventBus();
+    const replies: BusMessage[] = [];
+    bus.subscribe("agent.skill.response.c3", "t", (m) => { replies.push(m); });
+    const store = new TaskTrackerStore(dbPath);
+    const tracker = new TaskTracker({ bus, store, resolveExecutor: () => fakeExecutor() });
+
+    await (tracker as unknown as { _sweep: () => Promise<void> })._sweep();
+
+    expect(replies).toHaveLength(1);
+    expect((replies[0].payload as Record<string, unknown>).content).toBe("done!");
+    expect(store.loadAll()).toHaveLength(0); // forgotten after terminal
+    store.close();
+  });
+
+  test("escalates (not drops) a rehydrated task whose executor never re-registers", async () => {
+    const seed = new TaskTrackerStore(dbPath);
+    seed.upsert({ correlationId: "c4", taskId: "t4", agentName: "gone", replyTopic: "agent.skill.response.c4", registeredAt: Date.now(), pollIntervalMs: 30000 });
+    seed.close();
+
+    const bus = new InMemoryEventBus();
+    const replies: BusMessage[] = [];
+    bus.subscribe("agent.skill.response.c4", "t", (m) => { replies.push(m); });
+    const store = new TaskTrackerStore(dbPath);
+    // resolver returns undefined (agent gone) + zero grace → escalate immediately.
+    const tracker = new TaskTracker({ bus, store, resolveExecutor: () => undefined, rehydrateGraceMs: 0 });
+
+    await (tracker as unknown as { _sweep: () => Promise<void> })._sweep();
+
+    expect(replies).toHaveLength(1);
+    const p = replies[0].payload as Record<string, unknown>;
+    expect(p.taskState).toBe("failed");
+    expect(String(p.error)).toContain("interrupted");
+    expect(store.loadAll()).toHaveLength(0);
+    store.close();
+  });
+});

--- a/src/executor/task-tracker-store.ts
+++ b/src/executor/task-tracker-store.ts
@@ -1,0 +1,156 @@
+/**
+ * TaskTrackerStore — durable backing for in-flight A2A task tracking.
+ *
+ * The TaskTracker keeps a Map of tasks that returned non-terminal ("working")
+ * and owes each caller a reply on its reply topic. That Map was purely
+ * in-memory, so a restart (watchtower auto-pulls several times a day) silently
+ * dropped every owed reply. This store persists the serializable task record so
+ * the tracker can rehydrate on boot, resume polling once the agent's executor
+ * re-registers, and — if it never does — escalate rather than drop.
+ *
+ * Only serializable fields are stored; the live `executor` reference and the
+ * `onTerminal` callback are reconstructed/omitted on rehydration.
+ *
+ * Failure modes: a DB open/IO failure is logged loudly and the store degrades
+ * to a no-op (tracking falls back to in-memory-only) rather than crashing.
+ */
+
+import { Database } from "bun:sqlite";
+import { existsSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+export interface PersistedTask {
+  correlationId: string;
+  taskId: string;
+  agentName: string;
+  skillName?: string;
+  dispatcherAgent?: string;
+  replyTopic: string;
+  parentId?: string;
+  registeredAt: number;
+  pollIntervalMs: number;
+  callbackToken?: string;
+  sourceInterface?: string;
+  sourceChannelId?: string;
+  sourceUserId?: string;
+}
+
+interface Row {
+  correlation_id: string;
+  task_id: string;
+  agent_name: string;
+  skill_name: string | null;
+  dispatcher_agent: string | null;
+  reply_topic: string;
+  parent_id: string | null;
+  registered_at: number;
+  poll_interval_ms: number;
+  callback_token: string | null;
+  source_interface: string | null;
+  source_channel_id: string | null;
+  source_user_id: string | null;
+}
+
+export class TaskTrackerStore {
+  private db: Database | null = null;
+  private readonly dbPath: string;
+
+  constructor(dbPath: string) {
+    this.dbPath = resolve(dbPath);
+    try {
+      const dir = dirname(this.dbPath);
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+      this.db = new Database(this.dbPath);
+      this.db.exec("PRAGMA journal_mode=WAL;");
+      this.db.exec("PRAGMA synchronous=NORMAL;");
+      this.db.exec("PRAGMA busy_timeout=5000;");
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS tracked_tasks (
+          correlation_id   TEXT PRIMARY KEY,
+          task_id          TEXT NOT NULL,
+          agent_name       TEXT NOT NULL,
+          skill_name       TEXT,
+          dispatcher_agent TEXT,
+          reply_topic      TEXT NOT NULL,
+          parent_id        TEXT,
+          registered_at    INTEGER NOT NULL,
+          poll_interval_ms INTEGER NOT NULL,
+          callback_token   TEXT,
+          source_interface TEXT,
+          source_channel_id TEXT,
+          source_user_id   TEXT
+        );
+      `);
+      console.log(`[task-store] Ready at ${this.dbPath}`);
+    } catch (err) {
+      console.error("[task-store] Init failed — task persistence disabled (in-memory only):", err);
+      this.db = null;
+    }
+  }
+
+  upsert(t: PersistedTask): void {
+    if (!this.db) return;
+    try {
+      this.db.query(
+        `INSERT INTO tracked_tasks
+           (correlation_id, task_id, agent_name, skill_name, dispatcher_agent, reply_topic,
+            parent_id, registered_at, poll_interval_ms, callback_token,
+            source_interface, source_channel_id, source_user_id)
+         VALUES ($cid, $tid, $agent, $skill, $disp, $reply, $parent, $reg, $poll, $token, $si, $sc, $su)
+         ON CONFLICT(correlation_id) DO UPDATE SET
+           task_id=$tid, agent_name=$agent, skill_name=$skill, dispatcher_agent=$disp,
+           reply_topic=$reply, parent_id=$parent, registered_at=$reg, poll_interval_ms=$poll,
+           callback_token=$token, source_interface=$si, source_channel_id=$sc, source_user_id=$su`,
+      ).run({
+        $cid: t.correlationId, $tid: t.taskId, $agent: t.agentName, $skill: t.skillName ?? null,
+        $disp: t.dispatcherAgent ?? null, $reply: t.replyTopic, $parent: t.parentId ?? null,
+        $reg: t.registeredAt, $poll: t.pollIntervalMs, $token: t.callbackToken ?? null,
+        $si: t.sourceInterface ?? null, $sc: t.sourceChannelId ?? null, $su: t.sourceUserId ?? null,
+      });
+    } catch (err) {
+      console.warn(`[task-store] upsert ${t.correlationId} failed:`, err);
+    }
+  }
+
+  delete(correlationId: string): void {
+    if (!this.db) return;
+    try {
+      this.db.query("DELETE FROM tracked_tasks WHERE correlation_id = $cid").run({ $cid: correlationId });
+    } catch (err) {
+      console.warn(`[task-store] delete ${correlationId} failed:`, err);
+    }
+  }
+
+  loadAll(): PersistedTask[] {
+    if (!this.db) return [];
+    try {
+      const rows = this.db.query("SELECT * FROM tracked_tasks").all() as Row[];
+      return rows.map((r) => ({
+        correlationId: r.correlation_id,
+        taskId: r.task_id,
+        agentName: r.agent_name,
+        skillName: r.skill_name ?? undefined,
+        dispatcherAgent: r.dispatcher_agent ?? undefined,
+        replyTopic: r.reply_topic,
+        parentId: r.parent_id ?? undefined,
+        registeredAt: r.registered_at,
+        pollIntervalMs: r.poll_interval_ms,
+        callbackToken: r.callback_token ?? undefined,
+        sourceInterface: r.source_interface ?? undefined,
+        sourceChannelId: r.source_channel_id ?? undefined,
+        sourceUserId: r.source_user_id ?? undefined,
+      }));
+    } catch (err) {
+      console.warn("[task-store] loadAll failed:", err);
+      return [];
+    }
+  }
+
+  close(): void {
+    if (this.db) {
+      try { this.db.exec("PRAGMA wal_checkpoint(TRUNCATE);"); } catch { /* ignore */ }
+      this.db.close();
+      this.db = null;
+    }
+  }
+}

--- a/src/executor/task-tracker.ts
+++ b/src/executor/task-tracker.ts
@@ -15,6 +15,7 @@
 import type { EventBus } from "../../lib/types.ts";
 import type { A2AExecutor } from "./executors/a2a-executor.ts";
 import type { AgentSkillResponsePayload } from "../event-bus/payloads.ts";
+import type { TaskTrackerStore, PersistedTask } from "./task-tracker-store.ts";
 import { Part } from "@a2a-js/sdk";
 import { partText, parseWorldStateDelta } from "@protolabs/a2a";
 
@@ -76,6 +77,12 @@ export interface TaskTrackerOptions {
   defaultPollIntervalMs?: number;
   /** Max time to track a task before giving up (ms). Default: 1hr. */
   maxTrackingMs?: number;
+  /** Durable backing — when set, tasks survive restarts (rehydrated on boot). */
+  store?: TaskTrackerStore;
+  /** Resolve the live A2A executor for an agent (used to rehydrate after restart). */
+  resolveExecutor?: (agentName: string, skill?: string) => A2AExecutor | undefined;
+  /** Grace period after boot before an unresolvable rehydrated task is escalated (ms). Default: 5min. */
+  rehydrateGraceMs?: number;
 }
 
 export class TaskTracker {
@@ -88,13 +95,91 @@ export class TaskTracker {
   /** Tracks task IDs for which world.state.delta events have already been published. */
   private readonly publishedDeltaTaskIds = new Set<string>();
 
+  /** Durable store (optional). */
+  private readonly store?: TaskTrackerStore;
+  private readonly resolveExecutor?: (agentName: string, skill?: string) => A2AExecutor | undefined;
+  private readonly rehydrateGraceMs: number;
+  private readonly bootAt = Date.now();
+  /** Persisted tasks awaiting executor re-registration after a restart. */
+  private readonly pending = new Map<string, PersistedTask>();
+
   constructor(opts: TaskTrackerOptions) {
     this.bus = opts.bus;
     this.sweepIntervalMs = opts.sweepIntervalMs ?? 10_000;
     this.defaultPollIntervalMs = opts.defaultPollIntervalMs ?? 30_000;
     this.maxTrackingMs = opts.maxTrackingMs ?? 60 * 60_000;
+    this.store = opts.store;
+    this.resolveExecutor = opts.resolveExecutor;
+    this.rehydrateGraceMs = opts.rehydrateGraceMs ?? 5 * 60_000;
+    // Rehydrate in-flight tasks owed a reply. They can't poll until the agent's
+    // executor re-registers (A2A card discovery), so park them in `pending`;
+    // _sweep promotes them once resolvable, or escalates after the grace window.
+    for (const row of this.store?.loadAll() ?? []) {
+      this.pending.set(row.correlationId, row);
+    }
+    if (this.pending.size > 0) {
+      console.log(`[task-tracker] rehydrated ${this.pending.size} in-flight task(s) from store — awaiting executor re-registration`);
+    }
     this.sweepTimer = setInterval(() => { void this._sweep(); }, this.sweepIntervalMs);
     this.sweepTimer.unref?.();
+  }
+
+  /** Remove a task from memory + pending + durable store. */
+  private _forget(correlationId: string): void {
+    this.tasks.delete(correlationId);
+    this.pending.delete(correlationId);
+    this.store?.delete(correlationId);
+  }
+
+  /**
+   * Try to bring a persisted (rehydrated) task back to active polling by
+   * resolving its agent's executor. Returns the live task, or null if the
+   * executor isn't registered yet. `onTerminal` (the outcome-emit callback) is
+   * not persisted, so a rehydrated task still publishes its reply but emits no
+   * outcome telemetry — an acceptable loss vs. dropping the reply entirely.
+   */
+  private _rehydrate(row: PersistedTask): TrackedTask | null {
+    const executor = this.resolveExecutor?.(row.agentName, row.skillName);
+    if (!executor) return null;
+    const task: TrackedTask = { ...row, executor, lastPolledAt: 0 };
+    this.tasks.set(row.correlationId, task);
+    this.pending.delete(row.correlationId);
+    return task;
+  }
+
+  /** Promote rehydrated tasks once their executor re-registers; escalate the unresolvable. */
+  private _promoteRehydrated(now: number): void {
+    if (this.pending.size === 0) return;
+    for (const [, row] of [...this.pending]) {
+      if (this._rehydrate(row)) {
+        console.log(`[task-tracker] resumed ${row.agentName} task ${row.taskId.slice(0, 8)}… after restart`);
+        continue;
+      }
+      // Executor still unregistered — escalate (don't silently drop) once the
+      // task ages out or the post-boot grace window elapses.
+      if (now - row.registeredAt > this.maxTrackingMs || now - this.bootAt >= this.rehydrateGraceMs) {
+        this._escalateInterrupted(row);
+      }
+    }
+  }
+
+  /** Publish a failure to the reply topic for a task that couldn't be resumed. */
+  private _escalateInterrupted(row: PersistedTask): void {
+    console.warn(`[task-tracker] could not resume ${row.agentName} task ${row.taskId.slice(0, 8)}… — escalating as interrupted`);
+    const payload: AgentSkillResponsePayload = {
+      error: "Task interrupted by a workstacean restart and could not be resumed — please retry.",
+      correlationId: row.correlationId,
+      taskState: "failed",
+      taskId: row.taskId,
+    };
+    this.bus.publish(row.replyTopic, {
+      id: crypto.randomUUID(),
+      correlationId: row.correlationId,
+      topic: row.replyTopic,
+      timestamp: Date.now(),
+      payload,
+    });
+    this._forget(row.correlationId);
   }
 
   /** Register a task for tracking. Dispatcher calls this after executor returns working. */
@@ -138,6 +223,14 @@ export class TaskTracker {
       sourceUserId: params.sourceUserId,
       onTerminal: params.onTerminal,
     });
+    const t = this.tasks.get(params.correlationId)!;
+    this.store?.upsert({
+      correlationId: t.correlationId, taskId: t.taskId, agentName: t.agentName,
+      skillName: t.skillName, dispatcherAgent: t.dispatcherAgent, replyTopic: t.replyTopic,
+      parentId: t.parentId, registeredAt: t.registeredAt, pollIntervalMs: t.pollIntervalMs,
+      callbackToken: t.callbackToken, sourceInterface: t.sourceInterface,
+      sourceChannelId: t.sourceChannelId, sourceUserId: t.sourceUserId,
+    });
     console.log(
       `[task-tracker] Tracking ${params.agentName} task ${params.taskId.slice(0, 8)}… (correlationId: ${params.correlationId.slice(0, 8)}…)`,
     );
@@ -145,7 +238,7 @@ export class TaskTracker {
 
   /** Look up the callback token for a tracked task. Used by the webhook route. */
   getCallbackToken(correlationId: string): string | undefined {
-    return this.tasks.get(correlationId)?.callbackToken;
+    return this.tasks.get(correlationId)?.callbackToken ?? this.pending.get(correlationId)?.callbackToken;
   }
 
   /**
@@ -154,7 +247,13 @@ export class TaskTracker {
    * we update lastPolledAt so the polling loop gives the task more time.
    */
   handleCallback(correlationId: string, body: Record<string, unknown>): void {
-    const task = this.tasks.get(correlationId);
+    // Recover a task whose poll loop was lost to a restart: the callback token
+    // is persisted, so an agent's push callback can re-find it in `pending`.
+    let task = this.tasks.get(correlationId);
+    if (!task) {
+      const row = this.pending.get(correlationId);
+      if (row) task = this._rehydrate(row) ?? undefined;
+    }
     if (!task) return;
 
     const status = (body.status ?? {}) as { state?: string; message?: { parts?: unknown[] } };
@@ -169,7 +268,7 @@ export class TaskTracker {
         `but no approval gate is wired — terminating with failure. Question: ${statusText || "(none)"}`,
       );
       this._publishResponse(task, undefined, `Agent asked for human input but no approval gate is wired: ${statusText || "(no question text)"}`, "failed");
-      this.tasks.delete(correlationId);
+      this._forget(correlationId);
       return;
     }
 
@@ -190,7 +289,7 @@ export class TaskTracker {
 
     this._extractAndPublishDeltas(task.taskId, task.agentName, artifacts);
     this._publishResponse(task, isError ? undefined : content, isError ? (content || state) : undefined, state);
-    this.tasks.delete(correlationId);
+    this._forget(correlationId);
     console.log(
       `[task-tracker] Callback for ${task.taskId.slice(0, 8)}… → terminal state "${state}" (via webhook)`,
     );
@@ -198,7 +297,7 @@ export class TaskTracker {
 
   /** Stop tracking a task (e.g., on cancel). */
   untrack(correlationId: string): void {
-    this.tasks.delete(correlationId);
+    this._forget(correlationId);
   }
 
   /** Get snapshot of currently-tracked tasks — for API endpoint. */
@@ -223,11 +322,13 @@ export class TaskTracker {
   private async _sweep(): Promise<void> {
     const now = Date.now();
 
+    this._promoteRehydrated(now);
+
     for (const task of this.tasks.values()) {
       // Age-out: task has been working for too long
       if (now - task.registeredAt > this.maxTrackingMs) {
         this._publishResponse(task, undefined, `Task tracking timeout (>${Math.round(this.maxTrackingMs / 60_000)}min)`);
-        this.tasks.delete(task.correlationId);
+        this._forget(task.correlationId);
         continue;
       }
 
@@ -246,7 +347,7 @@ export class TaskTracker {
             `but no approval gate is wired — terminating with failure. Question: ${result.text || "(none)"}`,
           );
           this._publishResponse(task, undefined, `Agent asked for human input but no approval gate is wired: ${result.text || "(no question text)"}`, "failed");
-          this.tasks.delete(task.correlationId);
+          this._forget(task.correlationId);
           continue;
         }
 
@@ -261,7 +362,7 @@ export class TaskTracker {
           // result.data carries the extension payloads pollTask extracted.
           await task.executor.recordTerminalExtensions(task.skillName ?? "unknown", task.correlationId, result.data);
           this._publishResponse(task, result.text, result.isError ? result.text : undefined, state, result.data);
-          this.tasks.delete(task.correlationId);
+          this._forget(task.correlationId);
           console.log(
             `[task-tracker] Task ${task.taskId.slice(0, 8)}… reached terminal state "${state}" after ${Math.round((now - task.registeredAt) / 1000)}s`,
           );

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,8 +58,11 @@ import { ContextMailbox } from "../lib/dm/context-mailbox.ts";
 const contextMailbox = new ContextMailbox();
 
 // --- Task tracker — tracks long-running A2A tasks that returned non-terminal state ---
+// (constructed below, after executorRegistry, so it can resolve executors to
+// rehydrate in-flight tasks after a restart — #793)
 import { TaskTracker } from "./executor/task-tracker.ts";
-const taskTracker = new TaskTracker({ bus });
+import { TaskTrackerStore } from "./executor/task-tracker-store.ts";
+import type { A2AExecutor } from "./executor/executors/a2a-executor.ts";
 
 // Handle to the dispatcher's in-flight check — assigned when its (lazy) factory
 // runs below. Read via a closure in apiContext so the poll endpoint can report
@@ -172,6 +175,18 @@ const enabledBuiltins = (process.env.ENABLED_PLUGINS ?? "").split(",").map((s) =
 // consumed by SkillDispatcherPlugin (sole agent.skill.request subscriber).
 const { ExecutorRegistry } = await import("./executor/executor-registry.js");
 const executorRegistry = new ExecutorRegistry();
+
+// Durable task tracking — in-flight A2A tasks survive restarts and resume
+// polling once their agent's executor re-registers (else escalate). (#793)
+const taskTrackerStore = new TaskTrackerStore(`${dataDir}/tasks.db`);
+const taskTracker = new TaskTracker({
+  bus,
+  store: taskTrackerStore,
+  resolveExecutor: (agentName, skill) => {
+    const e = executorRegistry.resolve(skill ?? "chat", [agentName]);
+    return e && typeof (e as A2AExecutor).pollTask === "function" ? (e as A2AExecutor) : undefined;
+  },
+});
 
 const pluginRegistry: PluginRegistryEntry[] = [
   {
@@ -802,6 +817,7 @@ async function gracefulShutdown(signal: string): Promise<void> {
     ["telemetry", () => telemetry.close()],
     ["fleet-state", () => fleetStateRepo.close()],
     ["research-store", () => researchStore.close()],
+    ["task-store", () => taskTrackerStore.close()],
   ] as const) {
     try { closer(); } catch (e) { console.warn(`[shutdown] ${name} close threw:`, e); }
   }


### PR DESCRIPTION
Closes #793 (P0, epic #790).

TaskTracker held in-flight A2A tasks (each owed a reply on a reply topic) in a pure in-memory `Map`. A restart (watchtower, several/day) erased it → the caller **never got a response, silently** — the exact "escalate, don't drop" violation the audit flagged.

## Changes
- **`TaskTrackerStore`** (new, `${dataDir}/tasks.db`) — persists the serializable task record. WAL + `busy_timeout`; no-op degrade on DB failure.
- **`track()`** persists; terminal/untrack delete (single `_forget`).
- **Rehydrate on boot** — persisted tasks park in `pending`, promote to active polling once `resolveExecutor(agentName, skill)` (registry lookup) finds the re-registered A2A executor. Unresolvable tasks **escalate** to the reply topic ("interrupted — please retry") after a grace window — never silently dropped.
- **handleCallback recovery** — a push callback for a task lost from memory is recovered from `pending` (callback token persisted).
- Wired in `src/index.ts` (after `executorRegistry`; store closed in graceful shutdown from #792).

Caveat: the in-memory `onTerminal` outcome callback isn't persisted, so a rehydrated task still publishes its reply but may skip the outcome-telemetry event — acceptable vs. dropping the reply.

## Tests
Store round-trip · persist-on-track + delete-on-terminal · rehydrate→resume-to-completion · unresolvable→escalate. **1070 green, tsc clean, no new lint.** Docs: `flow-agent-runtime-telemetry.md`.

Part of #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)