### PR TITLE
chore(logging): migrate lib/plugins integration core to structured logger

### DIFF
--- a/lib/plugins/a2a-delivery.ts
+++ b/lib/plugins/a2a-delivery.ts
@@ -15,6 +15,9 @@ import { existsSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import * as YAML from "yaml";
 import type { Plugin, EventBus, BusMessage } from "../types";
+import { logger } from "../log.ts";
+
+const log = logger("a2a-delivery");
 
 interface A2ATarget {
   url: string;
@@ -81,7 +84,7 @@ export class A2ADeliveryPlugin implements Plugin {
     });
 
     const count = Object.keys(this.targets).length;
-    console.log(`[a2a-delivery] Ready — ${count} target(s) configured`);
+    log.info(`Ready — ${count} target(s) configured`);
   }
 
   uninstall(): void {
@@ -102,7 +105,7 @@ export class A2ADeliveryPlugin implements Plugin {
       const parsed = YAML.parse(raw) as A2AConfig | null;
       this.targets = parsed?.targets ?? {};
     } catch (err) {
-      console.error(`[a2a-delivery] Failed to load ${this.configPath}:`, err);
+      log.error(`Failed to load ${this.configPath}`, { err });
       this.targets = {};
     }
   }
@@ -112,32 +115,32 @@ export class A2ADeliveryPlugin implements Plugin {
     if (!payload || payload.channel !== "a2a") return;
 
     if (typeof payload.content !== "string" || payload.content.trim() === "") {
-      console.error(
-        `[a2a-delivery] cron "${msg.topic}" channel=a2a but payload.content is missing or not a non-empty string — drop`,
+      log.error(
+        `cron "${msg.topic}" channel=a2a but payload.content is missing or not a non-empty string — drop`,
       );
       return;
     }
 
     const agentName = payload.agent_name;
     if (!agentName) {
-      console.error(
-        `[a2a-delivery] cron "${msg.topic}" channel=a2a but payload.agent_name is missing — drop`,
+      log.error(
+        `cron "${msg.topic}" channel=a2a but payload.agent_name is missing — drop`,
       );
       return;
     }
 
     const target = this.targets[agentName];
     if (!target) {
-      console.error(
-        `[a2a-delivery] cron "${msg.topic}" agent_name="${agentName}" has no configured target in ${this.configPath} — drop`,
+      log.error(
+        `cron "${msg.topic}" agent_name="${agentName}" has no configured target in ${this.configPath} — drop`,
       );
       return;
     }
 
     const url = (expandEnv(target.url) ?? "").trim();
     if (!url) {
-      console.error(
-        `[a2a-delivery] cron "${msg.topic}" agent_name="${agentName}" has empty url after env expansion (raw="${target.url}") — drop`,
+      log.error(
+        `cron "${msg.topic}" agent_name="${agentName}" has empty url after env expansion (raw="${target.url}") — drop`,
       );
       return;
     }
@@ -183,13 +186,13 @@ export class A2ADeliveryPlugin implements Plugin {
       if (rpcError) {
         throw new Error(`JSON-RPC error: ${rpcError}`);
       }
-      console.log(
-        `[a2a-delivery] Delivered cron "${msg.topic}" → ${agentName} (${url})`,
+      log.info(
+        `Delivered cron "${msg.topic}" → ${agentName} (${url})`,
       );
     } catch (err) {
-      console.error(
-        `[a2a-delivery] Delivery failed for cron "${msg.topic}" → ${agentName} (${url}):`,
-        err,
+      log.error(
+        `Delivery failed for cron "${msg.topic}" → ${agentName} (${url})`,
+        { err },
       );
     }
   }

--- a/lib/plugins/circuit-breaker.ts
+++ b/lib/plugins/circuit-breaker.ts
@@ -12,6 +12,9 @@
  */
 
 import type { CircuitState, CircuitBreakerState } from "../types/budget.ts";
+import { logger } from "../log.ts";
+
+const log = logger("circuit-breaker");
 
 // ── Circuit breaker config ────────────────────────────────────────────────────
 
@@ -83,7 +86,7 @@ export class CircuitBreaker {
         const elapsed = Date.now() - (circuit.openedAt ?? 0);
         if (elapsed >= this.config.recoveryWindowMs) {
           circuit.state = "HALF_OPEN";
-          console.log(`[circuit-breaker] ${key}: OPEN → HALF_OPEN (recovery window elapsed)`);
+          log.info(`${key}: OPEN → HALF_OPEN (recovery window elapsed)`);
           return true; // allow one test request
         }
         return false;
@@ -113,14 +116,12 @@ export class CircuitBreaker {
     ) {
       circuit.state = "OPEN";
       circuit.openedAt = Date.now();
-      console.warn(
-        `[circuit-breaker] ${key}: CLOSED → OPEN after ${circuit.failureCount} failures`,
-      );
+      log.warn(`${key}: CLOSED → OPEN after ${circuit.failureCount} failures`);
     } else if (circuit.state === "HALF_OPEN") {
       // Failed in recovery window — re-open
       circuit.state = "OPEN";
       circuit.openedAt = Date.now();
-      console.warn(`[circuit-breaker] ${key}: HALF_OPEN → OPEN (failure during recovery)`);
+      log.warn(`${key}: HALF_OPEN → OPEN (failure during recovery)`);
     }
 
     return { ...circuit };
@@ -139,7 +140,7 @@ export class CircuitBreaker {
       circuit.state = "CLOSED";
       circuit.failureCount = 0;
       circuit.openedAt = null;
-      console.log(`[circuit-breaker] ${key}: → CLOSED (recovered)`);
+      log.info(`${key}: → CLOSED (recovered)`);
     } else {
       // CLOSED — reset failure count on success
       circuit.failureCount = 0;
@@ -171,8 +172,8 @@ export class CircuitBreaker {
       circuit.openedAt = null;
     }
 
-    console.warn(
-      `[circuit-breaker] OVERRIDE ${key}: ${prevState} → ${targetState} ` +
+    log.warn(
+      `OVERRIDE ${key}: ${prevState} → ${targetState} ` +
         `by ${approvedBy}. Justification: ${justification}`,
     );
 
@@ -214,9 +215,8 @@ export async function withCircuitBreaker<T>(
   fn: () => Promise<T>,
 ): Promise<T> {
   if (!_apiBreaker.isAllowed(name, "api")) {
-    const msg = `[circuit-breaker] ${name}: circuit OPEN — call rejected`;
-    console.warn(msg);
-    throw new Error(msg);
+    log.warn(`${name}: circuit OPEN — call rejected`);
+    throw new Error(`circuit breaker ${name}: circuit OPEN — call rejected`);
   }
   try {
     const result = await fn();

--- a/lib/plugins/feature-notifier.ts
+++ b/lib/plugins/feature-notifier.ts
@@ -26,6 +26,9 @@
 
 import type { ChannelRegistry } from "../channels/channel-registry.ts";
 import type { Plugin, EventBus, BusMessage } from "../types.ts";
+import { logger } from "../log.ts";
+
+const log = logger("feature-notifier");
 
 function expandEnv(val: string | undefined): string {
   if (!val) return "";
@@ -66,7 +69,7 @@ export class FeatureNotifierPlugin implements Plugin {
         this.handle(bus, msg, formatFailed);
       }),
     );
-    console.log("[feature-notifier] Installed — watching feature.completed + feature.failed");
+    log.info("Installed — watching feature.completed + feature.failed");
   }
 
   uninstall(): void {
@@ -79,13 +82,13 @@ export class FeatureNotifierPlugin implements Plugin {
     const payload = (msg.payload ?? {}) as Record<string, unknown>;
     const slug = String(payload.projectSlug ?? "");
     if (!slug) {
-      console.warn("[feature-notifier] feature event missing projectSlug — skipping");
+      log.warn("feature event missing projectSlug — skipping");
       return;
     }
 
     const channel = this.channelRegistry.getProjectChannel(slug, "dev");
     if (!channel) {
-      console.warn(`[feature-notifier] No dev channel binding for project "${slug}" in channels.yaml — skipping`);
+      log.warn(`No dev channel binding for project "${slug}" in channels.yaml — skipping`);
       return;
     }
 
@@ -102,15 +105,15 @@ export class FeatureNotifierPlugin implements Plugin {
         timestamp: Date.now(),
         payload: { content, channel: channelId },
       });
-      console.log(`[feature-notifier] Posted to ${slug} dev channel (${channelId})`);
+      log.info(`Posted to ${slug} dev channel (${channelId})`);
     } else if (webhook) {
       // Fallback: direct webhook POST (used when no bot channel is bound).
       fetch(webhook, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ content }),
-      }).catch((err) => console.error("[feature-notifier] Webhook POST failed:", err));
-      console.log(`[feature-notifier] Webhook POST to ${slug} dev channel`);
+      }).catch((err) => log.error("Webhook POST failed", { err }));
+      log.info(`Webhook POST to ${slug} dev channel`);
     }
   }
 }

--- a/lib/plugins/feature-remediation.ts
+++ b/lib/plugins/feature-remediation.ts
@@ -26,6 +26,9 @@
 
 import type { Plugin, EventBus, BusMessage } from "../types.ts";
 import { getFleetConfig } from "../fleet/fleet-config.ts";
+import { logger } from "../log.ts";
+
+const log = logger("feature-remediation");
 
 export interface FeatureBlockedPayload {
   projectSlug?: string;
@@ -86,7 +89,7 @@ export class FeatureRemediationPlugin implements Plugin {
     }));
     this.sweepTimer = setInterval(() => this._sweep(), ENTRY_TTL_MS);
     this.sweepTimer.unref?.();
-    console.log("[feature-remediation] installed — routing feature.blocked");
+    log.info("installed — routing feature.blocked");
   }
 
   uninstall(): void {
@@ -102,13 +105,13 @@ export class FeatureRemediationPlugin implements Plugin {
   private _onBlocked(msg: BusMessage): void {
     const p = (msg.payload ?? {}) as FeatureBlockedPayload;
     if (!p.featureId) {
-      console.warn("[feature-remediation] feature.blocked without featureId — dropping");
+      log.warn("feature.blocked without featureId — dropping");
       return;
     }
     const kind = p.kind ?? "unknown";
 
     if (IGNORE_KINDS.has(kind)) {
-      console.log(`[feature-remediation] ${p.featureId} kind=${kind} — protoMaker self-heals; ignoring`);
+      log.info(`${p.featureId} kind=${kind} — protoMaker self-heals; ignoring`);
       return;
     }
 
@@ -127,7 +130,7 @@ export class FeatureRemediationPlugin implements Plugin {
       return;
     }
     if (entry.lastAttemptAt && this.now() - entry.lastAttemptAt < COOLDOWN_MS) {
-      console.log(`[feature-remediation] ${p.featureId} kind=${kind} — within cooldown, skipping`);
+      log.info(`${p.featureId} kind=${kind} — within cooldown, skipping`);
       return;
     }
 
@@ -147,7 +150,7 @@ export class FeatureRemediationPlugin implements Plugin {
       ...(p.prNumber ? [`PR #${p.prNumber}${p.branchName ? ` (branch ${p.branchName})` : ""}.`] : []),
       `Investigate and take the smallest unblocking action, or escalate with a crisp ask.`,
     ];
-    console.log(`[feature-remediation] → Roxy unblock_feature: ${p.featureId} (kind=${p.kind}, attempt via dispatch)`);
+    log.info(`→ Roxy unblock_feature: ${p.featureId} (kind=${p.kind}, attempt via dispatch)`);
     this.bus.publish("agent.skill.request", {
       id: crypto.randomUUID(),
       correlationId: crypto.randomUUID(),
@@ -182,7 +185,7 @@ export class FeatureRemediationPlugin implements Plugin {
       ...(p.prNumber ? [`PR #${p.prNumber}.`] : []),
     ].join("\n");
     const urgency = HITL_KINDS.has(p.kind ?? "") ? "high" : "medium";
-    console.log(`[feature-remediation] STUCK → escalating to operator: ${p.featureId} (kind=${p.kind}) — ${why}`);
+    log.warn(`STUCK → escalating to operator: ${p.featureId} (kind=${p.kind}) — ${why}`);
     this.bus.publish("operator.message.request", {
       id: crypto.randomUUID(),
       correlationId: crypto.randomUUID(),

--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -31,6 +31,7 @@ import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
 import type { EventBus, BusMessage, Plugin } from "../types.ts";
 import { makeGitHubAuth } from "../github-auth.ts";
+import { logger } from "../log.ts";
 import { isProductionLike } from "../runtime-env.ts";
 import { getFleetConfig } from "../fleet/fleet-config.ts";
 import { withCircuitBreaker } from "./circuit-breaker.ts";
@@ -44,6 +45,8 @@ import {
   type ReviewCommentPayload,
   type ReviewDismissalPayload,
 } from "../../src/webhooks/github-comment-response.ts";
+
+const log = logger("github");
 
 // ── Config types ──────────────────────────────────────────────────────────────
 
@@ -402,12 +405,12 @@ export class GitHubPlugin implements Plugin {
   install(bus: EventBus): void {
     const getToken = makeGitHubAuth();
     if (!getToken) {
-      console.log("[github] No auth configured (GITHUB_APP_ID or GITHUB_TOKEN required) — plugin disabled");
+      log.warn("No auth configured (GITHUB_APP_ID or GITHUB_TOKEN required) — plugin disabled");
       return;
     }
 
     const usingApp = !!(process.env.GITHUB_APP_ID && process.env.GITHUB_APP_PRIVATE_KEY);
-    console.log(`[github] Auth: ${usingApp ? "GitHub App (quinn[bot])" : "PAT (GITHUB_TOKEN)"}`);
+    log.info(`Auth: ${usingApp ? "GitHub App (quinn[bot])" : "PAT (GITHUB_TOKEN)"}`);
 
     this.config = loadConfig(this.workspaceDir);
     const webhookSecret = process.env.GITHUB_WEBHOOK_SECRET ?? "";
@@ -423,7 +426,7 @@ export class GitHubPlugin implements Plugin {
             "webhook receiver in production.",
         );
       }
-      console.warn("[github] GITHUB_WEBHOOK_SECRET not set — signature verification disabled (dev only)");
+      log.warn("GITHUB_WEBHOOK_SECRET not set — signature verification disabled (dev only)");
     }
 
     // ── Hot-reload github.yaml ────────────────────────────────────────────────
@@ -437,7 +440,7 @@ export class GitHubPlugin implements Plugin {
       reloadDebounceTimer = setTimeout(() => {
         this.config = loadConfig(this.workspaceDir);
         const repoCount = this.projectRegistry.getGithubCoords().length;
-        console.log(`[github] Config reloaded — ${repoCount} monitored repo(s)`);
+        log.info(`Config reloaded — ${repoCount} monitored repo(s)`);
       }, 300);
     };
 
@@ -473,7 +476,7 @@ export class GitHubPlugin implements Plugin {
         if (webhookSecret) {
           const sig = req.headers.get("X-Hub-Signature-256");
           if (!await validateSignature(webhookSecret, body, sig)) {
-            console.warn("[github] Invalid webhook signature — request rejected");
+            log.warn("Invalid webhook signature — request rejected");
             return new Response("Unauthorized", { status: 401 });
           }
         }
@@ -491,7 +494,7 @@ export class GitHubPlugin implements Plugin {
       },
     });
 
-    console.log(`[github] Webhook receiver on :${port}/webhook/github`);
+    log.info(`Webhook receiver on :${port}/webhook/github`);
   }
 
   uninstall(): void {
@@ -537,7 +540,7 @@ export class GitHubPlugin implements Plugin {
           source: { interface: "github" as const },
         });
 
-        console.log(`[github] repository.created: ${fullName} → ${topic}`);
+        log.info(`repository.created: ${fullName} → ${topic}`);
       }
       return;
     }
@@ -560,7 +563,7 @@ export class GitHubPlugin implements Plugin {
           payload: rel,
           source: { interface: "github" as const },
         });
-        console.log(`[github] release.published: ${rel.owner}/${rel.repo} ${rel.version} → release.published`);
+        log.info(`release.published: ${rel.owner}/${rel.repo} ${rel.version} → release.published`);
       }
       return;
     }
