### PR TITLE
chore(ci): bump release-tools pin v1.1.0 → v2.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           echo "Diffing $PREV → $TAG"
 
       - name: Post release notes to Discord
-        uses: protoLabsAI/release-tools@b7c3531dd67accb57ca09242f47d8c0eb1ace8eb # v1.1.0
+        uses: protoLabsAI/release-tools@6ed11005cf2b68dbdf302f0fc2bcf2a13533e42e # v2.1.1
         with:
           version: ${{ steps.tags.outputs.version }}
           previous-version: ${{ steps.tags.outputs.previous }}


### PR DESCRIPTION
## What

Bumps the `protoLabsAI/release-tools` pin in `release.yml` from the stale **v1.1.0** to the current **v2.1.1** (SHA-pinned `6ed1100`, zizmor-style, version comment preserved).

## Why it's safe

The release-notes action interface is **backward-compatible** with our usage:
- inputs `version` + `previous-version` — unchanged, still required
- env `GATEWAY_API_KEY` + `DISCORD_RELEASE_WEBHOOK` — unchanged
- new inputs (`post-discord`, `dry-run`, `model`, `base-url`, `repo`, `footer`) are all optional with defaults; `post-discord` defaults `true`, preserving current Discord-posting behavior

The **only v2 breaking change** — `feat!: remove review-code (superseded by Quinn)` — is the code-review subcommand, which this workflow does **not** use. The release-notes path (`rewrite-release-notes`) only gained improvements (repo-name-led Discord embed title). No changes to our `with:`/`env:` blocks required.

Verified the action.yml interface at v2.1.1 directly and the v2.0→v2.1 changelog. YAML validates; lint-workflows CI (zizmor + actionlint) gates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)