### PR TITLE
feat(ceremonies): roxy.board-pulse — recurring board sweep for Roxy

### DIFF
--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -6,8 +6,8 @@ importance: 0.7
 relatedFiles: []
 usageStats:
   loaded: 7
-  referenced: 3
-  successfulFeatures: 3
+  referenced: 4
+  successfulFeatures: 4
 ---
 # api
 
@@ -29,3 +29,17 @@ usageStats:
 - **Rejected:** Using the same `pr-review:` prefix as standard PR reviews.
 - **Trade-offs:** Adds slight complexity to the key management but provides much higher observability and prevents collision-based logic errors.
 - **Breaking if changed:** If removed, the system might lose the ability to differentiate why a review was triggered, potentially leading to duplicate processing or inability to apply CI-specific logic.
+
+### Use of a specific 'ci-review:' dedup prefix for auto-generated reviews. (2026-06-01)
+- **Context:** Automated re-triggering of PR reviews via CI completion webhooks (workflow_run/check_suite).
+- **Why:** To prevent infinite loops and collisions between manual 'pr-review:' triggers and automated 'ci-review:' triggers during the same lifecycle.
+- **Rejected:** Using the standard 'pr-review:' prefix for both manual and automated triggers.
+- **Trade-offs:** Adds complexity to the deduplication logic but provides granular control over which type of review is being suppressed or allowed.
+- **Breaking if changed:** Removing the unique prefix would cause the system to incorrectly identify automated CI reviews as manual ones, potentially blocking legitimate subsequent reviews.
+
+### Filtering webhook triggers based on a 'TERMINAL_CONCLUSIONS' set. (2026-06-01)
+- **Context:** Determining whether a CI run result should trigger a formal Quinn review.
+- **Why:** Not all workflow completions are meaningful for a code review (e.g., linting failures vs. successful test suites). Only specific terminal states represent a valid state for re-evaluation.
+- **Rejected:** Triggering a review on any 'completed' status regardless of the outcome or type.
+- **Trade-offs:** Harder to maintain as new CI tools are added, but prevents noise and unnecessary automated comments.
+- **Breaking if changed:** Changing this set without updating CI configurations could lead to 'silent' successes where CI passes but no review is ever triggered.

