### PR TITLE
chore(logging): migrate google subsystem to structured logger

### DIFF
--- a/lib/plugins/google.ts
+++ b/lib/plugins/google.ts
@@ -25,6 +25,9 @@ import { createDriveService } from "./google/drive.ts";
 import { createDocsService } from "./google/docs.ts";
 import { createGmailService, createGmailOutbound, type GmailConfig } from "./google/gmail.ts";
 import { createCalendarService, type CalendarConfig } from "./google/calendar.ts";
+import { logger } from "../log.ts";
+
+const log = logger("google");
 
 // Re-export utilities used by OnboardingPlugin
 export { getGoogleAccessToken } from "./google/auth.ts";
@@ -41,13 +44,13 @@ interface GoogleConfig {
 function loadConfig(workspaceDir: string): GoogleConfig {
   const configPath = join(workspaceDir, "google.yaml");
   if (!existsSync(configPath)) {
-    console.log("[google] No google.yaml found — using defaults");
+    log.info("No google.yaml found — using defaults");
     return defaultConfig();
   }
   try {
     return parseYaml(readFileSync(configPath, "utf8")) as GoogleConfig;
   } catch (err) {
-    console.error("[google] Failed to parse google.yaml:", err);
+    log.error("Failed to parse google.yaml", { err });
     return defaultConfig();
   }
 }
@@ -83,7 +86,7 @@ export class GooglePlugin implements Plugin {
 
   install(bus: EventBus): void {
     if (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET || !process.env.GOOGLE_REFRESH_TOKEN) {
-      console.log("[google] GOOGLE_CLIENT_ID/SECRET/REFRESH_TOKEN not set — plugin disabled");
+      log.info("GOOGLE_CLIENT_ID/SECRET/REFRESH_TOKEN not set — plugin disabled");
       return;
     }
 
@@ -104,7 +107,7 @@ export class GooglePlugin implements Plugin {
     // Hot-reload google.yaml
     const configPath = join(this.workspaceDir, "google.yaml");
     watchFile(configPath, { interval: 1_000 }, () => {
-      console.log("[google] google.yaml changed — reloading config");
+      log.info("google.yaml changed — reloading config");
       const prevGmailLabels = JSON.stringify(this.config.gmail?.watchLabels ?? []);
       const prevGmailInterval = this.config.gmail?.pollIntervalMinutes;
       const prevCalInterval = this.config.calendar?.pollIntervalMinutes;
@@ -134,10 +137,10 @@ export class GooglePlugin implements Plugin {
         payload: { plugin: "google", config: "google.yaml" },
       });
 
-      console.log("[google] google.yaml reloaded");
+      log.info("google.yaml reloaded");
     });
 
-    console.log("[google] Plugin installed — Drive, Docs, Gmail, Calendar active");
+    log.info("Plugin installed — Drive, Docs, Gmail, Calendar active");
   }
 
   uninstall(): void {
@@ -148,6 +151,6 @@ export class GooglePlugin implements Plugin {
     this.calendar.stop();
     this.tokenRefresher?.stop();
     unwatchFile(join(this.workspaceDir, "google.yaml"));
-    console.log("[google] Plugin uninstalled");
+    log.info("Plugin uninstalled");
   }
 }

--- a/lib/plugins/google/auth.ts
+++ b/lib/plugins/google/auth.ts
@@ -4,6 +4,9 @@
  */
 
 import type { EventBus } from "../../types.ts";
+import { logger } from "../../log.ts";
+
+const log = logger("google-auth");
 
 interface TokenState {
   accessToken: string;
@@ -55,7 +58,7 @@ async function _doTokenRefresh(
 
       if (!resp.ok) {
         const errBody = await resp.text().catch(() => "");
-        console.error(`[google] Token refresh failed (attempt ${attempt}): ${resp.status} ${errBody}`);
+        log.error(`Token refresh failed (attempt ${attempt})`, { status: resp.status, errBody });
         if (attempt < 3) await _sleep(1_000 * attempt);
         continue;
       }
@@ -65,10 +68,10 @@ async function _doTokenRefresh(
         accessToken: data.access_token,
         expiresAt: Date.now() + data.expires_in * 1_000,
       };
-      console.log(`[google] Access token refreshed (expires in ${data.expires_in}s)`);
+      log.info(`Access token refreshed (expires in ${data.expires_in}s)`);
       return _tokenState.accessToken;
     } catch (err) {
-      console.error(`[google] Token refresh error (attempt ${attempt}):`, err);
+      log.error(`Token refresh error (attempt ${attempt})`, { err });
       if (attempt < 3) await _sleep(1_000 * attempt);
     }
   }
@@ -95,10 +98,10 @@ export function createTokenRefresher(bus: EventBus): TokenRefresher {
 
         const timeToExpiry = _tokenState.expiresAt - Date.now();
         if (timeToExpiry < 10 * 60_000) {
-          console.log("[google] Access token nearing expiry — refreshing proactively");
+          log.info("Access token nearing expiry — refreshing proactively");
           const newToken = await getGoogleAccessToken();
           if (!newToken) {
-            console.error("[google] Proactive token refresh failed — publishing auth.token_refresh_failed");
+            log.error("Proactive token refresh failed — publishing auth.token_refresh_failed");
             bus.publish("auth.token_refresh_failed", {
               id: crypto.randomUUID(),
               correlationId: crypto.randomUUID(),

--- a/lib/plugins/google/calendar.ts
+++ b/lib/plugins/google/calendar.ts
@@ -3,8 +3,11 @@
  */
 
 import type { EventBus } from "../../types.ts";
+import { logger } from "../../log.ts";
 import { withCircuitBreaker } from "../circuit-breaker.ts";
 import { getGoogleAccessToken } from "./auth.ts";
+
+const log = logger("google-calendar");
 
 export interface CalendarConfig {
   orgCalendarId: string;
@@ -49,7 +52,7 @@ export function createCalendarService(getConfig: () => CalendarConfig): Calendar
       );
 
       if (!resp.ok) {
-        console.warn(`[google] Calendar list failed: ${resp.status}`);
+        log.warn("Calendar list failed", { status: resp.status });
         return;
       }
 
@@ -88,9 +91,9 @@ export function createCalendarService(getConfig: () => CalendarConfig): Calendar
         source: { interface: "google" },
       });
 
-      console.log(`[google] Calendar: published ${events.length} event(s) within next 7 days`);
+      log.info(`Calendar: published ${events.length} event(s) within next 7 days`);
     } catch (err) {
-      console.error("[google] Calendar poll error:", err);
+      log.error("Calendar poll error", { err });
     }
   }
 
@@ -99,14 +102,14 @@ export function createCalendarService(getConfig: () => CalendarConfig): Calendar
       const config = getConfig();
       const calendarId = config.orgCalendarId;
       if (!calendarId) {
-        console.log("[google] Calendar polling skipped — no orgCalendarId configured");
+        log.info("Calendar polling skipped — no orgCalendarId configured");
         return;
       }
 
       const intervalMs = (config.pollIntervalMinutes ?? 60) * 60_000;
       initTimeout = setTimeout(() => _pollCalendar(bus), 15_000);
       pollTimer = setInterval(() => _pollCalendar(bus), intervalMs);
-      console.log(`[google] Calendar poller started (interval: ${config.pollIntervalMinutes}m)`);
+      log.info(`Calendar poller started (interval: ${config.pollIntervalMinutes}m)`);
     },
 
     stop() {

--- a/lib/plugins/google/docs.ts
+++ b/lib/plugins/google/docs.ts
@@ -3,8 +3,11 @@
  */
 
 import type { EventBus, BusMessage } from "../../types.ts";
+import { logger } from "../../log.ts";
 import { withCircuitBreaker } from "../circuit-breaker.ts";
 import { getGoogleAccessToken } from "./auth.ts";
+
+const log = logger("google-docs");
 
 export interface DocsService {
   start(bus: EventBus): void;
@@ -33,7 +36,7 @@ export function createDocsService(): DocsService {
     const token = await getGoogleAccessToken();
 
     if (!token) {
-      console.warn("[google] Docs operation skipped — no access token");
+      log.warn("Docs operation skipped — no access token");
       _reply(msg, { success: false, error: "No Google access token available" });
       return;
     }
@@ -49,7 +52,7 @@ export function createDocsService(): DocsService {
       }
       _reply(msg, result);
     } catch (err) {
-      console.error("[google] Docs handler error:", err);
+      log.error("Docs handler error", { err });
       _reply(msg, { success: false, error: String(err) });
     }
   }

--- a/lib/plugins/google/drive.ts
+++ b/lib/plugins/google/drive.ts
@@ -6,6 +6,9 @@
 import type { EventBus, BusMessage } from "../../types.ts";
 import { withCircuitBreaker } from "../circuit-breaker.ts";
 import { getGoogleAccessToken } from "./auth.ts";
+import { logger } from "../../log.ts";
+
+const log = logger("google-drive");
 
 export interface DriveService {
   start(bus: EventBus): void;
@@ -34,7 +37,7 @@ export function createDriveService(): DriveService {
     const token = await getGoogleAccessToken();
 
     if (!token) {
-      console.warn("[google] Drive operation skipped — no access token");
+      log.warn("Drive operation skipped — no access token");
       _reply(msg, { success: false, error: "No Google access token available" });
       return;
     }
@@ -50,7 +53,7 @@ export function createDriveService(): DriveService {
       }
       _reply(msg, result);
     } catch (err) {
-      console.error("[google] Drive handler error:", err);
+      log.error("Drive handler error", { err });
       _reply(msg, { success: false, error: String(err) });
     }
   }
@@ -191,13 +194,13 @@ export async function createDriveFolder(
   parentId: string,
 ): Promise<{ id: string; name: string } | null> {
   if (!parentId) {
-    console.warn("[google] createDriveFolder: parentId is empty — skipping");
+    log.warn("createDriveFolder: parentId is empty — skipping");
     return null;
   }
 
   const token = await getGoogleAccessToken();
   if (!token) {
-    console.warn("[google] createDriveFolder: no access token available");
+    log.warn("createDriveFolder: no access token available");
     return null;
   }
 
@@ -220,15 +223,15 @@ export async function createDriveFolder(
 
     if (!resp.ok) {
       const errBody = await resp.text().catch(() => "");
-      console.error(`[google] Drive folder creation failed: ${resp.status} ${errBody}`);
+      log.error(`Drive folder creation failed: ${resp.status} ${errBody}`);
       return null;
     }
 
     const data = await resp.json() as { id: string; name: string };
-    console.log(`[google] Drive folder created: "${data.name}" (${data.id})`);
+    log.info(`Drive folder created: "${data.name}" (${data.id})`);
     return data;
   } catch (err) {
-    console.error("[google] Drive folder creation error:", err);
+    log.error("Drive folder creation error", { err });
     return null;
   }
 }

--- a/lib/plugins/google/gmail.ts
+++ b/lib/plugins/google/gmail.ts
@@ -23,6 +23,9 @@
 import type { EventBus, BusMessage } from "../../types.ts";
 import { withCircuitBreaker } from "../circuit-breaker.ts";
 import { getGoogleAccessToken } from "./auth.ts";
+import { logger } from "../../log.ts";
+
+const log = logger("gmail");
 
 export interface GmailConfig {
   watchLabels: string[];
@@ -88,7 +91,7 @@ export function createGmailService(getConfig: () => GmailConfig): GmailService {
         );
 
         if (!listResp.ok) {
-          console.warn(`[google] Gmail list failed for label "${label}": ${listResp.status}`);
+          log.warn(`Gmail list failed for label "${label}": ${listResp.status}`);
           continue;
         }
 
@@ -179,12 +182,12 @@ export function createGmailService(getConfig: () => GmailConfig): GmailService {
             },
           });
 
-          console.log(
-            `[google] Gmail: routed message from "${from}" (label: ${label}${rule?.skillHint ? `, skill: ${rule.skillHint}` : ""})`,
+          log.info(
+            `Gmail: routed message from "${from}" (label: ${label}${rule?.skillHint ? `, skill: ${rule.skillHint}` : ""})`,
           );
         }
       } catch (err) {
-        console.error(`[google] Gmail poll error for label "${label}":`, err);
+        log.error(`Gmail poll error for label "${label}"`, { err });
       }
     }
   }