@@ -577,7 +580,7 @@ export class GitHubPlugin implements Plugin {
     // Requires the GitHub App to subscribe to `workflow_run` + `check_suite`.
     if ((event === "workflow_run" || event === "check_suite") && payload.action === "completed") {
       void this._handleCiCompletion(event, payload, bus, getToken).catch((err) => {
-        console.error(`[github] CI-completion re-review failed: ${err instanceof Error ? err.message : err}`);
+        log.error("CI-completion re-review failed", { err });
       });
       return;
     }
@@ -666,7 +669,7 @@ export class GitHubPlugin implements Plugin {
           const mergePayload = parsePRMergePayload(event, payload);
           if (mergePayload) {
             void handlePRMerge(mergePayload, getToken).catch((err) =>
-              console.warn(`[github] PR-merge indexing failed for ${owner}/${repoName}#${prNumber}: ${err instanceof Error ? err.message : err}`),
+              log.warn(`PR-merge indexing failed for ${owner}/${repoName}#${prNumber}`, { err }),
             );
           }
         }
@@ -679,12 +682,12 @@ export class GitHubPlugin implements Plugin {
     // pushback. Independent of the @mention / auto-review paths and best-effort.
     if (event === "pull_request_review_comment" && payload.action === "created") {
       void this._trackCommentResponse(payload, getToken).catch((err) =>
-        console.warn(`[github] comment-response tracking failed: ${err instanceof Error ? err.message : err}`),
+        log.warn("comment-response tracking failed", { err }),
       );
     }
     if (event === "pull_request_review" && payload.action === "dismissed") {
       void this._trackReviewDismissal(payload).catch((err) =>
-        console.warn(`[github] review-dismissal tracking failed: ${err instanceof Error ? err.message : err}`),
+        log.warn("review-dismissal tracking failed", { err }),
       );
     }
 
@@ -704,8 +707,8 @@ export class GitHubPlugin implements Plugin {
       (event === "issues" || event === "issue_comment" || event === "pull_request_review_comment") &&
       isAgentBotActor(ctx.author)
     ) {
-      console.log(
-        `[github] Dropping ${event}.${payload.action} on ${ctx.owner}/${ctx.repo}#${ctx.number} — ` +
+      log.info(
+        `Dropping ${event}.${payload.action} on ${ctx.owner}/${ctx.repo}#${ctx.number} — ` +
         `authored by agent bot ${ctx.author} (self-cascade guard, see #556)`,
       );
       return;
@@ -747,7 +750,7 @@ export class GitHubPlugin implements Plugin {
     if (!ctx.body.toLowerCase().includes(config.mentionHandle.toLowerCase())) return;
 
     if (config.admins?.length && !config.admins.some(a => a.toLowerCase() === ctx.author.toLowerCase())) {
-      console.log(`[github] ${event} from @${ctx.author} ignored — not in admins list`);
+      log.info(`${event} from @${ctx.author} ignored — not in admins list`);
       return;
     }
 
@@ -774,8 +777,8 @@ export class GitHubPlugin implements Plugin {
           body: JSON.stringify({ content: "eyes" }),
         }),
       );
-      if (!res.ok) console.error(`[github] reaction failed ${res.status}: ${await res.text()}`);
-    })().catch(err => console.error("[github] reaction error:", err));
+      if (!res.ok) log.error(`reaction failed ${res.status}: ${await res.text()}`);
+    })().catch(err => log.error("reaction error", { err }));
 
     // A top-level comment on a PR arrives as an `issue_comment` event — GitHub
     // models PR conversation comments as issue comments. The default
