### PR TITLE
fix(reliability): plugin isolation + sqlite busy_timeout + A2A breaker (#799)

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -253,6 +253,10 @@ bunx tsc --noEmit
 
 The project uses TypeScript strict mode. All exported types should have JSDoc comments on non-obvious fields.
 
+## SQLite store conventions
+
+Every bun:sqlite store sets the same connection pragmas at init: `journal_mode=WAL`, `synchronous=NORMAL`, and **`busy_timeout=5000`** (so a contended writer blocks-and-retries instead of throwing `SQLITE_BUSY` — several subsystems share `knowledge.db` / `events.db`). `close()` runs `PRAGMA wal_checkpoint(TRUNCATE)` before closing (graceful shutdown, #792).
+
 ## Changing a SQLite store schema
 
 The bun:sqlite stores back a **persistent prod volume** (`/data`), and deploy is a watchtower image pull with no migration step. So a bare `CREATE TABLE IF NOT EXISTS` change silently no-ops against an existing DB and drifts at query time. Use the versioned migration runner instead (`lib/sqlite-migrate.ts`):

--- a/lib/plugins/discord/rate-limit.ts
+++ b/lib/plugins/discord/rate-limit.ts
@@ -34,6 +34,7 @@ export function openRateLimitDb(ctx: DiscordContext, dataDir: string): void {
 
     ctx.rlDb = new Database(join(dataDir, "events.db"));
     ctx.rlDb.exec("PRAGMA journal_mode=WAL");
+    ctx.rlDb.exec("PRAGMA busy_timeout=5000");
     ctx.rlDb.exec(`
       CREATE TABLE IF NOT EXISTS rate_limits (
         user_id TEXT NOT NULL,

--- a/lib/plugins/logger.ts
+++ b/lib/plugins/logger.ts
@@ -24,6 +24,8 @@ export class LoggerPlugin implements Plugin {
     }
 
     this.db = new Database(`${this.dataDir}/events.db`);
+    this.db.exec("PRAGMA journal_mode=WAL;");
+    this.db.exec("PRAGMA busy_timeout=5000;");
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS events (
         id TEXT NOT NULL,

--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -22,6 +22,7 @@ import {
   type Task,
 } from "@a2a-js/sdk";
 import type { IExecutor, SkillRequest, SkillResult } from "../types.ts";
+import { withCircuitBreaker } from "../../../lib/plugins/circuit-breaker.ts";
 import {
   WORLDSTATE_DELTA_MIME_TYPE,
   parseWorldStateDelta,
@@ -489,7 +490,9 @@ export class A2AExecutor implements IExecutor {
     params: Parameters<Client["sendMessage"]>[0],
     req: SkillRequest,
   ): Promise<SkillResult> {
-    const result = await client.sendMessage(params);
+    // Fast-fail when the remote agent is in a sustained outage instead of
+    // waiting the full per-request timeout on every dispatch (#799).
+    const result = await withCircuitBreaker(`a2a:${this.config.name}`, () => client.sendMessage(params));
 
     // A2A 1.0: SendMessageResult is Message | Task with no `kind` discriminator.
     // Discriminate structurally — a Task carries an `id` + `status`, a Message

--- a/src/index.ts
+++ b/src/index.ts
@@ -548,12 +548,25 @@ registeredPlugins.push(operatorRoutingPlugin);
 // start() only arms the 5-min background refresh.
 projectRegistry.start();
 
+// Registry plugins are isolated: a single integration whose factory()/install()
+// throws (bad workspace YAML, transient import, missing optional dep) is logged
+// loud + skipped, so it can't take down the whole switchboard at boot. Core
+// plugins (above) stay fail-fast — they're foundational. (#799)
+const failedPlugins: Array<{ name: string; error: string }> = [];
 for (const entry of pluginRegistry) {
-  if (entry.condition()) {
+  if (!entry.condition()) continue;
+  try {
     const plugin = await entry.factory();
     plugin.install(bus);
     registeredPlugins.push(plugin);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    failedPlugins.push({ name: entry.name, error: msg });
+    console.error(`[startup] plugin "${entry.name}" failed to install — skipping (the rest still boot):`, err);
   }
+}
+if (failedPlugins.length > 0) {
+  console.error(`[startup] ${failedPlugins.length} plugin(s) failed: ${failedPlugins.map(p => p.name).join(", ")}`);
 }
 
 // Guard: warn if skill-dispatcher is installed but no executor registrars ran.

--- a/src/knowledge/ceremonyOutcomes.ts
+++ b/src/knowledge/ceremonyOutcomes.ts
@@ -31,6 +31,7 @@ export class CeremonyOutcomesRepository {
       this.db = new Database(this.dbPath);
       this.db.exec("PRAGMA journal_mode=WAL;");
       this.db.exec("PRAGMA synchronous=NORMAL;");
+      this.db.exec("PRAGMA busy_timeout=5000;");
       this.db.exec(`
         CREATE TABLE IF NOT EXISTS ceremony_outcomes (
           id           INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/knowledge/conversation-store.ts
+++ b/src/knowledge/conversation-store.ts
@@ -52,6 +52,7 @@ export class ConversationStore {
       this.db = new Database(this.dbPath);
       this.db.exec("PRAGMA journal_mode=WAL;");
       this.db.exec("PRAGMA synchronous=NORMAL;");
+      this.db.exec("PRAGMA busy_timeout=5000;");
       this.db.exec(`
         CREATE TABLE IF NOT EXISTS conversation_turns (
           id          INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/knowledge/fleet-state.ts
+++ b/src/knowledge/fleet-state.ts
@@ -56,6 +56,7 @@ export class FleetStateRepository {
       this.db = new Database(this.dbPath);
       this.db.exec("PRAGMA journal_mode=WAL;");
       this.db.exec("PRAGMA synchronous=NORMAL;");
+      this.db.exec("PRAGMA busy_timeout=5000;");
 
       this.db.exec(`
         CREATE TABLE IF NOT EXISTS fleet_outcome_records (

--- a/src/knowledge/knowledge-store.ts
+++ b/src/knowledge/knowledge-store.ts
@@ -57,6 +57,7 @@ export class KnowledgeStore {
       this.db = new Database(this.dbPath);
       this.db.exec("PRAGMA journal_mode=WAL;");
       this.db.exec("PRAGMA synchronous=NORMAL;");
+      this.db.exec("PRAGMA busy_timeout=5000;");
       this.db.exec(`
         CREATE TABLE IF NOT EXISTS chunks (
           id          INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/knowledge/research-store.ts
+++ b/src/knowledge/research-store.ts
@@ -68,6 +68,7 @@ export class ResearchStore {
       this.db = new Database(this.dbPath);
       this.db.exec("PRAGMA journal_mode=WAL;");
       this.db.exec("PRAGMA synchronous=NORMAL;");
+      this.db.exec("PRAGMA busy_timeout=5000;");
       this.db.exec(`
         CREATE TABLE IF NOT EXISTS research_chunks (
           id          INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/storage/push-notification-store.ts
+++ b/src/storage/push-notification-store.ts
@@ -70,6 +70,7 @@ export class SqlitePushNotificationStore implements PushNotificationStore {
       this.db = new Database(this.dbPath);
       this.db.exec("PRAGMA journal_mode=WAL;");
       this.db.exec("PRAGMA synchronous=NORMAL;");
+      this.db.exec("PRAGMA busy_timeout=5000;");
       this.db.exec(`
         CREATE TABLE IF NOT EXISTS push_notifications (
           task_id     TEXT NOT NULL,

--- a/src/telemetry/telemetry-service.ts
+++ b/src/telemetry/telemetry-service.ts
@@ -66,6 +66,7 @@ export class TelemetryService {
       this.db = new Database(this.dbPath);
       this.db.exec("PRAGMA journal_mode=WAL;");
       this.db.exec("PRAGMA synchronous=NORMAL;");
+      this.db.exec("PRAGMA busy_timeout=5000;");
       this.db.exec(`
         CREATE TABLE IF NOT EXISTS telemetry_counters (
           kind     TEXT NOT NULL,


### PR DESCRIPTION
Closes #799 (P1, epic #790). Grouped reliability hardening.

- **Plugin-boot isolation** (`src/index.ts`) — registry plugins install in a try/catch; a failing integration is logged loud + skipped (recorded in a startup-failure list) instead of halting the whole boot. Core plugins stay fail-fast.
- **sqlite `busy_timeout=5000`** added to the 9 stores that lacked it — contended writers on the shared `knowledge.db`/`events.db` block-and-retry instead of throwing `SQLITE_BUSY`.
- **A2A circuit breaker** — the blocking dispatch path (`_executeBlocking` → `client.sendMessage`) wraps `withCircuitBreaker("a2a:<agent>", …)`, so a down remote agent fast-fails rather than making every dispatch wait the full timeout.

**1061 green (no regression), tsc clean, no new lint.** Docs: `development.md`.

Part of #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)