### PR TITLE
feat(ops): real /ready endpoint + container healthcheck (#795)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,6 +4,15 @@ services:
       context: .
       target: release
     restart: unless-stopped
+    # Readiness gate (#795) — checks local invariants (sqlite open). Uses bun
+    # (always in the image) so no curl/wget dependency. The HTTP API is on
+    # localhost:3000 inside the container.
+    healthcheck:
+      test: ["CMD", "bun", "-e", "fetch('http://localhost:3000/ready').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 40s
     ports:
       - "8081:8080"   # Event viewer UI
       - "8082:8082"   # GitHub webhook receiver

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -243,11 +243,12 @@ Each row links to the route definition as `path:line` so jumping from this index
 |---|---|---|---|
 | `GET` | `/api/skills/:agentName` | `src/api/operations.ts:256` | — |
 
-### `/health`
+### `/health` + `/ready`
 
 | Method | Path | Source | Description |
 |---|---|---|---|
-| `GET` | `/health` | `src/api/operations.ts:246` | — |
+| `GET` | `/health` | `src/api/operations.ts` | Cheap liveness — the process is up. Always 200. |
+| `GET` | `/ready` | `src/api/operations.ts` | Readiness — gates on local invariants (sqlite open). 200 `ready` / 503 `unready`. The LLM gateway is probed and reported in the body but does **not** gate readiness (an external outage shouldn't restart-loop the container; agent runs fail fast instead). The prod compose `healthcheck` polls this. |
 
 ### `/publish`
 

--- a/src/api/__tests__/ready.test.ts
+++ b/src/api/__tests__/ready.test.ts
@@ -1,0 +1,42 @@
+/**
+ * #795 — /ready readiness probe. Gates on local invariants (sqlite); the
+ * gateway is reported but does not gate (LLM_GATEWAY_URL unset in tests).
+ */
+import { describe, test, expect } from "bun:test";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { ExecutorRegistry } from "../../executor/executor-registry.ts";
+import { createRoutes } from "../operations.ts";
+import type { ApiContext, Route } from "../types.ts";
+import type { TelemetryService } from "../../telemetry/telemetry-service.ts";
+
+function readyRoute(ctx: ApiContext): Route {
+  const r = createRoutes(ctx).find((x) => x.method === "GET" && x.path === "/ready");
+  if (!r) throw new Error("no /ready route");
+  return r;
+}
+function baseCtx(telemetry?: TelemetryService): ApiContext {
+  return { workspaceDir: "/tmp", bus: new InMemoryEventBus(), plugins: [], executorRegistry: new ExecutorRegistry(), telemetry };
+}
+const fakeTelemetry = (healthy: boolean) => ({ healthCheck: () => healthy }) as unknown as TelemetryService;
+
+describe("/ready", () => {
+  test("200 ready when sqlite is healthy; gateway 'unconfigured' when LLM_GATEWAY_URL unset", async () => {
+    const res = await readyRoute(baseCtx(fakeTelemetry(true))).handler(new Request("http://x/ready"), {});
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.status).toBe("ready");
+    expect(body.sqlite).toBe(true);
+    expect(body.gateway).toBe("unconfigured");
+  });
+
+  test("503 unready when sqlite is down", async () => {
+    const res = await readyRoute(baseCtx(fakeTelemetry(false))).handler(new Request("http://x/ready"), {});
+    expect(res.status).toBe(503);
+    expect((await res.json() as Record<string, unknown>).status).toBe("unready");
+  });
+
+  test("200 when no telemetry is wired (sqlite check skipped → assumed ok)", async () => {
+    const res = await readyRoute(baseCtx(undefined)).handler(new Request("http://x/ready"), {});
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -138,6 +138,30 @@ export function createRoutes(ctx: ApiContext): Route[] {
     return Response.json({ success: true });
   }
 
+  /**
+   * Readiness probe (#795). Gates on LOCAL invariants the instance needs to
+   * serve (sqlite open). The LLM gateway is probed for visibility but does NOT
+   * gate readiness — an external gateway outage shouldn't restart-loop the
+   * container (agent runs fail fast via #794 instead). `/health` stays a cheap
+   * liveness check.
+   */
+  async function handleReady(): Promise<Response> {
+    const sqlite = ctx.telemetry ? ctx.telemetry.healthCheck() : true;
+    let gateway: boolean | "unconfigured" = "unconfigured";
+    const gw = process.env.LLM_GATEWAY_URL;
+    if (gw) {
+      try {
+        const r = await fetch(new URL("/health", gw), { signal: AbortSignal.timeout(2000) });
+        gateway = r.ok;
+      } catch { gateway = false; }
+    }
+    const ready = sqlite;
+    return Response.json(
+      { status: ready ? "ready" : "unready", sqlite, gateway, timestamp: Date.now() },
+      { status: ready ? 200 : 503 },
+    );
+  }
+
   async function handleOnboard(req: Request): Promise<Response> {
     const caller = authenticateCaller(req);
     if (!caller?.isAdmin) return unauthorized();
@@ -259,6 +283,7 @@ export function createRoutes(ctx: ApiContext): Route[] {
 
   return [
     { method: "GET",  path: "/health",                  handler: () => Response.json({ status: "ok", timestamp: Date.now() }) },
+    { method: "GET",  path: "/ready",                   handler: () => handleReady() },
     { method: "POST", path: "/publish",                 handler: (req) => handlePublish(req) },
     { method: "POST", path: "/api/onboard",             handler: (req) => handleOnboard(req) },
     { method: "GET",  path: "/api/projects",            handler: () => Response.json({ success: true, data: ctx.projectRegistry?.getProjects() ?? [] }) },

--- a/src/telemetry/telemetry-service.ts
+++ b/src/telemetry/telemetry-service.ts
@@ -203,6 +203,16 @@ export class TelemetryService {
     });
   }
 
+  /** Readiness probe: the backing sqlite is open and answers a trivial query. */
+  healthCheck(): boolean {
+    try {
+      this.db?.query("SELECT 1").get();
+      return !!this.db;
+    } catch {
+      return false;
+    }
+  }
+
   close(): void {
     try {
       this.db?.exec("PRAGMA wal_checkpoint(TRUNCATE);");


### PR DESCRIPTION
Closes #795 (P0, epic #790).

`/health` returned a static `{status:"ok"}` that checked nothing, and prod compose had no `healthcheck` — watchtower/compose couldn't distinguish a wedged container from a healthy one, so a bad `:main` shipped looking healthy.

## Changes
- **`/ready`** — gates on **local** invariants (`sqlite SELECT 1` via `TelemetryService.healthCheck()`); 200 `ready` / 503 `unready`. The LLM gateway is probed (2s timeout) and reported in the body but **does not gate readiness** — an external gateway outage shouldn't restart-loop the container (agent runs fail fast via #794). `/health` stays cheap liveness.
- **`docker-compose.prod.yml`** — `healthcheck` polls `/ready` via `bun -e fetch` (no curl/wget dependency).

## Tests
`/ready` 200-healthy / 503-sqlite-down / 200-no-telemetry. **1073 green, tsc clean, no new lint.** Docs: `http-api.md`.

Part of #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)