@@ -820,7 +823,7 @@ export class GitHubPlugin implements Plugin {
       reply: { topic: replyTopic },
     });
 
-    console.log(`[github] ${event} on ${ctx.owner}/${ctx.repo}#${ctx.number} → ${skillHint ?? "default"}`);
+    log.info(`${event} on ${ctx.owner}/${ctx.repo}#${ctx.number} → ${skillHint ?? "default"}`);
   }
 
   /** Tracks recently-dispatched (owner/repo#number) to suppress duplicate webhook deliveries. */
@@ -840,7 +843,7 @@ export class GitHubPlugin implements Plugin {
     if (!opts.skipDedup) {
       const lastDispatched = this.recentDispatches.get(dedupKey);
       if (lastDispatched && Date.now() - lastDispatched < GitHubPlugin.DEDUP_WINDOW_MS) {
-        console.log(`[github] Auto-review: skipping duplicate ${dedupKey} (dispatched ${Date.now() - lastDispatched}ms ago)`);
+        log.info(`Auto-review: skipping duplicate ${dedupKey} (dispatched ${Date.now() - lastDispatched}ms ago)`);
         return;
       }
     }
@@ -849,7 +852,7 @@ export class GitHubPlugin implements Plugin {
     const pr = payload.pull_request as Record<string, unknown>;
     const isDraft = pr?.draft as boolean;
     if (isDraft) {
-      console.log(`[github] Auto-review: skipping draft PR ${ctx.owner}/${ctx.repo}#${ctx.number}`);
+      log.info(`Auto-review: skipping draft PR ${ctx.owner}/${ctx.repo}#${ctx.number}`);
       return;
     }
 
@@ -910,7 +913,7 @@ export class GitHubPlugin implements Plugin {
       reply: { topic: replyTopic },
     });
 
-    console.log(`[github] Auto-review: ${ctx.owner}/${ctx.repo}#${ctx.number} (${action}) → pr_review`);
+    log.info(`Auto-review: ${ctx.owner}/${ctx.repo}#${ctx.number} (${action}) → pr_review`);
 
     // Leading acknowledgment comment so the PR shows Quinn engagement
     // immediately, not minutes later when the formal verdict review
@@ -929,8 +932,9 @@ export class GitHubPlugin implements Plugin {
         { owner: ctx.owner, repo: ctx.repo, number: ctx.number },
         "👀 Quinn is reviewing — verdict (PASS / WARN / FAIL) + findings to follow.",
       ).catch((err) => {
-        console.warn(
-          `[github] Auto-review: leading-comment post failed for ${ctx.owner}/${ctx.repo}#${ctx.number}: ${err instanceof Error ? err.message : err}`,
+        log.warn(
+          `Auto-review: leading-comment post failed for ${ctx.owner}/${ctx.repo}#${ctx.number}`,
+          { err },
         );
       });
     }
@@ -977,7 +981,7 @@ export class GitHubPlugin implements Plugin {
         | null;
       if (!quinnHasReviewed(reviews ?? undefined)) continue;
       if (!(await this._ciTerminal(getToken, owner, repo, headSha))) {
-        console.log(`[github] CI-completion (${event}): ${owner}/${repo}#${number} — checks not all terminal yet, deferring`);
+        log.info(`CI-completion (${event}): ${owner}/${repo}#${number} — checks not all terminal yet, deferring`);
         continue;
       }
 
@@ -1004,8 +1008,8 @@ export class GitHubPlugin implements Plugin {
         const approveKey = `approve-on-green:${owner}/${repo}#${number}@${headSha.slice(0, 7)}`;
         const lastApproved = this.recentDispatches.get(approveKey);
         if (lastApproved && Date.now() - lastApproved < GitHubPlugin.DEDUP_WINDOW_MS) {
-          console.log(
-            `[github] CI-completion (${event}): skipping duplicate approve-on-green ${approveKey} ` +
+          log.info(
+            `CI-completion (${event}): skipping duplicate approve-on-green ${approveKey} ` +
               `(approved ${Date.now() - lastApproved}ms ago)`,
           );
           continue;
@@ -1022,14 +1026,14 @@ export class GitHubPlugin implements Plugin {
             "CI terminal-green, no blockers on prior review — auto-approving on green (#748).",
             [],
           );
-          console.log(
-            `[github] CI-completion (${event}): auto-approved ${owner}/${repo}#${number} @${headSha.slice(0, 7)} ` +
+          log.info(
+            `CI-completion (${event}): auto-approved ${owner}/${repo}#${number} @${headSha.slice(0, 7)} ` +
               `(terminal-green, prior Quinn review COMMENTED) — #748`,
           );
         } catch (err) {
-          console.error(
-            `[github] CI-completion (${event}): auto-approve failed for ${owner}/${repo}#${number}: ` +
-              `${err instanceof Error ? err.message : err}`,
+          log.error(
+            `CI-completion (${event}): auto-approve failed for ${owner}/${repo}#${number}`,
+            { err },
           );
         }
         continue;
@@ -1049,7 +1053,7 @@ export class GitHubPlugin implements Plugin {
       // a single meaningful dispatch; the dispatcher's @sha7 cooldown collapses
       // any workflow_run+check_suite co-arrival.
       const synthPayload: Record<string, unknown> = { action: "ci_completed", pull_request: pr };
-      console.log(`[github] CI-completion (${event}): re-dispatching pr_review for ${owner}/${repo}#${number} @${headSha.slice(0, 7)}`);
+      log.info(`CI-completion (${event}): re-dispatching pr_review for ${owner}/${repo}#${number} @${headSha.slice(0, 7)}`);
       // event="pull_request" so the published topic is byte-identical to a
       // normal auto-review (the routed path is proven); the "ci_completed"
       // action just suppresses the opened-only leading comment.
@@ -1077,12 +1081,12 @@ export class GitHubPlugin implements Plugin {
         }),
       );
       if (!res.ok) {
-        console.warn(`[github] GET ${path} → ${res.status}`);
+        log.warn(`GET ${path} → ${res.status}`);
         return null;
       }
       return await res.json();
     } catch (err) {
-      console.error(`[github] GET ${path} error:`, err);
+      log.error(`GET ${path} error`, { err });
       return null;
     }
   }
@@ -1178,12 +1182,12 @@ export class GitHubPlugin implements Plugin {
         }),
       );
       if (!res.ok) {
-        console.error(`[github] Failed to post comment: ${res.status} ${await res.text()}`);
+        log.error(`Failed to post comment: ${res.status} ${await res.text()}`);
       } else {
-        console.log(`[github] Comment posted to ${ctx.owner}/${ctx.repo}#${ctx.number}`);
+        log.info(`Comment posted to ${ctx.owner}/${ctx.repo}#${ctx.number}`);
       }
     } catch (err) {
-      console.error("[github] Error posting comment:", err);
+      log.error("Error posting comment", { err });
     }
   }
 }

