### PR TITLE
feat(observability): /metrics + app-self alerting (#800 part 1/2)

### DIFF
--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -249,6 +249,7 @@ Each row links to the route definition as `path:line` so jumping from this index
 |---|---|---|---|
 | `GET` | `/health` | `src/api/operations.ts` | Cheap liveness — the process is up. Always 200. |
 | `GET` | `/ready` | `src/api/operations.ts` | Readiness — gates on local invariants (sqlite open). 200 `ready` / 503 `unready`. The LLM gateway is probed and reported in the body but does **not** gate readiness (an external outage shouldn't restart-loop the container; agent runs fail fast instead). The prod compose `healthcheck` polls this. |
+| `GET` | `/metrics` | `src/api/operations.ts` | Prometheus text-exposition metrics (`lib/metrics.ts`): `workstacean_dispatch_total{skill,success}`, `workstacean_dispatch_duration_ms` histogram, `workstacean_bus_handler_errors_total{plugin}`. Low-cardinality labels only. (#800) |
 
 ### `/publish`
 

--- a/lib/__tests__/bus-system-error.test.ts
+++ b/lib/__tests__/bus-system-error.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { InMemoryEventBus } from "../bus.ts";
+import type { BusMessage } from "../types";
+
+const msg = (topic: string): BusMessage => ({ id: crypto.randomUUID(), correlationId: "c", topic, timestamp: 0, payload: {} });
+
+describe("bus emits system.error when a handler throws (#800)", () => {
+  test("a throwing subscriber → system.error event (siblings unaffected)", () => {
+    const bus = new InMemoryEventBus();
+    const errors: BusMessage[] = [];
+    bus.subscribe("system.error", "test", (m) => { errors.push(m); });
+    let siblingRan = false;
+    bus.subscribe("topic.x", "boom-plugin", () => { throw new Error("kaboom"); });
+    bus.subscribe("topic.x", "ok-plugin", () => { siblingRan = true; });
+
+    bus.publish("topic.x", msg("topic.x"));
+
+    expect(siblingRan).toBe(true); // sibling isolation preserved
+    expect(errors).toHaveLength(1);
+    const p = errors[0].payload as Record<string, unknown>;
+    expect(p.source).toBe("bus-handler");
+    expect(p.plugin).toBe("boom-plugin");
+    expect(String(p.error)).toContain("kaboom");
+  });
+
+  test("a throw in the system.error handler itself does NOT loop", () => {
+    const bus = new InMemoryEventBus();
+    let calls = 0;
+    bus.subscribe("system.error", "loopy", () => { calls++; throw new Error("in handler"); });
+    bus.subscribe("topic.y", "boom", () => { throw new Error("orig"); });
+
+    expect(() => bus.publish("topic.y", msg("topic.y"))).not.toThrow();
+    // system.error fired once (from topic.y); its handler threw but did NOT
+    // re-emit another system.error → no infinite loop.
+    expect(calls).toBe(1);
+  });
+});

--- a/lib/__tests__/metrics.test.ts
+++ b/lib/__tests__/metrics.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { MetricsRegistry } from "../metrics.ts";
+
+describe("MetricsRegistry", () => {
+  test("renders counters with labels in Prometheus format", () => {
+    const m = new MetricsRegistry();
+    m.inc("workstacean_dispatch_total", { skill: "chat", success: "true" });
+    m.inc("workstacean_dispatch_total", { skill: "chat", success: "true" });
+    m.inc("workstacean_dispatch_total", { skill: "chat", success: "false" });
+    const out = m.render();
+    expect(out).toContain("# TYPE workstacean_dispatch_total counter");
+    expect(out).toContain('workstacean_dispatch_total{skill="chat",success="true"} 2');
+    expect(out).toContain('workstacean_dispatch_total{skill="chat",success="false"} 1');
+  });
+
+  test("renders a histogram with cumulative buckets, sum, and count", () => {
+    const m = new MetricsRegistry();
+    m.observe("workstacean_dispatch_duration_ms", 80, { skill: "chat" });   // bucket le=100
+    m.observe("workstacean_dispatch_duration_ms", 3000, { skill: "chat" }); // bucket le=5000
+    const out = m.render();
+    expect(out).toContain("# TYPE workstacean_dispatch_duration_ms histogram");
+    // cumulative: le=100 has 1, le=5000 has 2, +Inf has 2
+    expect(out).toContain('workstacean_dispatch_duration_ms_bucket{le="100",skill="chat"} 1');
+    expect(out).toContain('workstacean_dispatch_duration_ms_bucket{le="5000",skill="chat"} 2');
+    expect(out).toContain('workstacean_dispatch_duration_ms_bucket{le="+Inf",skill="chat"} 2');
+    expect(out).toContain('workstacean_dispatch_duration_ms_sum{skill="chat"} 3080');
+    expect(out).toContain('workstacean_dispatch_duration_ms_count{skill="chat"} 2');
+  });
+});

--- a/lib/bus.ts
+++ b/lib/bus.ts
@@ -1,4 +1,5 @@
 import type { BusMessage, MessageHandler, Subscription, TopicInfo, ConsumerInfo } from "./types";
+import { metrics } from "./metrics.ts";
 
 export class InMemoryEventBus {
   private subscriptions = new Map<string, Subscription[]>();
@@ -32,6 +33,19 @@ export class InMemoryEventBus {
             sub.handler(message);
           } catch (e) {
             console.error(`Error in handler for ${pattern}:`, e);
+            // App-self observability (#800): count + surface the swallow so a
+            // handler erroring on every message is visible/alertable. Guard
+            // against a loop if the system.error handler itself throws.
+            metrics.inc("workstacean_bus_handler_errors_total", { plugin: sub.pluginName });
+            if (topic !== "system.error") {
+              this.publish("system.error", {
+                id: crypto.randomUUID(),
+                correlationId: message.correlationId,
+                topic: "system.error",
+                timestamp: Date.now(),
+                payload: { source: "bus-handler", pattern, plugin: sub.pluginName, error: e instanceof Error ? e.message : String(e) },
+              });
+            }
           }
         }
       }

--- a/lib/metrics.ts
+++ b/lib/metrics.ts
@@ -1,0 +1,97 @@
+/**
+ * Minimal in-process metrics registry rendered in Prometheus text-exposition
+ * format — no external dependency (fits the single-node deploy). Backs the
+ * `GET /metrics` endpoint so dispatch/error/latency can be scraped + alerted on
+ * over time, instead of only the in-memory 24h fleet-health snapshot. (#800)
+ *
+ * Counters are monotonic; histograms use a fixed latency-oriented bucket set.
+ * Labels are low-cardinality only (skill, success, name) — never user/PR ids.
+ */
+
+type Labels = Record<string, string>;
+
+const LATENCY_BUCKETS_MS = [50, 100, 250, 500, 1000, 2500, 5000, 10_000, 30_000, 60_000];
+
+function labelKey(labels: Labels): string {
+  const keys = Object.keys(labels).sort();
+  return keys.map((k) => `${k}=${JSON.stringify(String(labels[k]))}`).join(",");
+}
+
+interface Histogram {
+  labels: Labels;
+  bucketCounts: number[]; // cumulative counts are computed at render time
+  rawCounts: number[]; // per-bucket (le) counts
+  sum: number;
+  count: number;
+}
+
+export class MetricsRegistry {
+  private counters = new Map<string, { name: string; labels: Labels; value: number }>();
+  private histograms = new Map<string, Histogram & { name: string }>();
+
+  inc(name: string, labels: Labels = {}, by = 1): void {
+    const k = `${name}|${labelKey(labels)}`;
+    const cur = this.counters.get(k);
+    if (cur) cur.value += by;
+    else this.counters.set(k, { name, labels, value: by });
+  }
+
+  observe(name: string, valueMs: number, labels: Labels = {}): void {
+    const k = `${name}|${labelKey(labels)}`;
+    let h = this.histograms.get(k);
+    if (!h) {
+      h = { name, labels, bucketCounts: [], rawCounts: new Array(LATENCY_BUCKETS_MS.length + 1).fill(0), sum: 0, count: 0 };
+      this.histograms.set(k, h);
+    }
+    let i = LATENCY_BUCKETS_MS.findIndex((b) => valueMs <= b);
+    if (i === -1) i = LATENCY_BUCKETS_MS.length; // +Inf bucket
+    h.rawCounts[i] += 1;
+    h.sum += valueMs;
+    h.count += 1;
+  }
+
+  /** Render the registry in Prometheus 0.0.4 text-exposition format. */
+  render(): string {
+    const lines: string[] = [];
+    const counterNames = new Set([...this.counters.values()].map((c) => c.name));
+    for (const name of counterNames) {
+      lines.push(`# TYPE ${name} counter`);
+      for (const c of this.counters.values()) {
+        if (c.name !== name) continue;
+        lines.push(`${name}${renderLabels(c.labels)} ${c.value}`);
+      }
+    }
+    const histoNames = new Set([...this.histograms.values()].map((h) => h.name));
+    for (const name of histoNames) {
+      lines.push(`# TYPE ${name} histogram`);
+      for (const h of this.histograms.values()) {
+        if (h.name !== name) continue;
+        let cumulative = 0;
+        for (let i = 0; i < LATENCY_BUCKETS_MS.length; i++) {
+          cumulative += h.rawCounts[i];
+          lines.push(`${name}_bucket${renderLabels({ ...h.labels, le: String(LATENCY_BUCKETS_MS[i]) })} ${cumulative}`);
+        }
+        cumulative += h.rawCounts[LATENCY_BUCKETS_MS.length];
+        lines.push(`${name}_bucket${renderLabels({ ...h.labels, le: "+Inf" })} ${cumulative}`);
+        lines.push(`${name}_sum${renderLabels(h.labels)} ${h.sum}`);
+        lines.push(`${name}_count${renderLabels(h.labels)} ${h.count}`);
+      }
+    }
+    return lines.join("\n") + "\n";
+  }
+
+  /** Test/reset hook. */
+  reset(): void {
+    this.counters.clear();
+    this.histograms.clear();
+  }
+}
+
+function renderLabels(labels: Labels): string {
+  const keys = Object.keys(labels).sort();
+  if (keys.length === 0) return "";
+  return "{" + keys.map((k) => `${k}=${JSON.stringify(String(labels[k]))}`).join(",") + "}";
+}
+
+/** Process-wide registry. */
+export const metrics = new MetricsRegistry();

--- a/lib/plugins/__tests__/app-alert.test.ts
+++ b/lib/plugins/__tests__/app-alert.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { InMemoryEventBus } from "../../bus.ts";
+import { AppAlertPlugin } from "../app-alert.ts";
+
+function emitError(bus: InMemoryEventBus, payload: Record<string, unknown>) {
+  bus.publish("system.error", {
+    id: crypto.randomUUID(), correlationId: "c", topic: "system.error", timestamp: 0, payload,
+  });
+}
+
+describe("AppAlertPlugin", () => {
+  test("posts a throttled message to the ops webhook per error-key", async () => {
+    const posts: string[] = [];
+    const fetchImpl = (async (_url: string, init?: { body?: string }) => {
+      posts.push(JSON.parse(init!.body!).content);
+      return { ok: true } as Response;
+    }) as unknown as typeof fetch;
+    let t = 1000;
+    const bus = new InMemoryEventBus();
+    const plugin = new AppAlertPlugin({ webhookUrl: "https://ops", throttleMs: 60_000, now: () => t, fetchImpl });
+    plugin.install(bus);
+
+    emitError(bus, { source: "bus-handler", plugin: "discord", error: "boom" });
+    emitError(bus, { source: "bus-handler", plugin: "discord", error: "boom again" }); // same key, throttled
+    await new Promise((r) => setTimeout(r, 0));
+    expect(posts).toHaveLength(1);
+    expect(posts[0]).toContain("discord");
+
+    t += 61_000; // past throttle window
+    emitError(bus, { source: "bus-handler", plugin: "discord", error: "later" });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(posts).toHaveLength(2);
+    plugin.uninstall();
+  });
+
+  test("a failing webhook never throws back into the bus", async () => {
+    const bus = new InMemoryEventBus();
+    const fetchImpl = (async () => { throw new Error("network down"); }) as unknown as typeof fetch;
+    const plugin = new AppAlertPlugin({ webhookUrl: "https://ops", fetchImpl });
+    plugin.install(bus);
+    expect(() => emitError(bus, { source: "x", error: "y" })).not.toThrow();
+    await new Promise((r) => setTimeout(r, 0));
+    plugin.uninstall();
+  });
+
+  test("no webhook configured → no post, no throw", async () => {
+    const bus = new InMemoryEventBus();
+    const plugin = new AppAlertPlugin({ webhookUrl: undefined });
+    plugin.install(bus);
+    expect(() => emitError(bus, { source: "x", error: "y" })).not.toThrow();
+    plugin.uninstall();
+  });
+});

--- a/lib/plugins/app-alert.ts
+++ b/lib/plugins/app-alert.ts
@@ -1,0 +1,73 @@
+/**
+ * AppAlertPlugin — surfaces app-SELF failures to the ops Discord webhook.
+ *
+ * The fleet-alerts evaluator alerts on fleet *agents*; nothing alerted on the
+ * switchboard itself. This subscribes to `system.error` (emitted by the bus when
+ * a subscriber handler throws — #800) and posts a throttled message to
+ * `DISCORD_OPS_WEBHOOK_URL`, so a handler erroring on every message (or another
+ * app-level fault) becomes visible instead of a silent console.error.
+ *
+ * Throttled per error-key to avoid a storm, and it NEVER throws back into the
+ * bus (that would re-emit `system.error` → loop).
+ */
+
+import type { Plugin, EventBus, BusMessage } from "../types.ts";
+
+interface SystemErrorPayload {
+  source?: string;
+  plugin?: string;
+  pattern?: string;
+  error?: string;
+}
+
+export class AppAlertPlugin implements Plugin {
+  readonly name = "app-alert";
+  readonly description = "Posts app-self errors (system.error) to the ops Discord webhook, throttled";
+  readonly capabilities = ["system.error", "ops-alert"];
+
+  private bus?: EventBus;
+  private subId?: string;
+  private readonly webhookUrl?: string;
+  private readonly throttleMs: number;
+  private readonly lastSent = new Map<string, number>();
+  private readonly now: () => number;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: { webhookUrl?: string; throttleMs?: number; now?: () => number; fetchImpl?: typeof fetch } = {}) {
+    this.webhookUrl = opts.webhookUrl ?? process.env.DISCORD_OPS_WEBHOOK_URL;
+    this.throttleMs = opts.throttleMs ?? 60_000;
+    this.now = opts.now ?? Date.now;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  install(bus: EventBus): void {
+    this.bus = bus;
+    this.subId = bus.subscribe("system.error", this.name, (m) => { void this._onError(m); });
+    console.log(`[app-alert] installed — system.error → ops webhook${this.webhookUrl ? "" : " (no DISCORD_OPS_WEBHOOK_URL; logging only)"}`);
+  }
+
+  uninstall(): void {
+    if (this.subId) this.bus?.unsubscribe(this.subId);
+    this.subId = undefined;
+  }
+
+  private async _onError(msg: BusMessage): Promise<void> {
+    const p = (msg.payload ?? {}) as SystemErrorPayload;
+    const key = `${p.source ?? "?"}:${p.plugin ?? p.pattern ?? "?"}`;
+    const now = this.now();
+    if (now - (this.lastSent.get(key) ?? Number.NEGATIVE_INFINITY) < this.throttleMs) return; // per-key throttle
+    this.lastSent.set(key, now);
+    if (!this.webhookUrl) return;
+    const content = `🚨 **workstacean app error** — ${p.source ?? "?"} (${p.plugin ?? p.pattern ?? "?"}): ${String(p.error ?? "").slice(0, 300)}`;
+    try {
+      await this.fetchImpl(this.webhookUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content }),
+      });
+    } catch (e) {
+      // Must not throw back into the bus (would re-emit system.error → loop).
+      console.warn("[app-alert] ops webhook post failed:", e);
+    }
+  }
+}

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -10,6 +10,7 @@ import { serveWorkspaceYaml } from "./types.ts";
 import type { CallerIdentity } from "../../lib/auth/agent-keys.ts";
 import { getPendingHumanInput } from "./human-input.ts";
 import { safeKeyEqual, isPublishTopicDenied } from "../../lib/runtime-env.ts";
