### PR TITLE
chore(logging): migrate discord subsystem to structured logger

### DIFF
--- a/lib/plugins/discord.ts
+++ b/lib/plugins/discord.ts
@@ -13,6 +13,7 @@ import type { ProjectRegistry } from "../../src/plugins/project-registry.ts";
 import { ConversationManager } from "../conversation/conversation-manager.ts";
 import { ConversationTracer } from "../conversation/conversation-tracer.ts";
 import { IdentityRegistry } from "../identity/identity-registry.ts";
+import { logger } from "../log.ts";
 
 import { loadConfig, createMainClient, buildContext, type DiscordContext } from "./discord/core.ts";
 import { compileSpamPatterns, openRateLimitDb } from "./discord/rate-limit.ts";
@@ -22,6 +23,8 @@ import { registerInboundHandlers, handleDM, setupDmAccumulator } from "./discord
 import { registerSlashCommandHandlers, registerSlashCommands } from "./discord/slash-commands.ts";
 import { registerOutboundHandlers } from "./discord/outbound.ts";
 import { registerLifecycleHandlers } from "./discord/lifecycle.ts";
+
+const log = logger("discord");
 
 // Re-export for API routes (discord operations agent)
 export { pendingReplies, canSendProgress } from "./discord/outbound.ts";
@@ -72,13 +75,13 @@ export class DiscordPlugin implements Plugin {
         conversationId: entry.conversationId,
         turnCount: entry.turnNumber,
         endedBy: "timeout",
-      }).catch(err => console.error("[discord] Langfuse endTrace error:", err));
+      }).catch(err => log.error("Langfuse endTrace error", { err }));
     });
   }
 
   install(bus: EventBus): void {
     if (!process.env.DISCORD_BOT_TOKEN) {
-      console.log("[discord] DISCORD_BOT_TOKEN not set — plugin disabled");
+      log.info("DISCORD_BOT_TOKEN not set — plugin disabled");
       return;
     }
 
@@ -128,7 +131,7 @@ export class DiscordPlugin implements Plugin {
 
     // ── Ready ──────────────────────────────────────────────────────────────
     this.client.once(Events.ClientReady, async c => {
-      console.log(`[discord] Logged in as ${c.user.tag}`);
+      log.info(`Logged in as ${c.user.tag}`);
       await registerSlashCommands(ctx);
       warmDmChannels(ctx, c).catch(() => {});
     });
@@ -148,10 +151,10 @@ export class DiscordPlugin implements Plugin {
       const prevCmds = JSON.stringify(prev.commands ?? []);
       const newCmds = JSON.stringify(newConfig.commands ?? []);
       if (prevCmds !== newCmds && this.client?.isReady()) {
-        console.log("[discord] discord.yaml changed — re-registering slash commands");
-        await registerSlashCommands(ctx).catch(console.error);
+        log.info("discord.yaml changed — re-registering slash commands");
+        await registerSlashCommands(ctx).catch(err => log.error("slash command re-registration failed", { err }));
       } else {
-        console.log("[discord] discord.yaml reloaded");
+        log.info("discord.yaml reloaded");
       }
     });
 
@@ -164,7 +167,7 @@ export class DiscordPlugin implements Plugin {
     const agentsPath = join(this.workspaceDir, "agents.yaml");
     if (existsSync(agentsPath)) {
       watchFile(agentsPath, { interval: 5_000 }, () => {
-        console.log("[discord] agents.yaml changed — reloading agent client pool");
+        log.info("agents.yaml changed — reloading agent client pool");
         reloadAgentPool(ctx);
       });
     }
@@ -178,7 +181,7 @@ export class DiscordPlugin implements Plugin {
 
       for (const [name, client] of ctx.agentClients) {
         client.destroy();
-        console.log(`[discord] Destroyed agent client: ${name}`);
+        log.info(`Destroyed agent client: ${name}`);
       }
       ctx.agentClients.clear();
 

--- a/lib/plugins/discord/agent-pool.ts
+++ b/lib/plugins/discord/agent-pool.ts
@@ -12,6 +12,9 @@ import { Events, type Message } from "discord.js";
 import { createAgentClient } from "./core.ts";
 import { warmDmChannels } from "./dm-warming.ts";
 import type { DiscordContext } from "./core.ts";
+import { logger } from "../../log.ts";
+
+const log = logger("discord");
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -38,7 +41,7 @@ export function loadAgentPoolDefs(workspaceDir: string): AgentPoolEntry[] {
         if (entry?.name) seen.set(entry.name, entry);
       }
     } catch (err) {
-      console.error("[discord] Failed to parse agents.yaml:", err);
+      log.error("Failed to parse agents.yaml", { err });
     }
   }
 
@@ -63,11 +66,11 @@ export function loadAgentPoolDefs(workspaceDir: string): AgentPoolEntry[] {
             }
           }
         } catch (err) {
-          console.error(`[discord] Failed to parse agent file ${file}:`, err);
+          log.error(`Failed to parse agent file ${file}`, { err });
         }
       }
     } catch (err) {
-      console.error("[discord] Failed to enumerate workspace/agents/:", err);
+      log.error("Failed to enumerate workspace/agents/", { err });
     }
   }
 