--- a/lib/plugins/issue-closer.ts
+++ b/lib/plugins/issue-closer.ts
@@ -19,6 +19,9 @@
 
 import type { Plugin, EventBus, BusMessage } from "../types.ts";
 import { closeIssue as defaultCloseIssue } from "../github-issues.ts";
+import { logger } from "../log.ts";
+
+const log = logger("issue-closer");
 
 interface FeatureCompletedPayload {
   featureId?: string;
@@ -55,7 +58,7 @@ export class IssueCloserPlugin implements Plugin {
         void this._onCompleted(msg);
       }),
     );
-    console.log("[issue-closer] installed — closing originating GitHub issues on feature.completed");
+    log.info("installed — closing originating GitHub issues on feature.completed");
   }
 
   uninstall(): void {
@@ -71,7 +74,7 @@ export class IssueCloserPlugin implements Plugin {
     }
     const [owner, name] = p.repo.split("/");
     if (!owner || !name) {
-      console.warn(`[issue-closer] feature.completed has malformed repo "${p.repo}" — cannot close #${p.githubIssueNumber}`);
+      log.warn(`feature.completed has malformed repo "${p.repo}" — cannot close #${p.githubIssueNumber}`);
       return;
     }
     const comment = [
@@ -82,10 +85,10 @@ export class IssueCloserPlugin implements Plugin {
       .join("\n");
     try {
       await this.closeFn(owner, name, p.githubIssueNumber, { comment, reason: "completed" });
-      console.log(`[issue-closer] closed ${p.repo}#${p.githubIssueNumber} (feature ${p.featureId ?? "?"} shipped)`);
+      log.info(`closed ${p.repo}#${p.githubIssueNumber} (feature ${p.featureId ?? "?"} shipped)`);
     } catch (err) {
       // Loud, but never breaks the bus / other feature.completed consumers.
-      console.warn(`[issue-closer] failed to close ${p.repo}#${p.githubIssueNumber}: ${String(err).slice(0, 300)}`);
+      log.warn(`failed to close ${p.repo}#${p.githubIssueNumber}`, { err });
     }
   }
 }

--- a/lib/plugins/linear-agent-session-poller.ts
+++ b/lib/plugins/linear-agent-session-poller.ts
@@ -24,6 +24,9 @@ import { join } from "node:path";
 import type { EventBus, Plugin } from "../types.ts";
 import { LinearAgentActivityClient } from "../linear/agent-activity-client.ts";
 import { getLinearAvaTokenManager } from "../linear/ava-oauth-token-manager.ts";
+import { logger } from "../log.ts";
+
+const log = logger("linear-session-poller");
 
 const GRAPHQL_URL = "https://api.linear.app/graphql";
 const POLL_INTERVAL_MS = 20_000;
@@ -93,13 +96,13 @@ export class LinearAgentSessionPoller implements Plugin {
 
   install(bus: EventBus): void {
     if (!this.apiKey) {
-      console.warn("[linear-session-poller] LINEAR_API_KEY not set — stale-session recovery disabled");
+      log.warn("LINEAR_API_KEY not set — stale-session recovery disabled");
       return;
     }
     this.timer = setInterval(() => void this._poll(bus), this.intervalMs);
     this.timer.unref?.();
     void this._poll(bus); // immediate first sweep
-    console.log(`[linear-session-poller] recovering stale agent sessions every ${this.intervalMs / 1000}s`);
+    log.info(`recovering stale agent sessions every ${this.intervalMs / 1000}s`);
   }
 
   uninstall(): void {
@@ -112,7 +115,7 @@ export class LinearAgentSessionPoller implements Plugin {
     try {
       sessions = await fetchStaleSessions(this.apiKey!, this.fetchImpl);
     } catch (err) {
-      console.error(`[linear-session-poller] poll failed: ${err instanceof Error ? err.message : String(err)}`);
+      log.error(`poll failed: ${err instanceof Error ? err.message : String(err)}`);
       return;
     }
     this._prune();
@@ -129,12 +132,12 @@ export class LinearAgentSessionPoller implements Plugin {
           assigned = await this.assignedToAva(s.issueId);
         } catch (err) {
           // Transient/auth error — don't mark handled, retry next sweep.
-          console.warn(`[linear-session-poller] assignee check failed for session ${s.id} — retry next sweep: ${err instanceof Error ? err.message : String(err)}`);
+          log.warn(`assignee check failed for session ${s.id} — retry next sweep: ${err instanceof Error ? err.message : String(err)}`);
           continue;
         }
         if (!assigned) {
           this.handled.set(key, Date.now()); // mark so we don't re-check this stale state every sweep
-          console.log(`[linear-session-poller] stale session ${s.id}${s.issueIdentifier ? ` (${s.issueIdentifier})` : ""} not assigned to Ava — skipping recovery`);
+          log.info(`stale session ${s.id}${s.issueIdentifier ? ` (${s.issueIdentifier})` : ""} not assigned to Ava — skipping recovery`);
           continue;
         }
       }
@@ -157,7 +160,7 @@ export class LinearAgentSessionPoller implements Plugin {
         },
         reply: { topic: `linear.agent_activity.${s.id}`, format: "markdown" as const },
       });
-      console.log(`[linear-session-poller] recovered stale session ${s.id}${s.issueIdentifier ? ` (${s.issueIdentifier})` : ""} → dispatched to Ava`);
+      log.info(`recovered stale session ${s.id}${s.issueIdentifier ? ` (${s.issueIdentifier})` : ""} → dispatched to Ava`);
     }
   }
 

--- a/lib/plugins/linear-proto-bridge.ts
+++ b/lib/plugins/linear-proto-bridge.ts
@@ -28,6 +28,9 @@
  */
 
 import type { EventBus, BusMessage, Plugin } from "../types.ts";
+import { logger } from "../log.ts";
+
+const log = logger("linear-proto-bridge");
 
 const DEFAULT_TRIGGER_LABEL = "proto-task";
 
@@ -67,9 +70,7 @@ export class LinearProtoBridgePlugin implements Plugin {
     );
     this.subscriptionIds.push(subId);
 
-    console.log(
-      `[linear-proto-bridge] installed — gating on label "${this.triggerLabel}"`,
-    );
+    log.info(`installed — gating on label "${this.triggerLabel}"`);
   }
 
   uninstall(): void {
@@ -132,8 +133,8 @@ export class LinearProtoBridgePlugin implements Plugin {
       source: { interface: "linear" as const },
     });
 
-    console.log(
-      `[linear-proto-bridge] ${payload.identifier ?? payload.issueId} → code.execute@proto ` +
+    log.info(
+      `${payload.identifier ?? payload.issueId} → code.execute@proto ` +
         `(label="${this.triggerLabel}", reply → ${replyTopic})`,
     );
   }

