### PR TITLE
fix(reliability): deadline + circuit-breaker on the LLM gateway / agent run (#794)

### DIFF
--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -10,7 +10,7 @@ Every variable recognised by protoWorkstacean is declared in the zod `EnvSchema`
 
 - **63** variables declared in `EnvSchema`
 - **0** required (no `.optional()`); the rest are optional
-- **29** variable(s) read via `process.env` at runtime but **not** in `EnvSchema` (see [Read directly (not in EnvSchema)](#read-directly-not-in-envschema))
+- **33** variable(s) read via `process.env` at runtime but **not** in `EnvSchema` (see [Read directly (not in EnvSchema)](#read-directly-not-in-envschema))
 
 ## Core / runtime
 
@@ -144,21 +144,27 @@ These variables are read via `process.env` somewhere in `src/` or `lib/` but are
 | `A2A_CHAT_REPLY_TIMEOUT_MS` | `src/api/ava-tools.ts` |
 | `A2A_INPUT_REQUIRED_TTL_MS` | `src/api/human-input.ts` |
 | `A2A_STREAM_HEARTBEAT_MS` | `src/api/a2a-server.ts` |
+| `AGENT_RUN_BUDGET_MS` | `src/executor/executors/deep-agent-executor.ts` |
 | `AUTOMAKER_API_KEY` | `lib/plugins/protomaker-board-bridge.ts`, `src/plugins/project-registry.ts` |
 | `CLAWPATCH_CHECKOUT_ROOT` | `lib/checkout-cache.ts` |
 | `CLAWPATCH_REPO_PATH_MAP` | `src/api/clawpatch.ts` |
-| `WORKSTACEAN_PUBLISH_TOPIC_DENYLIST` | `lib/runtime-env.ts` — CSV of topic prefixes rejected at `POST /publish` (overrides the control-plane default). |
 | `CLAWPATCH_STATE_ROOT` | `src/api/clawpatch.ts` |
 | `CREATE_ISSUE_DEDUP_DISABLED` | `src/api/github.ts` |
 | `CREATE_ISSUE_DEDUP_WINDOW_MS` | `src/api/github.ts` |
 | `DEEP_AGENT_CHAT_POLL_INTERVAL_MS` | `src/executor/executors/deep-agent-executor.ts` |
 | `DISCORD_AGENT_OPS_CHANNEL` | `src/api/ava-tools.ts`, `src/plugins/skill-broker-plugin.ts` |
 | `LINEAR_PROTO_BRIDGE_LABEL` | `lib/plugins/linear-proto-bridge.ts` |
-| `NODE_ENV` | `lib/plugins/linear.ts` |
-| `OPENAI_BASE_URL` | `src/executor/executors/deep-agent-executor.ts` |
+| `LLM_GATEWAY_TIMEOUT_MS` | `src/executor/executors/deep-agent-executor.ts` |
+| `LLM_MAX_RETRIES` | `src/executor/executors/deep-agent-executor.ts` |
+| `MEMORY_HARVEST_MAX_AGE_DAYS` | `src/agent-runtime/agent-runtime-plugin.ts` |
+| `MEMORY_HARVEST_SWEEP_HOURS` | `src/agent-runtime/agent-runtime-plugin.ts` |
+| `MEMORY_SUMMARY_MODEL` | `src/agent-runtime/agent-runtime-plugin.ts` |
+| `OPENAI_BASE_URL` | `src/agent-runtime/agent-runtime-plugin.ts`, `src/executor/executors/deep-agent-executor.ts`, `src/services/embeddings/gateway-embed.ts` |
 | `PROTOLABS_AGENTS_JSON` | `src/plugins/skill-broker-plugin.ts` |
 | `PROTOMAKER_API_BASE` | `lib/plugins/protomaker-board-bridge.ts`, `src/plugins/project-registry.ts` |
 | `QUINN_DISCORD_TOKEN` | `lib/types/channels.ts` |
+| `RESEARCH_EMBED_DIM` | `src/knowledge/research-store.ts` |
+| `RESEARCH_EMBED_MODEL` | `src/services/embeddings/gateway-embed.ts` |
 | `SEARXNG_URL` | `src/executor/executors/deep-agent-executor.ts` |
 | `WORKSTACEAN_AGENT_BOT_LOGINS` | `lib/plugins/github.ts` |
 | `WORKSTACEAN_DISPATCH_DROP_ESCALATION_COOLDOWN_MS` | `src/plugins/dispatch-drop-escalator-plugin.ts` |

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -18,6 +18,7 @@ import type { IExecutor, SkillRequest, SkillResult } from "../types.ts";
 import { runStructuredFinalizer, type ForcedToolCaller } from "./structured-finalizer.ts";
 import { AgentMemory, memoryAppliesTo } from "../../knowledge/agent-memory.ts";
 import type { ToolCallArtifactData } from "@protolabs/a2a";
+import { withCircuitBreaker } from "../../../lib/plugins/circuit-breaker.ts";
 
 const LANGFUSE_ENABLED = !!(process.env.LANGFUSE_PUBLIC_KEY && process.env.LANGFUSE_SECRET_KEY);
 
@@ -994,6 +995,10 @@ export class DeepAgentExecutor implements IExecutor {
     return new ChatOpenAI({
       model: modelName,
       temperature: 0,
+      // Per-request deadline + bounded retries so a hung/partial-outage gateway
+      // can't block a turn forever (was unbounded — #794).
+      timeout: Number(process.env.LLM_GATEWAY_TIMEOUT_MS) || 120_000,
+      maxRetries: Number(process.env.LLM_MAX_RETRIES ?? 2),
       configuration: this.gatewayUrl ? { baseURL: this.gatewayUrl } : undefined,
       apiKey: this.apiKey,
     });
@@ -1123,9 +1128,14 @@ export class DeepAgentExecutor implements IExecutor {
       type RunMessage = { _getType?: () => string; constructor?: { name?: string }; content?: unknown; tool_calls?: unknown };
       let result: { messages?: RunMessage[] } = { messages: [] };
       let narrated = 0;
+      // Wall-clock deadline on the whole run + a circuit breaker on the gateway,
+      // so a hung gateway aborts (→ error result → dispatcher publishes failure)
+      // instead of blocking the slot forever, and a sustained outage fast-fails. (#794)
+      const AGENT_RUN_BUDGET_MS = Number(process.env.AGENT_RUN_BUDGET_MS) || 300_000;
+      await withCircuitBreaker(`llm-gateway:${this.agentDef.name}`, async () => {
       for await (const state of await agent.stream(
         { messages: [...history.map(t => ({ role: t.role, content: t.content })), { role: "user", content: userContent }] },
-        { recursionLimit: effectiveMaxTurns * 2 + 1, callbacks, streamMode: "values" },
+        { recursionLimit: effectiveMaxTurns * 2 + 1, callbacks, streamMode: "values", signal: AbortSignal.timeout(AGENT_RUN_BUDGET_MS) },
       )) {
         result = state as unknown as { messages?: RunMessage[] };
         const msgs = result.messages ?? [];
@@ -1155,6 +1165,7 @@ export class DeepAgentExecutor implements IExecutor {
         }
         narrated = msgs.length;
       }
+      });
 
       const messages = result.messages ?? [];
       console.log(`[deep-agent:${this.agentDef.name}] ${messages.length} messages returned`);


### PR DESCRIPTION
Closes #794 (P0, epic #790).

The hottest path had **no deadline**: `ChatOpenAI` was built with no `timeout`/`maxRetries` and `agent.stream` got no `AbortSignal`. A hung gateway (TCP up, no bytes — a common partial outage) blocked the run forever: `activeExecutions` stayed active, the reply topic never fired, the slot never freed. A2A + GitHub/Google have circuit breakers; the in-process LLM path had nothing.

## Changes
- `_buildModel`: `timeout` (`LLM_GATEWAY_TIMEOUT_MS`, default 120s) + `maxRetries` (`LLM_MAX_RETRIES`, default 2).
- The streaming run is wrapped in `withCircuitBreaker("llm-gateway:<agent>", …)` and gets `signal: AbortSignal.timeout(AGENT_RUN_BUDGET_MS)` (default 5 min). On abort or breaker-open, the existing `execute()` catch returns `isError` → the dispatcher publishes a **failure to the reply topic** instead of hanging.

## Tests
**1070 green (no regression), tsc clean, no new lint.** (The run loop isn't LLM-mocked in this codebase; the breaker util itself is unit-tested, and the change is config + wrapper.) Docs: `env-vars.md` regenerated.

Part of #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)