@@ -98,7 +101,7 @@ export function initAgentPool(
   for (const [agentName, tokenEnvKey] of byName) {
     const token = process.env[tokenEnvKey];
     if (!token) {
-      console.warn(`[discord] No token for agent "${agentName}" (env: ${tokenEnvKey}) — will use bus bot`);
+      log.warn(`No token for agent "${agentName}" (env: ${tokenEnvKey}) — will use bus bot`);
       continue;
     }
 
@@ -106,32 +109,32 @@ export function initAgentPool(
       const agentClient = createAgentClient();
 
       agentClient.once(Events.ClientReady, async c => {
-        console.log(`[discord] Agent client "${agentName}" logged in as ${c.user.tag}`);
+        log.info(`Agent client "${agentName}" logged in as ${c.user.tag}`);
         await warmDmChannels(ctx, c).catch(err =>
-          console.warn(`[discord] Agent client "${agentName}" DM pre-warm failed:`, err),
+          log.warn(`Agent client "${agentName}" DM pre-warm failed`, { err }),
         );
       });
 
       agentClient.on(Events.MessageCreate, async (message) => {
         if (message.author.bot) return;
         if (message.guild) return;
-        console.log(`[discord] Agent client "${agentName}" received DM from ${message.author.tag} (${message.author.id})`);
+        log.info(`Agent client "${agentName}" received DM from ${message.author.tag} (${message.author.id})`);
         await handleDM(message, agentName);
       });
 
       agentClient.login(token).catch(err => {
-        console.warn(`[discord] Agent client "${agentName}" login failed:`, err);
+        log.warn(`Agent client "${agentName}" login failed`, { err });
         ctx.agentClients.delete(agentName);
       });
 
       ctx.agentClients.set(agentName, agentClient);
       created++;
     } catch (err) {
-      console.warn(`[discord] Failed to create client for agent "${agentName}":`, err);
+      log.warn(`Failed to create client for agent "${agentName}"`, { err });
     }
   }
 
-  console.log(`[discord] Agent client pool: ${created} client(s) initialized (${byName.size} agents configured)`);
+  log.info(`Agent client pool: ${created} client(s) initialized (${byName.size} agents configured)`);
 }
 
 // ── Pool reload ───────────────────────────────────────────────────────────────
@@ -147,7 +150,7 @@ export function reloadAgentPool(ctx: DiscordContext): void {
     if (!newAgentNames.has(name)) {
       client.destroy();
       ctx.agentClients.delete(name);
-      console.log(`[discord] Pool: removed agent client "${name}"`);
+      log.info(`Pool: removed agent client "${name}"`);
     }
   }
 
