### PR TITLE
feat(forkability): fleet.yaml role bindings + config-driven bot-login + GITHUB_APP_* (#798)

### DIFF
--- a/docs/explanation/agent-identity.md
+++ b/docs/explanation/agent-identity.md
@@ -33,7 +33,7 @@ Quinn and the protoMaker team each have their own GitHub App installation. Each 
 
 When a PR review response lands for Quinn:
 1. The GitHub context is resolved from the inbound `correlationId` (owner, repo, number)
-2. The Quinn container mints a JWT using `QUINN_APP_ID` + `QUINN_APP_PRIVATE_KEY`
+2. The Quinn container mints a JWT using `GITHUB_APP_ID` + `GITHUB_APP_PRIVATE_KEY`
 3. Exchanges it for a GitHub installation token (refreshed every 45 min by an entrypoint daemon)
 4. Submits the formal review via the GitHub API — shows as `@protoquinn[bot]`
 

--- a/docs/how-to/use-quinn-pr-review.md
+++ b/docs/how-to/use-quinn-pr-review.md
@@ -18,8 +18,8 @@ Quinn reviews pull requests and issues via GitHub webhook. It uses codebase-wide
 | `GITHUB_TOKEN` | Yes | PAT — enables the GitHub plugin and posts comment replies |
 | `GITHUB_WEBHOOK_SECRET` | Recommended | Validates `X-Hub-Signature-256` on inbound payloads |
 | `GITHUB_WEBHOOK_PORT` | No | Webhook HTTP server port (default: `8082`) |
-| `QUINN_APP_ID` | For bot comments | GitHub App ID — Quinn posts as `protoquinn[bot]` |
-| `QUINN_APP_PRIVATE_KEY` | For bot comments | GitHub App private key (PKCS#1 PEM) |
+| `GITHUB_APP_ID` | For bot comments | GitHub App ID — Quinn posts as `protoquinn[bot]` |
+| `GITHUB_APP_PRIVATE_KEY` | For bot comments | GitHub App private key (PKCS#1 PEM) |
 | `QDRANT_URL` | For vector context | `http://qdrant:6333` |
 | `OLLAMA_URL` | For embeddings | `http://ollama:11434` |
 | `OLLAMA_EMBED_MODEL` | For embeddings | `nomic-embed-text` |

--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -24,14 +24,14 @@ Receives GitHub webhook events and routes `@mention` comments to the agent fleet
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `GITHUB_TOKEN` | Yes* | PAT used to post comment replies (enables the plugin) |
-| `QUINN_APP_ID` | No | GitHub App ID — preferred over the PAT for write operations (comments, PR ops, issue closure) so they author as `@protoquinn[bot]` |
-| `QUINN_APP_PRIVATE_KEY` | No | GitHub App PEM private key (newlines as `\n`). Must be set together with `QUINN_APP_ID` |
+| `GITHUB_APP_ID` | No | GitHub App ID — preferred over the PAT for write operations (comments, PR ops, issue closure) so they author as `@protoquinn[bot]` |
+| `GITHUB_APP_PRIVATE_KEY` | No | GitHub App PEM private key (newlines as `\n`). Must be set together with `GITHUB_APP_ID` |
 | `GITHUB_WEBHOOK_SECRET` | Recommended | Validates `X-Hub-Signature-256` on inbound payloads |
 | `GITHUB_WEBHOOK_PORT` | No | Port for the webhook HTTP server (default: `8082`) |
 
 The plugin is automatically skipped if `GITHUB_TOKEN` is not set.
 
-\* Write operations resolve auth via the shared `makeGitHubAuth` (`lib/github-auth.ts`): the Quinn GitHub App when both `QUINN_APP_ID` and `QUINN_APP_PRIVATE_KEY` are set, otherwise the `GITHUB_TOKEN` PAT. Setting exactly one of the App pair is a misconfiguration and fails loud rather than silently writing as the operator's PAT identity.
+\* Write operations resolve auth via the shared `makeGitHubAuth` (`lib/github-auth.ts`): the Quinn GitHub App when both `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` are set, otherwise the `GITHUB_TOKEN` PAT. Setting exactly one of the App pair is a misconfiguration and fails loud rather than silently writing as the operator's PAT identity.
 
 ### 2. github.yaml
 
@@ -151,7 +151,7 @@ The portfolio pipeline files GitHub issues as the spine (Ava fans out per-repo i
 
 **Best-effort.** A close failure is logged loudly but never disturbs other `feature.completed` consumers (e.g. the Discord feature-notifier on the same event). `feature.failed` is intentionally **not** handled — a failed or escalated feature's issue must stay open for attention.
 
-**Auth.** Like PR operations, `closeIssue` authenticates via the shared `makeGitHubAuth` (`lib/github-auth.ts`): the Quinn GitHub App when `QUINN_APP_ID` + `QUINN_APP_PRIVATE_KEY` are set, otherwise the `GITHUB_TOKEN` PAT fallback. The plugin is registered in `src/index.ts` only when GitHub auth is present. A missing comment is non-fatal (logged, then the close proceeds); a failed PATCH throws so the caller surfaces it.
+**Auth.** Like PR operations, `closeIssue` authenticates via the shared `makeGitHubAuth` (`lib/github-auth.ts`): the Quinn GitHub App when `GITHUB_APP_ID` + `GITHUB_APP_PRIVATE_KEY` are set, otherwise the `GITHUB_TOKEN` PAT fallback. The plugin is registered in `src/index.ts` only when GitHub auth is present. A missing comment is non-fatal (logged, then the close proceeds); a failed PATCH throws so the caller surfaces it.
 
 ## Org Webhook: repository.created
 

--- a/docs/reference/config-files.md
+++ b/docs/reference/config-files.md
@@ -33,8 +33,8 @@ _This is a reference doc. It covers all `workspace/*.yaml` schemas and environme
 | `GITHUB_TOKEN` | Yes | PAT — enables the plugin; posts comment replies |
 | `GITHUB_WEBHOOK_SECRET` | Recommended | Validates `X-Hub-Signature-256` on inbound payloads |
 | `GITHUB_WEBHOOK_PORT` | No | Webhook HTTP server port (default: `8082`) |
-| `QUINN_APP_ID` | For bot comments | GitHub App ID — Quinn's responses post as `protoquinn[bot]` |
-| `QUINN_APP_PRIVATE_KEY` | For bot comments | GitHub App private key (PKCS#1 PEM) |
+| `GITHUB_APP_ID` | For bot comments | GitHub App ID — Quinn's responses post as `protoquinn[bot]` |
+| `GITHUB_APP_PRIVATE_KEY` | For bot comments | GitHub App private key (PKCS#1 PEM) |
 
 ### Discord Plugin
 
@@ -144,6 +144,21 @@ skills:
 **`model`** is any alias the LiteLLM gateway recognises. See your gateway config for the full alias list.
 
 ---
+
+## workspace/fleet.yaml
+
+Maps abstract **roles** to concrete agents — the one file a fork edits to re-skin the fleet without touching code. Loaded by `lib/fleet/fleet-config.ts`; the dispatch/review/remediation paths read these roles instead of hardcoding agent names. All keys default to the proto-labs fleet's values, so an unmodified deploy needs no fleet.yaml.
+
+```yaml
+roles:
+  helm: ava          # default target for untargeted A2A requests + the OpenAI-compat chat alias
+  reviewer: quinn    # runs PR review
+  remediator: roxy   # dispatched to unblock a blocked feature (feature.blocked)
+github:
+  reviewerBotLogins: [protoquinn, "protoquinn[bot]"]   # reviewer's own GitHub identities (review-loop matching)
+```
+
+A fork also sets the GitHub App credentials via env: `GITHUB_APP_ID` + `GITHUB_APP_PRIVATE_KEY` (the agent's reviews/comments/issue-closes post as that App's bot).
 
 ## workspace/agents.yaml
 

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -8,7 +8,7 @@ Every variable recognised by protoWorkstacean is declared in the zod `EnvSchema`
 
 ## Summary
 
-- **63** variables declared in `EnvSchema`
+- **62** variables declared in `EnvSchema`
 - **0** required (no `.optional()`); the rest are optional
 - **33** variable(s) read via `process.env` at runtime but **not** in `EnvSchema` (see [Read directly (not in EnvSchema)](#read-directly-not-in-envschema))
 
@@ -85,12 +85,11 @@ Every variable recognised by protoWorkstacean is declared in the zod `EnvSchema`
 
 | Variable | Required? | Description |
 |---|---|---|
-| `GITHUB_APP_ID` | optional | Legacy alias — prefer QUINN_APP_ID. |
+| `GITHUB_APP_ID` | optional | GitHub App credentials — the agent's reviews/comments/issue-closes post as the App's bot identity. |
+| `GITHUB_APP_PRIVATE_KEY` | optional | — |
 | `GITHUB_TOKEN` | optional | — |
 | `GITHUB_WEBHOOK_PORT` | optional | — |
 | `GITHUB_WEBHOOK_SECRET` | optional | — |
-| `QUINN_APP_ID` | optional | — |
-| `QUINN_APP_PRIVATE_KEY` | optional | — |
 
 ## Linear
 

--- a/docs/reference/onboarding-plugin.md
+++ b/docs/reference/onboarding-plugin.md
@@ -21,7 +21,7 @@ Steps run in sequence. Each step is individually idempotent — re-running the f
 | # | Step | What it does | Skip condition |
 |---|------|-------------|----------------|
 | 1 | **validate** | Checks `slug`, `title`, and `github` are present; validates `github` is `owner/repo` format; rejects duplicate in-flight runs for the same slug | Missing required fields or invalid format |
-| 2 | **github_webhook** | Registers a GitHub repo webhook for `issues`, `issue_comment`, `pull_request`, `pull_request_review_comment` events; lists existing webhooks first and skips if the target URL is already registered | No GitHub auth (`QUINN_APP_ID` or `GITHUB_TOKEN`), or `WORKSTACEAN_PUBLIC_URL` not set, or webhook already exists |
+| 2 | **github_webhook** | Registers a GitHub repo webhook for `issues`, `issue_comment`, `pull_request`, `pull_request_review_comment` events; lists existing webhooks first and skips if the target URL is already registered | No GitHub auth (`GITHUB_APP_ID` or `GITHUB_TOKEN`), or `WORKSTACEAN_PUBLIC_URL` not set, or webhook already exists |
 | 3 | **drive_folder** | Creates a Google Drive folder named after the project title, under the org root folder (`drive.orgFolderId` in `workspace/google.yaml`) | Google credentials not set, `google.yaml` missing, or `drive.orgFolderId` empty |
 | 4 | **bus_notify** | Publishes `message.inbound.onboard.complete` with project metadata and per-step outcomes for downstream consumers | Never skipped |
 | 5 | **reply** | Sends a confirmation message (or error) to the inbound message's reply topic | No reply topic in the inbound message |
@@ -107,8 +107,8 @@ When the GitHub org webhook is registered and a new repository is created under 
 | Variable | Required by | Default | Purpose |
 |----------|-------------|---------|---------|
 | `WORKSTACEAN_PUBLIC_URL` | github_webhook | — | Base URL for webhook registration (e.g. `https://ws.example.com`) |
-| `QUINN_APP_ID` | github_webhook | — | GitHub App ID for auth (used by `makeGitHubAuth`) |
-| `QUINN_APP_PRIVATE_KEY` | github_webhook | — | GitHub App private key |
+| `GITHUB_APP_ID` | github_webhook | — | GitHub App ID for auth (used by `makeGitHubAuth`) |
+| `GITHUB_APP_PRIVATE_KEY` | github_webhook | — | GitHub App private key |
 | `GITHUB_TOKEN` | github_webhook | — | Alternative GitHub PAT for webhook registration |
 | `GITHUB_WEBHOOK_SECRET` | github_webhook | — | Optional HMAC secret for GitHub webhooks |
 | `GOOGLE_CLIENT_ID` | drive_folder | — | Google OAuth client ID |

--- a/lib/fleet/__tests__/fleet-config.test.ts
+++ b/lib/fleet/__tests__/fleet-config.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadFleetConfig, FLEET_DEFAULTS } from "../fleet-config.ts";
+
+const dirs: string[] = [];
+function ws(yaml?: string): string {
+  const d = mkdtempSync(join(tmpdir(), "fleet-"));
+  dirs.push(d);
+  if (yaml !== undefined) writeFileSync(join(d, "fleet.yaml"), yaml);
+  return d;
+}
+afterEach(() => { for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true }); });
+
+describe("loadFleetConfig", () => {
+  test("returns proto-labs defaults when no fleet.yaml exists", () => {
+    expect(loadFleetConfig(ws())).toEqual(FLEET_DEFAULTS);
+  });
+
+  test("merges role + reviewerBotLogins overrides over defaults", () => {
+    const cfg = loadFleetConfig(ws(`
+roles:
+  helm: bob
+  reviewer: carol
+github:
+  reviewerBotLogins: [carolbot, "carolbot[bot]"]
+`));
+    expect(cfg.helm).toBe("bob");
+    expect(cfg.reviewer).toBe("carol");
+    expect(cfg.remediator).toBe("roxy"); // not overridden → default
+    expect(cfg.reviewerBotLogins).toEqual(["carolbot", "carolbot[bot]"]);
+  });
+
+  test("falls back to defaults on malformed yaml (never throws)", () => {
+    expect(loadFleetConfig(ws("roles: [this is: not valid: ]]"))).toMatchObject({ helm: "ava" });
+  });
+});

--- a/lib/fleet/fleet-config.ts
+++ b/lib/fleet/fleet-config.ts
@@ -1,0 +1,76 @@
+/**
+ * Fleet role bindings — the one place that maps abstract roles (helm, reviewer,
+ * remediator) to concrete agent names, plus the reviewer's GitHub bot-login
+ * identities. Lets a fork re-skin the fleet by editing `workspace/fleet.yaml`
+ * instead of the dispatch/review/remediation code, which used to hardcode
+ * `ava` / `quinn` / `roxy` / `protoquinn`.
+ *
+ * Defaults are the proto-labs fleet's values, so an unmodified deploy needs no
+ * fleet.yaml. A fork drops one in:
+ *
+ *   roles:
+ *     helm: bob          # default target for untargeted requests + the chat model alias
+ *     reviewer: carol    # PR-review agent
+ *     remediator: dave   # feature.blocked unblock agent
+ *   github:
+ *     reviewerBotLogins: [carolbot, "carolbot[bot]"]   # the reviewer's own GitHub identities
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+
+export interface FleetConfig {
+  /** Default target for untargeted inbound requests + the OpenAI-compat chat alias. */
+  helm: string;
+  /** Agent that runs PR review. */
+  reviewer: string;
+  /** Agent dispatched to unblock a blocked feature. */
+  remediator: string;
+  /** GitHub login bases identifying the reviewer's OWN reviews (so the review loop matches them). */
+  reviewerBotLogins: string[];
+}
+
+export const FLEET_DEFAULTS: FleetConfig = {
+  helm: "ava",
+  reviewer: "quinn",
+  remediator: "roxy",
+  reviewerBotLogins: ["protoquinn", "protoquinn[bot]"],
+};
+
+interface RawFleet {
+  roles?: Partial<Record<"helm" | "reviewer" | "remediator", string>>;
+  github?: { reviewerBotLogins?: string[] };
+}
+
+/** Load + merge `workspace/fleet.yaml` over the defaults. Never throws. */
+export function loadFleetConfig(workspaceDir: string = process.env.WORKSPACE_DIR ?? "workspace"): FleetConfig {
+  const path = join(workspaceDir, "fleet.yaml");
+  if (!existsSync(path)) return { ...FLEET_DEFAULTS };
+  try {
+    const raw = (parseYaml(readFileSync(path, "utf8")) as RawFleet) ?? {};
+    const logins = raw.github?.reviewerBotLogins;
+    return {
+      helm: raw.roles?.helm?.trim() || FLEET_DEFAULTS.helm,
+      reviewer: raw.roles?.reviewer?.trim() || FLEET_DEFAULTS.reviewer,
+      remediator: raw.roles?.remediator?.trim() || FLEET_DEFAULTS.remediator,
+      reviewerBotLogins: Array.isArray(logins) && logins.length ? logins : FLEET_DEFAULTS.reviewerBotLogins,
+    };
+  } catch (e) {
+    console.warn("[fleet] failed to parse fleet.yaml — using defaults:", e);
+    return { ...FLEET_DEFAULTS };
+  }
+}
+
+let cached: FleetConfig | null = null;
+
+/** Process-wide fleet config (loaded once). */
+export function getFleetConfig(): FleetConfig {
+  if (!cached) cached = loadFleetConfig();
+  return cached;
+}
+
+/** Test hook — inject a config or reset to force a reload. */
+export function setFleetConfigForTesting(config?: FleetConfig): void {
+  cached = config ?? null;
+}

--- a/lib/github-auth.ts
+++ b/lib/github-auth.ts
@@ -6,8 +6,8 @@
  * plugins stay self-contained.
  *
  * Env vars:
- *   QUINN_APP_ID          GitHub App ID
- *   QUINN_APP_PRIVATE_KEY PEM private key (newlines as \n in env)
+ *   GITHUB_APP_ID          GitHub App ID
+ *   GITHUB_APP_PRIVATE_KEY PEM private key (newlines as \n in env)
  *   GITHUB_TOKEN          PAT fallback when App credentials are absent
  */
 
@@ -73,8 +73,8 @@ export class GitHubAppAuth {
  * Returns a token getter for the Quinn GitHub App, or falls back to GITHUB_TOKEN PAT.
  * Returns null if no auth is configured.
  *
- * **Fail-loud on partial App config.** If exactly one of `QUINN_APP_ID` and
- * `QUINN_APP_PRIVATE_KEY` is set (the other empty / unset), refuse to
+ * **Fail-loud on partial App config.** If exactly one of `GITHUB_APP_ID` and
+ * `GITHUB_APP_PRIVATE_KEY` is set (the other empty / unset), refuse to
  * silently fall back to the PAT path — that's how Quinn's PR reviews
  * started showing up as the operator (mabry1985) instead of
  * @protoquinn[bot] when infisical hiccuped and only injected half the
@@ -89,8 +89,8 @@ export class GitHubAppAuth {
 export function makeGitHubAuth(
   env: Record<string, string | undefined> = process.env,
 ): ((owner: string, repo: string) => Promise<string>) | null {
-  const appId = (env.QUINN_APP_ID ?? "").trim();
-  const privateKey = (env.QUINN_APP_PRIVATE_KEY ?? "").trim();
+  const appId = (env.GITHUB_APP_ID ?? "").trim();
+  const privateKey = (env.GITHUB_APP_PRIVATE_KEY ?? "").trim();
 
   if (appId && privateKey) {
     const app = new GitHubAppAuth(appId, privateKey);
@@ -102,8 +102,8 @@ export function makeGitHubAuth(
   // path that needs auth throws loudly instead of silently writing as the
   // operator's PAT identity.
   if (appId || privateKey) {
-    const present  = appId ? "QUINN_APP_ID"          : "QUINN_APP_PRIVATE_KEY";
-    const missing  = appId ? "QUINN_APP_PRIVATE_KEY" : "QUINN_APP_ID";
+    const present  = appId ? "GITHUB_APP_ID"          : "GITHUB_APP_PRIVATE_KEY";
+    const missing  = appId ? "GITHUB_APP_PRIVATE_KEY" : "GITHUB_APP_ID";
     throw new Error(
       `[github-auth] partial GitHub App config: ${present} set but ${missing} empty/unset. ` +
         `Refusing to fall back to GITHUB_TOKEN PAT — that would silently author commits / ` +

--- a/lib/github-issues.ts
+++ b/lib/github-issues.ts
@@ -47,7 +47,7 @@ export async function closeIssue(
   const auth = opts.authGetter ?? makeGitHubAuth();
   if (!auth) {
     throw new Error(
-      `[github-issues] no GitHub auth configured (set QUINN_APP_ID+QUINN_APP_PRIVATE_KEY or GITHUB_TOKEN) — cannot close ${owner}/${name}#${issueNumber}`,
+      `[github-issues] no GitHub auth configured (set GITHUB_APP_ID+GITHUB_APP_PRIVATE_KEY or GITHUB_TOKEN) — cannot close ${owner}/${name}#${issueNumber}`,
     );
   }
   const doFetch = opts.fetchImpl ?? fetch;

--- a/lib/plugins/__tests__/github-reviewer-bot-login.test.ts
+++ b/lib/plugins/__tests__/github-reviewer-bot-login.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { quinnHasReviewed, quinnLatestReviewState } from "../github.ts";
+import { setFleetConfigForTesting, FLEET_DEFAULTS } from "../../fleet/fleet-config.ts";
+
+afterEach(() => setFleetConfigForTesting());
+
+const review = (login: string, state: string) => ({ user: { login }, state });
+
+describe("reviewer-bot-login matching is fleet-config-driven (#798)", () => {
+  test("default config matches protoquinn reviews", () => {
+    const reviews = [review("protoquinn[bot]", "COMMENTED")];
+    expect(quinnHasReviewed(reviews)).toBe(true);
+    expect(quinnLatestReviewState(reviews)).toBe("COMMENTED");
+  });
+
+  test("a fork's reviewer bot is matched once fleet.yaml sets reviewerBotLogins", () => {
+    setFleetConfigForTesting({ ...FLEET_DEFAULTS, reviewer: "carol", reviewerBotLogins: ["carolbot", "carolbot[bot]"] });
+    const reviews = [review("carolbot[bot]", "CHANGES_REQUESTED")];
+    expect(quinnHasReviewed(reviews)).toBe(true);
+    expect(quinnLatestReviewState(reviews)).toBe("CHANGES_REQUESTED");
+    // and it no longer matches the old hardcoded protoquinn
+    expect(quinnHasReviewed([review("protoquinn[bot]", "APPROVED")])).toBe(false);
+  });
+});

--- a/lib/plugins/feature-remediation.ts
+++ b/lib/plugins/feature-remediation.ts
@@ -25,6 +25,7 @@
  */
 
 import type { Plugin, EventBus, BusMessage } from "../types.ts";
+import { getFleetConfig } from "../fleet/fleet-config.ts";
 
 export interface FeatureBlockedPayload {
   projectSlug?: string;
@@ -155,7 +156,7 @@ export class FeatureRemediationPlugin implements Plugin {
       payload: {
         skill: "unblock_feature",
         content: lines.join("\n"),
-        targets: ["roxy"],
+        targets: [getFleetConfig().remediator],
         meta: {
           systemActor: "feature-remediation",
           featureId: p.featureId,

--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -18,7 +18,7 @@
  * Config: workspace/github.yaml (mention handle, skill hints per event type)
  *
  * Auth (in priority order):
- *   QUINN_APP_ID + QUINN_APP_PRIVATE_KEY   GitHub App — comments post as quinn[bot]
+ *   GITHUB_APP_ID + GITHUB_APP_PRIVATE_KEY   GitHub App — comments post as quinn[bot]
  *   GITHUB_TOKEN                           PAT fallback
  *
  * Other env vars:
@@ -32,6 +32,7 @@ import { parse as parseYaml } from "yaml";
 import type { EventBus, BusMessage, Plugin } from "../types.ts";
 import { makeGitHubAuth } from "../github-auth.ts";
 import { isProductionLike } from "../runtime-env.ts";
+import { getFleetConfig } from "../fleet/fleet-config.ts";
 import { withCircuitBreaker } from "./circuit-breaker.ts";
 import type { ProjectRegistry } from "../../src/plugins/project-registry.ts";
 import type { ReleasePublishedPayload } from "../../src/event-bus/payloads.ts";
@@ -90,6 +91,16 @@ function agentBotLogins(): Set<string> {
 export function isAgentBotActor(login: string | undefined | null): boolean {
   if (!login) return false;
   return agentBotLogins().has(login.toLowerCase());
+}
+
+/**
+ * Login bases (lowercased, trailing "[bot]" stripped) that identify the
+ * reviewer agent's OWN GitHub reviews — config-driven via `fleet.yaml`'s
+ * `github.reviewerBotLogins` (default `protoquinn`), so a fork's reviewer bot
+ * is matched by the review loop instead of the hardcoded `protoquinn`. (#798)
+ */
+function reviewerLoginBases(): string[] {
+  return [...new Set(getFleetConfig().reviewerBotLogins.map((l) => l.toLowerCase().replace(/\[bot\]$/, "")))];
 }
 
 function loadConfig(workspaceDir: string): GitHubConfig {
@@ -171,12 +182,15 @@ export function allChecksTerminal(checkRuns: Array<Record<string, unknown>> | un
   return checkRuns.every((r) => r.status === "completed");
 }
 
-/** True iff @protoquinn[bot] has already left a review on the PR (the provisional→formal case). */
-export function quinnHasReviewed(reviews: Array<Record<string, unknown>> | undefined): boolean {
+/** True iff the reviewer bot has already left a review on the PR (the provisional→formal case). */
+export function quinnHasReviewed(
+  reviews: Array<Record<string, unknown>> | undefined,
+  bases: string[] = reviewerLoginBases(),
+): boolean {
   if (!Array.isArray(reviews)) return false;
   return reviews.some((r) => {
     const login = (r.user as Record<string, unknown> | undefined)?.login;
-    return typeof login === "string" && login.toLowerCase().startsWith("protoquinn");
+    return typeof login === "string" && bases.some((b) => login.toLowerCase().startsWith(b));
   });
 }
 
@@ -215,12 +229,13 @@ export function allChecksGreen(checkRuns: Array<Record<string, unknown>> | undef
  */
 export function quinnLatestReviewState(
   reviews: Array<Record<string, unknown>> | undefined,
+  bases: string[] = reviewerLoginBases(),
 ): string | undefined {
   if (!Array.isArray(reviews)) return undefined;
   let state: string | undefined;
   for (const r of reviews) {
     const login = (r.user as Record<string, unknown> | undefined)?.login;
-    if (typeof login === "string" && login.toLowerCase().startsWith("protoquinn")) {
+    if (typeof login === "string" && bases.some((b) => login.toLowerCase().startsWith(b))) {
       const s = r.state;
       if (typeof s === "string") state = s.toUpperCase();
     }
@@ -387,11 +402,11 @@ export class GitHubPlugin implements Plugin {
   install(bus: EventBus): void {
     const getToken = makeGitHubAuth();
     if (!getToken) {
-      console.log("[github] No auth configured (QUINN_APP_ID or GITHUB_TOKEN required) — plugin disabled");
+      console.log("[github] No auth configured (GITHUB_APP_ID or GITHUB_TOKEN required) — plugin disabled");
       return;
     }
 
-    const usingApp = !!(process.env.QUINN_APP_ID && process.env.QUINN_APP_PRIVATE_KEY);
+    const usingApp = !!(process.env.GITHUB_APP_ID && process.env.GITHUB_APP_PRIVATE_KEY);
     console.log(`[github] Auth: ${usingApp ? "GitHub App (quinn[bot])" : "PAT (GITHUB_TOKEN)"}`);
 
     this.config = loadConfig(this.workspaceDir);
@@ -721,7 +736,8 @@ export class GitHubPlugin implements Plugin {
     if (event === "pull_request" && payload.action === "review_requested") {
       const reviewer = payload.requested_reviewer as Record<string, unknown> | undefined;
       const login = (reviewer?.login as string | undefined)?.toLowerCase();
-      if (login === "protoquinn" || login === "protoquinn[bot]") {
+      const isReviewerBot = !!login && getFleetConfig().reviewerBotLogins.some((l) => l.toLowerCase() === login);
+      if (isReviewerBot) {
         this._handleAutoReview(event, payload, ctx, bus, getToken, { skipDedup: true });
       }
       return;

--- a/lib/plugins/onboarding.ts
+++ b/lib/plugins/onboarding.ts
@@ -23,7 +23,7 @@
  *   msg.reply.topic                  — confirmation text back to caller
  *
  * Env vars:
- *   QUINN_APP_ID, QUINN_APP_PRIVATE_KEY, GITHUB_TOKEN
+ *   GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY, GITHUB_TOKEN
  *   GITHUB_WEBHOOK_SECRET
  *   WORKSTACEAN_PUBLIC_URL  base URL for webhook registration (e.g. https://ws.example.com)
  */
@@ -233,7 +233,7 @@ export class OnboardingPlugin implements Plugin {
   private async _stepGitHubWebhook(req: OnboardRequest): Promise<StepResult> {
     const getToken = makeGitHubAuth();
     if (!getToken) {
-      return { status: "skip", detail: "No GitHub auth configured (QUINN_APP_ID or GITHUB_TOKEN required)" };
+      return { status: "skip", detail: "No GitHub auth configured (GITHUB_APP_ID or GITHUB_TOKEN required)" };
     }
 
     const publicUrl = process.env.WORKSTACEAN_PUBLIC_URL;

--- a/src/api/__tests__/a2a-server.test.ts
+++ b/src/api/__tests__/a2a-server.test.ts
@@ -207,7 +207,7 @@ describe("BusAgentExecutor (Phase 7)", () => {
       expect(requestPayload).toBeDefined();
       expect((requestPayload as { targets: string[] }).targets).toEqual(["ava"]);
       expect((requestPayload as { skill: string }).skill).toBe("chat");
-      expect(logCalls.some(l => l.includes("[a2a-server]") && l.includes("defaulting to [ava]"))).toBe(true);
+      expect(logCalls.some(l => l.includes("[a2a-server]") && l.includes("defaulting to helm [ava]"))).toBe(true);
     } finally {
       console.log = origLog;
     }

--- a/src/api/a2a-server.ts
+++ b/src/api/a2a-server.ts
@@ -41,6 +41,7 @@ import { textPart, partText, textArtifact, dataArtifact, emitToolCall, type Tool
 import type { Route, ApiContext } from "./types.ts";
 import type { BusMessage } from "../../lib/types.ts";
 import { buildAgentCard } from "./agent-card.ts";
+import { getFleetConfig } from "../../lib/fleet/fleet-config.ts";
 import { SqlitePushNotificationStore } from "../storage/push-notification-store.ts";
 
 /**
@@ -138,14 +139,15 @@ class BusAgentExecutor implements AgentExecutor {
     const explicitTargets = Array.isArray(metadata.targets)
       ? (metadata.targets as unknown[]).filter((v): v is string => typeof v === "string")
       : [];
-    // This endpoint (ava.proto-labs.ai/a2a) defaults to Ava when no target is
-    // specified. The orchestrator agent card aggregates the full fleet's
-    // skills, but the routing default must be Ava — she's the helm. Callers
-    // route elsewhere by passing explicit `metadata.targets`.
+    // Untargeted requests default to the fleet's helm agent (the orchestrator
+    // card aggregates the whole fleet's skills, but routing needs one default).
+    // The helm is config-driven (workspace/fleet.yaml), not hardcoded — #798.
+    // Callers route elsewhere via explicit `metadata.targets`.
     let targets: string[];
     if (explicitTargets.length === 0) {
-      targets = ["ava"];
-      console.log("[a2a-server] no target specified, defaulting to [ava] for message/send");
+      const helm = getFleetConfig().helm;
+      targets = [helm];
+      console.log(`[a2a-server] no target specified, defaulting to helm [${helm}] for message/send`);
     } else {
       targets = explicitTargets;
     }

--- a/src/api/openai-compat.ts
+++ b/src/api/openai-compat.ts
@@ -26,6 +26,7 @@
 import type { Route, ApiContext } from "./types.ts";
 import type { BusMessage } from "../../lib/types.ts";
 import { buildAgentCard } from "./agent-card.ts";
+import { getFleetConfig } from "../../lib/fleet/fleet-config.ts";
 
 interface ChatMessage {
   role: "system" | "user" | "assistant" | "tool";
@@ -51,11 +52,12 @@ interface SkillRouting {
  * Accepts:
  *   - "skill"           → { skill, targets: [] }
  *   - "agent/skill"     → { skill, targets: [agent] }
- *   - "ava" (special)   → { skill: "chat", targets: ["ava"] }
+ *   - "<helm>" (special) → { skill: "chat", targets: [helm] }  (helm from fleet.yaml)
  */
 function modelToRouting(model: string): SkillRouting {
   if (!model) return { skill: "chat", targets: [] };
-  if (model === "ava") return { skill: "chat", targets: ["ava"] };
+  const helm = getFleetConfig().helm;
+  if (model === helm) return { skill: "chat", targets: [helm] };
   const slash = model.indexOf("/");
   if (slash > 0) {
     return {

--- a/src/api/pr-inspector.ts
+++ b/src/api/pr-inspector.ts
@@ -3,7 +3,7 @@
  *
  * Wraps the GitHub REST + GraphQL APIs behind one action-shaped endpoint.
  * Authenticates as `@protoquinn[bot]` via the GitHub App credentials
- * (`QUINN_APP_ID` + `QUINN_APP_PRIVATE_KEY`) — reuses the same
+ * (`GITHUB_APP_ID` + `GITHUB_APP_PRIVATE_KEY`) — reuses the same
  * shared `makeGitHubAuth` helper (`lib/github-auth.ts`). Falls back to `GITHUB_TOKEN`
  * when the App credentials aren't set.
  *
@@ -108,7 +108,7 @@ async function ghFetch(
   init: RequestInit = {},
 ): Promise<Response> {
   const getToken = resolveAuth();
-  if (!getToken) throw new Error("no GitHub credentials (QUINN_APP_* or GITHUB_TOKEN)");
+  if (!getToken) throw new Error("no GitHub credentials (GITHUB_APP_* or GITHUB_TOKEN)");
   const token = await getToken(owner, name);
   return fetch(url, {
     ...init,
@@ -391,7 +391,7 @@ async function coderabbitThreads(owner: string, name: string, pr: number): Promi
 
 async function diffSummary(owner: string, name: string, pr: number): Promise<string> {
   const getToken = resolveAuth();
-  if (!getToken) throw new Error("no GitHub credentials (QUINN_APP_* or GITHUB_TOKEN)");
+  if (!getToken) throw new Error("no GitHub credentials (GITHUB_APP_* or GITHUB_TOKEN)");
   const token = await getToken(owner, name);
   const resp = await fetch(`https://api.github.com/repos/${owner}/${name}/pulls/${pr}`, {
     signal: AbortSignal.timeout(GH_FETCH_TIMEOUT_MS),

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -71,10 +71,9 @@ export const EnvSchema = z
 
     // GitHub
     GITHUB_TOKEN:          z.string().optional(),
-    /** Legacy alias — prefer QUINN_APP_ID. */
-    GITHUB_APP_ID:         z.string().optional(),
-    QUINN_APP_ID:          z.string().optional(),
-    QUINN_APP_PRIVATE_KEY: z.string().optional(),
+    /** GitHub App credentials — the agent's reviews/comments/issue-closes post as the App's bot identity. */
+    GITHUB_APP_ID:          z.string().optional(),
+    GITHUB_APP_PRIVATE_KEY: z.string().optional(),
     GITHUB_WEBHOOK_SECRET: z.string().optional(),
     GITHUB_WEBHOOK_PORT:   z.string().optional(),
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,7 +217,7 @@ const pluginRegistry: PluginRegistryEntry[] = [
     // Needs GitHub auth (Quinn App or PAT) to act; without it closeIssue throws
     // and the plugin logs it, so gate on auth being present.
     name: "issue-closer",
-    condition: () => !!(process.env.QUINN_APP_ID || process.env.GITHUB_TOKEN),
+    condition: () => !!(process.env.GITHUB_APP_ID || process.env.GITHUB_TOKEN),
     factory: async () => {
       const { IssueCloserPlugin } = await import("../lib/plugins/issue-closer");
       return new IssueCloserPlugin();

--- a/workspace/fleet.yaml
+++ b/workspace/fleet.yaml
@@ -1,0 +1,16 @@
+# Fleet role bindings — map abstract roles to concrete agents. This is the one
+# file a fork edits to re-skin the fleet; the dispatch / review / remediation
+# code reads these roles instead of hardcoding agent names. Values below are the
+# defaults baked into the code (lib/fleet/fleet-config.ts), shown explicitly.
+roles:
+  helm: ava          # default target for untargeted A2A requests + the OpenAI-compat chat alias
+  reviewer: quinn    # runs PR review
+  remediator: roxy   # dispatched to unblock a blocked feature (feature.blocked)
+
+github:
+  # The reviewer's own GitHub bot identities — so the review loop recognizes
+  # its own reviews (provisional→formal, approve-on-green). A fork sets these to
+  # its reviewer App's login(s).
+  reviewerBotLogins:
+    - protoquinn
+    - protoquinn[bot]


### PR DESCRIPTION
Closes #798 (the last P0, epic #790). The single biggest forkability lever.

The framework is config-driven, but the proto-labs fleet's *role wiring* + bot identity were hardcoded, so a renamed fork silently mis-routed. This lifts them into config.

## ⚠️ DEPLOY COORDINATION (read first)
The GitHub App credential env vars are **renamed** `QUINN_APP_ID`/`QUINN_APP_PRIVATE_KEY` → `GITHUB_APP_ID`/`GITHUB_APP_PRIVATE_KEY` (greenfield, no fallback per the agreed approach). **Add `GITHUB_APP_ID` + `GITHUB_APP_PRIVATE_KEY` to prod Infisical (same values) BEFORE this merges/deploys**, or Quinn's GitHub App auth falls back to PAT / fails.

## Changes
- **`workspace/fleet.yaml`** + `lib/fleet/fleet-config.ts` — roles (`helm`/`reviewer`/`remediator`) → agent names + the reviewer's GitHub bot logins. Defaults = proto-labs values (unmodified deploy needs no file).
- **Role bindings** now config-driven: a2a-server untargeted default → `helm` (was `["ava"]`); feature-remediation → `remediator` (was `["roxy"]`); openai-compat chat alias → `helm`.
- **Reviewer bot-login** — the review-loop predicates (`quinnHasReviewed`/`quinnLatestReviewState`/re-review) match `fleet.github.reviewerBotLogins` instead of the hardcoded `protoquinn`, so a fork's reviewer bot closes the approve-on-green loop.
- **`GITHUB_APP_*` rename** across github-auth, github plugin, pr-inspector, issue-closer, onboarding, index.

## Tests
fleet-config (defaults / merge / malformed-safe) + reviewer-bot-login fork matching (a fork's `carolbot` matches, `protoquinn` no longer does). **1061 green, tsc clean, no new lint.** Docs: `config-files.md` (fleet.yaml), `env-vars.md` regen, + secret rename across 5 docs.

## Noted follow-up (P2, not in scope)
The agent-card `name`/`description` still embeds the proto-labs roster string, and the A2A extension URIs use the `proto-labs.ai` domain — cosmetic, deferred.

Part of #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)