### PR TITLE
fix(data): events.db retention + secret redaction + auto-vacuum (#801)

### DIFF
--- a/docs/guides/deploy-with-docker.md
+++ b/docs/guides/deploy-with-docker.md
@@ -93,6 +93,13 @@ DATA_DIR=/data
 
 For a full list of all supported variables, see [reference/env-vars.md](../reference/env-vars).
 
+## Data volume + backups
+
+The `workstacean-data` named volume holds the SQLite databases — `knowledge.db` (conversation memory + FTS5 + embeddings), `events.db` (the bus event log), `tasks.db` (in-flight A2A tasks), and push-notification configs. Losing it loses agent memory + the research corpus, so back it up.
+
+- **Bounded growth.** `events.db` (the `#`-subscribed event sink) self-purges on a retention window — default 7 days, override with `LOGGER_EVENTS_RETENTION_MS` — and secret-keyed fields are redacted before persistence (#801). Other stores are bounded by their own caps.
+- **Backup.** Schedule a periodic snapshot off-host, e.g. `sqlite3 /data/knowledge.db ".backup /backup/knowledge-$(date +%F).db"` from a sidecar/cron, or run [litestream](https://litestream.io) against the volume for continuous replication. Test the restore.
+
 ## Workspace volume
 
 The `workspace/` directory is bind-mounted read-write, so configuration changes are applied on the host (via `git pull`) without rebuilding the image:

--- a/lib/plugins/__tests__/logger-redaction-retention.test.ts
+++ b/lib/plugins/__tests__/logger-redaction-retention.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { InMemoryEventBus } from "../../bus.ts";
+import { LoggerPlugin, redactSecrets } from "../logger.ts";
+
+describe("redactSecrets (#801)", () => {
+  test("masks secret-keyed fields, keeps everything else", () => {
+    const out = redactSecrets({
+      content: "hello world",
+      apiKey: "sk-123",
+      meta: { authorization: "Bearer xyz", refresh_token: "r1", note: "ok" },
+      QUINN_APP_PRIVATE_KEY: "-----BEGIN-----",
+      nested: [{ password: "p", keep: 1 }],
+    }) as Record<string, unknown>;
+    expect(out.content).toBe("hello world");
+    expect(out.apiKey).toBe("[redacted]");
+    expect((out.meta as Record<string, unknown>).authorization).toBe("[redacted]");
+    expect((out.meta as Record<string, unknown>).refresh_token).toBe("[redacted]");
+    expect((out.meta as Record<string, unknown>).note).toBe("ok");
+    expect(out.QUINN_APP_PRIVATE_KEY).toBe("[redacted]");
+    expect(((out.nested as unknown[])[0] as Record<string, unknown>).password).toBe("[redacted]");
+    expect(((out.nested as unknown[])[0] as Record<string, unknown>).keep).toBe(1);
+  });
+  test("leaves empty/absent secret values + handles cycles", () => {
+    const cyc: Record<string, unknown> = { token: "" };
+    cyc.self = cyc;
+    const out = redactSecrets(cyc) as Record<string, unknown>;
+    expect(out.token).toBe(""); // empty not masked
+    expect(out.self).toBe("[circular]");
+  });
+});
+
+describe("LoggerPlugin retention + redaction at rest", () => {
+  let dir: string;
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("persists redacted payloads and purges old events on sweep", () => {
+    dir = mkdtempSync(join(tmpdir(), "logger-"));
+    const bus = new InMemoryEventBus();
+    const plugin = new LoggerPlugin(dir);
+    plugin.install(bus);
+
+    bus.publish("agent.skill.request", {
+      id: "m1", correlationId: "c1", topic: "agent.skill.request", timestamp: Date.now(),
+      payload: { content: "do it", apiKey: "sekret" },
+    });
+
+    const db = (plugin as unknown as { db: import("bun:sqlite").Database }).db;
+    const row = db.query("SELECT payload FROM events WHERE id='m1'").get() as { payload: string };
+    expect(row.payload).toContain("do it");
+    expect(row.payload).not.toContain("sekret");
+    expect(row.payload).toContain("[redacted]");
+
+    // Backdate it past the retention window, then sweep.
+    db.run("UPDATE events SET timestamp = ? WHERE id='m1'", [Date.now() - 30 * 86400000]);
+    (plugin as unknown as { _sweepRetention: () => void })._sweepRetention();
+    expect(db.query("SELECT COUNT(*) n FROM events").get()).toEqual({ n: 0 });
+
+    plugin.uninstall();
+  });
+});

--- a/lib/plugins/logger.ts
+++ b/lib/plugins/logger.ts
@@ -3,12 +3,34 @@ import { mkdirSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import type { Plugin, EventBus, BusMessage, LoggerTurnQueryRequest, LoggerTurnQueryResponse, ConversationTurn } from "../types";
 
+/** Object keys whose values are masked before an event is persisted (#801). */
+const SECRET_KEY_RE = /(token|secret|password|passwd|api[-_]?key|private[-_]?key|authorization|bearer|refresh[-_]?token|client[-_]?secret|credential)/i;
+
+/**
+ * Deep-clone `value`, masking any property whose KEY looks secret-bearing, so
+ * the events.db sink (which persists every bus message) never stores tokens /
+ * OAuth state in cleartext. Free-text content is left intact — only key-named
+ * secrets are redacted. Cyclic refs are guarded.
+ */
+export function redactSecrets(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (seen.has(value as object)) return "[circular]";
+  seen.add(value as object);
+  if (Array.isArray(value)) return value.map((v) => redactSecrets(v, seen));
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    out[k] = SECRET_KEY_RE.test(k) && v != null && v !== "" ? "[redacted]" : redactSecrets(v, seen);
+  }
+  return out;
+}
+
 export class LoggerPlugin implements Plugin {
   name = "logger";
   description = "Event log subscriber - writes all messages to SQLite";
   capabilities: string[] = ["persist", "query"];
 
   private db: Database | null = null;
+  private retentionTimer: ReturnType<typeof setInterval> | null = null;
   private subscriptionId: string | null = null;
   private querySubscriptionId: string | null = null;
   private bus: EventBus | null = null;
@@ -26,6 +48,10 @@ export class LoggerPlugin implements Plugin {
     this.db = new Database(`${this.dataDir}/events.db`);
     this.db.exec("PRAGMA journal_mode=WAL;");
     this.db.exec("PRAGMA busy_timeout=5000;");
+    // INCREMENTAL auto-vacuum so reclaimed space (after retention deletes) can
+    // be returned without a full locking VACUUM. Takes effect on a fresh DB; an
+    // existing one keeps its mode but retention still bounds row growth. (#801)
+    this.db.exec("PRAGMA auto_vacuum=INCREMENTAL;");
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS events (
         id TEXT NOT NULL,
@@ -54,6 +80,13 @@ export class LoggerPlugin implements Plugin {
       this.log(msg);
     });
 
+    // Retention: this sink subscribes to `#` (every bus message), so without a
+    // sweep events.db grows without bound on the data volume. Purge rows older
+    // than the window + reclaim space. (#801)
+    this._sweepRetention();
+    this.retentionTimer = setInterval(() => this._sweepRetention(), 60 * 60_000);
+    this.retentionTimer.unref?.();
+
     this.querySubscriptionId = bus.subscribe("logger.turn.query", this.name, (msg: BusMessage) => {
       const req = msg.payload as LoggerTurnQueryRequest;
       const turns = this.getRecentTurnsForUser(req.userId, req.agentName, req.limit, req.maxAgeMs);
@@ -70,6 +103,10 @@ export class LoggerPlugin implements Plugin {
   }
 
   uninstall(): void {
+    if (this.retentionTimer) {
+      clearInterval(this.retentionTimer);
+      this.retentionTimer = null;
+    }
     if (this.db) {
       this.db.close();
       this.db = null;
@@ -78,11 +115,29 @@ export class LoggerPlugin implements Plugin {
 
   private log(msg: BusMessage): void {
     if (!this.db) return;
-    
+    // Redact secret-keyed fields before persisting — this sink stores the whole
+    // message and would otherwise write tokens/OAuth state in cleartext. (#801)
+    const safe = redactSecrets(msg);
     this.db.run(
       "INSERT INTO events (id, correlation_id, parent_id, topic, payload, timestamp, source) VALUES (?, ?, ?, ?, ?, ?, ?)",
-      [msg.id, msg.correlationId, msg.parentId ?? null, msg.topic, JSON.stringify(msg), msg.timestamp, msg.topic.split(".")[0]]
+      [msg.id, msg.correlationId, msg.parentId ?? null, msg.topic, JSON.stringify(safe), msg.timestamp, msg.topic.split(".")[0]]
     );
+  }
+
+  /** Delete events older than the retention window + reclaim freed pages. */
+  private _sweepRetention(): void {
+    if (!this.db) return;
+    const ms = Number(process.env.LOGGER_EVENTS_RETENTION_MS) || 7 * 24 * 60 * 60_000;
+    try {
+      const cutoff = Date.now() - ms;
+      const deleted = this.db.run("DELETE FROM events WHERE timestamp < ?", [cutoff]);
+      this.db.exec("PRAGMA incremental_vacuum;");
+      if ((deleted as { changes?: number }).changes) {
+        console.log(`[logger] retention sweep: purged ${(deleted as { changes?: number }).changes} event(s) older than ${Math.round(ms / 86400000)}d`);
+      }
+    } catch (err) {
+      console.warn("[logger] retention sweep failed:", err);
+    }
   }
 
   getEvents(limit: number = 100): BusMessage[] {


### PR DESCRIPTION
Closes #801 (P1, epic #790).

The logger sink subscribes to `#` (every bus message) and persisted the **full message to `events.db` with no redaction and no retention** — tokens/OAuth state in cleartext, unbounded growth on the data volume.

## Changes
- **Redaction** — `redactSecrets()` deep-masks secret-keyed fields (`token`/`secret`/`apiKey`/`password`/`authorization`/`refresh_token`/`private_key`/…) before persisting; free text kept; cyclic-safe.
- **Retention** — hourly sweep deletes events older than the window (`LOGGER_EVENTS_RETENTION_MS`, default 7d) + `PRAGMA incremental_vacuum`. On install + interval (unref'd); cleared on uninstall.
- **`auto_vacuum=INCREMENTAL`** at init.
- **Backup** documented (`deploy-with-docker.md`: `sqlite3 .backup` / litestream) — infra, not code.

## Tests
`redactSecrets` (masking / empties / cycles) + logger persists-redacted + purges-old-on-sweep. **1064 green, tsc clean, no new lint.**

Part of #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)