### PR TITLE
chore(logging): migrate dispatch-spine console.* to structured logger

### DIFF
--- a/src/agent-runtime/agent-runtime-plugin.ts
+++ b/src/agent-runtime/agent-runtime-plugin.ts
@@ -38,6 +38,9 @@ import { WorkspaceWatcher } from "../../lib/workspace-watcher.ts";
 import { computeAgentDiff, hashDefinition } from "./agent-diff.ts";
 import { existsSync } from "node:fs";
 import { join, basename } from "node:path";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("agent-runtime");
 
 export interface AgentRuntimeConfig {
   workspaceDir: string;
@@ -142,12 +145,12 @@ export class AgentRuntimePlugin implements Plugin {
     for (const { def, file } of entries) {
       counts[def.runtime ?? "deep-agent"] += 1;
       this._register(def, file);
-      console.log(`[agent-runtime] Loaded agent "${def.name}" (${def.role}, model: ${def.model})`);
+      log.info(`Loaded agent "${def.name}" (${def.role}, model: ${def.model})`);
     }
 
     const agentNames = entries.map(e => `${e.def.name}(${e.def.runtime ?? "deep-agent"})`).join(", ") || "(none)";
-    console.log(
-      `[agent-runtime] Registered ${entries.length} agent(s) ` +
+    log.info(
+      `Registered ${entries.length} agent(s) ` +
       `[deep-agent: ${counts["deep-agent"]}, proto-sdk: ${counts["proto-sdk"]}]: ${agentNames}`,
     );
 
@@ -232,7 +235,7 @@ export class AgentRuntimePlugin implements Plugin {
     try {
       entries = loadAgentEntries(this.config.workspaceDir);
     } catch (err) {
-      console.error(`[agent-runtime] reload failed: ${err instanceof Error ? err.message : String(err)}`);
+      log.error(`reload failed: ${err instanceof Error ? err.message : String(err)}`);
       return;
     }
 
@@ -244,8 +247,8 @@ export class AgentRuntimePlugin implements Plugin {
       const reg = this.registered.get(name);
       if (!reg) continue;
       if (existsSync(reg.file)) {
-        console.warn(
-          `[agent-runtime] "${name}" no longer parses from ${basename(reg.file)} — keeping the running instance (fix or delete the file)`,
+        log.warn(
+          `"${name}" no longer parses from ${basename(reg.file)} — keeping the running instance (fix or delete the file)`,
         );
         continue;
       }
@@ -254,7 +257,7 @@ export class AgentRuntimePlugin implements Plugin {
 
     for (const def of diff.added) {
       this._register(def, fileByName.get(def.name) ?? "");
-      console.log(`[agent-runtime] + "${def.name}" hot-added (${def.skills.length} skill(s)) — no restart`);
+      log.info(`+ "${def.name}" hot-added (${def.skills.length} skill(s)) — no restart`);
     }
 
     for (const def of diff.changed) {
@@ -263,7 +266,7 @@ export class AgentRuntimePlugin implements Plugin {
       for (const skill of old.skills) this.executorRegistry.unregister(skill, def.name);
       this._register(def, fileByName.get(def.name) ?? old.file);
       this._disposeExecutor(def.name, old.executor);
-      console.log(`[agent-runtime] ~ "${def.name}" reloaded (${def.skills.length} skill(s)) — no restart`);
+      log.info(`~ "${def.name}" reloaded (${def.skills.length} skill(s)) — no restart`);
     }
 
     // An agent may have just gained a `memory` block via the live edit — start
@@ -275,7 +278,7 @@ export class AgentRuntimePlugin implements Plugin {
     for (const skill of reg.skills) this.executorRegistry.unregister(skill, name);
     this.registered.delete(name);
     this._disposeExecutor(name, reg.executor);
-    console.log(`[agent-runtime] - "${name}" hot-removed (${reg.skills.length} skill(s) unregistered) — no restart`);
+    log.info(`- "${name}" hot-removed (${reg.skills.length} skill(s) unregistered) — no restart`);
   }
 
   /** Best-effort executor teardown — never blocks the apply or aborts in-flight work. */
@@ -283,7 +286,7 @@ export class AgentRuntimePlugin implements Plugin {
     void Promise.resolve()
       .then(() => executor.dispose?.())
       .catch((err) =>
-        console.warn(`[agent-runtime] dispose("${name}") failed: ${err instanceof Error ? err.message : String(err)}`),
+        log.warn(`dispose("${name}") failed: ${err instanceof Error ? err.message : String(err)}`),
       );
   }
 
@@ -328,7 +331,7 @@ export class AgentRuntimePlugin implements Plugin {
         },
       });
     } catch (err) {
-      console.warn(`[agent-runtime] tool.call publish failed for ${event.agentName}:`, err);
+      log.warn(`tool.call publish failed for ${event.agentName}`, { err });
     }
 
     // Also emit real streaming progress: a2a-server translates
@@ -347,7 +350,7 @@ export class AgentRuntimePlugin implements Plugin {
         payload: { text, step: "tool_call", meta: { tools: event.toolNames } },
       });
     } catch (err) {
-      console.warn(`[agent-runtime] progress publish failed for ${event.agentName}:`, err);
+      log.warn(`progress publish failed for ${event.agentName}`, { err });
     }
   };
 
@@ -375,7 +378,7 @@ export class AgentRuntimePlugin implements Plugin {
         payload: { text: event.text, step: event.step ?? "progress" },
       });
     } catch (err) {
-      console.warn(`[agent-runtime] progress publish failed for ${event.agentName}:`, err);
+      log.warn(`progress publish failed for ${event.agentName}`, { err });
     }
   };
 
@@ -401,7 +404,7 @@ export class AgentRuntimePlugin implements Plugin {
         payload: { frame: event.frame },
       });
     } catch (err) {
-      console.warn(`[agent-runtime] toolframe publish failed for ${event.agentName}:`, err);
+      log.warn(`toolframe publish failed for ${event.agentName}`, { err });
     }
   };
 

--- a/src/executor/executors/a2a-executor.ts
+++ b/src/executor/executors/a2a-executor.ts
@@ -44,6 +44,9 @@ import {
   type ExtensionContext,
   type ExtensionInterceptor,
 } from "../extension-registry.ts";