@@ -162,20 +165,20 @@ export function reloadAgentPool(ctx: DiscordContext): void {
       const agentClient = createAgentClient();
 
       agentClient.once(Events.ClientReady, c => {
-        console.log(`[discord] Agent client "${agent.name}" logged in as ${c.user.tag}`);
+        log.info(`Agent client "${agent.name}" logged in as ${c.user.tag}`);
       });
 
       agentClient.login(token).catch(err => {
-        console.warn(`[discord] Agent client "${agent.name}" login failed:`, err);
+        log.warn(`Agent client "${agent.name}" login failed`, { err });
         ctx.agentClients.delete(agent.name);
       });
 
       ctx.agentClients.set(agent.name, agentClient);
-      console.log(`[discord] Pool: added agent client "${agent.name}"`);
+      log.info(`Pool: added agent client "${agent.name}"`);
     } catch (err) {
-      console.warn(`[discord] Failed to create client for agent "${agent.name}":`, err);
+      log.warn(`Failed to create client for agent "${agent.name}"`, { err });
     }
   }
 
-  console.log(`[discord] Pool reloaded: ${ctx.agentClients.size} active agent client(s)`);
+  log.info(`Pool reloaded: ${ctx.agentClients.size} active agent client(s)`);
 }

--- a/lib/plugins/discord/core.ts
+++ b/lib/plugins/discord/core.ts
@@ -21,6 +21,9 @@ import { ConversationTracer, type TurnData } from "../../conversation/conversati
 import { IdentityRegistry } from "../../identity/identity-registry.ts";
 import type { DmAccumulator } from "../../dm/dm-accumulator.ts";
 import type { ContextMailbox } from "../../dm/context-mailbox.ts";
+import { logger } from "../../log.ts";
+
+const log = logger("discord");
 
 // ── Config types ──────────────────────────────────────────────────────────────
 