--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -1,0 +1,17 @@
+---
+tags: [api]
+summary: api implementation decisions and patterns
+relevantTo: [api]
+importance: 0.7
+relatedFiles: []
+usageStats:
+  loaded: 1
+  referenced: 0
+  successfulFeatures: 0
+---
+# api
+
+#### [Pattern] Using a WeakMap within the Registry to track in-flight execution counts per IExecutor instance. (2026-06-01)
+- **Problem solved:** The registry needs to know how many active requests are currently being handled by a specific executor instance to determine when it is safe to call `dispose()`.
+- **Why this works:** Using a WeakMap prevents memory leaks because the entry is automatically garbage collected once the executor instance itself is no longer referenced, avoiding the need for manual cleanup of the counter map.
+- **Trade-offs:** Provides automatic memory management at the cost of slightly more complex debugging if one needs to inspect the registry state (as WeakMap contents aren't enumerable).

--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,7 +5,7 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 9
+  loaded: 10
   referenced: 6
   successfulFeatures: 6
 ---
@@ -69,3 +69,7 @@ usageStats:
 - **Context:** A unit test was attempting to access a private static property `TERMINAL_CONCLUSIONS` in `GitHubPlugin` to verify CI state transitions.
 - **Why:** Removing the `private` modifier on a `static readonly` constant is a pragmatic way to allow package-level testing without adding complex getter methods or changing the object's internal state management. Since the set represents a fixed domain contract rather than mutable state, it doesn't violate encapsulation principles as severely as exposing instance variables.
 - **Breaking if changed:** If this were a mutable property instead of `readonly`, removing `private` would expose the internal state to unintended modification by consumers.
+
+#### [Gotcha] Partial implementation of fallback mechanisms can create 'silent' failure paths where one part of a dependency chain works while another fails. (2026-06-02)
+- **Situation:** The PAT (Personal Access Token) fallback was implemented for the GitHub Check Runs endpoint but omitted for the PR Detail endpoint.
+- **Root cause:** The App token would fail with a 403 on the PR detail fetch (needed to resolve the head SHA), causing the entire CI inspection process to crash before it ever reached the endpoint that actually had the fallback logic.

--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,7 +5,7 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 7
+  loaded: 8
   referenced: 4
   successfulFeatures: 4
 ---
@@ -50,3 +50,10 @@ usageStats:
 - **Rejected:** Restarting the entire service for configuration or plugin changes.
 - **Trade-offs:** Increases complexity of the API surface but provides much higher availability during development and production tuning.
 - **Breaking if changed:** Removing these endpoints would force manual service restarts to apply any agent-level changes.
+
+### Implement a transparent, tiered authentication fallback mechanism (App Token -> PAT). (2026-06-02)
+- **Context:** The system needed to resolve CI status visibility issues without requiring immediate reconfiguration of the GitHub App.
+- **Why:** This allows the system to remain functional during the transition period while the App permissions are being updated, providing a graceful degradation/recovery path.
+- **Rejected:** Requiring manual intervention or failing immediately upon the first 403 was rejected because it blocks the automated review workflow.
+- **Trade-offs:** Easier deployment and higher availability; harder to debug if the logs don't explicitly state that a fallback occurred.
+- **Breaking if changed:** Changing the order (PAT first) would increase latency for the standard operating mode and potentially use more privileged credentials than necessary for routine tasks.

--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -43,3 +43,10 @@ usageStats:
 - **Rejected:** Triggering a review on any 'completed' status regardless of the outcome or type.
 - **Trade-offs:** Harder to maintain as new CI tools are added, but prevents noise and unnecessary automated comments.
 - **Breaking if changed:** Changing this set without updating CI configurations could lead to 'silent' successes where CI passes but no review is ever triggered.
+
+### Implementation of a Management API for runtime control (reload/unregister) and diagnostics. (2026-06-02)
+- **Context:** Need for operational control over dynamic agent lifecycles without full system restarts.
+- **Why:** Decouples the management of individual agents from the main process lifecycle, allowing hot-reloading of specific plugins/agents.
+- **Rejected:** Restarting the entire service for configuration or plugin changes.
+- **Trade-offs:** Increases complexity of the API surface but provides much higher availability during development and production tuning.
+- **Breaking if changed:** Removing these endpoints would force manual service restarts to apply any agent-level changes.

--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -6,8 +6,8 @@ importance: 0.7
 relatedFiles: []
 usageStats:
   loaded: 10
-  referenced: 6
-  successfulFeatures: 6
+  referenced: 7
+  successfulFeatures: 7
 ---
 # api
 
@@ -73,3 +73,10 @@ usageStats:
 #### [Gotcha] Partial implementation of fallback mechanisms can create 'silent' failure paths where one part of a dependency chain works while another fails. (2026-06-02)
 - **Situation:** The PAT (Personal Access Token) fallback was implemented for the GitHub Check Runs endpoint but omitted for the PR Detail endpoint.
 - **Root cause:** The App token would fail with a 403 on the PR detail fetch (needed to resolve the head SHA), causing the entire CI inspection process to crash before it ever reached the endpoint that actually had the fallback logic.
+
+### Mandatory projectPath propagation in multi-tenant/multi-repo orchestration (2026-06-02)
+- **Context:** The `pr-remediator` tool calls must explicitly pass `projectPath` extracted from metadata.
+- **Why:** To prevent 'context bleeding' where an agent operating on one repository accidentally executes tools against the orchestrator's own codebase or a default project path.
+- **Rejected:** Assuming the agent can resolve the target project path based on the repository name alone.
+- **Trade-offs:** Requires more rigorous metadata management at the dispatch layer, but provides strict isolation between different target projects.
+- **Breaking if changed:** Removing `projectPath` from tool call requirements would allow agents to execute commands in the wrong working directory, potentially corrupting the orchestrator's environment.

--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,9 +5,9 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 11
-  referenced: 7
-  successfulFeatures: 7
+  loaded: 12
+  referenced: 8
+  successfulFeatures: 8
 ---
 # api
 
@@ -87,3 +87,10 @@ usageStats:
 - **Rejected:** Maintaining the A2A pattern would require both services to share deep knowledge of each other's internal agent skills and state, increasing coupling.
 - **Trade-offs:** HTTP is easier to monitor and integrate with standard tooling, but loses some of the high-level abstraction provided by the agentic skill framework.
 - **Breaking if changed:** Reverting to A2A would re-introduce the need for defensive coding in the receiving service (protoMaker) and break the existing HTTP signal/submit implementation.
+
+### Agent capability discovery uses a standardized '.well-known' endpoint pattern for probing. (2026-06-02)
+- **Context:** Implementing capability discovery for remote A2A (Agent-to-Agent) endpoints.
+- **Why:** Leveraging '.well-known/agent-card.json' and '.well-known/agent.json' provides a predictable, discoverable way for the management console to fetch agent metadata (skills, description, etc.) without requiring manual configuration for every new endpoint.
+- **Rejected:** Hardcoded API routes per agent or requiring agents to register their full schema via a central database.
+- **Trade-offs:** Easier for decentralized agent deployment but requires all agents to adhere to the specific '.well-known' convention.
+- **Breaking if changed:** If the convention changes, the probe mechanism will fail to identify skills or reachability for existing agents.

--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,9 +5,9 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 8
-  referenced: 4
-  successfulFeatures: 4
+  loaded: 9
+  referenced: 5
+  successfulFeatures: 5
 ---
 # api
 
@@ -57,3 +57,10 @@ usageStats:
 - **Rejected:** Requiring manual intervention or failing immediately upon the first 403 was rejected because it blocks the automated review workflow.
 - **Trade-offs:** Easier deployment and higher availability; harder to debug if the logs don't explicitly state that a fallback occurred.
 - **Breaking if changed:** Changing the order (PAT first) would increase latency for the standard operating mode and potentially use more privileged credentials than necessary for routine tasks.
+
+### Utilizing GitHub Rulesets API instead of the legacy Branch Protection API. (2026-06-02)
+- **Context:** Configuring mandatory review requirements for the main branch in protoMaker.
+- **Why:** Rulesets provide more granular control and are the modern replacement for branch protection, allowing for better enforcement through 'required_reviewer_ids'.
+- **Rejected:** Legacy Branch Protection API; rejected because it is being phased out and rulesets offer superior targeting (e.g., via conditions).
+- **Trade-offs:** Rulesets require a different payload structure and endpoint compared to established branch protection scripts.
+- **Breaking if changed:** Changing back to branch protection might lose the ability to specifically target Quinn via App ID within the rule parameters.

--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -64,3 +64,8 @@ usageStats:
 - **Rejected:** Legacy Branch Protection API; rejected because it is being phased out and rulesets offer superior targeting (e.g., via conditions).
 - **Trade-offs:** Rulesets require a different payload structure and endpoint compared to established branch protection scripts.
 - **Breaking if changed:** Changing back to branch protection might lose the ability to specifically target Quinn via App ID within the rule parameters.
+
+### Exposing static constants by removing 'private' visibility for testability (2026-06-02)
+- **Context:** A unit test was attempting to access a private static property `TERMINAL_CONCLUSIONS` in `GitHubPlugin` to verify CI state transitions.
+- **Why:** Removing the `private` modifier on a `static readonly` constant is a pragmatic way to allow package-level testing without adding complex getter methods or changing the object's internal state management. Since the set represents a fixed domain contract rather than mutable state, it doesn't violate encapsulation principles as severely as exposing instance variables.
+- **Breaking if changed:** If this were a mutable property instead of `readonly`, removing `private` would expose the internal state to unintended modification by consumers.

--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -6,8 +6,8 @@ importance: 0.7
 relatedFiles: []
 usageStats:
   loaded: 9
-  referenced: 5
-  successfulFeatures: 5
+  referenced: 6
+  successfulFeatures: 6
 ---
 # api
 

--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -6,8 +6,8 @@ importance: 0.7
 relatedFiles: []
 usageStats:
   loaded: 12
-  referenced: 8
-  successfulFeatures: 8
+  referenced: 9
+  successfulFeatures: 9
 ---
 # api
 

--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,7 +5,7 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 10
+  loaded: 11
   referenced: 7
   successfulFeatures: 7
 ---
@@ -80,3 +80,10 @@ usageStats:
 - **Rejected:** Assuming the agent can resolve the target project path based on the repository name alone.
 - **Trade-offs:** Requires more rigorous metadata management at the dispatch layer, but provides strict isolation between different target projects.
 - **Breaking if changed:** Removing `projectPath` from tool call requirements would allow agents to execute commands in the wrong working directory, potentially corrupting the orchestrator's environment.
+
+### Migrate from A2A (Agent-to-Agent) communication to standard HTTP + Webhooks for inter-service integration. (2026-06-02)
+- **Context:** The `_runTriageSweep` function in protoMaker was previously being triggered via an A2A skill request (`agent.skill.request` with `agentId: 'protomaker'`), which forced the receiver to implement defensive code to handle unexpected dispatch formats.
+- **Why:** Standardizing on HTTP/Webhooks provides a more robust, predictable, and decoupled integration boundary compared to agent-specific skill dispatching.
+- **Rejected:** Maintaining the A2A pattern would require both services to share deep knowledge of each other's internal agent skills and state, increasing coupling.
+- **Trade-offs:** HTTP is easier to monitor and integrate with standard tooling, but loses some of the high-level abstraction provided by the agentic skill framework.
+- **Breaking if changed:** Reverting to A2A would re-introduce the need for defensive coding in the receiving service (protoMaker) and break the existing HTTP signal/submit implementation.

--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,9 +5,9 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 5
-  referenced: 1
-  successfulFeatures: 1
+  loaded: 6
+  referenced: 2
+  successfulFeatures: 2
 ---
 # api
 
@@ -15,3 +15,10 @@ usageStats:
 - **Problem solved:** The registry needs to know how many active requests are currently being handled by a specific executor instance to determine when it is safe to call `dispose()`.
 - **Why this works:** Using a WeakMap prevents memory leaks because the entry is automatically garbage collected once the executor instance itself is no longer referenced, avoiding the need for manual cleanup of the counter map.
 - **Trade-offs:** Provides automatic memory management at the cost of slightly more complex debugging if one needs to inspect the registry state (as WeakMap contents aren't enumerable).
+
+### Implementation of distinct dedup key prefixes (`ci-review:` vs `pr-review:`) for different trigger types. (2026-06-01)
+- **Context:** Preventing race conditions or duplicate review actions when a PR review is triggered by both a code commit and a CI completion event.
+- **Why:** Ensures that the state machine can distinguish between a review initiated by developer activity (commit) and one initiated by automated infrastructure (CI), allowing them to coexist or transition without colliding in the deduplication logic.
+- **Rejected:** Using a single unified dedup key based only on the PR number/SHA.
+- **Trade-offs:** Increases complexity in the key generation logic but provides granular control over which event type 'owns' the current review cycle.
+- **Breaking if changed:** If prefixes are merged, a CI completion might inadvertently suppress a manual re-review or vice versa due to key collision.

--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,9 +5,9 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 2
-  referenced: 0
-  successfulFeatures: 0
+  loaded: 5
+  referenced: 1
+  successfulFeatures: 1
 ---
 # api
 

--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,7 +5,7 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 1
+  loaded: 2
   referenced: 0
   successfulFeatures: 0
 ---

--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,9 +5,9 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 6
-  referenced: 2
-  successfulFeatures: 2
+  loaded: 7
+  referenced: 3
+  successfulFeatures: 3
 ---
 # api
 
@@ -22,3 +22,10 @@ usageStats:
 - **Rejected:** Using a single unified dedup key based only on the PR number/SHA.
 - **Trade-offs:** Increases complexity in the key generation logic but provides granular control over which event type 'owns' the current review cycle.
 - **Breaking if changed:** If prefixes are merged, a CI completion might inadvertently suppress a manual re-review or vice versa due to key collision.
+
+### Use a specific `ci-review:` prefix for the deduplication key when re-dispatching reviews via CI completion events. (2026-06-01)
+- **Context:** The system needs to trigger an automatic review after CI passes, but must avoid infinite loops or colliding with standard PR review triggers.
+- **Why:** It distinguishes between a review triggered by a manual/standard PR event and one triggered specifically by a CI status change, allowing for granular control over which logic applies to which trigger.
+- **Rejected:** Using the same `pr-review:` prefix as standard PR reviews.
+- **Trade-offs:** Adds slight complexity to the key management but provides much higher observability and prevents collision-based logic errors.
+- **Breaking if changed:** If removed, the system might lose the ability to differentiate why a review was triggered, potentially leading to duplicate processing or inability to apply CI-specific logic.

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -6,8 +6,8 @@ importance: 0.7
 relatedFiles: []
 usageStats:
   loaded: 20
-  referenced: 4
-  successfulFeatures: 4
+  referenced: 5
+  successfulFeatures: 5
 ---
 # architecture
 
@@ -87,3 +87,8 @@ usageStats:
 - **Problem solved:** CI completion webhooks can fire multiple times or for different check suites on the same commit.
 - **Why this works:** To prevent Quinn from repeatedly reviewing a PR that already has a definitive status (APPROVED or CHANGES_REQUESTED), saving compute and avoiding noise in the PR timeline.
 - **Trade-offs:** Requires the system to maintain/check the state of previous reviews, but significantly reduces redundant API calls and LLM usage.
+
+#### [Pattern] SHA-to-PR resolution with stale SHA guards in webhook handlers. (2026-06-01)
+- **Problem solved:** Handling asynchronous GitHub webhooks where the event payload might not directly contain the Pull Request object.
+- **Why this works:** GitHub's `workflow_run` and `check_suite` events focus on the commit SHA. Since multiple PRs can share a SHA (or a SHA can move), the system must explicitly resolve the current open PR and verify the SHA hasn't moved since the event was triggered.
+- **Trade-offs:** Requires extra API calls to fetch PR details and perform validation, increasing latency slightly.

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -5,7 +5,7 @@ relevantTo: [architecture]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 21
+  loaded: 22
   referenced: 6
   successfulFeatures: 6
 ---

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -5,9 +5,9 @@ relevantTo: [architecture]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 23
-  referenced: 7
-  successfulFeatures: 7
+  loaded: 24
+  referenced: 8
+  successfulFeatures: 8
 ---
 # architecture
 
@@ -130,3 +130,10 @@ usageStats:
 - **Problem solved:** Updating A2A agent configurations in 'agents.yaml'.
 - **Why this works:** When an agent is added/deleted via the management API, the system performs three distinct actions: updates the persistent YAML file, triggers a 'skill-broker' plugin refresh, and unregisters from the 'executorRegistry'. This ensures the filesystem, the skill discovery service, and the active execution engine remain synchronized.
 - **Trade-offs:** Increases complexity in the management handler but eliminates the latency/inconsistency window inherent in polling.
+
+### Namespacing skills using `{serverName}.{toolName}` format. (2026-06-02)
+- **Context:** Multiple MCP servers might provide tools with identical names (e.g., two different 'read_file' tools).
+- **Why:** Ensures unique identifiers within the global `executorRegistry` and prevents collision between different MCP providers.
+- **Rejected:** Using just the tool name as the skill identifier.
+- **Trade-offs:** Makes the skill name slightly more verbose but guarantees uniqueness and allows the agent to distinguish between providers.
+- **Breaking if changed:** Changing the naming convention would break existing agent prompts or configurations that rely on specific tool identifiers.

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -6,8 +6,8 @@ importance: 0.7
 relatedFiles: []
 usageStats:
   loaded: 21
-  referenced: 5
-  successfulFeatures: 5
+  referenced: 6
+  successfulFeatures: 6
 ---
 # architecture
 
@@ -97,3 +97,15 @@ usageStats:
 - **Problem solved:** Preventing data loss or inconsistent states when unregistering executors that may have in-flight requests.
 - **Why this works:** Ensures that active dispatches are allowed to complete before the executor is destroyed, preventing abrupt termination of tasks.
 - **Trade-offs:** Introduces latency during unregistration if many tasks are in flight, but ensures task integrity.
+
+### Hybrid Agent Runtime Model: Distinguishing between 'In-process' agents (running via DeepAgentExecutor/LangGraph) and 'External A2A' agents (running via A2AExecutor). (2026-06-02)
+- **Context:** The system evolved from having all agents as external A2A services to moving some (like Quinn and Ava) into the core workspace process.
+- **Why:** Moving agents in-process reduces network latency and simplifies orchestration for core lifecycle tasks, while keeping complex or heavy-duty teams (like protoMaker) as external A2A services allows for independent scaling and deployment.
+- **Rejected:** Keeping all agents as external A2A services (which was the previous state), which added unnecessary overhead for tightly coupled agents.
+- **Trade-offs:** Easier local development and faster execution for in-process agents, but increased complexity in the codebase due to managing two different executor types (DeepAgentExecutor vs A2AExecutor).
+- **Breaking if changed:** Changing this would require a complete rewrite of the ExecutorRegistry and how the message bus dispatches skills to agents.
+
+#### [Pattern] Unified Executor Registry abstraction for heterogeneous agent runtimes. (2026-06-02)
+- **Problem solved:** Managing both in-process LangGraph agents and external HTTP-based A2A agents.
+- **Why this works:** By registering both types into a single `ExecutorRegistry`, the message bus can dispatch skills identically regardless of whether the target is a local function call or a remote HTTP request.
+- **Trade-offs:** Provides a clean, polymorphic interface for the rest of the system at the cost of slightly more complex registration logic.

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -5,7 +5,7 @@ relevantTo: [architecture]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 20
+  loaded: 21
   referenced: 5
   successfulFeatures: 5
 ---

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -5,9 +5,9 @@ relevantTo: [architecture]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 22
-  referenced: 6
-  successfulFeatures: 6
+  loaded: 23
+  referenced: 7
+  successfulFeatures: 7
 ---
 # architecture
 
@@ -125,3 +125,8 @@ usageStats:
 - **Rejected:** Using a simple timer or single-shot execution.
 - **Trade-offs:** Adds overhead of checking state on every cycle, but ensures eventual consistency in highly autonomous environments.
 - **Breaking if changed:** If the 'Check for existing work' step is removed, the system will enter a loop of creating infinite 'address review' features for the same PR.
+
+#### [Pattern] Event-driven synchronization between configuration files and runtime plugin state. (2026-06-02)
+- **Problem solved:** Updating A2A agent configurations in 'agents.yaml'.
+- **Why this works:** When an agent is added/deleted via the management API, the system performs three distinct actions: updates the persistent YAML file, triggers a 'skill-broker' plugin refresh, and unregisters from the 'executorRegistry'. This ensures the filesystem, the skill discovery service, and the active execution engine remain synchronized.
+- **Trade-offs:** Increases complexity in the management handler but eliminates the latency/inconsistency window inherent in polling.

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -1,0 +1,58 @@
+---
+tags: [architecture]
+summary: architecture implementation decisions and patterns
+relevantTo: [architecture]
+importance: 0.7
+relatedFiles: []
+usageStats:
+  loaded: 12
+  referenced: 0
+  successfulFeatures: 0
+---
+# architecture
+
+#### [Gotcha] Hostname parsing heuristic fails when agents operate across different network namespaces (Tailscale vs direct network). Single-label hostname format is not uniform across network topologies. (2026-04-20)
+- **Situation:** The original _pickCallbackBaseUrl used hostname parsing to derive callback base URL, assuming all agents were on the same network topology. Tailscale agents have different hostname structure, breaking the heuristic.
+- **Root cause:** Network topology fundamentally changes hostname resolution patterns. Tailscale overlays a different namespace where the assumptions about hostname structure no longer hold. Cannot reliably infer network topology from hostname alone.
+- **How to avoid:** Required explicit configuration instead of inferring from agent properties, but eliminated a class of hard-to-debug network connectivity failures.
+
+### Use explicit `external: boolean` flag in agent configuration rather than attempting automatic detection of Tailscale/external agents. (2026-04-20)
+- **Context:** Needed to support agents that operate in different network namespaces where the hostname heuristic doesn't apply.
+- **Why:** Network topology is a deployment-time concern. Explicit configuration is clearer, testable, and doesn't require fragile runtime detection logic. Treats network configuration as data, not magic.
+- **Rejected:** Auto-detection based on agent name, domain suffix, or other heuristics would create implicit behavior that's hard to debug and couples agent identity to network topology.
+- **Trade-offs:** Requires manual configuration per external agent, but avoids special cases in routing logic and makes network topology explicit and debuggable.
+- **Breaking if changed:** Removing the external flag check in _pickCallbackBaseUrl forces all agents through the hostname heuristic, breaking Tailscale connectivity. Adding new external agents requires explicit configuration.
+
+#### [Pattern] Push configuration through multiple layers: deployment config (agents.yaml) → agent config class (A2AAgentConfig) → executor (A2AExecutor getter) → dispatcher logic (_pickCallbackBaseUrl). (2026-04-20)
+- **Problem solved:** The external flag flows from yaml through TypeScript config to execution logic, with each layer exposing what it needs.
+- **Why this works:** Separates concerns: deployment configuration is independent of business logic. Each layer exposes only what it uses. Makes it easy to trace how a configuration option affects behavior.
+- **Trade-offs:** Requires maintaining field definitions across multiple classes, but makes configuration flow explicit and auditable.
+
+#### [Gotcha] Single-label hostname heuristic for callback URLs breaks when agents have different network access patterns than the controller (Tailscale external agents) (2026-04-20)
+- **Situation:** Push notification routing assumed controller and agent see the same hostname resolution. Tailscale steamdeck agent externally routed cannot resolve internal-only hostnames.
+- **Root cause:** Network topology determines whether a hostname is resolvable. A heuristic that works for co-located agents fails for agents with external IP access patterns.
+- **How to avoid:** Moved complexity from implicit detection to explicit configuration. Less magic, but requires operator knowledge of network topology.
+
+### Callback URL routing uses explicit topology flag (external: boolean) rather than inferred from agent properties (2026-04-20)
+- **Context:** Multiple agents in different network positions (internal vs. Tailscale external) need different callback strategies
+- **Why:** Operator declaratively knows whether an agent is external. Prevents fragile heuristics and keeps routing logic deterministic.
+- **Rejected:** Dynamic detection via probe requests (latency cost, race conditions); detection via DNS reverse-lookup (environment-specific)
+- **Trade-offs:** Requires YAML configuration maintenance but eliminates implicit magic. Configuration intent is explicit and auditable.
+- **Breaking if changed:** Removing the flag disables the capability to override routing per-agent; agents must then use auto-detected heuristics which fail for external Tailscale.
+
+#### [Pattern] Conditional callback URL selection: _pickCallbackBaseUrl() short-circuits to WORKSTACEAN_BASE_URL when external=true, bypassing hostname heuristic (2026-04-20)
+- **Problem solved:** Controller exposes callback URL via both internal hostname (heuristic) and fully-qualified base URL (external). Agents need path chosen by topology.
+- **Why this works:** External agents require absolute URL with proper DNS resolution. Heuristic is optimization for internal agents. Conditional selection keeps both strategies available without collision.
+- **Trade-offs:** Added conditional branch in routing logic. Simpler than topology auto-detection, more explicit than pure heuristic.
+
+### Network topology declared explicitly in configuration (agents.yaml external flag) rather than inferred from hostname heuristics (2026-04-20)
+- **Context:** Push-notification callback routing must correctly reach agents deployed in different network contexts; hostname-based heuristic approach failed for Tailscale agents
+- **Why:** Topology is operational metadata subject to deployment changes, not a code invariant; explicit configuration is more reliable and maintainable than hostname-pattern heuristics that depend on implicit assumptions
+- **Rejected:** Enhanced pattern matching (e.g., Tailscale device detection rules) — still vulnerable to breaking with future topology changes; hardcoded agent lists — doesn't scale
+- **Trade-offs:** Easier: correct routing, self-documenting, ops-team can update without code changes. Harder: configuration drift risk, no automatic topology detection
+- **Breaking if changed:** Removing the external flag and reverting to hostname heuristics will re-break Tailscale agent routing
+
+#### [Pattern] Configuration-driven short-circuit: explicit operational metadata bypasses code heuristics entirely without fallback (2026-04-20)
+- **Problem solved:** System has both heuristic-based fallback path and explicit configuration; when external=true, uses WORKSTACEAN_BASE_URL without attempting hostname analysis
+- **Why this works:** Operator knows topology better than code; explicit config should be unambiguous and fully trusted rather than merged with heuristic logic
+- **Trade-offs:** Easier: clear semantics and single decision point. Harder: requires accurate configuration; no automatic detection or intelligent fallback

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -5,9 +5,9 @@ relevantTo: [architecture]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 19
-  referenced: 3
-  successfulFeatures: 3
+  loaded: 20
+  referenced: 4
+  successfulFeatures: 4
 ---
 # architecture
 
@@ -82,3 +82,8 @@ usageStats:
 - **Rejected:** Polling CI status from the agent side.
 - **Trade-offs:** Requires handling specific webhook events (`check_suite.completed`, `workflow_run.completed`) and mapping SHAs to open PRs, which increases integration surface area compared to simple polling.
 - **Breaking if changed:** Removing this logic reverts the system to a purely advisory role where it can never formally pass a PR through a gate automatically.
+
+#### [Pattern] Implementing a 'Formal Review' guard (`_hasFormalQuinnReview`) before re-triggering automation. (2026-06-01)
+- **Problem solved:** CI completion webhooks can fire multiple times or for different check suites on the same commit.
+- **Why this works:** To prevent Quinn from repeatedly reviewing a PR that already has a definitive status (APPROVED or CHANGES_REQUESTED), saving compute and avoiding noise in the PR timeline.
+- **Trade-offs:** Requires the system to maintain/check the state of previous reviews, but significantly reduces redundant API calls and LLM usage.

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -113,3 +113,15 @@ usageStats:
 #### [Pattern] Registry-only MCP Client Plugin pattern (2026-06-02)
 - **Problem solved:** Implementing an MCP (Model Context Protocol) client plugin to integrate external tools into the agent ecosystem.
 - **Why this works:** By making the `McpClientPlugin` a 'registrar only' component that populates an `ExecutorRegistry`, it maintains a clean separation of concerns. The plugin handles discovery and configuration (via `mcp-servers.yaml`), while the `SkillDispatcherPlugin` remains the single source of truth for skill requests, preventing multiple plugins from competing for the same event bus signals.
+
+#### [Pattern] Autonomous Agent Instruction Injection via Dispatch Metadata (2026-06-02)
+- **Problem solved:** Implementing a PR remediator that dispatches tasks to an autonomous agent (Ava).
+- **Why this works:** By embedding high-fidelity, step-by-step execution protocols (Triage -> Assign -> Kick off -> Review) directly into the dispatch payload, the system ensures the agent operates with a deterministic state machine rather than relying on vague prompts.
+- **Trade-offs:** Increases payload size and complexity of the orchestrator, but significantly reduces 'hallucination loops' where agents fail to follow multi-step processes.
+
+### Idempotent Remediation via State Reconciliation (2026-06-02)
+- **Context:** The remediator re-dispatches every ~5 minutes.
+- **Why:** To handle transient failures or agent crashes without creating duplicate work. The agent is instructed to check for existing features (`list_features`) before creating new ones.
+- **Rejected:** Using a simple timer or single-shot execution.
+- **Trade-offs:** Adds overhead of checking state on every cycle, but ensures eventual consistency in highly autonomous environments.
+- **Breaking if changed:** If the 'Check for existing work' step is removed, the system will enter a loop of creating infinite 'address review' features for the same PR.

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -5,9 +5,9 @@ relevantTo: [architecture]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 15
-  referenced: 1
-  successfulFeatures: 1
+  loaded: 18
+  referenced: 2
+  successfulFeatures: 2
 ---
 # architecture
 
@@ -63,3 +63,15 @@ usageStats:
 - **Rejected:** Immediate replacement of executors, which would cause in-flight requests to fail with 'executor not found' or 'connection closed' errors.
 - **Trade-offs:** Increases complexity by requiring a WeakMap for in-flight counting and adding asynchronous waiting logic to the unregistration process; however, it provides much higher system stability during configuration changes.
 - **Breaking if changed:** Removing the `unregisterAgent` drain logic or the `dispose()` hook would lead to either interrupted user requests or leaked resources (e.g., open sockets/processes) from old executors.
+
+### Implementation of a durable, unified live state using a repository pattern for plugin hydration. (2026-06-01)
+- **Context:** The AgentFleetHealthPlugin needed to maintain rolling 24h windows of agent performance (success/latency/cost) but would lose this data on restart.
+- **Why:** By introducing `FleetStateRepository` backed by `knowledge.db`, the system can hydrate in-memory Maps during the `install()` phase, ensuring continuity of telemetry without requiring a full historical replay of all events.
+- **Rejected:** Relying solely on in-memory state (lost on restart) or querying a full historical database on every request (too slow for real-time rollups).
+- **Trade-offs:** Increases complexity by requiring a dual-write strategy (in-memory window + durable store) and a hydration step at startup, but provides near-instantaneous read access to recent history.
+- **Breaking if changed:** Removing the hydration logic causes 'blind spots' in telemetry every time the service restarts; removing the repository prevents persistence entirely.
+
+#### [Pattern] Graceful degradation of durable storage in plugins. (2026-06-01)
+- **Problem solved:** The `AgentFleetHealthPlugin` depends on `fleetStateRepo` for persistence.
+- **Why this works:** The implementation uses an optional dependency (`private readonly fleetStateRepo?: FleetStateRepository`) and checks for its existence before attempting writes or hydration. This allows the plugin to function as a purely in-memory aggregator if the database layer is unavailable or not configured.
+- **Trade-offs:** Makes the code slightly more defensive with null checks, but significantly increases the portability and testability of the plugin.

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -5,9 +5,9 @@ relevantTo: [architecture]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 13
-  referenced: 0
-  successfulFeatures: 0
+  loaded: 14
+  referenced: 1
+  successfulFeatures: 1
 ---
 # architecture
 
@@ -56,3 +56,10 @@ usageStats:
 - **Problem solved:** System has both heuristic-based fallback path and explicit configuration; when external=true, uses WORKSTACEAN_BASE_URL without attempting hostname analysis
 - **Why this works:** Operator knows topology better than code; explicit config should be unambiguous and fully trusted rather than merged with heuristic logic
 - **Trade-offs:** Easier: clear semantics and single decision point. Harder: requires accurate configuration; no automatic detection or intelligent fallback
+
+### Implementing a 'drain-and-dispose' lifecycle for hot-reloading agents via an in-flight tracking mechanism in the ExecutorRegistry. (2026-06-01)
+- **Context:** Hot-reloading agent configurations (agents.yaml) requires replacing executors without dropping active skill dispatches or causing resource leaks.
+- **Why:** To ensure zero-downtime updates and graceful shutdown of old executor instances while allowing current requests to complete naturally.
+- **Rejected:** Immediate replacement of executors, which would cause in-flight requests to fail with 'executor not found' or 'connection closed' errors.
+- **Trade-offs:** Increases complexity by requiring a WeakMap for in-flight counting and adding asynchronous waiting logic to the unregistration process; however, it provides much higher system stability during configuration changes.
+- **Breaking if changed:** Removing the `unregisterAgent` drain logic or the `dispose()` hook would lead to either interrupted user requests or leaked resources (e.g., open sockets/processes) from old executors.

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -5,7 +5,7 @@ relevantTo: [architecture]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 14
+  loaded: 15
   referenced: 1
   successfulFeatures: 1
 ---

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -109,3 +109,7 @@ usageStats:
 - **Problem solved:** Managing both in-process LangGraph agents and external HTTP-based A2A agents.
 - **Why this works:** By registering both types into a single `ExecutorRegistry`, the message bus can dispatch skills identically regardless of whether the target is a local function call or a remote HTTP request.
 - **Trade-offs:** Provides a clean, polymorphic interface for the rest of the system at the cost of slightly more complex registration logic.
+
+#### [Pattern] Registry-only MCP Client Plugin pattern (2026-06-02)
+- **Problem solved:** Implementing an MCP (Model Context Protocol) client plugin to integrate external tools into the agent ecosystem.
+- **Why this works:** By making the `McpClientPlugin` a 'registrar only' component that populates an `ExecutorRegistry`, it maintains a clean separation of concerns. The plugin handles discovery and configuration (via `mcp-servers.yaml`), while the `SkillDispatcherPlugin` remains the single source of truth for skill requests, preventing multiple plugins from competing for the same event bus signals.

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -5,9 +5,9 @@ relevantTo: [architecture]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 18
-  referenced: 2
-  successfulFeatures: 2
+  loaded: 19
+  referenced: 3
+  successfulFeatures: 3
 ---
 # architecture
 
@@ -75,3 +75,10 @@ usageStats:
 - **Problem solved:** The `AgentFleetHealthPlugin` depends on `fleetStateRepo` for persistence.
 - **Why this works:** The implementation uses an optional dependency (`private readonly fleetStateRepo?: FleetStateRepository`) and checks for its existence before attempting writes or hydration. This allows the plugin to function as a purely in-memory aggregator if the database layer is unavailable or not configured.
 - **Trade-offs:** Makes the code slightly more defensive with null checks, but significantly increases the portability and testability of the plugin.
+
+### Transitioning from a 'hold' state (COMMENT only) to a 're-dispatch' model upon terminal CI conclusions. (2026-06-01)
+- **Context:** The system was previously holding verdicts in a provisional COMMENT state while CI was running, but lacked a mechanism to upgrade these to formal APPROVE/REQUEST_CHANGES once CI finished.
+- **Why:** To solve the 'stalled PR' problem where automation would provide feedback but never finalize the review process after the environment was validated.
+- **Rejected:** Polling CI status from the agent side.
+- **Trade-offs:** Requires handling specific webhook events (`check_suite.completed`, `workflow_run.completed`) and mapping SHAs to open PRs, which increases integration surface area compared to simple polling.
+- **Breaking if changed:** Removing this logic reverts the system to a purely advisory role where it can never formally pass a PR through a gate automatically.

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -92,3 +92,8 @@ usageStats:
 - **Problem solved:** Handling asynchronous GitHub webhooks where the event payload might not directly contain the Pull Request object.
 - **Why this works:** GitHub's `workflow_run` and `check_suite` events focus on the commit SHA. Since multiple PRs can share a SHA (or a SHA can move), the system must explicitly resolve the current open PR and verify the SHA hasn't moved since the event was triggered.
 - **Trade-offs:** Requires extra API calls to fetch PR details and perform validation, increasing latency slightly.
+
+#### [Pattern] Graceful executor disposal using a 'drain and dispose' pattern with a timeout. (2026-06-02)
+- **Problem solved:** Preventing data loss or inconsistent states when unregistering executors that may have in-flight requests.
+- **Why this works:** Ensures that active dispatches are allowed to complete before the executor is destroyed, preventing abrupt termination of tasks.
+- **Trade-offs:** Introduces latency during unregistration if many tasks are in flight, but ensures task integrity.

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -5,7 +5,7 @@ relevantTo: [architecture]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 12
+  loaded: 13
   referenced: 0
   successfulFeatures: 0
 ---

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 87
-  referenced: 13
-  successfulFeatures: 13
+  loaded: 88
+  referenced: 14
+  successfulFeatures: 14
 ---
 # gotchas
 
@@ -44,3 +44,8 @@ usageStats:
 - **Situation:** Refactoring `_dispatchToAva` from a synchronous return of a correlation ID to an asynchronous operation returning a Promise.
 - **Root cause:** When transitioning from a fire-and-forget pattern to a reliable awaitable pattern, all upstream callers (like `_handleDiagnoseResponse`) must be verified as `async`. Failure to do so results in unhandled promise rejections or race conditions where `_recordDispatch` executes before the dispatch actually succeeds.
 - **How to avoid:** Makes the control flow harder to reason about if not properly awaited, but allows for robust error handling and guaranteed order of operations (Dispatch -> Record).
+
+#### [Gotcha] Handling failed connections by storing a 'failed state' object in the connection map. (2026-06-02)
+- **Situation:** When a server fails to connect, it shouldn't just be ignored; it needs to be visible for observability.
+- **Root cause:** By storing the error message and setting `connected: false`, the system can report *why* a server is missing rather than just appearing as if it wasn't configured.
+- **How to avoid:** Requires handling `@ts-expect-error` for null clients/transports in the connection object, but improves debugging significantly.

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 76
-  referenced: 2
-  successfulFeatures: 2
+  loaded: 77
+  referenced: 3
+  successfulFeatures: 3
 ---
 # gotchas
 
@@ -25,3 +25,8 @@ usageStats:
 - **Situation:** Handling outcomes where the `systemActor` is not found in the `ExecutorRegistry`.
 - **Root cause:** Some system components act as actors but aren't formal executors. The implementation explicitly detects these 'synthetic actors', logs a warning once to prevent log flooding, and routes them to a separate `systemActorWindows` collection rather than the standard `agentWindows`.
 - **How to avoid:** Requires maintaining two separate Map collections in memory, but ensures high signal-to-noise ratio in agent health dashboards.
+
+#### [Gotcha] The necessity of a 'Stale SHA guard' during CI webhook handling. (2026-06-01)
+- **Situation:** In active development, a developer might push a new commit while a CI run for an older commit is still finishing.
+- **Root cause:** Webhooks for older commits can arrive late. If the system processes a 'success' for an old SHA, it might attempt to review a PR that has already moved forward, causing context mismatch.
+- **How to avoid:** Increases implementation complexity by requiring SHA verification against the current PR head, but ensures review accuracy.

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 75
-  referenced: 1
-  successfulFeatures: 1
+  loaded: 76
+  referenced: 2
+  successfulFeatures: 2
 ---
 # gotchas
 

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,7 +5,7 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 70
+  loaded: 71
   referenced: 0
   successfulFeatures: 0
 ---
@@ -15,3 +15,8 @@ usageStats:
 - **Situation:** Original callback URL heuristic assumed single-label hostnames (e.g., 'steamdeck') were exclusively docker-internal, but Tailscale mesh networking also uses single-label DNS for external VPN devices, causing misclassification
 - **Root cause:** Docker-internal networks and Tailscale VPN both opt for non-FQDN naming conventions; hostname patterns alone are insufficient to disambiguate network boundaries
 - **How to avoid:** Simple heuristic fails when a second network topology introduces the same naming pattern
+
+#### [Gotcha] The necessity of differentiating between 'detecting' a change and 'applying' a change in the AgentRuntimePlugin. (2026-06-01)
+- **Situation:** Initial implementation of workspace watchers often only detects that a file changed, but doesn't handle the complex state transition of removing old registrations and adding new ones.
+- **Root cause:** A simple 'reload all' approach is inefficient and disruptive; a 'diff-and-apply' approach minimizes the impact on the running system by only touching the specific agents that changed.
+- **How to avoid:** Requires maintaining a hash or version of the agent definition to perform effective diffing.

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 83
-  referenced: 9
-  successfulFeatures: 9
+  loaded: 84
+  referenced: 10
+  successfulFeatures: 10
 ---
 # gotchas
 

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 84
-  referenced: 10
-  successfulFeatures: 10
+  loaded: 85
+  referenced: 11
+  successfulFeatures: 11
 ---
 # gotchas
 
@@ -39,3 +39,8 @@ usageStats:
 #### [Gotcha] Type mismatch in array push operations involving nullable strings (2026-06-02)
 - **Situation:** In `executor-registry.ts`, a loop was pushing `r.skill` (which could be `string | null`) into `removedSkills` (a `string[]`).
 - **Root cause:** TypeScript's strict null checks prevent pushing nullable types into non-nullable arrays, which often occurs when registry metadata is partially populated or optional.
+
+#### [Gotcha] Async/Await mismatch during synchronous-to-asynchronous refactoring of dispatchers (2026-06-02)
+- **Situation:** Refactoring `_dispatchToAva` from a synchronous return of a correlation ID to an asynchronous operation returning a Promise.
+- **Root cause:** When transitioning from a fire-and-forget pattern to a reliable awaitable pattern, all upstream callers (like `_handleDiagnoseResponse`) must be verified as `async`. Failure to do so results in unhandled promise rejections or race conditions where `_recordDispatch` executes before the dispatch actually succeeds.
+- **How to avoid:** Makes the control flow harder to reason about if not properly awaited, but allows for robust error handling and guaranteed order of operations (Dispatch -> Record).

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 77
-  referenced: 3
-  successfulFeatures: 3
+  loaded: 78
+  referenced: 4
+  successfulFeatures: 4
 ---
 # gotchas
 

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 85
-  referenced: 11
-  successfulFeatures: 11
+  loaded: 86
+  referenced: 12
+  successfulFeatures: 12
 ---
 # gotchas
 

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 78
-  referenced: 4
-  successfulFeatures: 4
+  loaded: 79
+  referenced: 5
+  successfulFeatures: 5
 ---
 # gotchas
 
@@ -30,3 +30,8 @@ usageStats:
 - **Situation:** In active development, a developer might push a new commit while a CI run for an older commit is still finishing.
 - **Root cause:** Webhooks for older commits can arrive late. If the system processes a 'success' for an old SHA, it might attempt to review a PR that has already moved forward, causing context mismatch.
 - **How to avoid:** Increases implementation complexity by requiring SHA verification against the current PR head, but ensures review accuracy.
+
+#### [Gotcha] Type mismatch between registration metadata (string | undefined) and internal mapping keys (string). (2026-06-02)
+- **Situation:** The `byAgent` map uses a fallback key `__anonymous__` for undefined agent names, but the registration object itself still carries the `undefined` type.
+- **Root cause:** The internal implementation logic handles the nullability by providing a default string, but the TypeScript compiler enforces strict type safety on the original property.
+- **How to avoid:** Requires explicit handling of the fallback key in both the insertion and retrieval logic to maintain type safety.

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,7 +5,7 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 69
+  loaded: 70
   referenced: 0
   successfulFeatures: 0
 ---

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -1,0 +1,17 @@
+---
+tags: [gotchas]
+summary: gotchas implementation decisions and patterns
+relevantTo: [gotchas]
+importance: 0.7
+relatedFiles: []
+usageStats:
+  loaded: 69
+  referenced: 0
+  successfulFeatures: 0
+---
+# gotchas
+
+#### [Gotcha] Single-label DNS hostnames cannot reliably indicate network topology — multiple isolated networks can share identical naming patterns (2026-04-20)
+- **Situation:** Original callback URL heuristic assumed single-label hostnames (e.g., 'steamdeck') were exclusively docker-internal, but Tailscale mesh networking also uses single-label DNS for external VPN devices, causing misclassification
+- **Root cause:** Docker-internal networks and Tailscale VPN both opt for non-FQDN naming conventions; hostname patterns alone are insufficient to disambiguate network boundaries
+- **How to avoid:** Simple heuristic fails when a second network topology introduces the same naming pattern

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,7 +5,7 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 71
+  loaded: 72
   referenced: 0
   successfulFeatures: 0
 ---

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 72
-  referenced: 0
-  successfulFeatures: 0
+  loaded: 75
+  referenced: 1
+  successfulFeatures: 1
 ---
 # gotchas
 
@@ -20,3 +20,8 @@ usageStats:
 - **Situation:** Initial implementation of workspace watchers often only detects that a file changed, but doesn't handle the complex state transition of removing old registrations and adding new ones.
 - **Root cause:** A simple 'reload all' approach is inefficient and disruptive; a 'diff-and-apply' approach minimizes the impact on the running system by only touching the specific agents that changed.
 - **How to avoid:** Requires maintaining a hash or version of the agent definition to perform effective diffing.
+
+#### [Gotcha] Distinction between 'Registered Agents' and 'Synthetic Actors' in telemetry attribution. (2026-06-01)
+- **Situation:** Handling outcomes where the `systemActor` is not found in the `ExecutorRegistry`.
+- **Root cause:** Some system components act as actors but aren't formal executors. The implementation explicitly detects these 'synthetic actors', logs a warning once to prevent log flooding, and routes them to a separate `systemActorWindows` collection rather than the standard `agentWindows`.
+- **How to avoid:** Requires maintaining two separate Map collections in memory, but ensures high signal-to-noise ratio in agent health dashboards.

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 79
-  referenced: 5
-  successfulFeatures: 5
+  loaded: 80
+  referenced: 6
+  successfulFeatures: 6
 ---
 # gotchas
 

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 81
-  referenced: 7
-  successfulFeatures: 7
+  loaded: 82
+  referenced: 8
+  successfulFeatures: 8
 ---
 # gotchas
 

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 86
-  referenced: 12
-  successfulFeatures: 12
+  loaded: 87
+  referenced: 13
+  successfulFeatures: 13
 ---
 # gotchas
 

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 80
-  referenced: 6
-  successfulFeatures: 6
+  loaded: 81
+  referenced: 7
+  successfulFeatures: 7
 ---
 # gotchas
 

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 82
-  referenced: 8
-  successfulFeatures: 8
+  loaded: 83
+  referenced: 9
+  successfulFeatures: 9
 ---
 # gotchas
 
@@ -35,3 +35,7 @@ usageStats:
 - **Situation:** The `byAgent` map uses a fallback key `__anonymous__` for undefined agent names, but the registration object itself still carries the `undefined` type.
 - **Root cause:** The internal implementation logic handles the nullability by providing a default string, but the TypeScript compiler enforces strict type safety on the original property.
 - **How to avoid:** Requires explicit handling of the fallback key in both the insertion and retrieval logic to maintain type safety.
+
+#### [Gotcha] Type mismatch in array push operations involving nullable strings (2026-06-02)
+- **Situation:** In `executor-registry.ts`, a loop was pushing `r.skill` (which could be `string | null`) into `removedSkills` (a `string[]`).
+- **Root cause:** TypeScript's strict null checks prevent pushing nullable types into non-nullable arrays, which often occurs when registry metadata is partially populated or optional.

--- a/.automaker/skills/promote.md
+++ b/.automaker/skills/promote.md
@@ -1,0 +1,164 @@
+---
+description: Promote code from dev to main with automatic version bump and release. No staging branch — this repo uses feature -> dev -> main.
+category: engineering
+argument-hint: [dev-to-main]
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+  - Agent
+---
+
+# /promote — Release Promotion Pipeline
+
+You are the release promotion operator for protoWorkstacean. Your job is to move code safely through the `dev -> main` pipeline.
+
+## Release Pipeline Architecture
+
+Version bumps happen on **dev** before promotion to main.
+This eliminates sync-back conflicts entirely.
+
+```
+dev -> [prepare-release bumps version on dev] -> dev->main PR -> auto-release tags main
+```
+
+- `prepare-release.yml` — bumps version on dev based on conventional commits
+- `auto-release.yml` — tags main and creates GitHub Release after merge, then syncs back to dev
+
+## Workflow
+
+### 1. Pre-flight checks
+
+```bash
+git fetch origin dev main
+```
+
+Check divergence between dev and main:
+
+```bash
+git log --oneline origin/main..origin/dev   # what we're promoting
+git log --oneline origin/dev..origin/main   # what main has that dev doesn't
+```
+
+If main has commits dev doesn't, a sync merge is needed (see step 2).
+
+### 2. Sync merge (if needed)
+
+When main has commits that dev doesn't:
+
+1. Create a sync branch from dev:
+
+   ```bash
+   git checkout -b chore/sync-main-into-dev-$(date +%s) origin/dev
+   ```
+
+2. Merge main into it:
+
+   ```bash
+   git merge origin/main
+   ```
+
+3. If conflicts arise (typically in `package.json`):
+   - **version field**: Take the HIGHER semver
+   - Other fields: keep existing dev content
+
+4. Commit and push the sync branch
+5. Create and auto-merge a PR targeting `dev`
+6. Wait for it to merge (poll every 10s, max 5 min)
+
+### 3. Run prepare-release
+
+Before creating the dev→main promotion PR, trigger the version bump on dev:
+
+```bash
+gh workflow run prepare-release.yml --ref dev --repo protoLabsAI/protoWorkstacean
+```
+
+Wait for the workflow to complete:
+
+```bash
+# Poll every 15s, max 5 min
+for i in $(seq 1 20); do
+  STATUS=$(gh run list --workflow=prepare-release.yml --repo protoLabsAI/protoWorkstacean --limit 1 --json status --jq '.[0].status')
+  if [ "$STATUS" = "completed" ]; then
+    echo "prepare-release completed."
+    break
+  fi
+  echo "  Waiting for prepare-release... (${i}/20)"
+  sleep 15
+done
+```
+
+Check the run conclusion:
+
+```bash
+CONCLUSION=$(gh run list --workflow=prepare-release.yml --repo protoLabsAI/protoWorkstacean --limit 1 --json conclusion --jq '.[0].conclusion')
+if [ "$CONCLUSION" != "success" ]; then
+  echo "ERROR: prepare-release failed (conclusion: $CONCLUSION)"
+  exit 1
+fi
+```
+
+Then fetch the updated dev:
+
+```bash
+git fetch origin dev
+```
+
+### 4. Create the promotion PR
+
+```bash
+COMMITS=$(git log --oneline origin/main..origin/dev | head -20)
+gh pr create --base main --head dev \
+  --repo protoLabsAI/protoWorkstacean \
+  --title "promote: dev -> main" \
+  --body "## Summary
+${COMMITS}
+
+## Merge strategy
+Use **merge commit** (not squash) per branch strategy."
+```
+
+### 5. Enable auto-merge
+
+```bash
+gh pr merge <NUMBER> --auto --merge --repo protoLabsAI/protoWorkstacean
+```
+
+### 6. Monitor CI
+
+```bash
+gh pr checks <NUMBER> --watch --repo protoLabsAI/protoWorkstacean
+```
+
+Report the final status. If all checks pass and auto-merge fires, report success.
+
+### 7. Post-merge
+
+`auto-release.yml` fires automatically, tags the version, creates the GitHub Release, and syncs main back to dev. No additional action needed.
+
+## Error handling
+
+- If prepare-release fails: report the workflow run URL, do not proceed with promotion
+- If a sync PR fails CI: report the failure URL, do not proceed with promotion
+- If the promotion PR has conflicts after sync: unexpected divergence — report and stop
+- If CI fails on the promotion PR: report which check failed and the URL
+- Never force-push or use `--no-verify`
+
+## Example session
+
+```
+User: /promote
+
+Agent: Fetching branches...
+  dev is 7 commits ahead of main.
+  No divergence — clean promotion.
+  Triggering prepare-release on dev...
+  prepare-release completed — v0.8.0 bumped on dev.
+  Creating promotion PR: dev -> main...
+  PR #185 created: https://github.com/protoLabsAI/protoWorkstacean/pull/185
+  Auto-merge enabled. Watching CI...
+  All checks passed. PR auto-merged.
+  auto-release.yml will tag v0.8.0 and create the GitHub Release.
+```

--- a/docs/architecture/flow-pr-review.md
+++ b/docs/architecture/flow-pr-review.md
@@ -81,6 +81,20 @@ This is the same chokepoint-invariant shape as cooldown / target-guard / actor-f
                   ▼
             GitHub REST API
         POST /repos/{owner}/{repo}/pulls/{n}/reviews
+
+   ┌──────────────────────────────────────────────────────────────┐
+   │  Terminal-CI re-review trigger (check_suite / workflow_run)  │
+   │                                                              │
+   │  CI completes → _handleCiCompletion()                        │
+   │    1. terminal conclusion check (skip null = still running)  │
+   │    2. SHA → open PR lookup (GET /commits/{sha}/pulls/open)  │
+   │    3. stale SHA guard (skip if head.sha ≠ ci.head_sha)      │
+   │    4. formal review check (skip if Quinn already APPROVED/   │
+   │       CHANGES_REQUESTED)                                     │
+   │    5. re-dispatch _handleAutoReview(ci-review: dedup key)   │
+   │    → Quinn re-reviews → guardTerminalCi passes → formal     │
+   │      APPROVE/REQUEST_CHANGES lands                           │
+   └──────────────────────────────────────────────────────────────┘
 ```
 
 The chat-reply path (Quinn answering a comment, no verdict) still flows through `message.outbound.github.{o}.{r}.{n}` → `GitHubPlugin._postComment`. Only the formal verdict tools use the `pr-inspector.ts` backend.
@@ -120,16 +134,27 @@ sequenceDiagram
     Q->>Q: read PR diff via tools
     Q->>Q: analyze (LLM)
 
-    alt PASS
+    alt PASS (CI terminal)
         Q->>Bus: review_approve tool call → message.outbound.github.{o}.{r}.{n}
-    else WARN
-        Q->>Bus: review_comment tool call → message.outbound.github.{o}.{r}.{n}
+    else PASS (CI still running)
+        Q->>Bus: review_comment tool call → COMMENT<br/>(guardTerminalCi holds)
     else FAIL
         Q->>Bus: review_request_changes tool call → message.outbound.github.{o}.{r}.{n}
     end
 
     Bus->>GP: deliver outbound (correlationId match in pendingComments)
     GP->>GH: POST /repos/{o}/{r}/pulls/{n}/reviews
+
+    Note over GH,GP: Terminal-CI re-review path
+    GH->>GP: webhook (check_suite.completed / workflow_run.completed)
+    GP->>GP: _handleCiCompletion()<br/>terminal conclusion? SHA→PR lookup
+    GP->>GP: stale SHA guard + formal review check
+    GP->>GP: _handleAutoReview(ci-review: dedup key)
+    GP->>Bus: message.inbound.github.{o}.{r}.pull_request.{n}<br/>(skillHint=pr_review)
+    Bus->>Q: re-execute pr_review
+    Q->>Q: analyze (LLM)
+    Q->>Bus: review_approve / review_request_changes<br/>(guardTerminalCi now passes)
+    GP->>GH: POST /repos/{o}/{r}/pulls/{n}/reviews<br/>(formal APPROVE/CHANGES_REQUESTED)
 ```
 
 ---
@@ -174,6 +199,8 @@ authorLogins to drop: protoquinn[bot], ava[bot], protobot[bot], …
 ## Dedup window
 
 60s sliding window keyed by `(owner/repo, number)` ([github.ts:656](../../lib/plugins/github.ts)). Prevents fast-rebase floods (`git push --force` storms) from triggering N reviews. **Race:** if a real new commit lands within the 60s window, it doesn't trigger a review until the window clears. Acceptable today (PR review is best-effort, not real-time); revisit if it bites.
+
+**CI-completion dedup** uses a distinct prefix: `ci-review:owner/repo#N` (vs `pr-review:owner/repo#N` for commit-triggered). This allows CI completion to bypass the dedup window set by the initial review dispatch.
 
 Note this is separate from #437 cooldown (which is per-skill-per-repo and 30s) — both apply, dedup at the webhook tier and cooldown at the dispatcher tier.
 

--- a/docs/how-to/use-quinn-pr-review.md
+++ b/docs/how-to/use-quinn-pr-review.md
@@ -51,7 +51,7 @@ For a single repository: **Settings → Webhooks → Add webhook**
 | Content type | `application/json` |
 | Secret | Value of `GITHUB_WEBHOOK_SECRET` |
 | SSL verification | Enable |
-| Events | Issue comments, Issues, Pull request review comments, Pull requests |
+| Events | Issue comments, Issues, Pull request review comments, Pull requests, Check suites, Workflow runs |
 
 ### Org-level webhook (recommended)
 
@@ -69,7 +69,9 @@ gh api orgs/protoLabsAI/hooks \
   --field "events[]=issues" \
   --field "events[]=issue_comment" \
   --field "events[]=pull_request" \
-  --field "events[]=pull_request_review_comment"
+  --field "events[]=pull_request_review_comment" \
+  --field "events[]=check_suite" \
+  --field "events[]=workflow_run"
 ```
 
 ---

--- a/lib/plugins/__tests__/github-ci-completion.test.ts
+++ b/lib/plugins/__tests__/github-ci-completion.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import { GitHubPlugin } from "../github.ts";
+
+// Access private static members for testing
+const TERMINAL_CONCLUSIONS = GitHubPlugin.TERMINAL_CONCLUSIONS;
+
+describe("GitHubPlugin TERMINAL_CONCLUSIONS", () => {
+  test("contains all expected terminal conclusion values", () => {
+    expect(TERMINAL_CONCLUSIONS.has("success")).toBe(true);
+    expect(TERMINAL_CONCLUSIONS.has("failure")).toBe(true);
+    expect(TERMINAL_CONCLUSIONS.has("neutral")).toBe(true);
+    expect(TERMINAL_CONCLUSIONS.has("skipped")).toBe(true);
+    expect(TERMINAL_CONCLUSIONS.has("cancelled")).toBe(true);
+    expect(TERMINAL_CONCLUSIONS.has("timed_out")).toBe(true);
+    expect(TERMINAL_CONCLUSIONS.has("action_required")).toBe(true);
+  });
+
+  test("does NOT contain null or empty string", () => {
+    expect(TERMINAL_CONCLUSIONS.has("")).toBe(false);
+  });
+});
+
+// Test _isTerminalConclusion via reflection (private method)
+describe("GitHubPlugin._isTerminalConclusion", () => {
+  // Create a minimal plugin instance to access private method
+  function makePlugin() {
+    // Mock project registry
+    const registry = {
+      getByGithub: () => undefined,
+      getGithubCoords: () => [],
+    };
+    return new GitHubPlugin("/tmp/test-workspace", registry as any);
+  }
+
+  test("accepts all terminal string values", () => {
+    const plugin = makePlugin();
+    for (const value of TERMINAL_CONCLUSIONS) {
+      expect((plugin as any)._isTerminalConclusion(value)).toBe(true);
+    }
+  });
+
+  test("rejects null (still running)", () => {
+    const plugin = makePlugin();
+    expect((plugin as any)._isTerminalConclusion(null)).toBe(false);
+  });
+
+  test("rejects undefined", () => {
+    const plugin = makePlugin();
+    expect((plugin as any)._isTerminalConclusion(undefined)).toBe(false);
+  });
+
+  test("rejects non-string types", () => {
+    const plugin = makePlugin();
+    expect((plugin as any)._isTerminalConclusion(123)).toBe(false);
+    expect((plugin as any)._isTerminalConclusion(true)).toBe(false);
+    expect((plugin as any)._isTerminalConclusion({})).toBe(false);
+  });
+
+  test("rejects unknown string values", () => {
+    const plugin = makePlugin();
+    expect((plugin as any)._isTerminalConclusion("unknown")).toBe(false);
+    expect((plugin as any)._isTerminalConclusion("")).toBe(false);
+  });
+});
+
+// Test dedup key generation in _handleAutoReview opts
+describe("GitHubPlugin dedup key handling", () => {
+  test("ci-review prefix does not collide with pr-review prefix", () => {
+    const ciKey = "ci-review:owner/repo#42";
+    const prKey = "pr-review:owner/repo#42";
+    expect(ciKey).not.toBe(prKey);
+    expect(ciKey.startsWith("ci-review:")).toBe(true);
+    expect(prKey.startsWith("pr-review:")).toBe(true);
+  });
+});
+
+// Test webhook payload parsing for check_suite and workflow_run
+describe("CI-completion webhook payload extraction", () => {
+  test("check_suite payload contains head_sha and conclusion", () => {
+    const payload: Record<string, unknown> = {
+      action: "completed",
+      check_suite: {
+        id: 12345,
+        head_sha: "abc123def456",
+        conclusion: "success",
+        status: "completed",
+      },
+      repository: {
+        name: "test-repo",
+        owner: { login: "test-owner" },
+      },
+    };
+
+    const cs = payload.check_suite as Record<string, unknown>;
+    expect(cs.head_sha).toBe("abc123def456");
+    expect(cs.conclusion).toBe("success");
+  });
+
+  test("workflow_run payload contains head_sha and conclusion", () => {
+    const payload: Record<string, unknown> = {
+      action: "completed",
+      workflow_run: {
+        id: 67890,
+        head_sha: "def456abc123",
+        conclusion: "failure",
+        status: "completed",
+      },
+      repository: {
+        name: "test-repo",
+        owner: { login: "test-owner" },
+      },
+    };
+
+    const wr = payload.workflow_run as Record<string, unknown>;
+    expect(wr.head_sha).toBe("def456abc123");
+    expect(wr.conclusion).toBe("failure");
+  });
+
+  test("null conclusion means still running (should be skipped)", () => {
+    const payload: Record<string, unknown> = {
+      action: "completed",
+      check_suite: {
+        id: 12345,
+        head_sha: "abc123def456",
+        conclusion: null,
+        status: "completed",
+      },
+      repository: {
+        name: "test-repo",
+        owner: { login: "test-owner" },
+      },
+    };
+
+    const cs = payload.check_suite as Record<string, unknown>;
+    expect(cs.conclusion).toBeNull();
+  });
+});

--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -517,6 +517,23 @@ export class GitHubPlugin implements Plugin {
       }
     }
 
+    // ── Terminal-CI re-review: check_suite / workflow_run completed ──────────
+    // When CI finishes, resolve head SHA → open PR(s) and re-dispatch pr_review
+    // so Quinn can land a formal APPROVE/REQUEST_CHANGES (guardTerminalCi will
+    // pass now that all checks are terminal). Uses ci-review: dedup prefix to
+    // avoid collision with commit-triggered pr-review: dedup.
+    // Placed before extractContext — these events don't produce a context.
+    if (event === "check_suite" && payload.action === "completed") {
+      this._handleCiCompletion(payload, "check_suite", bus, getToken)
+        .catch((err) => console.error("[github] CI-completion (check_suite) error:", err));
+      return;
+    }
+    if (event === "workflow_run" && payload.action === "completed") {
+      this._handleCiCompletion(payload, "workflow_run", bus, getToken)
+        .catch((err) => console.error("[github] CI-completion (workflow_run) error:", err));
+      return;
+    }
+
     const ctx = extractContext(event, payload);
     if (!ctx) return;
 
@@ -661,10 +678,10 @@ export class GitHubPlugin implements Plugin {
     ctx: GitHubEventContext,
     bus: EventBus,
     getToken: (owner: string, repo: string) => Promise<string>,
-    opts: { skipDedup: boolean } = { skipDedup: false },
+    opts: { skipDedup: boolean; dedupKey?: string } = { skipDedup: false },
   ): void {
     const action = payload.action as string;
-    const dedupKey = `pr-review:${ctx.owner}/${ctx.repo}#${ctx.number}`;
+    const dedupKey = opts.dedupKey ?? `pr-review:${ctx.owner}/${ctx.repo}#${ctx.number}`;
     if (!opts.skipDedup) {
       const lastDispatched = this.recentDispatches.get(dedupKey);
       if (lastDispatched && Date.now() - lastDispatched < GitHubPlugin.DEDUP_WINDOW_MS) {
@@ -791,6 +808,214 @@ export class GitHubPlugin implements Plugin {
       }
     } catch (err) {
       console.error("[github] Error posting comment:", err);
+    }
+  }
+
+  /** Terminal CI conclusions — null means "still running". */
+  private static readonly TERMINAL_CONCLUSIONS = new Set([
+    "success", "failure", "neutral", "skipped", "cancelled", "timed_out", "action_required",
+  ]);
+
+  private _isTerminalConclusion(conclusion: unknown): boolean {
+    return typeof conclusion === "string" && GitHubPlugin.TERMINAL_CONCLUSIONS.has(conclusion);
+  }
+
+  /**
+   * Resolve open PR(s) at a given head SHA.
+   * Calls GET /repos/{owner}/{repo}/commits/{sha}/pulls/open
+   */
+  private async _resolvePrsForSha(
+    getToken: (owner: string, repo: string) => Promise<string>,
+    owner: string,
+    repo: string,
+    sha: string,
+  ): Promise<Array<{ number: number; sha: string }>> {
+    try {
+      const token = await getToken(owner, repo);
+      const url = `https://api.github.com/repos/${owner}/${repo}/commits/${encodeURIComponent(sha)}/pulls/open`;
+      const res = await withCircuitBreaker("github-api", () =>
+        fetch(url, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "User-Agent": "protoWorkstacean/1.0",
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+        }),
+      );
+      if (!res.ok) {
+        console.warn(`[github] CI-completion: SHA→PR lookup failed ${res.status} for ${owner}/${repo}@${sha}`);
+        return [];
+      }
+      const prs = (await res.json()) as Array<Record<string, unknown>>;
+      return prs.map((pr) => ({
+        number: pr.number as number,
+        sha: (pr.head as Record<string, unknown>)?.sha as string,
+      }));
+    } catch (err) {
+      console.warn(`[github] CI-completion: SHA→PR lookup error for ${owner}/${repo}@${sha}:`, err);
+      return [];
+    }
+  }
+
+  /**
+   * Check whether Quinn already has a formal (non-COMMENT) review on the PR.
+   * Returns true if APPROVED or CHANGES_REQUESTED review exists by protoquinn[bot].
+   */
+  private async _hasFormalQuinnReview(
+    getToken: (owner: string, repo: string) => Promise<string>,
+    owner: string,
+    repo: string,
+    prNumber: number,
+  ): Promise<boolean> {
+    try {
+      const token = await getToken(owner, repo);
+      const url = `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/reviews`;
+      const res = await withCircuitBreaker("github-api", () =>
+        fetch(url, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "User-Agent": "protoWorkstacean/1.0",
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+        }),
+      );
+      if (!res.ok) {
+        console.warn(`[github] CI-completion: review lookup failed ${res.status} for ${owner}/${repo}#${prNumber}`);
+        return false;
+      }
+      const reviews = (await res.json()) as Array<Record<string, unknown>>;
+      const quinnReview = reviews.find((r) => {
+        const login = ((r.user as Record<string, unknown> | undefined)?.login as string | undefined)?.toLowerCase();
+        return login === "protoquinn" || login === "protoquinn[bot]";
+      });
+      const quinnState = (quinnReview ?? {}).state as string | undefined;
+      return quinnState === "APPROVED" || quinnState === "CHANGES_REQUESTED";
+    } catch (err) {
+      console.warn(`[github] CI-completion: review lookup error for ${owner}/${repo}#${prNumber}:`, err);
+      return false;
+    }
+  }
+
+  /**
+   * Handle CI-completion webhook events (check_suite.completed / workflow_run.completed).
+   * Resolves head SHA → open PR(s) and re-dispatches pr_review through _handleAutoReview.
+   */
+  private async _handleCiCompletion(
+    payload: Record<string, unknown>,
+    eventType: "check_suite" | "workflow_run",
+    bus: EventBus,
+    getToken: (owner: string, repo: string) => Promise<string>,
+  ): Promise<void> {
+    const ciObject = eventType === "check_suite"
+      ? payload.check_suite as Record<string, unknown> | undefined
+      : payload.workflow_run as Record<string, unknown> | undefined;
+
+    if (!ciObject) {
+      console.warn(`[github] CI-completion: missing ${eventType} object in payload`);
+      return;
+    }
+
+    const headSha = ciObject.head_sha as string | undefined;
+    const repo = payload.repository as Record<string, unknown> | undefined;
+    const owner = ((repo?.owner as Record<string, unknown> | undefined)?.login as string) ?? "";
+    const repoName = (repo?.name as string) ?? "";
+
+    if (!headSha || !owner || !repoName) {
+      console.warn(`[github] CI-completion: missing head_sha or repo info (${eventType})`);
+      return;
+    }
+
+    // Only trigger on terminal conclusions (null = still running)
+    const conclusion = ciObject.conclusion as string | null | undefined;
+    if (!this._isTerminalConclusion(conclusion)) {
+      console.log(`[github] CI-completion: non-terminal conclusion "${conclusion}" — skipping (${eventType})`);
+      return;
+    }
+
+    // Resolve SHA → open PRs
+    const prs = await this._resolvePrsForSha(getToken, owner, repoName, headSha);
+    if (prs.length === 0) {
+      console.log(`[github] CI-completion: no open PRs at ${owner}/${repoName}@${headSha.slice(0, 7)}`);
+      return;
+    }
+
+    for (const pr of prs) {
+      // Stale SHA guard — skip if CI result is for a superseded commit
+      if (pr.sha !== headSha) {
+        console.log(`[github] CI-completion: stale SHA for ${owner}/${repoName}#${pr.number} (expected ${headSha.slice(0, 7)}, got ${pr.sha.slice(0, 7)})`);
+        continue;
+      }
+
+      // Skip if Quinn already has a formal review
+      if (await this._hasFormalQuinnReview(getToken, owner, repoName, pr.number)) {
+        console.log(`[github] CI-completion: Quinn already has formal review on ${owner}/${repoName}#${pr.number} — skipping`);
+        continue;
+      }
+
+      // Fetch PR details to build context
+      const prDetail = await this._fetchPrDetail(getToken, owner, repoName, pr.number);
+      if (!prDetail) continue;
+
+      const ctx: GitHubEventContext = {
+        owner,
+        repo: repoName,
+        number: pr.number,
+        title: prDetail.title as string,
+        url: prDetail.html_url as string,
+        body: (prDetail.body as string | null) ?? "",
+        author: ((prDetail.user as Record<string, unknown> | undefined)?.login as string) ?? "",
+      };
+
+      const syntheticPayload: Record<string, unknown> = {
+        action: "ci_completed",
+        pull_request: {
+          draft: prDetail.draft,
+          head: { sha: headSha },
+          title: ctx.title,
+          html_url: ctx.url,
+          body: ctx.body,
+          user: prDetail.user,
+        },
+      };
+
+      this._handleAutoReview(
+        eventType,
+        syntheticPayload,
+        ctx,
+        bus,
+        getToken,
+        { skipDedup: true, dedupKey: `ci-review:${owner}/${repoName}#${pr.number}` },
+      );
+    }
+  }
+
+  /** Fetch full PR detail from GitHub API. */
+  private async _fetchPrDetail(
+    getToken: (owner: string, repo: string) => Promise<string>,
+    owner: string,
+    repo: string,
+    prNumber: number,
+  ): Promise<Record<string, unknown> | null> {
+    try {
+      const token = await getToken(owner, repo);
+      const url = `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}`;
+      const res = await withCircuitBreaker("github-api", () =>
+        fetch(url, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "User-Agent": "protoWorkstacean/1.0",
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+        }),
+      );
+      if (!res.ok) {
+        console.warn(`[github] CI-completion: PR detail fetch failed ${res.status} for ${owner}/${repo}#${prNumber}`);
+        return null;
+      }
+      return (await res.json()) as Record<string, unknown>;
+    } catch (err) {
+      console.warn(`[github] CI-completion: PR detail fetch error for ${owner}/${repo}#${prNumber}:`, err);
+      return null;
     }
   }
 }

