### PR TITLE
feat(observability): structured logger module + reference adoption (#800 part 2/2)

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -272,6 +272,19 @@ runMigrations(this.db, [
 
 `runMigrations` applies only migrations newer than the DB's `PRAGMA user_version`, each in a transaction, bumping the version after each succeeds. **Never edit a shipped migration's `up` — append a new version.** `src/executor/task-tracker-store.ts` is the reference adoption; other stores adopt the same pattern on their next schema change.
 
+## Logging
+
+New/edited code uses the structured logger (`lib/log.ts`) over `console.*`:
+
+```ts
+import { logger } from "../log.ts";
+const log = logger("my-component");
+log.info("dispatched", { correlationId, skill });
+log.error("publish failed", { topic, err });   // Error → {message, stack}
+```
+
+Leveled (`LOG_LEVEL=debug|info|warn|error`), JSON in prod (`LOG_FORMAT=json` or `NODE_ENV=production`) so lines are filterable + queryable by field, readable in dev. `log.child({ correlationId })` binds fields onto every line. The bulk `console.*` migration is incremental — prefer the logger when you touch a file.
+
 ## Conventions
 
 - **Named exports only** in `.ts` files. Exception: `_meta.ts` files use a default export for Nextra.

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -10,7 +10,7 @@ Every variable recognised by protoWorkstacean is declared in the zod `EnvSchema`
 
 - **62** variables declared in `EnvSchema`
 - **0** required (no `.optional()`); the rest are optional
-- **33** variable(s) read via `process.env` at runtime but **not** in `EnvSchema` (see [Read directly (not in EnvSchema)](#read-directly-not-in-envschema))
+- **34** variable(s) read via `process.env` at runtime but **not** in `EnvSchema` (see [Read directly (not in EnvSchema)](#read-directly-not-in-envschema))
 
 ## Core / runtime
 
@@ -155,6 +155,7 @@ These variables are read via `process.env` somewhere in `src/` or `lib/` but are
 | `LINEAR_PROTO_BRIDGE_LABEL` | `lib/plugins/linear-proto-bridge.ts` |
 | `LLM_GATEWAY_TIMEOUT_MS` | `src/executor/executors/deep-agent-executor.ts` |
 | `LLM_MAX_RETRIES` | `src/executor/executors/deep-agent-executor.ts` |
+| `LOGGER_EVENTS_RETENTION_MS` | `lib/plugins/logger.ts` |
 | `MEMORY_HARVEST_MAX_AGE_DAYS` | `src/agent-runtime/agent-runtime-plugin.ts` |
 | `MEMORY_HARVEST_SWEEP_HOURS` | `src/agent-runtime/agent-runtime-plugin.ts` |
 | `MEMORY_SUMMARY_MODEL` | `src/agent-runtime/agent-runtime-plugin.ts` |

--- a/lib/__tests__/log.test.ts
+++ b/lib/__tests__/log.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { logger } from "../log.ts";
+
+// Capture console output for assertions.
+function capture(fn: () => void): string[] {
+  const lines: string[] = [];
+  const orig = { log: console.log, warn: console.warn, error: console.error };
+  console.log = (...a: unknown[]) => { lines.push(a.map(String).join(" ")); };
+  console.warn = console.log;
+  console.error = console.log;
+  try { fn(); } finally { Object.assign(console, orig); }
+  return lines;
+}
+const env = (o: Record<string, string>) => { Object.assign(process.env, o); };
+afterEach(() => { delete process.env.LOG_LEVEL; delete process.env.LOG_FORMAT; });
+
+describe("logger", () => {
+  test("JSON format emits one structured object per line with component + fields", () => {
+    env({ LOG_FORMAT: "json" });
+    const lines = capture(() => logger("a2a").info("dispatched", { correlationId: "c1", skill: "chat" }));
+    const obj = JSON.parse(lines[0]);
+    expect(obj).toMatchObject({ level: "info", component: "a2a", msg: "dispatched", correlationId: "c1", skill: "chat" });
+    expect(obj.ts).toBeDefined();
+  });
+
+  test("LOG_LEVEL gates lower-severity lines", () => {
+    env({ LOG_LEVEL: "warn", LOG_FORMAT: "json" });
+    const lines = capture(() => {
+      const l = logger("x");
+      l.debug("d"); l.info("i"); l.warn("w"); l.error("e");
+    });
+    expect(lines).toHaveLength(2); // warn + error only
+    expect(lines.map((l) => JSON.parse(l).level)).toEqual(["warn", "error"]);
+  });
+
+  test("child() binds fields onto every line", () => {
+    env({ LOG_FORMAT: "json" });
+    const lines = capture(() => logger("svc").child({ correlationId: "c9" }).info("hi", { extra: 1 }));
+    expect(JSON.parse(lines[0])).toMatchObject({ correlationId: "c9", extra: 1 });
+  });
+
+  test("Error fields are serialized to {message, stack}", () => {
+    env({ LOG_FORMAT: "json" });
+    const lines = capture(() => logger("x").error("boom", { err: new Error("kaboom") }));
+    expect(JSON.parse(lines[0]).err.message).toBe("kaboom");
+  });
+
+  test("dev format is a readable single line", () => {
+    const lines = capture(() => logger("x").info("hello", { a: 1 }));
+    expect(lines[0]).toContain("INFO [x] hello");
+    expect(lines[0]).toContain('{"a":1}');
+  });
+});

--- a/lib/bus.ts
+++ b/lib/bus.ts
@@ -1,5 +1,8 @@
 import type { BusMessage, MessageHandler, Subscription, TopicInfo, ConsumerInfo } from "./types";
 import { metrics } from "./metrics.ts";
+import { logger } from "./log.ts";
+
+const log = logger("bus");
 
 export class InMemoryEventBus {
   private subscriptions = new Map<string, Subscription[]>();
@@ -32,7 +35,7 @@ export class InMemoryEventBus {
           try {
             sub.handler(message);
           } catch (e) {
-            console.error(`Error in handler for ${pattern}:`, e);
+            log.error("subscriber handler threw", { pattern, plugin: sub.pluginName, topic, correlationId: message.correlationId, err: e });
             // App-self observability (#800): count + surface the swallow so a
             // handler erroring on every message is visible/alertable. Guard
             // against a loop if the system.error handler itself throws.

--- a/lib/log.ts
+++ b/lib/log.ts
@@ -1,0 +1,71 @@
+/**
+ * Thin structured logger (#800 part 2).
+ *
+ * Replaces ad-hoc `console.*` with leveled, optionally-JSON output carrying a
+ * component tag + structured fields (incl. correlationId), so prod logs can be
+ * filtered by level and aggregated/queried by field instead of grepping free
+ * text. Zero dependency.
+ *
+ * - `LOG_LEVEL` (debug|info|warn|error, default info) gates output.
+ * - `LOG_FORMAT=json` (or `NODE_ENV=production`) → one JSON object per line;
+ *   otherwise a readable `LEVEL [component] message {fields}` dev line.
+ *
+ * Usage:
+ *   const log = logger("a2a-server");
+ *   log.info("dispatched", { correlationId, skill });
+ *   log.error("publish failed", { topic, err });
+ *
+ * Migration is incremental — `console.*` still works; new/edited code should
+ * prefer this. The bulk sweep is tracked separately.
+ */
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+const ORDER: Record<LogLevel, number> = { debug: 10, info: 20, warn: 30, error: 40 };
+
+function configuredLevel(env: NodeJS.ProcessEnv = process.env): LogLevel {
+  const raw = (env.LOG_LEVEL ?? "info").toLowerCase();
+  return raw in ORDER ? (raw as LogLevel) : "info";
+}
+function useJson(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.LOG_FORMAT === "json" || env.NODE_ENV === "production";
+}
+
+export interface Logger {
+  debug(msg: string, fields?: Record<string, unknown>): void;
+  info(msg: string, fields?: Record<string, unknown>): void;
+  warn(msg: string, fields?: Record<string, unknown>): void;
+  error(msg: string, fields?: Record<string, unknown>): void;
+  /** Child logger with bound fields merged into every line (e.g. correlationId). */
+  child(bound: Record<string, unknown>): Logger;
+}
+
+function normalizeFields(fields?: Record<string, unknown>): Record<string, unknown> | undefined {
+  if (!fields) return undefined;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(fields)) {
+    out[k] = v instanceof Error ? { message: v.message, stack: v.stack } : v;
+  }
+  return out;
+}
+
+function emit(component: string, level: LogLevel, msg: string, bound: Record<string, unknown>, fields?: Record<string, unknown>): void {
+  if (ORDER[level] < ORDER[configuredLevel()]) return;
+  const merged = { ...bound, ...normalizeFields(fields) };
+  const hasFields = Object.keys(merged).length > 0;
+  const sink = level === "error" ? console.error : level === "warn" ? console.warn : console.log;
+  if (useJson()) {
+    sink(JSON.stringify({ level, component, msg, ...merged, ts: new Date().toISOString() }));
+  } else {
+    sink(`${level.toUpperCase()} [${component}] ${msg}${hasFields ? " " + JSON.stringify(merged) : ""}`);
+  }
+}
+
+export function logger(component: string, bound: Record<string, unknown> = {}): Logger {
+  return {
+    debug: (m, f) => emit(component, "debug", m, bound, f),
+    info: (m, f) => emit(component, "info", m, bound, f),
+    warn: (m, f) => emit(component, "warn", m, bound, f),
+    error: (m, f) => emit(component, "error", m, bound, f),
+    child: (extra) => logger(component, { ...bound, ...extra }),
+  };
+}

--- a/lib/plugins/app-alert.ts
+++ b/lib/plugins/app-alert.ts
@@ -12,6 +12,9 @@
  */
 
 import type { Plugin, EventBus, BusMessage } from "../types.ts";
+import { logger } from "../log.ts";
+
+const log = logger("app-alert");
 
 interface SystemErrorPayload {
   source?: string;
@@ -67,7 +70,7 @@ export class AppAlertPlugin implements Plugin {
       });
     } catch (e) {
       // Must not throw back into the bus (would re-emit system.error → loop).
-      console.warn("[app-alert] ops webhook post failed:", e);
+      log.warn("ops webhook post failed", { err: e });
     }
   }
 }


### PR DESCRIPTION
Second half of #800 (P1, epic #790) — the structured-logging foundation. **Completes #800** (part 1 shipped `/metrics` + app-self alerting in #814).

## Changes
- **`lib/log.ts`** — thin, dependency-free leveled logger. `LOG_LEVEL` gates output; `LOG_FORMAT=json` / `NODE_ENV=production` → one JSON object per line (filterable + queryable by field), else a readable dev line. Component tag + structured fields (Error → `{message,stack}`); `child()` binds fields (e.g. `correlationId`).
- **Reference adoption** at foundational sites: the bus handler-error path (`log.error` with `{pattern,plugin,topic,correlationId,err}`) + the AppAlertPlugin webhook-failure warn.
- The bulk `console.*` migration (~611 sites) is **intentionally incremental** — module + pattern are in place; new/edited code prefers the logger (documented in `development.md`). A 611-site mechanical sweep is deliberately not bundled (reckless mega-diff, low marginal value).

## Tests
logger: json/dev format · level gating · `child()` binding · Error serialization. **1076 green, tsc clean, lint gate passes.** Docs: `development.md`.

Completes #800. Part of #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)