--- a/lib/plugins/linear.ts
+++ b/lib/plugins/linear.ts
@@ -46,6 +46,9 @@ import { isProductionLike } from "../runtime-env.ts";
 import { LinearClient, type LinearPriority } from "../linear-client.ts";
 import { getLinearAvaTokenManager } from "../linear/ava-oauth-token-manager.ts";
 import { LinearAgentActivityClient } from "../linear/agent-activity-client.ts";
+import { logger } from "../log.ts";
+
+const log = logger("linear");
 
 // ── Limits ───────────────────────────────────────────────────────────────────
 
@@ -225,7 +228,7 @@ export class LinearPlugin implements Plugin {
           "unauthenticated webhook receiver in production.",
         );
       }
-      console.warn("[linear] LINEAR_WEBHOOK_SECRET not set — signature verification disabled (dev only)");
+      log.warn("LINEAR_WEBHOOK_SECRET not set — signature verification disabled (dev only)");
     }
 
     const dedup = new DeliveryDedup();
@@ -239,12 +242,12 @@ export class LinearPlugin implements Plugin {
     const tokenManager = getLinearAvaTokenManager(dataDir);
     const avaClient = tokenManager.isConfigured() ? new LinearAgentActivityClient(tokenManager) : null;
     this._avaClient = avaClient;
-    if (!avaClient) console.warn("[linear] LINEAR_AVA_CLIENT_ID/_SECRET not set — post-as-Ava disabled (replies fall back to personal key)");
+    if (!avaClient) log.warn("LINEAR_AVA_CLIENT_ID/_SECRET not set — post-as-Ava disabled (replies fall back to personal key)");
 
     // Outbound comments prefer Ava's identity; create/update still use the
     // personal-key client (team/state resolution lives there).
     if (client || avaClient) this._wireOutbound(bus, client, avaClient);
-    else console.warn("[linear] no LINEAR_API_KEY and no Ava OAuth — outbound Linear mutations disabled");
+    else log.warn("no LINEAR_API_KEY and no Ava OAuth — outbound Linear mutations disabled");
 
     if (avaClient) this._wireAgentActivity(bus, avaClient);
 
@@ -270,7 +273,7 @@ export class LinearPlugin implements Plugin {
           if (webhookSecret) {
             const sig = req.headers.get("linear-signature") ?? "";
             if (!verifyLinearSignature(bodyBuffer, sig, webhookSecret)) {
-              console.warn("[linear] Invalid webhook signature — request rejected");
+              log.warn("Invalid webhook signature — request rejected");
               return new Response("Unauthorized", { status: 401 });
             }
           }
@@ -285,7 +288,7 @@ export class LinearPlugin implements Plugin {
           const parsed = LinearWebhookEnvelopeSchema.safeParse(raw);
           if (!parsed.success) {
             const issues = parsed.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; ");
-            console.warn(`[linear] Webhook envelope failed schema validation — ${issues}`);
+            log.warn(`Webhook envelope failed schema validation — ${issues}`);
             return new Response(`Bad request: ${issues}`, { status: 400 });
           }
           const payload = parsed.data;
@@ -296,8 +299,8 @@ export class LinearPlugin implements Plugin {
           if (payload.webhookTimestamp != null) {
             const age = Date.now() - payload.webhookTimestamp;
             if (age > FRESHNESS_WINDOW_MS || age < -FRESHNESS_WINDOW_MS) {
-              console.warn(
-                `[linear] Webhook timestamp outside freshness window ` +
+              log.warn(
+                `Webhook timestamp outside freshness window ` +
                 `(age=${age}ms, max=${FRESHNESS_WINDOW_MS}ms) — request rejected`,
               );
               return new Response("Stale webhook timestamp", { status: 400 });
@@ -322,7 +325,7 @@ export class LinearPlugin implements Plugin {
           try {
             await this._handleWebhook(payload, bus);
           } catch (err) {
-            console.error("[linear] Webhook handler error — returning 500 for retry:", err);
+            log.error("Webhook handler error — returning 500 for retry", { err });
             return new Response("Internal handler error", { status: 500 });
           }
 
@@ -332,15 +335,15 @@ export class LinearPlugin implements Plugin {
     } catch (err) {
       // Server start failed (port in use, perms, etc.). Fail-loud but don't
       // block the whole process — outbound subscribers are still useful.
-      console.error(
-        `[linear] Failed to start webhook server on :${port} — inbound disabled. Outbound mutations remain active. Error:`,
-        err,
+      log.error(
+        `Failed to start webhook server on :${port} — inbound disabled. Outbound mutations remain active`,
+        { err },
       );
       this.server = null;
       return;
     }
 
-    console.log(`[linear] Webhook receiver on :${port}/webhooks/linear`);
+    log.info(`Webhook receiver on :${port}/webhooks/linear`);
   }
 
   uninstall(): void {
@@ -353,12 +356,12 @@ export class LinearPlugin implements Plugin {
 
     if (payload.type === "Issue") {
       if (!payload.data) {
-        console.warn(`[linear] Issue webhook missing data field — dropping`);
+        log.warn(`Issue webhook missing data field — dropping`);
         return;
       }
       const issueParsed = LinearIssueDataSchema.safeParse(payload.data);
       if (!issueParsed.success) {
-        console.warn(`[linear] Issue payload failed schema — dropping. ${issueParsed.error.issues.map(i => i.message).join("; ")}`);
+        log.warn(`Issue payload failed schema — dropping. ${issueParsed.error.issues.map(i => i.message).join("; ")}`);
         return;
       }
       this._publishIssue(issueParsed.data, action, bus);
@@ -366,12 +369,12 @@ export class LinearPlugin implements Plugin {
     }
     if (payload.type === "Comment") {
       if (!payload.data) {
-        console.warn(`[linear] Comment webhook missing data field — dropping`);
+        log.warn(`Comment webhook missing data field — dropping`);
         return;
       }
       const commentParsed = LinearCommentDataSchema.safeParse(payload.data);
       if (!commentParsed.success) {
-        console.warn(`[linear] Comment payload failed schema — dropping. ${commentParsed.error.issues.map(i => i.message).join("; ")}`);
+        log.warn(`Comment payload failed schema — dropping. ${commentParsed.error.issues.map(i => i.message).join("; ")}`);
         return;
       }
       this._publishComment(commentParsed.data, action, bus);
@@ -379,12 +382,12 @@ export class LinearPlugin implements Plugin {
     }
     if (payload.type === "Project") {
       if (!payload.data) {
-        console.warn(`[linear] Project webhook missing data field — dropping`);
+        log.warn(`Project webhook missing data field — dropping`);
         return;
       }
       const projectParsed = LinearProjectDataSchema.safeParse(payload.data);
       if (!projectParsed.success) {
-        console.warn(`[linear] Project payload failed schema — dropping. ${projectParsed.error.issues.map(i => i.message).join("; ")}`);
+        log.warn(`Project payload failed schema — dropping. ${projectParsed.error.issues.map(i => i.message).join("; ")}`);
         return;
       }
       this._publishProject(projectParsed.data, action, bus);
@@ -405,7 +408,7 @@ export class LinearPlugin implements Plugin {
     }
     // Unknown envelope type — log loudly + drop. Linear adds new resource
     // types over time; fail visibly so we know to extend the plugin.
-    console.warn(`[linear] Unhandled webhook type "${payload.type}" action="${payload.action}" — dropping (extend LinearPlugin to support)`);
+    log.warn(`Unhandled webhook type "${payload.type}" action="${payload.action}" — dropping (extend LinearPlugin to support)`);
   }
 
   private _publishAgentNotification(action: string, notification: Record<string, unknown>, bus: EventBus): void {
@@ -436,7 +439,7 @@ export class LinearPlugin implements Plugin {
         commentId,
       },
     });
-    console.log(`[linear] agent.${action}${issueId ? ` on issue ${issueId}` : ""}${isMention ? " → Ava (mention)" : ""}`);
+    log.info(`agent.${action}${issueId ? ` on issue ${issueId}` : ""}${isMention ? " → Ava (mention)" : ""}`);
   }
 
   private async _publishAgentSession(
@@ -462,10 +465,10 @@ export class LinearPlugin implements Plugin {
       try {
         assigned = await this._avaClient.isAssignedToAva(issueId);
       } catch (err) {
-        console.warn(`[linear] assignee check failed for issue ${issueId} — allowing (fail-open): ${err instanceof Error ? err.message : String(err)}`);
+        log.warn(`assignee check failed for issue ${issueId} — allowing (fail-open): ${err instanceof Error ? err.message : String(err)}`);
       }
       if (!assigned) {
-        console.log(`[linear] agent_session.${action} on issue ${issueId} — not assigned to Ava, dropping (no response)`);
+        log.info(`agent_session.${action} on issue ${issueId} — not assigned to Ava, dropping (no response)`);
         return;
       }
     }
@@ -493,7 +496,7 @@ export class LinearPlugin implements Plugin {
         ? { reply: { topic: `linear.agent_activity.${sessionId}`, format: "markdown" as const } }
         : {}),
     });
-    console.log(`[linear] agent_session.${action}${sessionId ? ` session=${sessionId}` : ""}`);
+    log.info(`agent_session.${action}${sessionId ? ` session=${sessionId}` : ""}`);
   }
 
   // ── Agent-session activities (post AS Ava via actor=app OAuth) ──────────────
@@ -518,7 +521,7 @@ export class LinearPlugin implements Plugin {
         ? "On it — taking a look and routing this."
         : "Got it — looking at that now.";
       void activity.thought(sessionId, ack).catch((err) => {
-        console.error(`[linear] agent-activity thought ack failed (session ${sessionId}): ${err instanceof Error ? err.message : String(err)}`);
+        log.error(`agent-activity thought ack failed (session ${sessionId}): ${err instanceof Error ? err.message : String(err)}`);
       });
     });
 
@@ -536,12 +539,12 @@ export class LinearPlugin implements Plugin {
       void activity.response(sessionId, body)
         .then(() => {
           publishResult(bus, msg.correlationId, "linear.agent_activity.result", { success: true, sessionId });
-          console.log(`[linear] response activity posted to session ${sessionId}`);
+          log.info(`response activity posted to session ${sessionId}`);
         })
         .catch((err) => {
           const errMsg = err instanceof Error ? err.message : String(err);
           publishResult(bus, msg.correlationId, "linear.agent_activity.result", { success: false, sessionId, error: errMsg });
-          console.error(`[linear] response activity failed (session ${sessionId}): ${errMsg}`);
+          log.error(`response activity failed (session ${sessionId}): ${errMsg}`);
         });
     });
   }
@@ -589,7 +592,7 @@ export class LinearPlugin implements Plugin {
         format: "markdown",
       },
     });
-    console.log(`[linear] issue.${action} ${issue.identifier ?? issue.id} "${issue.title}"`);
+    log.info(`issue.${action} ${issue.identifier ?? issue.id} "${issue.title}"`);
   }
 
   private _publishComment(comment: LinearCommentData, action: string, bus: EventBus): void {
@@ -623,7 +626,7 @@ export class LinearPlugin implements Plugin {
         format: "markdown",
       },
     });
-    console.log(`[linear] comment.${action} on ${comment.issue?.identifier ?? issueId}`);
+    log.info(`comment.${action} on ${comment.issue?.identifier ?? issueId}`);
   }
 
   private _publishProject(project: LinearProjectData, action: string, bus: EventBus): void {
@@ -649,7 +652,7 @@ export class LinearPlugin implements Plugin {
         userId: project.creator?.id,
       },
     });