+import { metrics } from "../../lib/metrics.ts";
 
 export function createRoutes(ctx: ApiContext): Route[] {
 
@@ -284,6 +285,7 @@ export function createRoutes(ctx: ApiContext): Route[] {
   return [
     { method: "GET",  path: "/health",                  handler: () => Response.json({ status: "ok", timestamp: Date.now() }) },
     { method: "GET",  path: "/ready",                   handler: () => handleReady() },
+    { method: "GET",  path: "/metrics",                 handler: () => new Response(metrics.render(), { headers: { "content-type": "text/plain; version=0.0.4; charset=utf-8" } }) },
     { method: "POST", path: "/publish",                 handler: (req) => handlePublish(req) },
     { method: "POST", path: "/api/onboard",             handler: (req) => handleOnboard(req) },
     { method: "GET",  path: "/api/projects",            handler: () => Response.json({ success: true, data: ctx.projectRegistry?.getProjects() ?? [] }) },

--- a/src/event-bus/all-topics.ts
+++ b/src/event-bus/all-topics.ts
@@ -199,3 +199,12 @@ export const FEATURE_TOPICS = {
   /** Published when a feature recovers — clears its remediation tracker. */
   FEATURE_UNBLOCKED: "feature.unblocked",
 } as const;
+
+export const SYSTEM_TOPICS = {
+  /**
+   * App-self error — published by the bus when a subscriber handler throws
+   * (#800). Consumed by AppAlertPlugin, which posts a throttled message to the
+   * ops Discord webhook. Payload: { source, plugin?, pattern?, error }.
+   */
+  SYSTEM_ERROR: "system.error",
+} as const;

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -30,6 +30,7 @@ import { IdentityRegistry } from "../../lib/identity/identity-registry.ts";
 import { ContextMailbox } from "../../lib/dm/context-mailbox.ts";
 import type { TaskTracker } from "./task-tracker.ts";
 import type { A2AExecutor } from "./executors/a2a-executor.ts";
+import { metrics } from "../../lib/metrics.ts";
 
 const WORKING_STATES = new Set(["submitted", "working"]);
 
@@ -696,6 +697,10 @@ export class SkillDispatcherPlugin implements Plugin {
     model?: string;
   }): void {
     if (!this.bus) return;
+    // Prometheus metrics — the single per-outcome chokepoint (#800). Labels are
+    // low-cardinality (skill + success); never correlationId/actor-with-ids.
+    metrics.inc("workstacean_dispatch_total", { skill: opts.skill, success: String(opts.success) });
+    metrics.observe("workstacean_dispatch_duration_ms", opts.durationMs, { skill: opts.skill });
     const topic = `autonomous.outcome.${opts.systemActor}.${opts.skill}`;
     const payload: AutonomousOutcomePayload = {
       correlationId: opts.correlationId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -518,6 +518,16 @@ const pluginRegistry: PluginRegistryEntry[] = [
       return new DispatchDropEscalatorPlugin();
     },
   },
+  {
+    // App-self alerting (#800): system.error (bus handler-throw, etc.) → ops
+    // Discord webhook, throttled. Gated on the webhook being configured.
+    name: "app-alert",
+    condition: () => !!process.env.DISCORD_OPS_WEBHOOK_URL,
+    factory: async () => {
+      const { AppAlertPlugin } = await import("../lib/plugins/app-alert.js");
+      return new AppAlertPlugin();
+    },
+  },
   // Built-ins: opt-in via ENABLED_PLUGINS=echo,...
   {
     name: "echo",


### PR DESCRIPTION
First half of #800 (P1, epic #790) — make the switchboard itself measurable + alertable. **Part 2 (structured logging) is a separate follow-up PR.**

## Changes
- **`lib/metrics.ts`** — minimal **dependency-free** Prometheus registry (counters + latency histograms, text-exposition render), exposed at **`GET /metrics`**.
- **Dispatcher instrumentation** — `_publishAutonomousOutcome` (the single per-outcome chokepoint) emits `workstacean_dispatch_total{skill,success}` + `workstacean_dispatch_duration_ms` histogram.
- **Bus handler-error visibility** — a thrown subscriber handler now increments `workstacean_bus_handler_errors_total{plugin}` **and** emits a loop-guarded `system.error` event, instead of a silent `console.error`.
- **`AppAlertPlugin`** — subscribes `system.error`, posts a **throttled** message to `DISCORD_OPS_WEBHOOK_URL` (never throws back into the bus). Closes the "nothing alerts on the app itself" gap (fleet-alerts only covered agents).
- `system.error` registered in `all-topics.ts`.

## Tests
metrics render (counters/histogram/labels) + app-alert (throttle / no-throw on webhook failure / no-webhook) + bus `system.error` (sibling isolation + loop guard). **1071 green, tsc clean, lint gate passes.** Docs: `http-api.md`.

## Remaining for #800
Structured logging (≈615 `console.*` → leveled/JSON logger with correlationId) — part 2.

Part of #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)