### PR TITLE
fix(github): dedup approve-on-green against co-arriving CI webhooks

### DIFF
--- a/lib/plugins/__tests__/github-approve-on-green.test.ts
+++ b/lib/plugins/__tests__/github-approve-on-green.test.ts
@@ -200,4 +200,26 @@ describe("_handleCiCompletion — deterministic approve-on-green", () => {
     });
     expect(captured.approvePosts.length).toBe(0);
   });
+
+  test("co-arriving terminal webhooks → exactly one APPROVE (dedup guard)", async () => {
+    // Reproduces the duplicate-approval spam: GitHub fires check_suite,
+    // workflow_run, and check_run completions near-simultaneously. They run
+    // concurrently and each reads `reviews` as COMMENTED before any APPROVE
+    // lands (the stub always returns COMMENTED, mirroring the real TOCTOU), so
+    // without the in-flight dedup every webhook would post its own approval.
+    const captured = stubFetch({
+      reviews: [{ user: { login: "protoquinn[bot]" }, state: "COMMENTED" }],
+      checkRuns: [{ status: "completed", conclusion: "success" }],
+    });
+    const bus = new InMemoryEventBus();
+    const plugin = new GitHubPlugin("/tmp/nonexistent-ws", new ProjectRegistry());
+    const getToken = async () => "fake-token";
+    const drive = () => (plugin as unknown as {
+      _handleCiCompletion: (e: string, p: Record<string, unknown>, b: InMemoryEventBus, g: () => Promise<string>) => Promise<void>;
+    })._handleCiCompletion("workflow_run", ciCompletionPayload(), bus, getToken);
+
+    await Promise.all([drive(), drive(), drive()]);
+
+    expect(captured.approvePosts.length).toBe(1);
+  });
 });

--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -993,6 +993,24 @@ export class GitHubPlugin implements Plugin {
       // unchanged LLM re-dispatch below.
       const latestState = quinnLatestReviewState(reviews ?? undefined);
       if (latestState === "COMMENTED" && (await this._ciGreen(getToken, owner, repo, headSha))) {
+        // Collapse co-arriving terminal webhooks. GitHub fires check_suite,
+        // workflow_run, and check_run completions near-simultaneously; each runs
+        // _handleCiCompletion concurrently and reads `reviews` before any has
+        // posted its APPROVE, so every one sees latestState COMMENTED and submits
+        // a duplicate. Unlike the LLM re-dispatch path below, this branch
+        // `continue`s and never reaches _handleAutoReview's dedup — so guard it
+        // here. The get/set is synchronous (no await between), so exactly one
+        // racing invocation claims the key; the rest skip.
+        const approveKey = `approve-on-green:${owner}/${repo}#${number}@${headSha.slice(0, 7)}`;
+        const lastApproved = this.recentDispatches.get(approveKey);
+        if (lastApproved && Date.now() - lastApproved < GitHubPlugin.DEDUP_WINDOW_MS) {
+          console.log(
+            `[github] CI-completion (${event}): skipping duplicate approve-on-green ${approveKey} ` +
+              `(approved ${Date.now() - lastApproved}ms ago)`,
+          );
+          continue;
+        }
+        this.recentDispatches.set(approveKey, Date.now());
         try {
           const submitter = new GitHubReviewSubmitter(getToken);
           await submitter.submitReview(


### PR DESCRIPTION
## Symptom

Quinn posts the formal **APPROVE three times** on a single PR (observed on #818), each with the identical `CI terminal-green, no blockers on prior review — auto-approving on green (#748).` message.

## Root cause — a TOCTOU race

The deterministic approve-on-terminal-green path (`#748`, `_handleCiCompletion`) guards idempotency with `latestState === "COMMENTED"`. That gate is self-limiting **only once an APPROVE has landed** — `latestState` then becomes `APPROVED` and later webhooks skip.

But when a PR's CI finishes, GitHub fires `check_suite.completed`, `workflow_run.completed`, and multiple `check_run.completed` webhooks **near-simultaneously**. They each run `_handleCiCompletion` concurrently and **all read the reviews list as `COMMENTED` before any has posted its APPROVE** → every one passes the guard and submits. N co-arriving webhooks → N approvals.

The LLM re-dispatch fall-through already collapses co-arrival through `_handleAutoReview`'s `recentDispatches` dedup — but the approve-on-green branch `continue`s and **never reaches that guard**. It was the one path with no collapse.

## Fix

Claim a synchronous in-flight key (`approve-on-green:{owner}/{repo}#{number}@{sha7}`) in the existing `recentDispatches` map at the top of the approve branch, **before** the `submitReview` await. The check-and-set has no `await` between `get` and `set`, so exactly one racing invocation claims the key; the rest log and `continue`. Reuses the same map + `DEDUP_WINDOW_MS` already proven on the re-dispatch path — no new state, no new config.

## Test

New case in `github-approve-on-green.test.ts`: three concurrent `_handleCiCompletion` calls on a **shared** plugin instance, all seeing `COMMENTED` (mirroring the real TOCTOU) → asserts **exactly one** APPROVE is posted. Without the guard this posts three.

- `bun test` — **1080 pass, 0 fail** (baseline 1079 + this test)
- biome lint clean

Behavior is otherwise unchanged: all the fail-closed gates (`CHANGES_REQUESTED`, already-`APPROVED`, no-prior-review, red/unverifiable CI) still fall through exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where concurrent CI completion webhooks could trigger duplicate automated approval submissions on pull requests. Added a deduplication mechanism to ensure only a single approval is posted when multiple CI events arrive simultaneously.

* **Tests**
  * Added test coverage for concurrent CI webhook handling to verify duplicate approval prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->