@@ -194,15 +197,15 @@ export function createGmailService(getConfig: () => GmailConfig): GmailService {
       const config = getConfig();
       const labels = config.watchLabels ?? [];
       if (!labels.length) {
-        console.log("[google] Gmail polling skipped — no watchLabels configured");
+        log.info("Gmail polling skipped — no watchLabels configured");
         return;
       }
 
       const intervalMs = (config.pollIntervalMinutes ?? 5) * 60_000;
       initTimeout = setTimeout(() => _pollGmail(bus), 10_000);
       pollTimer = setInterval(() => _pollGmail(bus), intervalMs);
-      console.log(
-        `[google] Gmail poller started (interval: ${config.pollIntervalMinutes}m, labels: ${labels.join(", ")})`,
+      log.info(
+        `Gmail poller started (interval: ${config.pollIntervalMinutes}m, labels: ${labels.join(", ")})`,
       );
     },
 
@@ -244,10 +247,10 @@ export function createGmailOutbound(): GmailOutboundService {
           await handleReply(msg);
         } catch (err) {
           const m = err instanceof Error ? err.message : String(err);
-          console.error(`[google] Gmail reply exception on ${msg.topic}: ${m}`);
+          log.error(`Gmail reply exception on ${msg.topic}: ${m}`);
         }
       });
