### PR TITLE
chore(release): bump to v0.8.1

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean-dashboard",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workstacean",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "scripts": {
     "start": "bun run src/index.ts",


### PR DESCRIPTION
Auto-generated by prepare-release.yml. Review + merge through the normal gate, then dispatch auto-release.yml to tag main and cut the GitHub Release.