@@ -69,7 +72,7 @@ export interface DiscordConfig {
 export function loadConfig(workspaceDir: string): DiscordConfig {
   const configPath = join(workspaceDir, "discord.yaml");
   if (!existsSync(configPath)) {
-    console.log("[discord] No discord.yaml found — using defaults");
+    log.info("No discord.yaml found — using defaults");
     return {
       channels: {},
       moderation: {

--- a/lib/plugins/discord/dm-warming.ts
+++ b/lib/plugins/discord/dm-warming.ts
@@ -8,6 +8,9 @@
 
 import type { Client } from "discord.js";
 import type { DiscordContext } from "./core.ts";
+import { logger } from "../../log.ts";
+
+const log = logger("discord");
 
 export async function warmDmChannels(ctx: DiscordContext, client: Client<true>): Promise<void> {
   const discordIds = ctx.identityRegistry
@@ -23,5 +26,5 @@ export async function warmDmChannels(ctx: DiscordContext, client: Client<true>):
       warmed++;
     } catch { /* skip if user not reachable */ }
   }
-  if (warmed) console.log(`[discord] Pre-warmed ${warmed} DM channel(s)`);
+  if (warmed) log.info(`Pre-warmed ${warmed} DM channel(s)`);
 }

--- a/lib/plugins/discord/inbound.ts
+++ b/lib/plugins/discord/inbound.ts
@@ -12,6 +12,9 @@ import { isRateLimited, isSpam } from "./rate-limit.ts";
 import { pendingReplies } from "./outbound.ts";
 import { buildMessageContext } from "./context.ts";
 import { alreadyHandled } from "./dedup.ts";
+import { logger } from "../../log.ts";
+
+const log = logger("discord");
 
 // ── Admin check ───────────────────────────────────────────────────────────────
 
@@ -140,8 +143,8 @@ export async function handleDMFlush(
     : contents.map((c, i) => `[${i + 1}/${contents.length}] ${c}`).join("\n\n");
 
   if (ctx.isExecutionActive?.(conversationId) && ctx.mailbox) {
-    console.log(
-      `[discord] Agent in-flight for ${conversationId} — queuing ${contents.length} message(s) to mailbox`,
+    log.info(
+      `Agent in-flight for ${conversationId} — queuing ${contents.length} message(s) to mailbox`,
     );
     ctx.mailbox.push(conversationId, {
       content: batchedContent,
@@ -160,7 +163,7 @@ export async function handleDMFlush(
   if (discordMessage) {
     pendingReplies.set(conversationId, { message: discordMessage });
   } else {
-    console.warn(`[discord] Could not fetch message for ${conversationId} via ${agentName ?? "main"} — reply will use unprompted push`);
+    log.warn(`Could not fetch message for ${conversationId} via ${agentName ?? "main"} — reply will use unprompted push`);
   }
 
   // Surrounding context for the DM (reply-to / scrollback / attachments).
@@ -174,7 +177,7 @@ export async function handleDMFlush(
       channelId,
       agentName,
       platform: "discord-dm",
-    }).catch(err => console.error("[discord] Langfuse startTrace error:", err));
+    }).catch(err => log.error("Langfuse startTrace error", { err }));
   }
   ctx.pendingTurns.set(conversationId, {
     conversationId,
@@ -282,7 +285,7 @@ export function registerInboundHandlers(ctx: DiscordContext): void {
     if (!isMentioned && !continueWithoutMention) return;
 
     if (!isAdmin(ctx, userId)) {
-      console.log(`[discord] message from ${userId} ignored — not in admins list`);
+      log.info(`message from ${userId} ignored — not in admins list`);
       return;
     }
 
@@ -336,7 +339,7 @@ export function registerInboundHandlers(ctx: DiscordContext): void {
           channelId: message.channelId,
           agentName: channelEntry?.agent,
           platform: "discord",
-        }).catch(err => console.error("[discord] Langfuse startTrace error:", err));
+        }).catch(err => log.error("Langfuse startTrace error", { err }));
       }
       ctx.pendingTurns.set(correlationId, {
         conversationId: correlationId,
@@ -374,7 +377,7 @@ export function registerInboundHandlers(ctx: DiscordContext): void {
     if (emoji !== "📋" && emoji !== RESEARCH_EMOJI) return;
     if (alreadyHandled(`react:${reaction.message.id}:${user.id}:${emoji}`)) return;
     if (!isAdmin(ctx, user.id)) {
-      console.log(`[discord] reaction from ${user.id} ignored — not in admins list`);
+      log.info(`reaction from ${user.id} ignored — not in admins list`);
       return;
     }
 

--- a/lib/plugins/discord/lifecycle.ts
+++ b/lib/plugins/discord/lifecycle.ts
@@ -9,26 +9,30 @@
  */
 
 import { Events, type Client } from "discord.js";
+import { logger } from "../../log.ts";
+
+const log = logger("discord");
 
 export function registerLifecycleHandlers(client: Client, label = "main"): void {
   client.on(Events.Error, (err) => {
-    console.error(`[discord:${label}] client error:`, err instanceof Error ? err.message : err);
+    log.error("client error", { label, err: err instanceof Error ? err.message : err });
   });
   client.on(Events.Warn, (msg) => {
-    console.warn(`[discord:${label}] warn: ${msg}`);
+    log.warn(`warn: ${msg}`, { label });
   });
   client.on(Events.ShardError, (err, shardId) => {
-    console.error(`[discord:${label}] shard ${shardId} error:`, err instanceof Error ? err.message : err);
+    log.error("shard error", { label, shardId, err: err instanceof Error ? err.message : err });
   });
   client.on(Events.ShardDisconnect, (event, shardId) => {
-    console.warn(
-      `[discord:${label}] shard ${shardId} disconnected (code ${event?.code ?? "?"}) — auto-reconnecting`,
+    log.warn(
+      `shard ${shardId} disconnected (code ${event?.code ?? "?"}) — auto-reconnecting`,
+      { label },
     );
   });
   client.on(Events.ShardReconnecting, (shardId) => {
-    console.log(`[discord:${label}] shard ${shardId} reconnecting…`);
+    log.info(`shard ${shardId} reconnecting…`, { label });
   });
   client.on(Events.ShardResume, (shardId, replayed) => {
-    console.log(`[discord:${label}] shard ${shardId} resumed (${replayed} event(s) replayed)`);
+    log.info(`shard ${shardId} resumed (${replayed} event(s) replayed)`, { label });
   });
 }

--- a/lib/plugins/discord/outbound.ts
+++ b/lib/plugins/discord/outbound.ts
@@ -15,6 +15,9 @@ import {
 } from "discord.js";
 import type { BusMessage } from "../../types.ts";
 import type { DiscordContext } from "./core.ts";
+import { logger } from "../../log.ts";
+
+const log = logger("discord");
 
 // ── Pending reply handles ─────────────────────────────────────────────────────
 // Kept outside bus payload so the SQLite logger never tries to serialize them.
@@ -50,7 +53,7 @@ export function registerOutboundHandlers(ctx: DiscordContext): void {
       ?? (correlationId ? ctx.pendingAgents.get(correlationId) : undefined);
     const agentClient = agentId ? ctx.agentClients.get(agentId) : undefined;
     if (agentId && !agentClient) {
-      console.debug(`[discord] No pool client for agent "${agentId}" — falling back to bus client`);
+      log.debug(`No pool client for agent "${agentId}" — falling back to bus client`);
     }
 
     if (correlationId) {
@@ -66,11 +69,11 @@ export function registerOutboundHandlers(ctx: DiscordContext): void {
             ...pendingTurn,
             output: content,
             endTime: new Date(),
-          }).catch(err => console.error("[discord] Langfuse traceTurn error:", err));
+          }).catch(err => log.error("Langfuse traceTurn error", { err }));
         }
 
         if (pending.interaction) {
-          await pending.interaction.editReply({ content }).catch(console.error);
+          await pending.interaction.editReply({ content }).catch(err => log.error("editReply failed", { err }));
           return;
         }
 
@@ -78,18 +81,18 @@ export function registerOutboundHandlers(ctx: DiscordContext): void {
           const isDM = !pending.message.guild;
 
           if (isDM) {
-            await (pending.message.channel as TextChannel).send({ content }).catch(console.error);
+            await (pending.message.channel as TextChannel).send({ content }).catch(err => log.error("DM send failed", { err }));
           } else if (agentClient) {
             const ch = agentClient.channels.cache.get(pending.message.channelId) as TextChannel | undefined;
             if (ch) {
-              console.debug(`[discord] Routing reply via agent client "${agentId}"`);
-              await ch.send({ content }).catch(console.error);
+              log.debug(`Routing reply via agent client "${agentId}"`);
+              await ch.send({ content }).catch(err => log.error("agent client reply send failed", { err }));
             } else {
-              console.warn(`[discord] Agent "${agentId}" channel cache miss — falling back to bus client`);
-              await pending.message.reply({ content }).catch(console.error);
+              log.warn(`Agent "${agentId}" channel cache miss — falling back to bus client`);
+              await pending.message.reply({ content }).catch(err => log.error("reply failed", { err }));
             }
           } else {
-            const reply = await pending.message.reply({ content }).catch(console.error);
+            const reply = await pending.message.reply({ content }).catch(err => log.error("reply failed", { err }));
             if (reply && !pending.message.channel.isThread()) {
               await reply.startThread({ name: content.slice(0, 50) || "Response" }).catch(() => {});
             }
@@ -114,10 +117,10 @@ export function registerOutboundHandlers(ctx: DiscordContext): void {
     if (channelId) {
       const sendClient = agentClient ?? ctx.client;
       if (agentClient) {
-        console.debug(`[discord] Routing push to channel ${channelId} via agent client "${agentId}"`);
+        log.debug(`Routing push to channel ${channelId} via agent client "${agentId}"`);
       }
       const ch = sendClient.channels.cache.get(channelId) as TextChannel | undefined;
-      await ch?.send({ content }).catch(console.error);
+      await ch?.send({ content }).catch(err => log.error("push send failed", { err }));
     }
   });
 
@@ -135,7 +138,7 @@ export function registerOutboundHandlers(ctx: DiscordContext): void {
     const parts = msg.topic.split(".");
     const userId = parts[parts.length - 1];
     if (!userId || !/^\d+$/.test(userId)) {
-      console.warn(`[discord] Invalid user ID on DM topic ${msg.topic}`);
+      log.warn(`Invalid user ID on DM topic ${msg.topic}`);
       return;
     }
 
@@ -147,9 +150,9 @@ export function registerOutboundHandlers(ctx: DiscordContext): void {
       const user = await client.users.fetch(userId);
       const dm = await user.createDM();
       await dm.send({ content });
-      console.log(`[discord] DM delivered to user ${userId} via ${agentId ?? "default"} bot`);
+      log.info(`DM delivered to user ${userId} via ${agentId ?? "default"} bot`);
     } catch (err) {
-      console.error(`[discord] DM to user ${userId} failed:`, err);
+      log.error(`DM to user ${userId} failed`, { err });
     }
   });
 

--- a/lib/plugins/discord/rate-limit.ts
+++ b/lib/plugins/discord/rate-limit.ts
@@ -6,6 +6,9 @@ import { existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import type { DiscordContext } from "./core.ts";
+import { logger } from "../../log.ts";
+
+const log = logger("discord");
 
 // ── Spam pattern compilation ──────────────────────────────────────────────────
 
@@ -13,12 +16,12 @@ export function compileSpamPatterns(patterns: string[]): RegExp[] {
   return patterns.flatMap(p => {
     try {
       if (/(\([^)]*[+*][^)]*\))[+*?]/.test(p)) {
-        console.warn(`[discord] Skipping potentially unsafe spam pattern (nested quantifiers): "${p}"`);
+        log.warn(`Skipping potentially unsafe spam pattern (nested quantifiers): "${p}"`);
         return [];
       }
       return [new RegExp(p, "i")];
     } catch (err) {
-      console.warn(`[discord] Skipping invalid spam pattern "${p}":`, err);
+      log.warn(`Skipping invalid spam pattern "${p}"`, { err });
       return [];
     }
   });
@@ -54,9 +57,9 @@ export function openRateLimitDb(ctx: DiscordContext, dataDir: string): void {
       ctx.rateLimits.set(row.user_id, hits);
     }
 
-    console.log(`[discord] Rate-limit DB opened (${rows.length} persisted hit(s) loaded)`);
+    log.info(`Rate-limit DB opened (${rows.length} persisted hit(s) loaded)`);
   } catch (err) {
-    console.warn("[discord] Could not open rate-limit DB — falling back to in-memory only:", err);
+    log.warn("Could not open rate-limit DB — falling back to in-memory only", { err });
     ctx.rlDb = null;
   }
 }
@@ -74,7 +77,7 @@ export function isRateLimited(ctx: DiscordContext, userId: string): boolean {
       ctx.rlDb.run("INSERT INTO rate_limits (user_id, ts) VALUES (?, ?)", [userId, now]);
       ctx.rlDb.run("DELETE FROM rate_limits WHERE user_id = ? AND ts <= ?", [userId, now - ctx.rateWindowMs]);
     } catch (err) {
-      console.warn("[discord] Failed to persist rate-limit hit:", err);
+      log.warn("Failed to persist rate-limit hit", { err });
     }
   }
 

--- a/lib/plugins/discord/slash-commands.ts
+++ b/lib/plugins/discord/slash-commands.ts
@@ -12,6 +12,9 @@ import { Events, type ChatInputCommandInteraction } from "discord.js";
 import { makeId, OPTION_TYPE_CODES } from "./core.ts";
 import { pendingReplies } from "./outbound.ts";
 import type { DiscordContext, CommandOption } from "./core.ts";
+import { logger } from "../../log.ts";
+
+const log = logger("discord");
 
 // ── Content interpolation ─────────────────────────────────────────────────────
 
@@ -37,11 +40,11 @@ export function interpolateContent(
 
 export async function registerSlashCommands(ctx: DiscordContext): Promise<void> {
   const guildId = process.env.DISCORD_GUILD_ID;
-  if (!guildId) { console.log("[discord] DISCORD_GUILD_ID not set — skipping slash command registration"); return; }
+  if (!guildId) { log.info("DISCORD_GUILD_ID not set — skipping slash command registration"); return; }
 
   const guild = ctx.client.guilds.cache.get(guildId);
-  if (!guild) { console.log(`[discord] Guild ${guildId} not found`); return; }
-  if (!ctx.config.commands.length) { console.log("[discord] No commands configured in discord.yaml"); return; }
+  if (!guild) { log.warn(`Guild ${guildId} not found`); return; }
+  if (!ctx.config.commands.length) { log.info("No commands configured in discord.yaml"); return; }
 
   const commandData = ctx.config.commands.map(cmd => {
     if (cmd.options?.length && !cmd.subcommands?.length) {
@@ -66,7 +69,7 @@ export async function registerSlashCommands(ctx: DiscordContext): Promise<void> 
   });
 
   await guild.commands.set(commandData);
-  console.log(`[discord] Registered ${commandData.length} command(s): ${commandData.map(c => `/${c.name}`).join(", ")}`);
+  log.info(`Registered ${commandData.length} command(s): ${commandData.map(c => `/${c.name}`).join(", ")}`);
 }
 
 // ── Register interaction handlers ─────────────────────────────────────────────
@@ -83,7 +86,7 @@ export function registerSlashCommandHandlers(ctx: DiscordContext): void {
         const choices = projects
           .filter(p => p.slug.toLowerCase().includes(typed) || p.name.toLowerCase().includes(typed))
           .slice(0, 25).map(p => ({ name: p.name, value: p.slug }));
-        await interaction.respond(choices).catch(console.error);
+        await interaction.respond(choices).catch(err => log.error("autocomplete respond failed", { err }));
       }
       return;
     }
@@ -95,7 +98,7 @@ export function registerSlashCommandHandlers(ctx: DiscordContext): void {
     if (!cmdConfig) return;
 
     if (ctx.config.admins?.length && !ctx.config.admins.includes(interaction.user.id)) {
-      console.log(`[discord] slash command from ${interaction.user.id} ignored — not in admins list`);
+      log.info(`slash command from ${interaction.user.id} ignored — not in admins list`);
       await interaction.reply({ content: "Not authorised.", ephemeral: true }).catch(() => {});
       return;
     }
@@ -131,7 +134,7 @@ export function registerSlashCommandHandlers(ctx: DiscordContext): void {
     const subcommands = cmdConfig.subcommands ?? [];
     const subName = interaction.options.getSubcommand(false) ?? subcommands[0]?.name;
     const subConfig = subcommands.find(s => s.name === subName) ?? subcommands[0];
-    if (!subConfig) { await interaction.editReply("Unknown subcommand.").catch(console.error); return; }
+    if (!subConfig) { await interaction.editReply("Unknown subcommand.").catch(err => log.error("editReply failed", { err })); return; }
 
     const content = interpolateContent(subConfig.content, subConfig.options ?? [], interaction);
     const correlationId = makeId();


### PR DESCRIPTION
## What

**Slice 3** of the `console.*` → `lib/log.ts` sweep (after #818 dispatch spine, #823 integration core). Converts the **Discord subsystem** onto the component-tagged logger.

**9 files, 0 remaining `console.*`:** `discord.ts` + `discord/{agent-pool, outbound, slash-commands, lifecycle, inbound, rate-limit, dm-warming, core}`.

## Notes

- All lines carried the `[discord]` tag → single component `"discord"`.
- `lifecycle.ts`'s dynamic `[discord:${label}]` collapses to component `"discord"` + a structured `label` field (the established dynamic-tag pattern).
- Bare `.catch(console.error)` rejection handlers became descriptive `log.error(msg, { err })` (clear failure paths).
- No output-sink/fallback console lines were present. No logic changes.

## Verification

- Full suite green under **both** dev and **`NODE_ENV=production`** (the image-build gate PR CI doesn't exercise): **1080 pass / 0 fail**
- `tsc --noEmit` + biome lint clean

Remaining: google subsystem, then `src/*` (knowledge/services/telemetry/api/webhooks). CLI/debug terminal-UX files stay `console`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)