+import { logger } from "../../../lib/log.ts";
+
+const log = logger("a2a-executor");
 
 /**
  * Auth scheme the executor applies on outbound requests.
@@ -251,7 +254,7 @@ export class A2AExecutor implements IExecutor {
       try {
         await i.before?.(extCtx);
       } catch (err) {
-        console.debug(`[a2a-executor] extension before-hook error:`, err);
+        log.debug("extension before-hook error", { err });
       }
     }
 
@@ -280,8 +283,8 @@ export class A2AExecutor implements IExecutor {
       if (this.config.streaming && !result.isError
         && !result.data?.taskId
         && (!result.text || result.text.startsWith(`Skill "${req.skill}" completed by`))) {
-        console.warn(
-          `[a2a-executor] ${this.config.name}: streaming returned empty result — falling back to message/send (agent SSE events may be missing "kind" field)`,
+        log.warn(
+          `${this.config.name}: streaming returned empty result — falling back to message/send (agent SSE events may be missing "kind" field)`,
         );
         result = await this._executeBlocking(client, params, req);
       }
@@ -299,7 +302,7 @@ export class A2AExecutor implements IExecutor {
           try {
             await i.after?.(extCtx, { text: result.text, data: result.data });
           } catch (err) {
-            console.debug(`[a2a-executor] extension after-hook error:`, err);
+            log.debug("extension after-hook error", { err });
           }
         }
       }
@@ -342,7 +345,7 @@ export class A2AExecutor implements IExecutor {
       try {
         await i.after?.(ctx, { text: "", data });
       } catch (err) {
-        console.debug(`[a2a-executor] extension after-hook error (async):`, err);
+        log.debug("extension after-hook error (async)", { err });
       }
     }
   }
@@ -391,8 +394,8 @@ export class A2AExecutor implements IExecutor {
       return true;
     } catch (err) {
       // Agent doesn't support push notifications — tracker falls back to polling
-      console.log(
-        `[a2a-executor] ${this.config.name}: push-notification register failed for ${taskId.slice(0, 8)}… — ${err instanceof Error ? err.message : String(err)}`,
+      log.warn(
+        `${this.config.name}: push-notification register failed for ${taskId.slice(0, 8)}… — ${err instanceof Error ? err.message : String(err)}`,
       );
       return false;
     }

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -19,6 +19,10 @@ import { runStructuredFinalizer, type ForcedToolCaller } from "./structured-fina
 import { AgentMemory, memoryAppliesTo } from "../../knowledge/agent-memory.ts";
 import type { ToolCallArtifactData } from "@protolabs/a2a";
 import { withCircuitBreaker } from "../../../lib/plugins/circuit-breaker.ts";
+import { logger } from "../../../lib/log.ts";
+
+const toolLog = logger("deep-agent:tool");
+const log = logger("deep-agent");
 
 const LANGFUSE_ENABLED = !!(process.env.LANGFUSE_PUBLIC_KEY && process.env.LANGFUSE_SECRET_KEY);
 
@@ -215,7 +219,7 @@ export function createLangChainTools(toolNames: string[], http: HttpClient, corr
   const all: Record<string, any> = {
     chat_with_agent: tool(
       async (input) => {
-        console.log(`[deep-agent:tool] chat_with_agent called: agent=${input.agent}, skill=${input.skill ?? "auto"}, msg="${input.message.slice(0, 80)}"`);
+        toolLog.info(`chat_with_agent called: agent=${input.agent}, skill=${input.skill ?? "auto"}, msg="${input.message.slice(0, 80)}"`);
         try {
           const body = agentName ? { ...input, dispatcherAgent: agentName } : input;
           const result = await http.post("/api/a2a/chat", body) as { success?: boolean; data?: Record<string, unknown> };
@@ -247,19 +251,19 @@ export function createLangChainTools(toolNames: string[], http: HttpClient, corr
                     ...(pd.confidence !== undefined ? { confidence: pd.confidence } : {}),
                   },
                 };
-                console.log(`[deep-agent:tool] chat_with_agent resolved pending ${input.agent} task: taskState=${pd.taskState}`);
+                toolLog.info(`chat_with_agent resolved pending ${input.agent} task: taskState=${pd.taskState}`);
                 return JSON.stringify(merged);
               }
               if (pd.taskState === "unknown") break; // never tracked / aged out
             }
-            console.log(`[deep-agent:tool] chat_with_agent ${input.agent} still pending after budget`);
+            toolLog.info(`chat_with_agent ${input.agent} still pending after budget`);
             return JSON.stringify(result);
           }
 
-          console.log(`[deep-agent:tool] chat_with_agent returned: ${JSON.stringify(result).slice(0, 200)}`);
+          toolLog.info(`chat_with_agent returned: ${JSON.stringify(result).slice(0, 200)}`);
           return JSON.stringify(result);
         } catch (e) {
-          console.error(`[deep-agent:tool] chat_with_agent ERROR:`, e);
+          toolLog.error("chat_with_agent ERROR", { err: e });
           throw e;
         }
       },
@@ -1092,7 +1096,7 @@ export class DeepAgentExecutor implements IExecutor {
       const usingModel = modelOverride && modelOverride !== this.agentDef.model
         ? ` (model override: ${modelOverride})`
         : "";
-      console.log(`[deep-agent:${this.agentDef.name}] invoke skill="${req.skill ?? "?"}" tools=${tools.length}/${agentTools.length} maxTurns=${effectiveMaxTurns} promptLen=${prompt.length} langfuse=${LANGFUSE_ENABLED}${usingModel}`);
+      log.info(`invoke skill="${req.skill ?? "?"}" tools=${tools.length}/${agentTools.length} maxTurns=${effectiveMaxTurns} promptLen=${prompt.length} langfuse=${LANGFUSE_ENABLED}${usingModel}`, { agent: this.agentDef.name });
 
       // Within-conversation history (Phase 1): replay recent turns so the agent
       // sees the conversation, not just the latest message.
@@ -1113,7 +1117,7 @@ export class DeepAgentExecutor implements IExecutor {
         try {
           this.onProgress({ agentName: this.agentDef.name, correlationId: req.correlationId, skill: req.skill, text: "thinking", step: "thinking" });
         } catch (cbErr) {
-          console.warn(`[deep-agent:${this.agentDef.name}] onProgress callback threw:`, cbErr);
+          log.warn("onProgress callback threw", { agent: this.agentDef.name, err: cbErr });
         }
       }
 
@@ -1142,13 +1146,13 @@ export class DeepAgentExecutor implements IExecutor {
         // Narrate any tool-call turn that streamed in this step and hasn't been
         // narrated yet — live, before its tools execute.
         for (const n of extractToolCallNarrations(msgs, narrated)) {
-          console.log(`[deep-agent:${this.agentDef.name}] tool calls: ${n.toolNames.join(", ")}`);
+          log.info(`tool calls: ${n.toolNames.join(", ")}`, { agent: this.agentDef.name });
           if (this.onToolCall) {
             try {
               this.onToolCall({ agentName: this.agentDef.name, correlationId: req.correlationId, skill: req.skill, toolNames: n.toolNames, toolCalls: n.toolCalls });
             } catch (cbErr) {
               // Telemetry must never break a running skill.
-              console.warn(`[deep-agent:${this.agentDef.name}] onToolCall callback threw:`, cbErr);
+              log.warn("onToolCall callback threw", { agent: this.agentDef.name, err: cbErr });
             }
           }
         }
@@ -1159,7 +1163,7 @@ export class DeepAgentExecutor implements IExecutor {
             try {
               this.onToolFrame({ agentName: this.agentDef.name, correlationId: req.correlationId, skill: req.skill, frame });
             } catch (cbErr) {
-              console.warn(`[deep-agent:${this.agentDef.name}] onToolFrame callback threw:`, cbErr);
+              log.warn("onToolFrame callback threw", { agent: this.agentDef.name, err: cbErr });
             }
           }
         }
@@ -1168,7 +1172,7 @@ export class DeepAgentExecutor implements IExecutor {
       });
 
       const messages = result.messages ?? [];
-      console.log(`[deep-agent:${this.agentDef.name}] ${messages.length} messages returned`);
+      log.info(`${messages.length} messages returned`, { agent: this.agentDef.name });
 
       let text = "";
       for (let i = messages.length - 1; i >= 0; i--) {
@@ -1206,8 +1210,9 @@ export class DeepAgentExecutor implements IExecutor {
           finalText,
           this._forcedToolCaller(llm),
         );
-        console.log(
-          `[deep-agent:${this.agentDef.name}] structured finalizer for "${req.skill}" → ${skillDef.resultMime}${finalized.repaired ? " (repaired)" : ""}`,
+        log.info(
+          `structured finalizer for "${req.skill}" → ${skillDef.resultMime}${finalized.repaired ? " (repaired)" : ""}`,
+          { agent: this.agentDef.name },
         );
         return {
           text: JSON.stringify(finalized.value),
@@ -1223,7 +1228,7 @@ export class DeepAgentExecutor implements IExecutor {
         correlationId: req.correlationId,
       };
     } catch (e) {
-      console.error(`[deep-agent:${this.agentDef.name}]`, e);
+      log.error("execute failed", { agent: this.agentDef.name, err: e });
       return {
         text: e instanceof Error ? e.message : String(e),
         isError: true,

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -31,6 +31,10 @@ import { ContextMailbox } from "../../lib/dm/context-mailbox.ts";
 import type { TaskTracker } from "./task-tracker.ts";
 import type { A2AExecutor } from "./executors/a2a-executor.ts";
 import { metrics } from "../../lib/metrics.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("skill-dispatcher");
+const latencyLog = logger("skill-latency");
 
 const WORKING_STATES = new Set(["submitted", "working"]);
 
@@ -186,7 +190,7 @@ export class SkillDispatcherPlugin implements Plugin {
     });
     this.subscriptionIds.push(subId);
 
-    console.log("[skill-dispatcher] Installed");
+    log.info("installed");
   }
 
   uninstall(): void {
@@ -234,7 +238,7 @@ export class SkillDispatcherPlugin implements Plugin {
     if (!skill) {
       this.activeExecutions.delete(correlationId);
       const dropMsg = "Received skill request with no skill — dropping";
-      console.warn(`[skill-dispatcher] ${dropMsg}`);
+      log.warn(dropMsg);
       this._publishDispatchDropped("no_skill", correlationId, dropMsg, { targets });
       this._publishResponse(replyTopic, correlationId, undefined, "No skill specified");
       return;
@@ -248,7 +252,7 @@ export class SkillDispatcherPlugin implements Plugin {
         ? `targets [${targets.join(", ")}] or skill "${skill}"`
         : `skill "${skill}"`;
       const dropMsg = `No executor found for ${searched} — dropping`;
-      console.warn(`[skill-dispatcher] ${dropMsg}`);
+      log.warn(dropMsg);
       this._publishDispatchDropped("target_unresolved", correlationId, dropMsg, { skill, targets });
       this._publishResponse(replyTopic, correlationId, undefined, `No executor registered for ${searched}`);
       return;
@@ -269,7 +273,7 @@ export class SkillDispatcherPlugin implements Plugin {
         const remaining = cooldownMs - elapsed;
         this.activeExecutions.delete(correlationId);
         const dropMsg = `Cooldown drop: "${key}" dispatched ${elapsed}ms ago (window=${cooldownMs}ms, ${remaining}ms remaining)`;
-        console.warn(`[skill-dispatcher] ${dropMsg}`);
+        log.warn(dropMsg);
         this._publishDispatchDropped("cooldown", correlationId, dropMsg, {
           skill,
           targets,
@@ -283,8 +287,8 @@ export class SkillDispatcherPlugin implements Plugin {
       this.lastDispatchAt.set(key, Date.now());
     }
 
-    console.log(
-      `[skill-dispatcher] Dispatching "${skill}" via ${executor.type}` +
+    log.info(
+      `Dispatching "${skill}" via ${executor.type}` +
       (targets.length > 0 ? ` (targets: ${targets.join(", ")})` : ""),
     );
 
@@ -427,13 +431,13 @@ export class SkillDispatcherPlugin implements Plugin {
           const callbackUrl = `${callbackBaseUrl.replace(/\/$/, "")}/api/a2a/callback/${encodeURIComponent(taskId)}`;
           void a2aExecutor.registerPushNotification(taskId, callbackUrl, callbackToken, correlationId, parentId)
             .then(ok => {
-              if (ok) console.log(`[skill-dispatcher] Push-notification registered for ${taskId.slice(0, 8)}… at ${callbackUrl}`);
+              if (ok) log.info("push-notification registered", { taskId: taskId.slice(0, 8), callbackUrl });
               // Failure path is logged by A2AExecutor.registerPushNotification with agent + reason.
             })
-            .catch(err => console.log("[skill-dispatcher] push-notification register failed:", err));
+            .catch(err => log.warn("push-notification register failed", { err }));
         } else if (callbackBaseUrl) {
-          console.log(
-            `[skill-dispatcher] ${a2aExecutor.name}: card.capabilities.pushNotifications=false — using polling for ${taskId.slice(0, 8)}…`,
+          log.info(
+            `${a2aExecutor.name}: card.capabilities.pushNotifications=false — using polling for ${taskId.slice(0, 8)}…`,
           );
         }
 
@@ -449,8 +453,8 @@ export class SkillDispatcherPlugin implements Plugin {
       }
 
       if (result.isError) {
-        console.error(
-          `[skill-dispatcher] Executor "${executor.type}" error for skill "${skill}": ${(result.text ?? "").slice(0, 500)}`,
+        log.error(
+          `Executor "${executor.type}" error for skill "${skill}": ${(result.text ?? "").slice(0, 500)}`,
         );
         this._publishActivity("skill.error", {
           agentName: targetAgent,
@@ -484,8 +488,8 @@ export class SkillDispatcherPlugin implements Plugin {
         // returned — critical for debugging A2A/agent behaviour when the skill
         // completes but produces no board side-effects.
         const preview = (result.text ?? "").replace(/\s+/g, " ").slice(0, 300);
-        console.log(
-          `[skill-dispatcher] Skill "${skill}" completed via ${executor.type} — ${(result.text ?? "").length} chars: ${preview}${(result.text ?? "").length > 300 ? "…" : ""}`,
+        log.info(
+          `Skill "${skill}" completed via ${executor.type} — ${(result.text ?? "").length} chars: ${preview}${(result.text ?? "").length > 300 ? "…" : ""}`,
         );
 
         // Trigger-to-done latency. When a surface plugin (today: github
@@ -505,8 +509,8 @@ export class SkillDispatcherPlugin implements Plugin {
           const repoRef = gh?.owner && gh?.repo && gh?.number
             ? ` [${gh.owner}/${gh.repo}#${gh.number}]`
             : "";
-          console.log(
-            `[skill-latency] ${skill} webhook→done ${(totalMs / 1000).toFixed(2)}s ` +
+          latencyLog.info(
+            `${skill} webhook→done ${(totalMs / 1000).toFixed(2)}s ` +
               `(queue ${queueMs}ms, execute ${(executeMs / 1000).toFixed(2)}s)${repoRef}`,
           );
 
@@ -532,9 +536,7 @@ export class SkillDispatcherPlugin implements Plugin {
                 },
               });
             } catch (err) {
-              console.warn(
-                `[skill-dispatcher] failed to publish agent.skill.latency: ${err instanceof Error ? err.message : err}`,
-              );
+              log.warn("failed to publish agent.skill.latency", { err });
             }
           }
         }
@@ -547,7 +549,7 @@ export class SkillDispatcherPlugin implements Plugin {
           durationMs: Date.now() - dispatchedAt,
         });
         if (result.data?.stopReason === "max_turns") {
-          console.warn("[skill-dispatcher] Agent hit maxTurns limit");
+          log.warn("agent hit maxTurns limit");
         }
 
         const completedAt = Date.now();
@@ -606,7 +608,7 @@ export class SkillDispatcherPlugin implements Plugin {
       );
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
-      console.error(`[skill-dispatcher] Unhandled error dispatching "${skill}": ${errorMsg}`);
+      log.error(`Unhandled error dispatching "${skill}": ${errorMsg}`);
       this._publishActivity("skill.error", {
         agentName: targetAgent,
         correlationId,
@@ -661,8 +663,8 @@ export class SkillDispatcherPlugin implements Plugin {
     if (queued.length === 0) return;
 
     const formatted = ContextMailbox.format(queued);
-    console.log(
-      `[skill-dispatcher] Draining ${queued.length} queued message(s) for ${correlationId} — starting new turn`,
+    log.info(
+      `Draining ${queued.length} queued message(s) for ${correlationId} — starting new turn`,
     );
 
     this.bus.publish("agent.skill.request", {
@@ -781,12 +783,12 @@ export class SkillDispatcherPlugin implements Plugin {
         body: JSON.stringify({ projectPath, title, description, status: "backlog", source: "github-triage" }),
       });
       if (resp.ok) {
-        console.log(`[skill-dispatcher] Filed GitHub triage on board: ${title}`);
+        log.info(`Filed GitHub triage on board: ${title}`);
       } else {
-        console.warn(`[skill-dispatcher] Board filing failed: ${resp.status}`);
+        log.warn(`Board filing failed: ${resp.status}`);
       }
     } catch (err) {
-      console.warn("[skill-dispatcher] Board filing error:", err);
+      log.warn("Board filing error", { err });
     }
   }
 
@@ -824,7 +826,7 @@ export class SkillDispatcherPlugin implements Plugin {
         payload,
       });
     } catch (err) {
-      console.warn(`[skill-dispatcher] activity-publish failed (${type}):`, err);
+      log.warn(`activity-publish failed (${type})`, { err });
     }
   }
 
@@ -848,8 +850,8 @@ export class SkillDispatcherPlugin implements Plugin {
   /**
    * Publish a dispatch-dropped telemetry event at the matching chokepoint
    * site. Topic is `dispatch.dropped.{reason}` so subscribers can filter
-   * by reason. The console.warn is kept alongside this for log-tail
-   * visibility — both paths fire independently.
+   * by reason. The `log.warn` at the drop site is kept alongside this for
+   * log-tail visibility — both paths fire independently.
    */
   private _publishDispatchDropped(
     reason: DispatchDropReason,

--- a/src/executor/task-tracker.ts
+++ b/src/executor/task-tracker.ts
@@ -18,6 +18,9 @@ import type { AgentSkillResponsePayload } from "../event-bus/payloads.ts";
 import type { TaskTrackerStore, PersistedTask } from "./task-tracker-store.ts";
 import { Part } from "@a2a-js/sdk";
 import { partText, parseWorldStateDelta } from "@protolabs/a2a";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("task-tracker");
 
 const TERMINAL_STATES = new Set(["completed", "failed", "canceled", "rejected"]);
 
@@ -118,7 +121,7 @@ export class TaskTracker {
       this.pending.set(row.correlationId, row);
     }
     if (this.pending.size > 0) {
-      console.log(`[task-tracker] rehydrated ${this.pending.size} in-flight task(s) from store — awaiting executor re-registration`);
+      log.info(`rehydrated ${this.pending.size} in-flight task(s) from store — awaiting executor re-registration`);
     }
     this.sweepTimer = setInterval(() => { void this._sweep(); }, this.sweepIntervalMs);
     this.sweepTimer.unref?.();
@@ -152,7 +155,7 @@ export class TaskTracker {
     if (this.pending.size === 0) return;
     for (const [, row] of [...this.pending]) {
       if (this._rehydrate(row)) {
-        console.log(`[task-tracker] resumed ${row.agentName} task ${row.taskId.slice(0, 8)}… after restart`);
+        log.info(`resumed ${row.agentName} task ${row.taskId.slice(0, 8)}… after restart`);
         continue;
       }
       // Executor still unregistered — escalate (don't silently drop) once the
@@ -165,7 +168,7 @@ export class TaskTracker {
 
   /** Publish a failure to the reply topic for a task that couldn't be resumed. */
   private _escalateInterrupted(row: PersistedTask): void {
-    console.warn(`[task-tracker] could not resume ${row.agentName} task ${row.taskId.slice(0, 8)}… — escalating as interrupted`);
+    log.warn(`could not resume ${row.agentName} task ${row.taskId.slice(0, 8)}… — escalating as interrupted`);
     const payload: AgentSkillResponsePayload = {
       error: "Task interrupted by a workstacean restart and could not be resumed — please retry.",
       correlationId: row.correlationId,
@@ -231,8 +234,8 @@ export class TaskTracker {
       callbackToken: t.callbackToken, sourceInterface: t.sourceInterface,
       sourceChannelId: t.sourceChannelId, sourceUserId: t.sourceUserId,
     });
-    console.log(
-      `[task-tracker] Tracking ${params.agentName} task ${params.taskId.slice(0, 8)}… (correlationId: ${params.correlationId.slice(0, 8)}…)`,
+    log.info(
+      `Tracking ${params.agentName} task ${params.taskId.slice(0, 8)}… (correlationId: ${params.correlationId.slice(0, 8)}…)`,
     );
   }
 
@@ -263,8 +266,8 @@ export class TaskTracker {
 
     if (state === "input-required") {
       const statusText = textOf(normalizeParts(status.message?.parts));
-      console.warn(
-        `[task-tracker] ${task.agentName} task ${task.taskId.slice(0, 8)}… is input-required ` +
+      log.warn(
+        `${task.agentName} task ${task.taskId.slice(0, 8)}… is input-required ` +
         `but no approval gate is wired — terminating with failure. Question: ${statusText || "(none)"}`,
       );
       this._publishResponse(task, undefined, `Agent asked for human input but no approval gate is wired: ${statusText || "(no question text)"}`, "failed");
@@ -290,8 +293,8 @@ export class TaskTracker {
     this._extractAndPublishDeltas(task.taskId, task.agentName, artifacts);
     this._publishResponse(task, isError ? undefined : content, isError ? (content || state) : undefined, state);
     this._forget(correlationId);
-    console.log(
-      `[task-tracker] Callback for ${task.taskId.slice(0, 8)}… → terminal state "${state}" (via webhook)`,
+    log.info(
+      `Callback for ${task.taskId.slice(0, 8)}… → terminal state "${state}" (via webhook)`,
     );
   }
 
@@ -342,8 +345,8 @@ export class TaskTracker {
         const state = result.data?.taskState;
 
         if (state === "input-required") {
-          console.warn(
-            `[task-tracker] ${task.agentName} task ${task.taskId.slice(0, 8)}… is input-required ` +
+          log.warn(
+            `${task.agentName} task ${task.taskId.slice(0, 8)}… is input-required ` +
             `but no approval gate is wired — terminating with failure. Question: ${result.text || "(none)"}`,
           );
           this._publishResponse(task, undefined, `Agent asked for human input but no approval gate is wired: ${result.text || "(no question text)"}`, "failed");
@@ -363,14 +366,14 @@ export class TaskTracker {
           await task.executor.recordTerminalExtensions(task.skillName ?? "unknown", task.correlationId, result.data);
           this._publishResponse(task, result.text, result.isError ? result.text : undefined, state, result.data);
           this._forget(task.correlationId);
-          console.log(
-            `[task-tracker] Task ${task.taskId.slice(0, 8)}… reached terminal state "${state}" after ${Math.round((now - task.registeredAt) / 1000)}s`,
+          log.info(
+            `Task ${task.taskId.slice(0, 8)}… reached terminal state "${state}" after ${Math.round((now - task.registeredAt) / 1000)}s`,
           );
         }
       } catch (err) {
-        console.warn(
-          `[task-tracker] poll failed for ${task.taskId.slice(0, 8)}…:`,
-          err instanceof Error ? err.message : String(err),
+        log.warn(
+          `poll failed for ${task.taskId.slice(0, 8)}…`,
+          { err: err instanceof Error ? err.message : String(err) },
         );
       }
     }
@@ -405,8 +408,8 @@ export class TaskTracker {
           timestamp: Date.now(),
           payload: { domain, path, op, value, sourceTaskId: taskId, sourceAgent: agentName },
         });
-        console.log(
-          `[task-tracker] world.state.delta: ${domain}.${path} op=${op} from ${agentName} (task ${taskId.slice(0, 8)}…)`,
+        log.info(
+          `world.state.delta: ${domain}.${path} op=${op} from ${agentName} (task ${taskId.slice(0, 8)}…)`,
         );
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,15 @@ import { ControlPlaneRegistrarPlugin } from "./plugins/control-plane-registrar-p
 import type { Plugin, } from "../lib/types";
 import { parseEnv } from "./config/env.ts";
 import { isProductionLike, safeKeyEqual } from "../lib/runtime-env.ts";
+import { logger } from "../lib/log.ts";
 // Fail-fast env validation — exits immediately on misconfiguration.
 parseEnv();
+
+const log = logger("startup");
+const langfuseLog = logger("langfuse");
+const busWsLog = logger("bus-ws");
+const shutdownLog = logger("shutdown");
+const fatalLog = logger("fatal");
 
 // --- Langfuse OTEL tracer — register BEFORE any plugin that emits spans ---
 // Without this, @langfuse/langchain's CallbackHandler (used by
@@ -20,7 +27,7 @@ parseEnv();
 // is captured. Gated on LANGFUSE_PUBLIC_KEY + LANGFUSE_SECRET_KEY.
 import { initLangfuseTracer, shutdownLangfuseTracer } from "./telemetry/langfuse-tracer.ts";
 const langfuseEnabled = initLangfuseTracer();
-console.log(`[langfuse] OTEL tracer ${langfuseEnabled ? "registered" : "skipped (no credentials)"}`);
+langfuseLog.info(`OTEL tracer ${langfuseEnabled ? "registered" : "skipped (no credentials)"}`);
 // --- Workspace config ---
 const workspaceDir = resolve(
   process.env.WORKSPACE_DIR || join(process.cwd(), "workspace")
@@ -109,8 +116,8 @@ channelRegistry.startWatching();
 import { ProjectRegistry } from "./plugins/project-registry.js";
 const projectRegistry = new ProjectRegistry();
 await projectRegistry.refreshNow();
-console.log(
-  `[startup] ProjectRegistry: ${projectRegistry.getProjects().length} project(s) loaded` +
+log.info(
+  `ProjectRegistry: ${projectRegistry.getProjects().length} project(s) loaded` +
     (projectRegistry.getLastError() ? ` (error: ${projectRegistry.getLastError()})` : ""),
 );
 
@@ -572,11 +579,11 @@ for (const entry of pluginRegistry) {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     failedPlugins.push({ name: entry.name, error: msg });
-    console.error(`[startup] plugin "${entry.name}" failed to install — skipping (the rest still boot):`, err);
+    log.error(`plugin "${entry.name}" failed to install — skipping (the rest still boot)`, { err });
   }
 }
 if (failedPlugins.length > 0) {
-  console.error(`[startup] ${failedPlugins.length} plugin(s) failed: ${failedPlugins.map(p => p.name).join(", ")}`);
+  log.error(`${failedPlugins.length} plugin(s) failed: ${failedPlugins.map(p => p.name).join(", ")}`);
 }
 
 // Guard: warn if skill-dispatcher is installed but no executor registrars ran.
@@ -587,8 +594,8 @@ if (failedPlugins.length > 0) {
     p.name === "agent-runtime" || p.name === "skill-broker" || p.name === "mcp-client",
   );
   if (hasDispatcher && !hasRegistrar) {
-    console.warn(
-      "[startup] skill-dispatcher is installed but no executor registrar (agent-runtime / skill-broker / mcp-client) is active. " +
+    log.warn(
+      "skill-dispatcher is installed but no executor registrar (agent-runtime / skill-broker / mcp-client) is active. " +
       "All agent.skill.request messages will be dropped. " +
       "Add workspace/agents/*.yaml, workspace/agents.yaml, or workspace/mcp-servers.d/ to register at least one agent or MCP server.",
     );
@@ -605,11 +612,11 @@ if (failedPlugins.length > 0) {
 
 const allPlugins = [...corePlugins, ...registeredPlugins];
 
-console.log("WorkStacean started.");
-console.log(`Workspace: ${workspaceDir}`);
-console.log(`Plugins: ${allPlugins.map((p) => p.name).join(", ")}`);
-console.log(`Topics: ${bus.topics().map((t) => t.pattern).join(", ")}`);
-console.log(`Type 'help' for commands.`);
+log.info("WorkStacean started.");
+log.info(`Workspace: ${workspaceDir}`);
+log.info(`Plugins: ${allPlugins.map((p) => p.name).join(", ")}`);
+log.info(`Topics: ${bus.topics().map((t) => t.pattern).join(", ")}`);
+log.info(`Type 'help' for commands.`);
 
 // Show CLI prompt after startup
 const cli = corePlugins.find((p) => p.name === "cli") as CLIPlugin;
@@ -624,8 +631,8 @@ const API_KEY = process.env.WORKSTACEAN_API_KEY;
 // `if (ctx.apiKey && …)` check short-circuits open — fine for local dev, a
 // wide-open control surface in prod. (#791)
 if (isProductionLike() && !API_KEY) {
-  console.error(
-    "[startup] WORKSTACEAN_API_KEY is required when NODE_ENV=production or " +
+  log.error(
+    "WORKSTACEAN_API_KEY is required when NODE_ENV=production or " +
       "WORKSTACEAN_PUBLIC_BASE_URL is set. Refusing to start an unauthenticated " +
       "HTTP/A2A surface in production. Set the key (Infisical) and redeploy.",
   );
@@ -795,12 +802,12 @@ const httpServer = Bun.serve<BusSubscribeWsData>({
         }
       });
       ws.data.subscriberId = subscriberId;
-      console.log(`[bus-ws] subscribed to "${topic}" (sub ${subscriberId})`);
+      busWsLog.info(`subscribed to "${topic}" (sub ${subscriberId})`);
     },
     close(ws) {
       const { topic, subscriberId } = ws.data;
       if (subscriberId) bus.unsubscribe(subscriberId);
-      console.log(`[bus-ws] unsubscribed from "${topic}"`);
+      busWsLog.info(`unsubscribed from "${topic}"`);
     },
     message() {
       // Read-only: external subscribers receive bus events; to publish,
@@ -809,7 +816,7 @@ const httpServer = Bun.serve<BusSubscribeWsData>({
   },
 });
 
-console.log(`HTTP API listening on port ${HTTP_PORT}`);
+log.info(`HTTP API listening on port ${HTTP_PORT}`);
 
 // ── Wire fleet-health into ExecutorRegistry for health-weighted dispatch ──
 {
@@ -830,10 +837,10 @@ let shuttingDown = false;
 async function gracefulShutdown(signal: string): Promise<void> {
   if (shuttingDown) return;
   shuttingDown = true;
-  console.log(`[shutdown] ${signal} received — draining…`);
-  try { httpServer.stop(); } catch (e) { console.warn("[shutdown] server.stop threw:", e); }
+  shutdownLog.info(`${signal} received — draining…`);
+  try { httpServer.stop(); } catch (e) { shutdownLog.warn("server.stop threw", { err: e }); }
   for (const plugin of allPlugins) {
-    try { plugin.uninstall?.(); } catch (e) { console.warn(`[shutdown] ${plugin.name} uninstall threw:`, e); }
+    try { plugin.uninstall?.(); } catch (e) { shutdownLog.warn(`${plugin.name} uninstall threw`, { err: e }); }
   }
   await shutdownLangfuseTracer();
   for (const [name, closer] of [
@@ -842,9 +849,9 @@ async function gracefulShutdown(signal: string): Promise<void> {
     ["research-store", () => researchStore.close()],
     ["task-store", () => taskTrackerStore.close()],
   ] as const) {
-    try { closer(); } catch (e) { console.warn(`[shutdown] ${name} close threw:`, e); }
+    try { closer(); } catch (e) { shutdownLog.warn(`${name} close threw`, { err: e }); }
   }
-  console.log("[shutdown] complete");
+  shutdownLog.info("complete");
   process.exit(0);
 }
 process.on("SIGTERM", () => void gracefulShutdown("SIGTERM"));
@@ -855,9 +862,9 @@ process.on("SIGINT", () => void gracefulShutdown("SIGINT"));
 // the process in an undefined state — log loud and exit non-zero so the
 // orchestrator restarts cleanly.
 process.on("unhandledRejection", (reason) => {
-  console.error("[fatal] unhandledRejection (process kept alive):", reason);
+  fatalLog.error("unhandledRejection (process kept alive)", { reason });
 });
 process.on("uncaughtException", (err) => {
-  console.error("[fatal] uncaughtException — exiting for a clean restart:", err);
+  fatalLog.error("uncaughtException — exiting for a clean restart", { err });
   process.exit(1);
 });

--- a/src/plugins/CeremonyPlugin.ts
+++ b/src/plugins/CeremonyPlugin.ts
@@ -49,12 +49,15 @@ import { CeremonyYamlLoader } from "../loaders/ceremonyYamlLoader.ts";
 import { CeremonyOutcomesRepository } from "../knowledge/ceremonyOutcomes.ts";
 import { CeremonyStateExtension } from "../world/extensions/CeremonyStateExtension.ts";
 import { CeremonyNotifier } from "../integrations/discord/CeremonyNotifier.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("ceremony");
 
 const DEBUG = process.env.DEBUG === "1" || process.env.DEBUG === "true";
 const HOT_RELOAD_INTERVAL_MS = 5_000;
 
 function debug(...args: unknown[]): void {
-  if (DEBUG) console.log("[DEBUG][ceremony]", ...args);
+  if (DEBUG) log.debug(String(args[0] ?? ""), { args: args.slice(1) });
 }
 
 /** File metadata used to detect changes during hot-reload polling. */
@@ -127,7 +130,7 @@ export class CeremonyPlugin implements Plugin {
     const subId = bus.subscribe("ceremony.#", this.name, (msg: BusMessage) => {
       if (msg.topic.endsWith(".completed")) {
         this._onCeremonyCompleted(msg).catch((err) => {
-          console.error("[ceremony] Error handling completed event:", err);
+          log.error("Error handling completed event", { err });
         });
       } else if (msg.topic.endsWith(".execute")) {
         // External trigger (e.g. from ActionDispatcher via world engine).
@@ -142,10 +145,10 @@ export class CeremonyPlugin implements Plugin {
           const ceremonyId = parts.slice(1, -1).join(".");
           const ceremony = this.ceremonies.get(ceremonyId);
           if (ceremony) {
-            console.log(`[ceremony] External trigger received for: ${ceremonyId}`);
+            log.info(`External trigger received for: ${ceremonyId}`);
             this._fireCeremony(ceremony);
           } else {
-            console.warn(`[ceremony] External trigger for unknown ceremony: ${ceremonyId}`);
+            log.warn(`External trigger for unknown ceremony: ${ceremonyId}`);
           }
         }
       }
@@ -161,7 +164,7 @@ export class CeremonyPlugin implements Plugin {
     // Start hot-reload watcher
     this._startHotReload();
 
-    console.log(`[ceremony] Plugin installed — loaded ${this.ceremonies.size} ceremony(ies)`);
+    log.info(`Plugin installed — loaded ${this.ceremonies.size} ceremony(ies)`);
   }
 
   uninstall(): void {
@@ -246,13 +249,13 @@ export class CeremonyPlugin implements Plugin {
           deployed++;
           debug("Deployed default ceremony:", file);
         } catch (err) {
-          console.warn(`[ceremony] Failed to deploy default ${file}:`, err);
+          log.warn(`Failed to deploy default ${file}`, { err });
         }
       }
     }
 
     if (deployed > 0) {
-      console.log(`[ceremony] Deployed ${deployed} default ceremony file(s) to ${ceremoniesDir}`);
+      log.info(`Deployed ${deployed} default ceremony file(s) to ${ceremoniesDir}`);
     }
   }
 
@@ -264,7 +267,7 @@ export class CeremonyPlugin implements Plugin {
         // Greenfield: disabled = disabled everywhere. Do not register, do not
         // schedule, and skip state extension so external `ceremony.<id>.execute`
         // triggers cannot resurrect the ceremony via the registry lookup.
-        console.log(`[ceremony] Skipping disabled ceremony: ${ceremony.id}`);
+        log.info(`Skipping disabled ceremony: ${ceremony.id}`);
         continue;
       }
       this.ceremonies.set(ceremony.id, ceremony);
@@ -297,7 +300,7 @@ export class CeremonyPlugin implements Plugin {
       this.timers.set(ceremony.id, timer);
       debug(`Scheduled: ${ceremony.id} fires at ${nextDate.toISOString()} (delay: ${Math.round(actualDelay / 1000)}s)`);
     } catch (err) {
-      console.error(`[ceremony] Failed to schedule ${ceremony.id}:`, err);
+      log.error(`Failed to schedule ${ceremony.id}`, { err });
     }
   }
 
@@ -340,12 +343,12 @@ export class CeremonyPlugin implements Plugin {
       payload: executePayload,
     };
 
-    console.log(`[ceremony] Firing: ${ceremony.id} (run ${runId})`);
+    log.info(`Firing: ${ceremony.id} (run ${runId})`);
     this.bus.publish(executeTopic, executeMsg);
 
     // Dispatch skill and publish completed
     this._dispatchSkillAndComplete(ceremony, context).catch((err) => {
-      console.error(`[ceremony] Dispatch error for ${ceremony.id}:`, err);
+      log.error(`Dispatch error for ${ceremony.id}`, { err });
     });
   }
 
@@ -419,7 +422,7 @@ export class CeremonyPlugin implements Plugin {
         // Per-ceremony timeout fired
         status = "timeout";
         error = `Skill dispatch timed out after ${ceremony.timeoutMs / 1000}s`;
-        console.warn(`[ceremony] Skill dispatch timeout for ${ceremony.id} (run ${context.runId})`);
+        log.warn(`Skill dispatch timeout for ${ceremony.id} (run ${context.runId})`);
       }
     } catch (err) {
       status = "failure";
@@ -476,12 +479,12 @@ export class CeremonyPlugin implements Plugin {
       this.notifier
         .notify(outcome, ceremony.name, ceremony.notifyChannel, ceremony.notifyWebhookEnv)
         .catch((err) => {
-          console.error("[ceremony] Discord notification error:", err);
+          log.error("Discord notification error", { err });
         });
     }
 
-    console.log(
-      `[ceremony] ${outcome.status.toUpperCase()}: ${outcome.ceremonyId} ` +
+    log.info(
+      `${outcome.status.toUpperCase()}: ${outcome.ceremonyId} ` +
       `(run ${outcome.runId}, ${outcome.duration}ms)`,
     );
   }
@@ -524,11 +527,11 @@ export class CeremonyPlugin implements Plugin {
             for (const ceremony of ceremonies) {
               if (this.ceremonies.has(ceremony.id)) continue;
               if (ceremony.enabled === false) {
-                console.log(`[ceremony] Skipping disabled ceremony: ${ceremony.id}`);
+                log.info(`Skipping disabled ceremony: ${ceremony.id}`);
                 continue;
               }
               this.registerCeremony(ceremony);
-              console.log(`[ceremony] Hot-loaded new ceremony: ${ceremony.id}`);
+              log.info(`Hot-loaded new ceremony: ${ceremony.id}`);
             }
           } else {
             // Changed file — reload all and reschedule changed ceremonies
@@ -552,7 +555,7 @@ export class CeremonyPlugin implements Plugin {
         // disabled = disabled everywhere.
         if (existing) {
           this.unregisterCeremony(ceremony.id);
-          console.log(`[ceremony] Hot-disabled ceremony: ${ceremony.id}`);
+          log.info(`Hot-disabled ceremony: ${ceremony.id}`);
         }
         continue;
       }
@@ -561,7 +564,7 @@ export class CeremonyPlugin implements Plugin {
         this.ceremonies.set(ceremony.id, ceremony);
         this.stateExtension.registerCeremony(ceremony);
         this._scheduleCeremony(ceremony);
-        console.log(`[ceremony] Hot-reloaded ceremony: ${ceremony.id}`);
+        log.info(`Hot-reloaded ceremony: ${ceremony.id}`);
       }
     }
   }

--- a/src/plugins/skill-broker-plugin.ts
+++ b/src/plugins/skill-broker-plugin.ts
@@ -36,6 +36,9 @@ import {
   BLAST_URI,
   type BlastRadius,
 } from "../executor/extensions/blast.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("skill-broker");
 
 interface AgentSkill {
   name: string;
@@ -164,7 +167,7 @@ export class SkillBrokerPlugin implements Plugin {
     this.opsChannel = process.env.DISCORD_AGENT_OPS_CHANNEL ?? "";
 
     for (const agent of this._loadAgents()) this._registerAgent(agent);
-    console.log(`[skill-broker] Registered ${this.agentDefs.size} A2A agent(s) (skills from yaml + agents.d/; discovery in progress)`);
+    log.info(`Registered ${this.agentDefs.size} A2A agent(s) (skills from yaml + agents.d/; discovery in progress)`);
 
     // Control-plane (ADR-0004 P3): live add/remove of A2A agents. The registrar
     // persists the entry to workspace/agents.d/; we register/unregister the
@@ -249,7 +252,7 @@ export class SkillBrokerPlugin implements Plugin {
     this.agentDefs.delete(name);
     this.executors.delete(name);
     this.fleetHealth.delete(name);
-    console.log(`[skill-broker] - A2A agent "${name}" unregistered`);
+    log.info(`- A2A agent "${name}" unregistered`);
   }
 
   uninstall(): void {
@@ -317,8 +320,8 @@ export class SkillBrokerPlugin implements Plugin {
         pushNotifications: caps?.pushNotifications === true,
       });
       if (priorStreaming !== executor.streaming || priorPush !== executor.pushNotifications) {
-        console.log(
-          `[skill-broker] ${agent.name}: capabilities updated — streaming=${executor.streaming} pushNotifications=${executor.pushNotifications}`,
+        log.info(
+          `${agent.name}: capabilities updated — streaming=${executor.streaming} pushNotifications=${executor.pushNotifications}`,
         );
       }
 
@@ -343,25 +346,25 @@ export class SkillBrokerPlugin implements Plugin {
 
       this.registeredSkills.set(agent.name, currentSkills);
       if (added > 0) {
-        console.log(
-          `[skill-broker] ${agent.name}: discovered ${added} new skill(s) from agent card (${Array.from(currentSkills).join(", ")})`,
+        log.info(
+          `${agent.name}: discovered ${added} new skill(s) from agent card (${Array.from(currentSkills).join(", ")})`,
         );
       }
       if (removed.length > 0) {
-        console.warn(
-          `[skill-broker] ${agent.name}: removed ${removed.length} skill(s) no longer in agent card — ${removed.join(", ")}`,
+        log.warn(
+          `${agent.name}: removed ${removed.length} skill(s) no longer in agent card — ${removed.join(", ")}`,
         );
       }
 
       this._loadHitlModeDeclarations(agent.name, card);
       this._loadBlastDeclarations(agent.name, card);
     } catch (err) {
-      // console.debug here would silently swallow real card-discovery
+      // log.debug here would silently swallow real card-discovery
       // bugs — see #593 where weeks of zero-skill agents went unnoticed.
       // Warn at the operator surface so the failure shows up in the same
       // place as the rest of the broker's per-agent lifecycle logs.
-      console.warn(
-        `[skill-broker] ${agent.name}: card discovery failed — ${err instanceof Error ? err.message : err}`,
+      log.warn(
+        `${agent.name}: card discovery failed — ${err instanceof Error ? err.message : err}`,
       );
     }
   }
@@ -400,7 +403,7 @@ export class SkillBrokerPlugin implements Plugin {
     }
 
     if (declared > 0) {
-      console.log(`[skill-broker] ${agentName}: loaded ${declared} hitl-mode declaration(s)`);
+      log.info(`${agentName}: loaded ${declared} hitl-mode declaration(s)`);
     }
   }
 
@@ -430,7 +433,7 @@ export class SkillBrokerPlugin implements Plugin {
     }
 
     if (declared > 0) {
-      console.log(`[skill-broker] ${agentName}: loaded ${declared} blast declaration(s)`);
+      log.info(`${agentName}: loaded ${declared} blast declaration(s)`);
     }
   }
 
@@ -458,8 +461,8 @@ export class SkillBrokerPlugin implements Plugin {
       // Per feedback_fail_fast_and_loud — fail loud at the boundary.
       const primaryMsg = primaryErr instanceof Error ? primaryErr.message : String(primaryErr);
       const legacyMsg = legacyErr instanceof Error ? legacyErr.message : String(legacyErr);
-      console.warn(
-        `[skill-broker] Failed to fetch agent card from ${baseUrl}: ` +
+      log.warn(
+        `Failed to fetch agent card from ${baseUrl}: ` +
           `primary path → ${primaryMsg}; legacy /.well-known/agent.json → ${legacyMsg}`,
       );
       return null;
@@ -487,19 +490,19 @@ export class SkillBrokerPlugin implements Plugin {
       try {
         const parsed = JSON.parse(envOverride) as { agents?: AgentDef[] };
         if (Array.isArray(parsed.agents)) {
-          console.log(`[skill-broker] Loaded ${parsed.agents.length} agent(s) from PROTOLABS_AGENTS_JSON`);
+          log.info(`Loaded ${parsed.agents.length} agent(s) from PROTOLABS_AGENTS_JSON`);
           return parsed.agents;
         }
-        console.warn("[skill-broker] PROTOLABS_AGENTS_JSON parsed but has no `agents` array — falling back to yaml");
+        log.warn("PROTOLABS_AGENTS_JSON parsed but has no `agents` array — falling back to yaml");
       } catch (err) {
-        console.error("[skill-broker] Failed to parse PROTOLABS_AGENTS_JSON — falling back to yaml:", err);
+        log.error("Failed to parse PROTOLABS_AGENTS_JSON — falling back to yaml", { err });
       }
     }
 
     // File path — committed default
     const agentsPath = join(this.workspaceDir, "agents.yaml");
     if (!existsSync(agentsPath)) {
-      console.warn("[skill-broker] agents.yaml not found and PROTOLABS_AGENTS_JSON unset — no A2A agents registered");
+      log.warn("agents.yaml not found and PROTOLABS_AGENTS_JSON unset — no A2A agents registered");
       return [];
     }
     try {
@@ -507,7 +510,7 @@ export class SkillBrokerPlugin implements Plugin {
       const parsed = parseYaml(raw) as { agents?: AgentDef[] };
       return parsed.agents ?? [];
     } catch (err) {
-      console.error("[skill-broker] Failed to load agents.yaml:", err);
+      log.error("Failed to load agents.yaml", { err });
       return [];
     }
   }
@@ -527,9 +530,9 @@ export class SkillBrokerPlugin implements Plugin {
         try {
           const def = parseYaml(readFileSync(join(dir, f), "utf8")) as AgentDef;
           if (def?.name && def.url) out.push(def);
-          else console.warn(`[skill-broker] agents.d/${f}: missing name/url — skipped`);
+          else log.warn(`agents.d/${f}: missing name/url — skipped`);
         } catch (err) {
-          console.error(`[skill-broker] Skipping agents.d/${f}: ${err instanceof Error ? err.message : String(err)}`);
+          log.error(`Skipping agents.d/${f}: ${err instanceof Error ? err.message : String(err)}`);
         }
       }
     } catch { /* dir vanished mid-scan */ }

--- a/src/router/router-plugin.ts
+++ b/src/router/router-plugin.ts
@@ -27,6 +27,10 @@ import type { ChannelRegistry } from "../../lib/channels/channel-registry.ts";
 import type { ProjectRegistry } from "../plugins/project-registry.ts";
 import { TTLCache } from "../../lib/ttl-cache.ts";
 import { TOPICS } from "../event-bus/topics.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("router");
+const linearLog = logger("linear");
 
 export interface RouterConfig {
   workspaceDir: string;
@@ -113,8 +117,8 @@ export class RouterPlugin implements Plugin {
       }),
     );
 
-    console.log(
-      `[router] Plugin installed — ${this.resolver.size} skill keyword entry/entries`,
+    log.info(
+      `Plugin installed — ${this.resolver.size} skill keyword entry/entries`,
     );
   }
 
@@ -224,14 +228,14 @@ export class RouterPlugin implements Plugin {
     }
 
     if (!match && !storedSession) {
-      console.log(
-        `[router] No skill match for topic "${msg.topic}"` +
+      log.info(
+        `No skill match for topic "${msg.topic}"` +
         (content ? ` content="${content.slice(0, 60)}"` : "") +
         " — dropping",
       );
       const linearEvent = extractLinearEvent(msg.topic);
       if (linearEvent) {
-        console.log(`[linear] event=${linearEvent} delivered to none (no skill match)`);
+        linearLog.info(`event=${linearEvent} delivered to none (no skill match)`);
       }
       return;
     }
@@ -260,16 +264,16 @@ export class RouterPlugin implements Plugin {
       `agent.skill.response.${runId}`;
 
     const via = match?.via ?? "sticky";
-    console.log(
-      `[router] ${msg.topic} → skill "${skill}" (via ${via})` +
+    log.info(
+      `${msg.topic} → skill "${skill}" (via ${via})` +
       (agentName ? ` [${agentName}]` : "") +
       ` reply → ${replyTopic}`,
     );
 
     const linearEvent = extractLinearEvent(msg.topic);
     if (linearEvent) {
-      console.log(
-        `[linear] event=${linearEvent} delivered to ${agentName ?? "none"} (skill=${skill})`,
+      linearLog.info(
+        `event=${linearEvent} delivered to ${agentName ?? "none"} (skill=${skill})`,
       );
     }
 
@@ -309,7 +313,7 @@ export class RouterPlugin implements Plugin {
     const match = this.resolver.resolve(skillHint, content);
 
     if (!match) {
-      console.log(`[router] cron "${msg.topic}" — no skill match, dropping`);
+      log.info(`cron "${msg.topic}" — no skill match, dropping`);
       return;
     }
 
@@ -317,8 +321,8 @@ export class RouterPlugin implements Plugin {
 
     const replyTopic = msg.reply?.topic ?? buildReplyTopic(channel, recipient);
 
-    console.log(
-      `[router] cron "${msg.topic}" → skill "${match.skill}" (via ${match.via}) → ${replyTopic}`,
+    log.info(
+      `cron "${msg.topic}" → skill "${match.skill}" (via ${match.via}) → ${replyTopic}`,
     );
 
     const skillRequest: BusMessage = {


### PR DESCRIPTION
## What

First focused slice of the bulk `console.*` → `lib/log.ts` sweep — **handoff 001 follow-up #2** (~611 call sites remained on `console.*` after the #800 logger landed). This converts the **highest-traffic server runtime spine** so prod logs filter by level and aggregate by structured field instead of grepping free text.

**9 files, 0 remaining `console.*` in the changed set:**
- `src/executor/skill-dispatcher-plugin.ts` (the reference conversion)
- `src/index.ts` (boot/entrypoint)
- `src/executor/executors/{deep-agent,a2a}-executor.ts`, `src/executor/task-tracker.ts`
- `src/plugins/{CeremonyPlugin,skill-broker-plugin}.ts`
- `src/agent-runtime/agent-runtime-plugin.ts`, `src/router/router-plugin.ts`

## Translation convention

Established on `skill-dispatcher-plugin` as the worked example, applied uniformly:

- existing `[tag]` prefix → the logger **component** (`logger("tag")`); prefix dropped from the message
- `console.log/warn/error/debug` → `log.info/warn/error/debug`; failure-path `console.log` promoted to `warn`/`error` where intent is clearly an error
- trailing comma-separated values (errors, ids) → **structured fields** (`{ err }`); human-sentence interpolations stay inline
- dynamic tag suffixes (e.g. per-agent `deep-agent:NAME`) collapse to a static component + a field (`{ agent }`)

No logic or control-flow changes — purely the `console` → `logger` swap (plus a couple of stale comments that named the old `console.warn`).

## Verification

- `bun test` — **1079 pass, 0 fail** (identical to `origin/main` baseline)
- `bun run lint` (biome) — clean (exit 0; the pre-existing `noNestedTernary` nursery warnings are untouched code)
- `tsc --noEmit` — clean
- `grep console.` across the 9 changed files — empty

## Scope / not in this PR

The remaining **~99 non-test files (~580 sites)** — integration plugins (`lib/plugins/*`), CLI/debug terminal-UX tooling, and `knowledge/`/`services/` — are deferred to follow-on slices or enforce-on-touch. CLI/debug files that print to the user as actual terminal UX are intentionally **not** in scope for logger migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced logging infrastructure across the system by migrating from console-based output to a structured logger utility. This provides improved diagnostic capabilities, clearer error messages, and better contextual information for troubleshooting runtime behavior and plugin lifecycle events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->