-    console.log(`[linear] project.${action} "${project.name}" (${project.id})`);
+    log.info(`project.${action} "${project.name}" (${project.id})`);
   }
 
   // ── Outbound ───────────────────────────────────────────────────────────────
@@ -691,11 +694,11 @@ export class LinearPlugin implements Plugin {
         try {
           await avaClient.createComment(issueId, body);
           publishResult(bus, msg.correlationId, "linear.reply.result", { success: true, issueId, as: "ava" });
-          console.log(`[linear] Comment posted AS Ava on issue ${issueId}`);
+          log.info(`Comment posted AS Ava on issue ${issueId}`);
           return;
         } catch (err) {
           const errMsg = err instanceof Error ? err.message : String(err);
-          console.warn(`[linear] post-as-Ava comment failed on ${issueId} (${errMsg}) — falling back to personal key`);
+          log.warn(`post-as-Ava comment failed on ${issueId} (${errMsg}) — falling back to personal key`);
         }
       }
       // 2) Fall back to the personal-key client.
@@ -703,7 +706,7 @@ export class LinearPlugin implements Plugin {
         publishResult(bus, msg.correlationId, "linear.reply.result", {
           success: false, issueId, error: "no Ava token and no LINEAR_API_KEY — cannot post comment",
         });
-        console.error(`[linear] cannot post comment on ${issueId} — no Ava token and no personal key`);
+        log.error(`cannot post comment on ${issueId} — no Ava token and no personal key`);
         return;
       }
       try {
@@ -714,8 +717,8 @@ export class LinearPlugin implements Plugin {
           as: "personal-key",
           error: ok ? undefined : "client.addComment returned false",
         });
-        if (ok) console.log(`[linear] Comment posted (personal key) on issue ${issueId}`);
-        else console.warn(`[linear] Failed to post comment on issue ${issueId}`);
+        if (ok) log.info(`Comment posted (personal key) on issue ${issueId}`);
+        else log.warn(`Failed to post comment on issue ${issueId}`);
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : String(err);
         publishResult(bus, msg.correlationId, "linear.reply.result", {
@@ -723,7 +726,7 @@ export class LinearPlugin implements Plugin {
           issueId,
           error: errMsg,
         });
-        console.error(`[linear] Comment exception on issue ${issueId}: ${errMsg}`);
+        log.error(`Comment exception on issue ${issueId}: ${errMsg}`);
       }
     });
 
@@ -763,9 +766,9 @@ export class LinearPlugin implements Plugin {
           error: result.success ? undefined : result.reason,
         });
         if (result.success) {
-          console.log(`[linear] Issue ${issueId} updated: ${JSON.stringify(payload)}`);
+          log.info(`Issue ${issueId} updated: ${JSON.stringify(payload)}`);
         } else {
-          console.warn(`[linear] Issue ${issueId} update skipped: ${result.reason}`);
+          log.warn(`Issue ${issueId} update skipped: ${result.reason}`);
         }
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : String(err);
@@ -774,7 +777,7 @@ export class LinearPlugin implements Plugin {
           issueId,
           error: errMsg,
         });
-        console.error(`[linear] Issue ${issueId} update exception: ${errMsg}`);
+        log.error(`Issue ${issueId} update exception: ${errMsg}`);
       }
     });
 
@@ -802,7 +805,7 @@ export class LinearPlugin implements Plugin {
           success: false,
           error: "missing teamKey or title",
         });
-        console.warn("[linear] linear.create.issue missing teamKey or title — skipping");
+        log.warn("linear.create.issue missing teamKey or title — skipping");
         return;
       }
       try {
@@ -820,15 +823,15 @@ export class LinearPlugin implements Plugin {
           issueId: newId,
           error: newId === null ? `team '${payload.teamKey}' not found or createIssue failed` : undefined,
         });
-        if (newId) console.log(`[linear] Created issue ${newId} in team ${payload.teamKey}`);
-        else console.warn(`[linear] Failed to create issue in team ${payload.teamKey}`);
+        if (newId) log.info(`Created issue ${newId} in team ${payload.teamKey}`);
+        else log.warn(`Failed to create issue in team ${payload.teamKey}`);
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : String(err);
         publishResult(bus, msg.correlationId, "linear.create.issue.result", {
           success: false,
           error: errMsg,
         });
-        console.error(`[linear] Create issue exception in team ${payload.teamKey}: ${errMsg}`);
+        log.error(`Create issue exception in team ${payload.teamKey}: ${errMsg}`);
       }
     });
   }