-      console.log("[google] Gmail outbound subscriber active (google.gmail.reply.#)");
+      log.info("Gmail outbound subscriber active (google.gmail.reply.#)");
     },
     stop() {
       if (subId && installedBus) {
@@ -270,14 +273,14 @@ async function handleReply(msg: BusMessage): Promise<void> {
     ? topic.slice("google.gmail.reply.".length)
     : "";
   if (!threadId) {
-    console.warn(`[google] Gmail reply: missing threadId in topic ${topic}`);
+    log.warn(`Gmail reply: missing threadId in topic ${topic}`);
     return;
   }
 
   const payload = (msg.payload ?? {}) as GmailReplyPayload;
   const body = payload.text ?? payload.content ?? payload.summary ?? "";
   if (!body.trim()) {
-    console.warn(`[google] Gmail reply on thread ${threadId.slice(0, 12)}…: empty body — skipping`);
+    log.warn(`Gmail reply on thread ${threadId.slice(0, 12)}…: empty body — skipping`);
     return;
   }
 
@@ -294,13 +297,13 @@ async function handleReply(msg: BusMessage): Promise<void> {
   }
 
   if (!ctx.to) {
-    console.warn(`[google] Gmail reply on thread ${threadId.slice(0, 12)}…: no recipient resolved — skipping`);
+    log.warn(`Gmail reply on thread ${threadId.slice(0, 12)}…: no recipient resolved — skipping`);
     return;
   }
 
   const token = await getGoogleAccessToken();
   if (!token) {
-    console.warn(`[google] Gmail reply on thread ${threadId.slice(0, 12)}…: no access token — skipping`);
+    log.warn(`Gmail reply on thread ${threadId.slice(0, 12)}…: no access token — skipping`);
     return;
   }
 
@@ -328,12 +331,12 @@ async function handleReply(msg: BusMessage): Promise<void> {
   );
   if (!sendResp.ok) {
     const errText = await sendResp.text().catch(() => "");
-    console.warn(
-      `[google] Gmail reply on thread ${threadId.slice(0, 12)}… failed: ${sendResp.status} ${errText.slice(0, 200)}`,
+    log.warn(
+      `Gmail reply on thread ${threadId.slice(0, 12)}… failed: ${sendResp.status} ${errText.slice(0, 200)}`,
     );
     return;
   }
-  console.log(`[google] Gmail reply sent on thread ${threadId.slice(0, 12)}… → ${ctx.to}`);
+  log.info(`Gmail reply sent on thread ${threadId.slice(0, 12)}… → ${ctx.to}`);
 }
 
 /**


### PR DESCRIPTION
## What

**Slice 4** of the `console.*` → `lib/log.ts` sweep (after #818 spine, #823 integration core, #824 discord). Converts the **Google subsystem** onto the component-tagged logger.

**6 files, 0 remaining `console.*`:** `google.ts` + `google/{gmail, drive, calendar, auth, docs}`. Components: `google`, `gmail`, `google-drive`, `google-calendar`, `google-auth`, `google-docs`.

Same convention as prior slices (tag→component, level-mapped, trailing `err`→`{ err }` field, human-sentence interpolations inline). No output-sink fallbacks present; no logic changes.

## Verification

- Full suite green under **both** dev and **`NODE_ENV=production`** (image-build gate): **1080 pass / 0 fail**
- `tsc --noEmit` + biome lint clean

Remaining: `src/*` long tail (knowledge / services / telemetry / api / webhooks / plugins / mcp / storage / loaders / etc). CLI/debug terminal-UX files stay `console`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)