### PR TITLE
feat(data): SQLite schema-migration framework (user_version) (#796)

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -253,6 +253,21 @@ bunx tsc --noEmit
 
 The project uses TypeScript strict mode. All exported types should have JSDoc comments on non-obvious fields.
 
+## Changing a SQLite store schema
+
+The bun:sqlite stores back a **persistent prod volume** (`/data`), and deploy is a watchtower image pull with no migration step. So a bare `CREATE TABLE IF NOT EXISTS` change silently no-ops against an existing DB and drifts at query time. Use the versioned migration runner instead (`lib/sqlite-migrate.ts`):
+
+```ts
+import { runMigrations } from "../../lib/sqlite-migrate.ts";
+// in the store's init, after the PRAGMAs:
+runMigrations(this.db, [
+  { version: 1, up: (d) => d.exec(`CREATE TABLE IF NOT EXISTS … `) }, // baseline
+  { version: 2, up: (d) => d.exec(`ALTER TABLE … ADD COLUMN … `) },   // future change
+]);
+```
+
+`runMigrations` applies only migrations newer than the DB's `PRAGMA user_version`, each in a transaction, bumping the version after each succeeds. **Never edit a shipped migration's `up` — append a new version.** `src/executor/task-tracker-store.ts` is the reference adoption; other stores adopt the same pattern on their next schema change.
+
 ## Conventions
 
 - **Named exports only** in `.ts` files. Exception: `_meta.ts` files use a default export for Nextra.

--- a/lib/__tests__/sqlite-migrate.test.ts
+++ b/lib/__tests__/sqlite-migrate.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { runMigrations, schemaVersion } from "../sqlite-migrate.ts";
+
+const fresh = () => new Database(":memory:");
+
+describe("runMigrations", () => {
+  test("applies migrations in order and stamps user_version", () => {
+    const db = fresh();
+    const v = runMigrations(db, [
+      { version: 1, up: (d) => d.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)") },
+      { version: 2, up: (d) => d.exec("ALTER TABLE t ADD COLUMN name TEXT") },
+    ]);
+    expect(v).toBe(2);
+    expect(schemaVersion(db)).toBe(2);
+    db.exec("INSERT INTO t (id, name) VALUES (1, 'x')"); // both migrations applied
+    db.close();
+  });
+
+  test("only runs migrations newer than the current version (idempotent re-run)", () => {
+    const db = fresh();
+    let ranV2 = 0;
+    const migs = [
+      { version: 1, up: (d: Database) => d.exec("CREATE TABLE t (id INTEGER)") },
+      { version: 2, up: (d: Database) => { ranV2++; d.exec("ALTER TABLE t ADD COLUMN name TEXT"); } },
+    ];
+    runMigrations(db, migs);
+    runMigrations(db, migs); // second run is a no-op
+    expect(ranV2).toBe(1);
+    expect(schemaVersion(db)).toBe(2);
+    db.close();
+  });
+
+  test("baseline v1 is a no-op on an existing (already-created) DB and just stamps the version", () => {
+    const db = fresh();
+    db.exec("CREATE TABLE t (id INTEGER)"); // simulate an existing prod table, user_version=0
+    expect(schemaVersion(db)).toBe(0);
+    const v1 = { version: 1, up: (d: Database) => d.exec("CREATE TABLE IF NOT EXISTS t (id INTEGER)") };
+    expect(runMigrations(db, [v1])).toBe(1);
+    expect(schemaVersion(db)).toBe(1);
+    db.close();
+  });
+
+  test("a throwing migration fails loud and does NOT advance the version", () => {
+    const db = fresh();
+    runMigrations(db, [{ version: 1, up: (d) => d.exec("CREATE TABLE t (id INTEGER)") }]);
+    expect(() => runMigrations(db, [{ version: 2, up: () => { throw new Error("boom"); } }])).toThrow("boom");
+    expect(schemaVersion(db)).toBe(1);
+    db.close();
+  });
+});

--- a/lib/sqlite-migrate.ts
+++ b/lib/sqlite-migrate.ts
@@ -1,0 +1,51 @@
+/**
+ * Minimal SQLite migration runner keyed on `PRAGMA user_version`.
+ *
+ * Every store used `CREATE TABLE IF NOT EXISTS` against a persistent prod volume
+ * with no versioning — so any non-additive schema change silently no-ops on an
+ * existing DB (the `IF NOT EXISTS` skips it) and drifts at query time. This gives
+ * each store an ordered, version-stamped migration list applied deterministically
+ * at init.
+ *
+ * Baselining: a store's current schema becomes migration **v1** (its body is the
+ * existing `CREATE TABLE IF NOT EXISTS …`, still idempotent). On an existing prod
+ * DB (user_version=0, tables already present) v1 is a no-op that just stamps the
+ * version; on a fresh DB it creates the tables. Future changes add v2, v3, … with
+ * `ALTER TABLE` etc. Each migration runs in a transaction; the version is bumped
+ * only after its `up` succeeds.
+ */
+
+import type { Database } from "bun:sqlite";
+
+export interface Migration {
+  /** Monotonic, 1-based. Applied in ascending order; only those > current run. */
+  version: number;
+  up: (db: Database) => void;
+}
+
+/** Current `user_version` (0 on a fresh/unstamped DB). */
+export function schemaVersion(db: Database): number {
+  const row = db.query("PRAGMA user_version").get() as { user_version?: number } | null;
+  return row?.user_version ?? 0;
+}
+
+/**
+ * Apply every migration whose version is greater than the DB's current
+ * `user_version`, in ascending order, each in its own transaction. Returns the
+ * resulting version. Throws (fail-loud) if a migration's `up` throws — the
+ * version is NOT advanced past a failed step.
+ */
+export function runMigrations(db: Database, migrations: Migration[]): number {
+  const ordered = [...migrations].sort((a, b) => a.version - b.version);
+  let current = schemaVersion(db);
+  for (const m of ordered) {
+    if (m.version <= current) continue;
+    db.transaction(() => {
+      m.up(db);
+      // PRAGMA can't be parameterized; version is an integer from our own list.
+      db.exec(`PRAGMA user_version = ${Math.trunc(m.version)};`);
+    })();
+    current = m.version;
+  }
+  return current;
+}

--- a/src/executor/task-tracker-store.ts
+++ b/src/executor/task-tracker-store.ts
@@ -18,6 +18,7 @@
 import { Database } from "bun:sqlite";
 import { existsSync, mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { runMigrations } from "../../lib/sqlite-migrate.ts";
 
 export interface PersistedTask {
   correlationId: string;
@@ -64,23 +65,33 @@ export class TaskTrackerStore {
       this.db.exec("PRAGMA journal_mode=WAL;");
       this.db.exec("PRAGMA synchronous=NORMAL;");
       this.db.exec("PRAGMA busy_timeout=5000;");
-      this.db.exec(`
-        CREATE TABLE IF NOT EXISTS tracked_tasks (
-          correlation_id   TEXT PRIMARY KEY,
-          task_id          TEXT NOT NULL,
-          agent_name       TEXT NOT NULL,
-          skill_name       TEXT,
-          dispatcher_agent TEXT,
-          reply_topic      TEXT NOT NULL,
-          parent_id        TEXT,
-          registered_at    INTEGER NOT NULL,
-          poll_interval_ms INTEGER NOT NULL,
-          callback_token   TEXT,
-          source_interface TEXT,
-          source_channel_id TEXT,
-          source_user_id   TEXT
-        );
-      `);
+      // Versioned schema (#796). v1 is the baseline; future changes append v2+
+      // with ALTER statements so an existing prod DB migrates deterministically
+      // instead of silently no-op'ing a CREATE TABLE IF NOT EXISTS. This is the
+      // reference pattern other stores adopt on their next schema change.
+      runMigrations(this.db, [
+        {
+          version: 1,
+          up: (d) =>
+            d.exec(`
+              CREATE TABLE IF NOT EXISTS tracked_tasks (
+                correlation_id   TEXT PRIMARY KEY,
+                task_id          TEXT NOT NULL,
+                agent_name       TEXT NOT NULL,
+                skill_name       TEXT,
+                dispatcher_agent TEXT,
+                reply_topic      TEXT NOT NULL,
+                parent_id        TEXT,
+                registered_at    INTEGER NOT NULL,
+                poll_interval_ms INTEGER NOT NULL,
+                callback_token   TEXT,
+                source_interface TEXT,
+                source_channel_id TEXT,
+                source_user_id   TEXT
+              );
+            `),
+        },
+      ]);
       console.log(`[task-store] Ready at ${this.dbPath}`);
     } catch (err) {
       console.error("[task-store] Init failed — task persistence disabled (in-memory only):", err);


### PR DESCRIPTION
Closes #796 (P0, epic #790).

Stores used `CREATE TABLE IF NOT EXISTS` against a **persistent prod volume** with no versioning — a non-additive schema change silently no-ops on an existing DB and drifts at query time. There was no migration runner.

## Changes
- **`lib/sqlite-migrate.ts`** (new) — `runMigrations(db, migrations[])` keyed on `PRAGMA user_version`: applies only versions > current, each in a transaction, bumping the version after each `up` succeeds; **fails loud** and doesn't advance past a throwing step. Plus `schemaVersion(db)`.
- **`task-tracker-store`** adopts it as the **reference**: its schema is now migration **v1** (baseline). Future changes append v2+ with `ALTER`. Idempotent on existing prod DBs (v1's `IF NOT EXISTS` no-ops, then stamps the version).
- Remaining stores adopt the same pattern on their next schema change — documented in `contributing/development.md`. Shipping the framework + reference adoption + the pattern is the "before the first schema change lands" fix the audit asked for.

## Tests
Migrate helper: ordered apply · idempotent re-run · baseline no-op on existing DB · throw-doesn't-advance. task-tracker persistence still green (its schema now flows through v1). **1056 green, tsc clean, no new lint.** Docs: `development.md`.

Part of #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)