--- a/lib/plugins/logger.ts
+++ b/lib/plugins/logger.ts
@@ -2,6 +2,9 @@ import { Database } from "bun:sqlite";
 import { mkdirSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import type { Plugin, EventBus, BusMessage, LoggerTurnQueryRequest, LoggerTurnQueryResponse, ConversationTurn } from "../types";
+import { logger } from "../log.ts";
+
+const log = logger("event-logger");
 
 /** Object keys whose values are masked before an event is persisted (#801). */
 const SECRET_KEY_RE = /(token|secret|password|passwd|api[-_]?key|private[-_]?key|authorization|bearer|refresh[-_]?token|client[-_]?secret|credential)/i;
@@ -133,10 +136,10 @@ export class LoggerPlugin implements Plugin {
       const deleted = this.db.run("DELETE FROM events WHERE timestamp < ?", [cutoff]);
       this.db.exec("PRAGMA incremental_vacuum;");
       if ((deleted as { changes?: number }).changes) {
-        console.log(`[logger] retention sweep: purged ${(deleted as { changes?: number }).changes} event(s) older than ${Math.round(ms / 86400000)}d`);
+        log.info(`retention sweep: purged ${(deleted as { changes?: number }).changes} event(s) older than ${Math.round(ms / 86400000)}d`);
       }
     } catch (err) {
-      console.warn("[logger] retention sweep failed:", err);
+      log.warn("retention sweep failed", { err });
     }
   }
 

--- a/lib/plugins/operator-routing.ts
+++ b/lib/plugins/operator-routing.ts
@@ -33,6 +33,9 @@
 
 import type { EventBus, BusMessage, Plugin } from "../types.ts";
 import type { IdentityRegistry } from "../identity/identity-registry.ts";
