### PR TITLE
fix(tests): force dev log format in format-coupled tests (unbreak image build)

### DIFF
--- a/lib/__tests__/log.test.ts
+++ b/lib/__tests__/log.test.ts
@@ -12,7 +12,14 @@ function capture(fn: () => void): string[] {
   return lines;
 }
 const env = (o: Record<string, string>) => { Object.assign(process.env, o); };
-afterEach(() => { delete process.env.LOG_LEVEL; delete process.env.LOG_FORMAT; });
+let prevNodeEnv: string | undefined;
+afterEach(() => {
+  delete process.env.LOG_LEVEL;
+  delete process.env.LOG_FORMAT;
+  if (prevNodeEnv === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = prevNodeEnv;
+  prevNodeEnv = undefined;
+});
 
 describe("logger", () => {
   test("JSON format emits one structured object per line with component + fields", () => {
@@ -46,6 +53,12 @@ describe("logger", () => {
   });
 
   test("dev format is a readable single line", () => {
+    // Dev format requires non-JSON output: useJson() is true when
+    // NODE_ENV==="production" (the Docker build gate runs the suite that way)
+    // OR LOG_FORMAT==="json". Force dev format by clearing NODE_ENV; afterEach
+    // restores it. LOG_FORMAT is already unset here.
+    prevNodeEnv = process.env.NODE_ENV;
+    delete process.env.NODE_ENV;
     const lines = capture(() => logger("x").info("hello", { a: 1 }));
     expect(lines[0]).toContain("INFO [x] hello");
     expect(lines[0]).toContain('{"a":1}');

--- a/src/router/__tests__/router-plugin.test.ts
+++ b/src/router/__tests__/router-plugin.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -421,6 +421,26 @@ describe("RouterPlugin", () => {
   });
 
   describe("linear event delivery surface", () => {
+    // These assertions read the human-readable (dev) log line emitted via the
+    // structured logger. useJson() keys on NODE_ENV==="production" ||
+    // LOG_FORMAT==="json", so the Docker build gate (NODE_ENV=production) would
+    // render JSON and break the `[linear] event=` substring matches. Force dev
+    // format for this surface and restore the ambient env afterward.
+    let prevNodeEnv: string | undefined;
+    let prevLogFormat: string | undefined;
+    beforeEach(() => {
+      prevNodeEnv = process.env.NODE_ENV;
+      prevLogFormat = process.env.LOG_FORMAT;
+      delete process.env.NODE_ENV;
+      delete process.env.LOG_FORMAT;
+    });
+    afterEach(() => {
+      if (prevNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = prevNodeEnv;
+      if (prevLogFormat === undefined) delete process.env.LOG_FORMAT;
+      else process.env.LOG_FORMAT = prevLogFormat;
+    });
+
     test("emits [linear] event=… delivered to <agent> alongside [router] log", async () => {
       const { workspaceDir, cleanup } = makeWorkspace({
         agents: { "quinn.yaml": quinnAgent, "ava.yaml": avaAgent },


### PR DESCRIPTION
## Why main's image build is red (and has been since this morning)

The Docker image runs `bun test` as a release gate with **`NODE_ENV=production`** (`Dockerfile:119` + `:125`). The structured logger's `useJson()` returns `true` when `NODE_ENV==="production"` **or** `LOG_FORMAT==="json"` → it emits JSON in the build. Four tests assert the **human-readable dev line** but don't control that toggle, so they fail *only inside the image build* — CI's plain `bun test` and local runs don't set `NODE_ENV=production`, which is why this slipped through PR CI:

- `logger > "dev format is a readable single line"` — **pre-existing** since the logger landed (#800/#815). `publish-image` has actually been red since `4ebdc7a` (06:33); the last green build was `9bab0fe` (06:29, pre-#815), so **watchtower has been stuck on the pre-#815 image for ~13h.**
- `RouterPlugin > "linear event delivery surface"` ×3 — **regressed by the `console.*`→logger sweep (#818)**: plain `console.log` printed the literal `[linear] event=` string regardless of env; the logger renders it as JSON under prod env, so the substring assertions broke.

## Fix

The tests that assert the readable format now establish dev-format env (clear `NODE_ENV` / `LOG_FORMAT`) and restore the ambient env afterward — a test that pins human-readable output should own the format toggle. **No production code changes.**

## Verification

- Full suite green under **`NODE_ENV=production`** (mirrors the Dockerfile gate exactly): **1080 pass / 0 fail**
- Full suite green under dev env: 1080 pass / 0 fail
- biome lint clean

Once merged, `publish-image` builds green again → watchtower pulls the current `:main` (which includes #818/#819/#820 + the v0.8.1 bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)