### PR TITLE
fix(ops): /ready gateway probe reports reachability, not a 2xx

### DIFF
--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -248,7 +248,7 @@ Each row links to the route definition as `path:line` so jumping from this index
 | Method | Path | Source | Description |
 |---|---|---|---|
 | `GET` | `/health` | `src/api/operations.ts` | Cheap liveness — the process is up. Always 200. |
-| `GET` | `/ready` | `src/api/operations.ts` | Readiness — gates on local invariants (sqlite open). 200 `ready` / 503 `unready`. The LLM gateway is probed and reported in the body but does **not** gate readiness (an external outage shouldn't restart-loop the container; agent runs fail fast instead). The prod compose `healthcheck` polls this. |
+| `GET` | `/ready` | `src/api/operations.ts` | Readiness — gates on local invariants (sqlite open). 200 `ready` / 503 `unready`. The LLM gateway is probed for **reachability** (any HTTP response counts — LiteLLM's `/health` is auth-gated and returns 401, which still means "up") and reported in the body, but does **not** gate readiness (an external outage shouldn't restart-loop the container; agent runs fail fast instead). The prod compose `healthcheck` polls this. |
 | `GET` | `/metrics` | `src/api/operations.ts` | Prometheus text-exposition metrics (`lib/metrics.ts`): `workstacean_dispatch_total{skill,success}`, `workstacean_dispatch_duration_ms` histogram, `workstacean_bus_handler_errors_total{plugin}`. Low-cardinality labels only. (#800) |
 
 ### `/publish`

--- a/src/api/__tests__/ready.test.ts
+++ b/src/api/__tests__/ready.test.ts
@@ -5,9 +5,24 @@
 import { describe, test, expect } from "bun:test";
 import { InMemoryEventBus } from "../../../lib/bus.ts";
 import { ExecutorRegistry } from "../../executor/executor-registry.ts";
-import { createRoutes } from "../operations.ts";
+import { createRoutes, gatewayReachable } from "../operations.ts";
 import type { ApiContext, Route } from "../types.ts";
 import type { TelemetryService } from "../../telemetry/telemetry-service.ts";
+
+describe("gatewayReachable (#795 follow-up)", () => {
+  test("any HTTP response = reachable — incl. a 401 from an auth-gated /health", async () => {
+    const f401 = (async () => ({ ok: false, status: 401 }) as Response) as unknown as typeof fetch;
+    expect(await gatewayReachable("http://gw", f401)).toBe(true);
+  });
+  test("a 2xx is reachable", async () => {
+    const f200 = (async () => ({ ok: true, status: 200 }) as Response) as unknown as typeof fetch;
+    expect(await gatewayReachable("http://gw", f200)).toBe(true);
+  });
+  test("a network error / timeout = unreachable", async () => {
+    const fThrow = (async () => { throw new Error("ECONNREFUSED"); }) as unknown as typeof fetch;
+    expect(await gatewayReachable("http://gw", fThrow)).toBe(false);
+  });
+});
 
 function readyRoute(ctx: ApiContext): Route {
   const r = createRoutes(ctx).find((x) => x.method === "GET" && x.path === "/ready");

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -12,6 +12,27 @@ import { getPendingHumanInput } from "./human-input.ts";
 import { safeKeyEqual, isPublishTopicDenied } from "../../lib/runtime-env.ts";
 import { metrics } from "../../lib/metrics.ts";
 
+/**
+ * Probe whether the LLM gateway is REACHABLE for the readiness report.
+ * Any HTTP response — including the 401 that LiteLLM's auth-gated `/health`
+ * returns without the master key — means the gateway is up; only a network
+ * error / timeout counts as unreachable. (Earlier this required a 2xx, so an
+ * auth-gated /health reported `gateway:false` on a perfectly healthy gateway.)
+ * Informational only — does not gate readiness.
+ */
+export async function gatewayReachable(
+  url: string,
+  fetchImpl: typeof fetch = fetch,
+  timeoutMs = 2000,
+): Promise<boolean> {
+  try {
+    await fetchImpl(new URL("/health", url), { signal: AbortSignal.timeout(timeoutMs) });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function createRoutes(ctx: ApiContext): Route[] {
 
   /**
@@ -148,14 +169,8 @@ export function createRoutes(ctx: ApiContext): Route[] {
    */
   async function handleReady(): Promise<Response> {
     const sqlite = ctx.telemetry ? ctx.telemetry.healthCheck() : true;
-    let gateway: boolean | "unconfigured" = "unconfigured";
     const gw = process.env.LLM_GATEWAY_URL;
-    if (gw) {
-      try {
-        const r = await fetch(new URL("/health", gw), { signal: AbortSignal.timeout(2000) });
-        gateway = r.ok;
-      } catch { gateway = false; }
-    }
+    const gateway: boolean | "unconfigured" = gw ? await gatewayReachable(gw) : "unconfigured";
     const ready = sqlite;
     return Response.json(
       { status: ready ? "ready" : "unready", sqlite, gateway, timestamp: Date.now() },


### PR DESCRIPTION
Follow-up to #795. In prod, `/ready` showed `gateway:false` on a healthy gateway: the probe only counted HTTP 2xx, but LiteLLM's `/health` is **auth-gated → 401** without the master key. Readiness should reflect *reachability*.

## Fix
- `gatewayReachable(url, fetchImpl?, timeoutMs?)` (exported, testable) — `true` on any resolved fetch (incl. 401), `false` only on network error/timeout. `handleReady` uses it.
- Still informational; does not gate readiness.

## Tests
401 → reachable · 2xx → reachable · network-error → unreachable. **1079 green, tsc clean, lint passes.** Docs: `http-api.md`.