+import { logger } from "../log.ts";
+
+const log = logger("operator-routing");
 
 /** Thrown when the plugin has no transport available for the operator. */
 export class OperatorUnreachableError extends Error {
@@ -84,9 +87,7 @@ export class OperatorRoutingPlugin implements Plugin {
         // callers (the tool handler) subscribe to this and surface the
         // error to the agent's ReAct loop.
         const errMsg = err instanceof Error ? err.message : String(err);
-        console.error(
-          `[operator-routing] FAILED to route message from ${req.from}: ${errMsg}`,
-        );
+        log.error(`FAILED to route message from ${req.from}: ${errMsg}`);
         bus.publish(`operator.message.failed.${req.correlationId}`, {
           id: crypto.randomUUID(),
           correlationId: req.correlationId,
@@ -141,8 +142,8 @@ export class OperatorRoutingPlugin implements Plugin {
       );
     }
 
-    console.log(
-      `[operator-routing] Delivered message from ${req.from} via ${delivered.join(", ")} (urgency=${req.urgency}, topic=${req.topic ?? "none"})`,
+    log.info(
+      `Delivered message from ${req.from} via ${delivered.join(", ")} (urgency=${req.urgency}, topic=${req.topic ?? "none"})`,
     );
   }
 }

--- a/lib/plugins/protomaker-board-bridge.ts
+++ b/lib/plugins/protomaker-board-bridge.ts
@@ -23,6 +23,9 @@
 import type { EventBus, BusMessage, Plugin } from "../types.ts";
 import type { ProjectRegistry } from "../../src/plugins/project-registry.ts";
 import type { GithubIssueOpenedPayload } from "../../src/event-bus/payloads.ts";
+import { logger } from "../log.ts";
+
+const log = logger("protomaker-board-bridge");
 
 const DEFAULT_PROTOMAKER_BASE = "http://protomaker-server:3008";
 
@@ -92,9 +95,7 @@ export class ProtoMakerBoardBridgePlugin implements Plugin {
     bus.subscribe("github.issue.opened", this.name, (msg: BusMessage) => {
       void this._forward(msg).catch((err) => {
         // Fire-and-forget subscriber — surface loudly, can't return to a caller.
-        console.error(
-          `[protomaker-board-bridge] forward failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
+        log.error("forward failed", { err });
       });
     });
   }
@@ -109,8 +110,8 @@ export class ProtoMakerBoardBridgePlugin implements Plugin {
     if (!project) return; // not a managed project repo — workstacean triage owns it
 
     if (!this.apiKey) {
-      console.warn(
-        `[protomaker-board-bridge] AUTOMAKER_API_KEY not set — cannot forward ${issue.owner}/${issue.repo}#${issue.number}`,
+      log.warn(
+        `AUTOMAKER_API_KEY not set — cannot forward ${issue.owner}/${issue.repo}#${issue.number}`,
       );
       return;
     }
@@ -130,8 +131,8 @@ export class ProtoMakerBoardBridgePlugin implements Plugin {
         `protoMaker signal/submit ${resp.status}: ${(await resp.text()).slice(0, 200)}`,
       );
     }
-    console.log(
-      `[protomaker-board-bridge] ${issue.owner}/${issue.repo}#${issue.number} → board "${project.slug}" (${project.path})`,
+    log.info(
+      `${issue.owner}/${issue.repo}#${issue.number} → board "${project.slug}" (${project.path})`,
     );
   }
 }

--- a/lib/plugins/scheduler.ts
+++ b/lib/plugins/scheduler.ts
@@ -3,14 +3,9 @@ import { join, resolve } from "node:path";
 import { CronExpressionParser } from "cron-parser";
 import * as YAML from "yaml";
 import type { Plugin, EventBus, BusMessage } from "../types";
+import { logger } from "../log.ts";
 
-const DEBUG = process.env.DEBUG === "1" || process.env.DEBUG === "true";
-
-function debug(...args: unknown[]): void {
-  if (DEBUG) {
-    console.log("[DEBUG]", ...args);
-  }
-}
+const log = logger("scheduler");
 
 interface ScheduleDefinition {
   id: string;
@@ -74,7 +69,7 @@ export class SchedulerPlugin implements Plugin {
       this.handleCommand(msg);
     });
 
-    debug("Scheduler ready. Timezone:", this.defaultTimezone, "Crons dir:", this.cronsDir);
+    log.debug("ready", { timezone: this.defaultTimezone, cronsDir: this.cronsDir });
   }
 
   uninstall(): void {
@@ -98,12 +93,12 @@ export class SchedulerPlugin implements Plugin {
         this.validate(def);
         this.schedule(def, filePath);
       } catch (err) {
-        console.error(`[Scheduler] Failed to load ${file}:`, err);
+        log.error(`Failed to load ${file}`, { err });
       }
     }
 
     if (files.length > 0) {
-      console.log(`[Scheduler] Loaded ${files.length} schedule(s) from ${this.cronsDir}`);
+      log.info(`Loaded ${files.length} schedule(s) from ${this.cronsDir}`);
     }
 
     this.watchForNewFiles();
@@ -126,9 +121,9 @@ export class SchedulerPlugin implements Plugin {
           this.validate(def);
           this.schedule(def, filePath);
           existing.add(file);
-          console.log(`[Scheduler] Hot-loaded new cron: ${file}`);
+          log.info(`Hot-loaded new cron: ${file}`);
         } catch (err) {
-          console.error(`[Scheduler] Failed to load ${file}:`, err);
+          log.error(`Failed to load ${file}`, { err });
         }
       }
     }, 5000);
@@ -161,7 +156,7 @@ export class SchedulerPlugin implements Plugin {
     this.cancelTimer(def.id);
 
     if (def.enabled === false) {
-      debug("Schedule disabled:", def.id);
+      log.debug("Schedule disabled", { id: def.id });
       return;
     }
 
@@ -194,7 +189,7 @@ export class SchedulerPlugin implements Plugin {
 
       // Fire immediately if missed (delay is negative and within reason — max 24h)
       if (delay < 0 && delay > -24 * 60 * 60 * 1000) {
-        debug("Firing missed schedule:", def.id, "was", Math.round(-delay / 1000 / 60), "min ago");
+        log.debug("Firing missed schedule", { id: def.id, agoMin: Math.round(-delay / 1000 / 60) });
         this.fire(def, filePath);
         if (def.type === "once") return; // one-shot, done
         // For recurring, schedule the next one after firing
@@ -215,9 +210,9 @@ export class SchedulerPlugin implements Plugin {
       this.timers.set(def.id, { definition: def, timer, filePath });
 
       const nextStr = nextDate.toISOString();
-      debug("Scheduled:", def.id, "fires at", nextStr, `(${Math.round(actualDelay / 1000 / 60)} min)`);
+      log.debug("Scheduled", { id: def.id, firesAt: nextStr, inMin: Math.round(actualDelay / 1000 / 60) });
     } catch (err) {
-      console.error(`[Scheduler] Failed to schedule ${def.id}:`, err);
+      log.error(`Failed to schedule ${def.id}`, { err });
     }
   }
 
@@ -239,9 +234,9 @@ export class SchedulerPlugin implements Plugin {
       // Delete the YAML file
       try {
         unlinkSync(filePath);
-        debug("Deleted one-shot schedule:", def.id);
+        log.debug("Deleted one-shot schedule", { id: def.id });
       } catch (err) {
-        console.error(`[Scheduler] Failed to delete ${filePath}:`, err);
+        log.error(`Failed to delete ${filePath}`, { err });
       }
       this.timers.delete(def.id);
     } else {
@@ -259,7 +254,7 @@ export class SchedulerPlugin implements Plugin {
       payload: { ...def.payload },
     };
 
-    console.log(`[Scheduler] Firing: ${def.id} → ${def.topic}`);
+    log.info(`Firing: ${def.id} → ${def.topic}`);
     this.bus.publish(def.topic, msg);
   }
 
@@ -297,7 +292,7 @@ export class SchedulerPlugin implements Plugin {
         this.handleResume(payload);
         break;
       default:
-        console.error(`[Scheduler] Unknown action: ${action}`);
+        log.error(`Unknown action: ${action}`);
     }
   }
 
@@ -310,7 +305,7 @@ export class SchedulerPlugin implements Plugin {
     payload?: { content?: string; sender?: string; channel?: string };
   }): void {
     if (!payload.id || !payload.schedule || !payload.topic || !payload.payload?.content) {
-      console.error("[Scheduler] add requires: id, schedule, topic, payload.content");
+      log.error("add requires: id, schedule, topic, payload.content");
       return;
     }
 
@@ -329,7 +324,7 @@ export class SchedulerPlugin implements Plugin {
     try {
       this.validate(def);
     } catch (err) {
-      console.error("[Scheduler] Invalid schedule:", err);
+      log.error("Invalid schedule", { err });
       return;
     }
 
@@ -337,7 +332,7 @@ export class SchedulerPlugin implements Plugin {
     this.saveYaml(def, filePath);
     this.schedule(def, filePath);
 
-    console.log(`[Scheduler] Added: ${def.id} (${def.type} ${def.schedule})`);
+    log.info(`Added: ${def.id} (${def.type} ${def.schedule})`);
   }
 
   private handleRemove(payload: { id?: string }): void {
@@ -350,7 +345,7 @@ export class SchedulerPlugin implements Plugin {
       unlinkSync(filePath);
     }
 
-    console.log(`[Scheduler] Removed: ${payload.id}`);
+    log.info(`Removed: ${payload.id}`);
   }
 
   private handleList(requestMsg: BusMessage): void {
@@ -382,7 +377,7 @@ export class SchedulerPlugin implements Plugin {
       this.cancelTimer(payload.id);
       active.definition.enabled = false;
       this.saveYaml(active.definition, active.filePath);
-      console.log(`[Scheduler] Paused: ${payload.id}`);
+      log.info(`Paused: ${payload.id}`);
     }
   }
 
@@ -396,7 +391,7 @@ export class SchedulerPlugin implements Plugin {
       def.enabled = true;
       this.saveYaml(def, filePath);
       this.schedule(def, filePath);
-      console.log(`[Scheduler] Resumed: ${payload.id}`);
+      log.info(`Resumed: ${payload.id}`);
     }
   }
 }

--- a/lib/plugins/signal.ts
+++ b/lib/plugins/signal.ts
@@ -1,4 +1,7 @@
 import type { Plugin, EventBus, BusMessage } from "../types";
+import { logger } from "../log.ts";
+
+const log = logger("signal");
 
 interface SignalEnvelope {
   envelope: {
@@ -37,7 +40,7 @@ export class SignalPlugin implements Plugin {
     this.signalNumber = process.env.SIGNAL_NUMBER;
 
     if (!this.signalUrl || !this.signalNumber) {
-      console.log("Signal not configured, skipping bridge");
+      log.info("Signal not configured, skipping bridge");
       return;
     }
 
@@ -65,13 +68,13 @@ export class SignalPlugin implements Plugin {
     const { baseUrl, auth } = parseAuth(this.signalUrl);
     const wsUrl = baseUrl.replace(/^https/, "wss") + `/v1/receive/${this.signalNumber}`;
     const wsUrlWithAuth = auth ? wsUrl.replace(/^wss?:\/\//, `wss://${auth}@`) : wsUrl;
-    console.log(`Connecting to Signal WebSocket: ${wsUrl}`);
+    log.info(`Connecting to Signal WebSocket: ${wsUrl}`);
 
     this.ws = new WebSocket(wsUrlWithAuth);
 
-    this.ws.onopen = () => console.log("Signal bridge connected");
-    this.ws.onerror = (err) => console.error("Signal WebSocket error:", err);
-    this.ws.onclose = () => console.log("Signal WebSocket closed");
+    this.ws.onopen = () => log.info("Signal bridge connected");
+    this.ws.onerror = (err) => log.error("Signal WebSocket error", { err });
+    this.ws.onclose = () => log.info("Signal WebSocket closed");
 
     this.ws.onmessage = (event) => {
       try {
@@ -87,7 +90,7 @@ export class SignalPlugin implements Plugin {
         if (!text) return;
 
         const sender = envelope.source;
-        console.log(`[Signal] ${sender}: ${text}`);
+        log.info(`${sender}: ${text}`);
 
         const msgId = crypto.randomUUID();
         const msg: BusMessage = {
@@ -102,7 +105,7 @@ export class SignalPlugin implements Plugin {
 
         this.bus!.publish(msg.topic, msg);
       } catch (e) {
-        console.error("Error processing Signal message:", e);
+        log.error("Error processing Signal message", { err: e });
       }
     };
   }
@@ -116,7 +119,7 @@ export class SignalPlugin implements Plugin {
     const content = (msg.payload as { content?: string })?.content;
 
     if (!recipient || !content) {
-      console.error("Invalid outbound signal message:", msg);
+      log.error("Invalid outbound signal message", { msg });
       return;
     }
 
@@ -141,10 +144,10 @@ export class SignalPlugin implements Plugin {
       });
       if (!res.ok) {
         const err = await res.text();
-        console.error(`Signal send failed: ${res.status} ${err}`);
+        log.error(`Signal send failed: ${res.status} ${err}`);
       }
     } catch (e) {
-      console.error(`Signal send error: ${e}`);
+      log.error("Signal send error", { err: e });
     }
   }
 }


### PR DESCRIPTION
## What

**Slice 2** of the `console.*` → `lib/log.ts` sweep (handoff 001 follow-up #2), following the dispatch-spine slice (#818). Converts the **integration-plugin core** onto the leveled, component-tagged logger.

**14 files, 0 remaining `console.*` in the changed set:**
`github`, `linear`, `scheduler`, `signal`, `a2a-delivery`, `linear-agent-session-poller`, `feature-remediation`, `feature-notifier`, `circuit-breaker`, `issue-closer`, `protomaker-board-bridge`, `linear-proto-bridge`, `operator-routing`, `logger` (the events.db LoggerPlugin).

## Convention

Same as #818 (`skill-dispatcher-plugin` reference): `[tag]` prefix → logger component (dropped from the message); `log/warn/error/debug` → `info/warn/error/debug` with failure-path `console.log` promoted; trailing `err`/values → structured fields; human-sentence interpolations stay inline.

## Notable decisions

- **`scheduler`**: dropped the bespoke `DEBUG`-env `debug()` helper — the logger's `LOG_LEVEL` gating replaces it (greenfield, no flag).
- **`lib/plugins/logger.ts`** (the events.db `LoggerPlugin`) logs via component `"event-logger"` — distinct from the `lib/log.ts` module it now consumes.
- **Excluded `debug.ts`**: `DebugPlugin` *intercepts* `console.*` to republish on the bus — its console refs are the interception machinery, not logging.
- No output-sink / "no webhook → print to console" fallback lines were present to preserve (checked the notifiers explicitly).

## Verification

- Full suite green under **both** dev env and **`NODE_ENV=production`** — the latter mirrors the Docker image-build gate that PR CI does *not* exercise (the gap that froze the deploy in #822): **1080 pass / 0 fail**
- `tsc --noEmit` clean; biome lint clean

## Remaining slices

discord subsystem, google subsystem, `src/*` (knowledge / services / telemetry / api / webhooks). CLI/debug terminal-UX files (`cli.ts`, `onboarding.ts`, `event-viewer.ts`, `echo.ts`, `debug.ts`) stay `console` by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)