--- a/src/api/__tests__/pr-inspector-ci-guard.test.ts
+++ b/src/api/__tests__/pr-inspector-ci-guard.test.ts
@@ -34,6 +34,11 @@ let ciForbidden: boolean;
 let ciPatFallbackSucceeds: boolean;
 // Track which tokens were used for check-runs calls (for test assertions)
 let checkRunsTokensUsed: string[];
+// When true, the PR detail endpoint returns 403 for the App token.
+// The PAT fallback succeeds if ciPatFallbackSucceeds is also true.
+let prDetailForbidden: boolean;
+// Track which tokens were used for PR detail calls (for test assertions)
+let prDetailTokensUsed: string[];
 
 function ctx(): ApiContext {
   return { bus: new InMemoryEventBus(), executorRegistry: {} as never } as unknown as ApiContext;
@@ -65,6 +70,8 @@ beforeEach(() => {
   ciForbidden = false;
   ciPatFallbackSucceeds = false;
   checkRunsTokensUsed = [];
+  prDetailForbidden = false;
+  prDetailTokensUsed = [];
   origFetch = globalThis.fetch;
 
   globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
@@ -76,6 +83,12 @@ beforeEach(() => {
 
     // PR detail → head SHA
     if (url.endsWith(`/pulls/${PR}`) && method === "GET") {
+      prDetailTokensUsed.push(token);
+      if (prDetailForbidden && token === "test-token") return new Response("Forbidden", { status: 403 });
+      if (prDetailForbidden && ciPatFallbackSucceeds && token !== "test-token") {
+        return new Response(JSON.stringify({ head: { sha: HEAD_SHA } }), { status: 200 });
+      }
+      if (prDetailForbidden) return new Response("Forbidden", { status: 403 });
       return new Response(JSON.stringify({ head: { sha: HEAD_SHA } }), { status: 200 });
     }
     // check-runs for head SHA

--- a/src/api/__tests__/pr-inspector-ci-guard.test.ts
+++ b/src/api/__tests__/pr-inspector-ci-guard.test.ts
@@ -29,6 +29,11 @@ let origFetch: typeof globalThis.fetch;
 // When true, the check-runs endpoint returns 403 — the reviewer-can't-see-CI
 // access gap (#fix: CI-403 → Gap, not a blocking FAIL).
 let ciForbidden: boolean;
+// When true, the PAT fallback (detected by a different token) succeeds even
+// when the App token is forbidden. Used to verify the PAT fallback path.
+let ciPatFallbackSucceeds: boolean;
+// Track which tokens were used for check-runs calls (for test assertions)
+let checkRunsTokensUsed: string[];
 
 function ctx(): ApiContext {
   return { bus: new InMemoryEventBus(), executorRegistry: {} as never } as unknown as ApiContext;
@@ -58,11 +63,16 @@ beforeEach(() => {
   checkRuns = [];
   reviewsPosted = [];
   ciForbidden = false;
+  ciPatFallbackSucceeds = false;
+  checkRunsTokensUsed = [];
   origFetch = globalThis.fetch;
 
   globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
     const method = init?.method ?? "GET";
+    const authHeader = (init?.headers as Record<string, string> | Headers | undefined)?.Authorization
+      ?? (init?.headers instanceof Headers ? init.headers.get("Authorization") : "");
+    const token = typeof authHeader === "string" ? authHeader.replace("Bearer ", "") : "";
 
     // PR detail → head SHA
     if (url.endsWith(`/pulls/${PR}`) && method === "GET") {
@@ -70,6 +80,13 @@ beforeEach(() => {
     }
     // check-runs for head SHA
     if (url.includes(`/commits/${HEAD_SHA}/check-runs`)) {
+      checkRunsTokensUsed.push(token);
+      // ciForbidden applies to the App token (test-token); if PAT fallback
+      // is enabled and the token is NOT the app token, succeed.
+      if (ciForbidden && token === "test-token") return new Response("Forbidden", { status: 403 });
+      if (ciForbidden && ciPatFallbackSucceeds && token !== "test-token") {
+        return new Response(JSON.stringify({ check_runs: checkRuns }), { status: 200 });
+      }
       if (ciForbidden) return new Response("Forbidden", { status: 403 });
       return new Response(JSON.stringify({ check_runs: checkRuns }), { status: 200 });
     }
@@ -81,11 +98,15 @@ beforeEach(() => {
     }
     throw new Error(`unexpected fetch in test: ${method} ${url}`);
   }) as typeof globalThis.fetch;
+
+  // Set GITHUB_TOKEN for PAT fallback tests
+  process.env.GITHUB_TOKEN = "test-pat-token";
 });
 
 afterEach(() => {
   globalThis.fetch = origFetch;
   setGithubAuthForTesting(undefined); // reset to lazy makeGitHubAuth()
+  delete process.env.GITHUB_TOKEN;
 });
 
 const PENDING: CheckRun[] = [
@@ -205,5 +226,89 @@ describe("pr-inspector CI inaccessible (403) → Gap, not a blocking FAIL", () =
     }), {});
     expect(res.status).toBe(200);
     expect(reviewsPosted).toEqual([{ event: "COMMENT", body: "review with CI-access gap noted" }]);
+  });
+});
+
+describe("pr-inspector CI 403 → PAT fallback succeeds", () => {
+  beforeEach(() => {
+    ciForbidden = true;
+    ciPatFallbackSucceeds = true;
+  });
+
+  test("check_ci succeeds via PAT fallback when App token is 403", async () => {
+    checkRuns = TERMINAL_GREEN;
+    const res = await getHandler()(inspect({
+      action: "check_ci", repo: REPO, pr_number: PR,
+    }), {});
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { success: boolean; data: { result: string } };
+    expect(json.success).toBe(true);
+    expect(json.data.result).toContain("CI Checks for PR#42");
+    expect(json.data.result).toContain("success");
+    // Verify both tokens were tried: App first, then PAT
+    expect(checkRunsTokensUsed).toHaveLength(2);
+    expect(checkRunsTokensUsed[0]).toBe("test-token");
+    expect(checkRunsTokensUsed[1]).toBe("test-pat-token");
+  });
+
+  test("APPROVE proceeds via PAT fallback when CI is terminal (no 409)", async () => {
+    checkRuns = TERMINAL_GREEN;
+    const res = await getHandler()(inspect({
+      action: "review_approve", repo: REPO, pr_number: PR,
+    }), {});
+    expect(res.status).toBe(200);
+    expect(reviewsPosted).toEqual([{ event: "APPROVE", body: "" }]);
+  });
+
+  test("REQUEST_CHANGES proceeds via PAT fallback when CI is terminal", async () => {
+    checkRuns = TERMINAL_RED;
+    const res = await getHandler()(inspect({
+      action: "review_request_changes", repo: REPO, pr_number: PR, body: "test failed",
+    }), {});
+    expect(res.status).toBe(200);
+    expect(reviewsPosted).toEqual([{ event: "REQUEST_CHANGES", body: "test failed" }]);
+  });
+
+  test("APPROVE held with 409 when CI is still pending (even via PAT fallback)", async () => {
+    checkRuns = PENDING;
+    const res = await getHandler()(inspect({
+      action: "review_approve", repo: REPO, pr_number: PR,
+    }), {});
+    expect(res.status).toBe(409);
+    expect(reviewsPosted).toHaveLength(0);
+  });
+});
+
+describe("pr-inspector CI 403 → no PAT → Gap (unchanged behavior)", () => {
+  test("check_ci returns Gap when App is 403 and no PAT is configured", async () => {
+    ciForbidden = true;
+    ciPatFallbackSucceeds = false;
+    delete process.env.GITHUB_TOKEN;
+    const res = await getHandler()(inspect({
+      action: "check_ci", repo: REPO, pr_number: PR,
+    }), {});
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { success: boolean; data: { result: string } };
+    expect(json.success).toBe(true);
+    expect(json.data.result).toContain("not accessible");
+    expect(json.data.result).toContain("403");
+    expect(json.data.result).toContain("Gap");
+    // Only the App token was tried (no PAT to fall back to)
+    expect(checkRunsTokensUsed).toHaveLength(1);
+    expect(checkRunsTokensUsed[0]).toBe("test-token");
+  });
+
+  test("check_ci returns Gap when both App and PAT are 403", async () => {
+    ciForbidden = true;
+    ciPatFallbackSucceeds = false; // PAT also returns 403
+    const res = await getHandler()(inspect({
+      action: "check_ci", repo: REPO, pr_number: PR,
+    }), {});
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { success: boolean; data: { result: string } };
+    expect(json.success).toBe(true);
+    expect(json.data.result).toContain("not accessible");
+    // Both tokens were tried
+    expect(checkRunsTokensUsed).toHaveLength(2);
   });
 });

--- a/src/api/pr-inspector.ts
+++ b/src/api/pr-inspector.ts
@@ -224,43 +224,79 @@ class CiAccessError extends Error {
  * throws a generic Error on any other GitHub error so the caller surfaces it
  * loudly rather than treating an unknown CI state as "all clear".
  *
- * When the App installation token gets 403 on check-runs, falls back to the
- * GITHUB_TOKEN PAT (which typically has broader read access) before giving up.
+ * When the App installation token gets 403 on the PR detail or check-runs,
+ * falls back to the GITHUB_TOKEN PAT (which typically has broader read
+ * access) before giving up. If PAT was used for the PR detail, check-runs
+ * skips the App attempt and goes straight to PAT to avoid a redundant 403.
  */
 async function fetchCheckRuns(
   owner: string,
   name: string,
   pr: number,
 ): Promise<{ headSha: string; runs: CheckRun[] }> {
-  const prResp = await ghFetch(owner, name, `https://api.github.com/repos/${owner}/${name}/pulls/${pr}`);
-  if (prResp.status === 403) throw new CiAccessError(403, `GitHub 403 fetching PR#${pr} in ${owner}/${name} — reviewer token lacks access`);
-  if (!prResp.ok) throw new Error(`GitHub API error fetching PR#${pr}: ${prResp.status} ${await prResp.text()}`);
+  const prUrl = `https://api.github.com/repos/${owner}/${name}/pulls/${pr}`;
+
+  // Try the App installation token first
+  let prResp = await ghFetch(owner, name, prUrl);
+  let usedPat = false;
+
+  // If the App token gets 403 on the PR detail, try the PAT as a fallback.
+  // The PAT typically has broader repo read access than an App installation
+  // token that may lack pull:read permission.
+  if (prResp.status === 403) {
+    const patResp = await ghFetchWithPat(owner, name, prUrl);
+    if (patResp) {
+      prResp = patResp;
+      usedPat = true;
+      if (prResp.status === 403) {
+        throw new CiAccessError(403, `GitHub 403 fetching PR#${pr} in ${owner}/${name} — both App and PAT tokens lack access`);
+      }
+      if (!prResp.ok) {
+        throw new Error(`GitHub API error fetching PR#${pr} (PAT fallback): ${prResp.status} ${await prResp.text()}`);
+      }
+      console.log(`[pr-inspector] PR#${pr} for ${owner}/${name} succeeded via PAT fallback after App 403`);
+    } else {
+      // No PAT available — throw the CiAccessError for the original 403
+      throw new CiAccessError(403, `GitHub 403 fetching PR#${pr} in ${owner}/${name} — reviewer token lacks access`);
+    }
+  } else if (!prResp.ok) {
+    throw new Error(`GitHub API error fetching PR#${pr}: ${prResp.status} ${await prResp.text()}`);
+  }
+
   const { head } = (await prResp.json()) as { head: { sha: string } };
 
   const checksUrl = `https://api.github.com/repos/${owner}/${name}/commits/${head.sha}/check-runs?per_page=100`;
 
-  // Try the App installation token first
-  let checksResp = await ghFetch(owner, name, checksUrl);
-
-  // If the App token gets 403 on check-runs, try the PAT as a fallback.
-  // The PAT typically has broader repo read access than an App installation
-  // token that may lack checks:read permission.
-  if (checksResp.status === 403) {
+  // If the PR detail was read via PAT, skip the App attempt for check-runs
+  // and go straight to PAT — the App token will get the same 403.
+  let checksResp: Response;
+  if (usedPat) {
     const patResp = await ghFetchWithPat(owner, name, checksUrl);
-    if (patResp) {
-      checksResp = patResp;
-      if (checksResp.status === 403) {
-        throw new CiAccessError(403, `GitHub 403 fetching check-runs for ${owner}/${name}#${pr} — both App and PAT tokens lack access`);
-      }
-      if (!checksResp.ok) {
-        throw new Error(`GitHub API error fetching check-runs (PAT fallback): ${checksResp.status} ${await checksResp.text()}`);
-      }
-      const { check_runs } = (await checksResp.json()) as { check_runs: CheckRun[] };
-      console.log(`[pr-inspector] check-runs for ${owner}/${name}#${pr} succeeded via PAT fallback after App 403`);
-      return { headSha: head.sha, runs: check_runs };
+    if (!patResp) {
+      throw new CiAccessError(403, `GitHub 403 fetching check-runs for ${owner}/${name}#${pr} — PAT not available`);
     }
-    // No PAT available — throw the CiAccessError for the original 403
-    throw new CiAccessError(403, `GitHub 403 fetching check-runs for ${owner}/${name}#${pr} — reviewer token lacks access`);
+    checksResp = patResp;
+  } else {
+    checksResp = await ghFetch(owner, name, checksUrl);
+
+    // If the App token gets 403 on check-runs, try the PAT as a fallback.
+    if (checksResp.status === 403) {
+      const patResp = await ghFetchWithPat(owner, name, checksUrl);
+      if (patResp) {
+        checksResp = patResp;
+        if (checksResp.status === 403) {
+          throw new CiAccessError(403, `GitHub 403 fetching check-runs for ${owner}/${name}#${pr} — both App and PAT tokens lack access`);
+        }
+        if (!checksResp.ok) {
+          throw new Error(`GitHub API error fetching check-runs (PAT fallback): ${checksResp.status} ${await checksResp.text()}`);
+        }
+        const { check_runs } = (await checksResp.json()) as { check_runs: CheckRun[] };
+        console.log(`[pr-inspector] check-runs for ${owner}/${name}#${pr} succeeded via PAT fallback after App 403`);
+        return { headSha: head.sha, runs: check_runs };
+      }
+      // No PAT available — throw the CiAccessError for the original 403
+      throw new CiAccessError(403, `GitHub 403 fetching check-runs for ${owner}/${name}#${pr} — reviewer token lacks access`);
+    }
   }
 
   if (!checksResp.ok) throw new Error(`GitHub API error fetching check-runs: ${checksResp.status} ${await checksResp.text()}`);

--- a/src/api/pr-inspector.ts
+++ b/src/api/pr-inspector.ts
@@ -124,6 +124,32 @@ async function ghFetch(
 }
 
 /**
+ * Fetch using the raw GITHUB_TOKEN PAT directly (bypassing the App token).
+ * Used as a fallback when the App installation token lacks permission to read
+ * check-runs (403). The PAT typically has broader repo read access.
+ */
+async function ghFetchWithPat(
+  owner: string,
+  name: string,
+  url: string,
+  init: RequestInit = {},
+): Promise<Response | null> {
+  const pat = process.env.GITHUB_TOKEN;
+  if (!pat) return null;
+  return fetch(url, {
+    ...init,
+    signal: init.signal ?? AbortSignal.timeout(GH_FETCH_TIMEOUT_MS),
+    headers: {
+      ...(init.headers ?? {}),
+      Authorization: `Bearer ${pat}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "protoquinn",
+    },
+  });
+}
+
+/**
  * Verify whether a path exists in a repo at a given ref. Read-only, single
  * GitHub call — used by Quinn to check cross-repo assumptions a diff depends
  * on (a `COPY --from` source path, a filtered workspace package directory, a
@@ -197,6 +223,9 @@ class CiAccessError extends Error {
  * the pending set). Throws `CiAccessError` on a 403 (reviewer can't see CI);
  * throws a generic Error on any other GitHub error so the caller surfaces it
  * loudly rather than treating an unknown CI state as "all clear".
+ *
+ * When the App installation token gets 403 on check-runs, falls back to the
+ * GITHUB_TOKEN PAT (which typically has broader read access) before giving up.
  */
 async function fetchCheckRuns(
   owner: string,
@@ -208,12 +237,32 @@ async function fetchCheckRuns(
   if (!prResp.ok) throw new Error(`GitHub API error fetching PR#${pr}: ${prResp.status} ${await prResp.text()}`);
   const { head } = (await prResp.json()) as { head: { sha: string } };
 
-  const checksResp = await ghFetch(
-    owner,
-    name,
-    `https://api.github.com/repos/${owner}/${name}/commits/${head.sha}/check-runs?per_page=100`,
-  );
-  if (checksResp.status === 403) throw new CiAccessError(403, `GitHub 403 fetching check-runs for ${owner}/${name}#${pr} — reviewer token lacks access`);
+  const checksUrl = `https://api.github.com/repos/${owner}/${name}/commits/${head.sha}/check-runs?per_page=100`;
+
+  // Try the App installation token first
+  let checksResp = await ghFetch(owner, name, checksUrl);
+
+  // If the App token gets 403 on check-runs, try the PAT as a fallback.
+  // The PAT typically has broader repo read access than an App installation
+  // token that may lack checks:read permission.
+  if (checksResp.status === 403) {
+    const patResp = await ghFetchWithPat(owner, name, checksUrl);
+    if (patResp) {
+      checksResp = patResp;
+      if (checksResp.status === 403) {
+        throw new CiAccessError(403, `GitHub 403 fetching check-runs for ${owner}/${name}#${pr} — both App and PAT tokens lack access`);
+      }
+      if (!checksResp.ok) {
+        throw new Error(`GitHub API error fetching check-runs (PAT fallback): ${checksResp.status} ${await checksResp.text()}`);
+      }
+      const { check_runs } = (await checksResp.json()) as { check_runs: CheckRun[] };
+      console.log(`[pr-inspector] check-runs for ${owner}/${name}#${pr} succeeded via PAT fallback after App 403`);
+      return { headSha: head.sha, runs: check_runs };
+    }
+    // No PAT available — throw the CiAccessError for the original 403
+    throw new CiAccessError(403, `GitHub 403 fetching check-runs for ${owner}/${name}#${pr} — reviewer token lacks access`);
+  }
+
   if (!checksResp.ok) throw new Error(`GitHub API error fetching check-runs: ${checksResp.status} ${await checksResp.text()}`);
   const { check_runs } = (await checksResp.json()) as { check_runs: CheckRun[] };
   return { headSha: head.sha, runs: check_runs };

--- a/workspace/ceremonies/roxy.board-pulse.yaml
+++ b/workspace/ceremonies/roxy.board-pulse.yaml
@@ -3,19 +3,17 @@ name: Roxy Board Pulse
 description: >
   Recurring board pulse for Roxy's managed projects. On each fire she runs her
   board_sweep skill: pulls the briefing (events since last look), reacts to what
-  matters — PR/CI → Quinn (pr_review), blocked/escalated → fix-or-escalate, stuck
-  in_progress → steer/reset, auto-mode paused → diagnose/restart, bug/triage →
-  Quinn — keeps auto-mode running on projects with ready work, updates her
-  cross-project ledger, and reports what she saw + did. This is Roxy's event
-  subscription: the fleet owns the cadence (this ceremony), she owns the reaction.
+  matters (PR/CI → Quinn, blocked/escalated → fix-or-escalate, stuck in_progress
+  → steer/reset, auto-mode paused → diagnose/restart, bug → Quinn), keeps
+  auto-mode running on projects with ready work, updates her cross-project
+  ledger, and reports. Roxy's event subscription — the fleet owns the cadence,
+  she owns the reaction.
 
-  Routes DIRECTLY to roxy (board_sweep is hers) — never targets [all], which 404s
-  on every agent that doesn't advertise the skill (see agent-health/board.retro).
-schedule: "0 * * * *" # hourly — tune up/down as real board volume grows
+  Routes DIRECTLY to roxy (board_sweep is hers) — never targets [all], which
+  404s on agents that don't advertise the skill.
+schedule: "0 * * * *" # hourly — tune up/down as board volume grows
 skill: board_sweep
 targets:
   - roxy
 notifyChannel: "" # set a Discord slug to post the sweep summary
-# Paused 2026-06-04: no managed projects yet (test portfolio ditched). Flip back
-# to true once Roxy has a real project with a protoMaker board.
-enabled: false
+enabled: true

--- a/workspace/ceremonies/roxy.board-pulse.yaml
+++ b/workspace/ceremonies/roxy.board-pulse.yaml
@@ -1,0 +1,19 @@
+id: roxy.board-pulse
+name: Roxy Board Pulse
+description: >
+  Recurring board pulse for Roxy's managed projects. On each fire she runs her
+  board_sweep skill: pulls the briefing (events since last look), reacts to what
+  matters — PR/CI → Quinn (pr_review), blocked/escalated → fix-or-escalate, stuck
+  in_progress → steer/reset, auto-mode paused → diagnose/restart, bug/triage →
+  Quinn — keeps auto-mode running on projects with ready work, updates her
+  cross-project ledger, and reports what she saw + did. This is Roxy's event
+  subscription: the fleet owns the cadence (this ceremony), she owns the reaction.
+
+  Routes DIRECTLY to roxy (board_sweep is hers) — never targets [all], which 404s
+  on every agent that doesn't advertise the skill (see agent-health/board.retro).
+schedule: "0 * * * *" # hourly — tune up/down as real board volume grows
+skill: board_sweep
+targets:
+  - roxy
+notifyChannel: "" # set a Discord slug to post the sweep summary
+enabled: true

--- a/workspace/ceremonies/roxy.board-pulse.yaml
+++ b/workspace/ceremonies/roxy.board-pulse.yaml
@@ -16,4 +16,6 @@ skill: board_sweep
 targets:
   - roxy
 notifyChannel: "" # set a Discord slug to post the sweep summary
-enabled: true
+# Paused 2026-06-04: no managed projects yet (test portfolio ditched). Flip back
+# to true once Roxy has a real project with a protoMaker board.
+enabled: false


### PR DESCRIPTION
Adds the recurring trigger for Roxy's event subscription on her managed projects. Hourly cron (`0 * * * *`) dispatches her `board_sweep` skill, routed **directly to `roxy`** (not `[all]` — `board_sweep` is hers; broadcasting 404s on agents that don't advertise it, per the disabled `agent-health`/`board.retro` ceremonies).

On each fire Roxy pulls the briefing and reacts to the events that matter (PR/CI → Quinn pr_review, blocked/escalated → fix-or-escalate, stuck in_progress → steer/reset, auto-mode paused → diagnose/restart, bug → Quinn bug_triage), keeps auto-mode running on projects with ready work, and reports. The reaction logic lives in Roxy's `project-operations` skill (roxy#38); this ceremony owns the cadence.

**Verified live** — hot-reloaded into the running service; test-fired via `/api/ceremonies/roxy.board-pulse/run` and the 09:00 cron both dispatched to roxy, who executed the sweep with A2A callbacks and no "No executor found" errors. Tune the schedule as board volume grows; set `notifyChannel` to post sweep summaries to Discord.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release-promotion pipeline for moving changes dev→main with automatic version bump, post-merge tagging/sync, and optional sync-merge flow.
  * CI completion now triggers automated PR re-evaluation and formal verdict posting.
  * Hourly board-sweep ceremony for status monitoring and steering.

* **Documentation**
  * Expanded webhook and PR-review flow docs with CI-completion re-review guidance and promotion workflow instructions.

* **Tests**
  * Added tests for CI completion behaviors, terminal conclusions, and auth fallback paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->