### PR TITLE
chore(logging): migrate src data layer (knowledge/services/telemetry) to logger

### DIFF
--- a/src/executor/skill-ab-test-plugin.ts
+++ b/src/executor/skill-ab-test-plugin.ts
@@ -28,6 +28,9 @@
 import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
 import type { ExecutorRegistry } from "./executor-registry.ts";
 import type { IExecutor, SkillRequest, SkillResult } from "./types.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("skill-ab-test");
 
 // ── Public types ──────────────────────────────────────────────────────────────
 
@@ -219,8 +222,8 @@ export class SkillAbTestPlugin implements Plugin {
     n: number,
   ): void {
     if (this.tests.has(skill)) {
-      console.warn(
-        `[skill-ab-test] Test for '${skill}' already in progress — ignoring duplicate registerTest()`,
+      log.warn(
+        `Test for '${skill}' already in progress — ignoring duplicate registerTest()`,
       );
       return;
     }
@@ -239,8 +242,8 @@ export class SkillAbTestPlugin implements Plugin {
       new AbTestExecutor(state, (winner, s) => this.commitWinner(winner, s)),
     );
 
-    console.info(
-      `[skill-ab-test] Started test for '${skill}' ` +
+    log.info(
+      `Started test for '${skill}' ` +
       `(n=${n}, control=${controlExecutor.type}, challenger=${challengerExecutor.type})`,
     );
   }
@@ -286,8 +289,8 @@ export class SkillAbTestPlugin implements Plugin {
       payload,
     });
 
-    console.info(
-      `[skill-ab-test] Test resolved for '${state.skill}': winner=${winner} (${reason})`,
+    log.info(
+      `Test resolved for '${state.skill}': winner=${winner} (${reason})`,
     );
   }
 
@@ -307,8 +310,8 @@ export class SkillAbTestPlugin implements Plugin {
     } | null;
 
     if (!p?.skill || typeof p.n !== "number") {
-      console.warn(
-        "[skill-ab-test] skill.ab_test.register message missing required fields (skill, n) — ignored",
+      log.warn(
+        "skill.ab_test.register message missing required fields (skill, n) — ignored",
       );
       return;
     }
@@ -319,8 +322,8 @@ export class SkillAbTestPlugin implements Plugin {
       : this.registry.resolve(p.skill);
 
     if (!controlExec) {
-      console.warn(
-        `[skill-ab-test] No control executor found for skill '${p.skill}' — cannot start test`,
+      log.warn(
+        `No control executor found for skill '${p.skill}' — cannot start test`,
       );
       return;
     }
@@ -330,8 +333,8 @@ export class SkillAbTestPlugin implements Plugin {
       : null;
 
     if (!challengerExec) {
-      console.warn(
-        `[skill-ab-test] No challenger executor found for skill '${p.skill}' — cannot start test`,
+      log.warn(
+        `No challenger executor found for skill '${p.skill}' — cannot start test`,
       );
       return;
     }

--- a/src/executor/task-tracker-store.ts
+++ b/src/executor/task-tracker-store.ts
@@ -19,6 +19,9 @@ import { Database } from "bun:sqlite";
 import { existsSync, mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { runMigrations } from "../../lib/sqlite-migrate.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("task-tracker-store");
 
 export interface PersistedTask {
   correlationId: string;
@@ -92,9 +95,9 @@ export class TaskTrackerStore {
             `),
         },
       ]);
-      console.log(`[task-store] Ready at ${this.dbPath}`);
+      log.info(`Ready at ${this.dbPath}`);
     } catch (err) {
-      console.error("[task-store] Init failed — task persistence disabled (in-memory only):", err);
+      log.error("Init failed — task persistence disabled (in-memory only)", { err });
       this.db = null;
     }
   }
@@ -119,7 +122,7 @@ export class TaskTrackerStore {
         $si: t.sourceInterface ?? null, $sc: t.sourceChannelId ?? null, $su: t.sourceUserId ?? null,
       });
     } catch (err) {
-      console.warn(`[task-store] upsert ${t.correlationId} failed:`, err);
+      log.warn(`upsert ${t.correlationId} failed`, { err });
     }
   }
 
@@ -128,7 +131,7 @@ export class TaskTrackerStore {
     try {
       this.db.query("DELETE FROM tracked_tasks WHERE correlation_id = $cid").run({ $cid: correlationId });
     } catch (err) {
-      console.warn(`[task-store] delete ${correlationId} failed:`, err);
+      log.warn(`delete ${correlationId} failed`, { err });
     }
   }
 
@@ -152,7 +155,7 @@ export class TaskTrackerStore {
         sourceUserId: r.source_user_id ?? undefined,
       }));
     } catch (err) {
-      console.warn("[task-store] loadAll failed:", err);
+      log.warn("loadAll failed", { err });
       return [];
     }
   }

--- a/src/knowledge/ceremonyOutcomes.ts
+++ b/src/knowledge/ceremonyOutcomes.ts
@@ -9,6 +9,9 @@ import { Database } from "bun:sqlite";
 import { mkdirSync, existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import type { CeremonyOutcome } from "../plugins/CeremonyPlugin.types.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("ceremony-outcomes");
 
 const MAX_OUTCOMES_PER_CEREMONY = 500;
 
@@ -52,10 +55,10 @@ export class CeremonyOutcomesRepository {
           ON ceremony_outcomes(started_at);
       `);
 
-      console.log(`[ceremony-outcomes] DB ready: ${this.dbPath}`);
+      log.info(`DB ready: ${this.dbPath}`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      console.error(`[ceremony-outcomes] DB init failed: ${msg}`);
+      log.error("DB init failed", { err: msg });
       this.db = null;
     }
   }
@@ -63,7 +66,7 @@ export class CeremonyOutcomesRepository {
   /** Persist a ceremony outcome. Returns true on success. */
   save(outcome: CeremonyOutcome): boolean {
     if (!this.db) {
-      console.warn("[ceremony-outcomes] DB unavailable — outcome not persisted:", outcome.runId);
+      log.warn("DB unavailable — outcome not persisted", { runId: outcome.runId });
       return false;
     }
 
@@ -107,7 +110,7 @@ export class CeremonyOutcomesRepository {
       return true;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      console.error(`[ceremony-outcomes] Save failed for run ${outcome.runId}: ${msg}`);
+      log.error(`Save failed for run ${outcome.runId}`, { err: msg });
       return false;
     }
   }
@@ -154,7 +157,7 @@ export class CeremonyOutcomesRepository {
         error: r.error ?? undefined,
       }));
     } catch (err) {
-      console.error(`[ceremony-outcomes] getRecent failed for ${ceremonyId}:`, err);
+      log.error(`getRecent failed for ${ceremonyId}`, { err });
       return [];
     }
   }

--- a/src/knowledge/conversation-harvester.ts
+++ b/src/knowledge/conversation-harvester.ts
@@ -15,6 +15,9 @@
 
 import type { AgentMemory } from "./agent-memory.ts";
 import type { ConversationTurn } from "./conversation-store.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("harvester");
 
 export type Summarizer = (transcript: string) => Promise<string>;
 
@@ -69,7 +72,7 @@ export class ConversationHarvester {
     if (this.timer) return;
     this.timer = setInterval(() => { void this.sweepOnce(); }, this.sweepIntervalMs);
     this.timer.unref?.();
-    console.log(`[harvester] started — maxAge=${Math.round(this.maxAgeMs / 86_400_000)}d sweep=${Math.round(this.sweepIntervalMs / 3_600_000)}h`);
+    log.info(`started — maxAge=${Math.round(this.maxAgeMs / 86_400_000)}d sweep=${Math.round(this.sweepIntervalMs / 3_600_000)}h`);
   }
 
   stop(): void {
@@ -104,11 +107,11 @@ export class ConversationHarvester {
         // Reclaim raw turns regardless — the summary (or empty) is the keeper.
         this.memory.conversations.deleteConversation(conv.contextId);
       } catch (err) {
-        console.warn(`[harvester] failed for ${conv.contextId}: ${err instanceof Error ? err.message : String(err)}`);
+        log.warn(`failed for ${conv.contextId}`, { err: err instanceof Error ? err.message : String(err) });
         // Leave it in place to retry next sweep.
       }
     }
-    if (harvested > 0) console.log(`[harvester] harvested ${harvested}/${candidates.length} conversation(s) into knowledge`);
+    if (harvested > 0) log.info(`harvested ${harvested}/${candidates.length} conversation(s) into knowledge`);
     return harvested;
   }
 }

--- a/src/knowledge/conversation-store.ts
+++ b/src/knowledge/conversation-store.ts
@@ -19,6 +19,9 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync, existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("conversation-store");
 
 export type TurnRole = "user" | "assistant";
 
@@ -75,9 +78,9 @@ export class ConversationStore {
         CREATE INDEX IF NOT EXISTS idx_conversation_meta_activity
           ON conversation_meta(last_activity);
       `);
-      console.log(`[conversation-store] DB ready: ${this.dbPath}`);
+      log.info(`DB ready: ${this.dbPath}`);
     } catch (err) {
-      console.error(`[conversation-store] DB init failed: ${err instanceof Error ? err.message : String(err)}`);
+      log.error("DB init failed", { err: err instanceof Error ? err.message : String(err) });
       this.db = null;
     }
   }
@@ -109,7 +112,7 @@ export class ConversationStore {
       });
       tx();
     } catch (err) {
-      console.warn(`[conversation-store] appendTurn failed for ${contextId}: ${err instanceof Error ? err.message : String(err)}`);
+      log.warn(`appendTurn failed for ${contextId}`, { err: err instanceof Error ? err.message : String(err) });
     }
   }
 
@@ -127,7 +130,7 @@ export class ConversationStore {
         .reverse()
         .map((r) => ({ role: r.role === "assistant" ? "assistant" : "user", content: r.content }));
     } catch (err) {
-      console.warn(`[conversation-store] recentTurns failed for ${contextId}: ${err instanceof Error ? err.message : String(err)}`);
+      log.warn(`recentTurns failed for ${contextId}`, { err: err instanceof Error ? err.message : String(err) });
       return [];
     }
   }
@@ -174,7 +177,7 @@ export class ConversationStore {
       });
       tx();
     } catch (err) {
-      console.warn(`[conversation-store] deleteConversation failed for ${contextId}: ${err instanceof Error ? err.message : String(err)}`);
+      log.warn(`deleteConversation failed for ${contextId}`, { err: err instanceof Error ? err.message : String(err) });
     }
   }
 

--- a/src/knowledge/fleet-state.ts
+++ b/src/knowledge/fleet-state.ts
@@ -19,6 +19,9 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync, existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("fleet-state");
 
 /** Keep at most this many records per system-actor; older rows are pruned on write. */
 const MAX_PER_AGENT = 500;
@@ -79,10 +82,10 @@ export class FleetStateRepository {
           ON fleet_outcome_records(skill, timestamp);
       `);
 
-      console.log(`[fleet-state] DB ready: ${this.dbPath}`);
+      log.info(`DB ready: ${this.dbPath}`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      console.warn(`[fleet-state] DB init failed, running in-memory only: ${msg}`);
+      log.warn("DB init failed, running in-memory only", { err: msg });
       this.db = null;
     }
   }
@@ -132,7 +135,7 @@ export class FleetStateRepository {
       return true;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      console.error(`[fleet-state] recordOutcome failed: ${msg}`);
+      log.error("recordOutcome failed", { err: msg });
       return false;
     }
   }
@@ -177,7 +180,7 @@ export class FleetStateRepository {
         timestamp: r.timestamp,
       }));
     } catch (err) {
-      console.error("[fleet-state] hydrateRecords failed:", err);
+      log.error("hydrateRecords failed", { err });
       return [];
     }
   }

--- a/src/knowledge/knowledge-store.ts
+++ b/src/knowledge/knowledge-store.ts
@@ -19,6 +19,9 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync, existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("knowledge-store");
 
 export interface KnowledgeChunk {
   id: number;
@@ -90,12 +93,12 @@ export class KnowledgeStore {
         `);
         this.ftsAvailable = true;
       } catch (err) {
-        console.warn(`[knowledge-store] FTS5 unavailable — using LIKE fallback: ${err instanceof Error ? err.message : String(err)}`);
+        log.warn("FTS5 unavailable — using LIKE fallback", { err: err instanceof Error ? err.message : String(err) });
         this.ftsAvailable = false;
       }
-      console.log(`[knowledge-store] DB ready: ${this.dbPath} (fts5=${this.ftsAvailable})`);
+      log.info(`DB ready: ${this.dbPath} (fts5=${this.ftsAvailable})`);
     } catch (err) {
-      console.error(`[knowledge-store] DB init failed: ${err instanceof Error ? err.message : String(err)}`);
+      log.error("DB init failed", { err: err instanceof Error ? err.message : String(err) });
       this.db = null;
     }
   }
@@ -109,7 +112,7 @@ export class KnowledgeStore {
         .run(content, opts.domain ?? "general", opts.heading ?? null, opts.source ?? null, Date.now());
       return Number(res.lastInsertRowid);
     } catch (err) {
-      console.warn(`[knowledge-store] addChunk failed: ${err instanceof Error ? err.message : String(err)}`);
+      log.warn("addChunk failed", { err: err instanceof Error ? err.message : String(err) });
       return null;
     }
   }
@@ -136,7 +139,7 @@ export class KnowledgeStore {
       }
       return this._likeSearch(tokens, k, domain);
     } catch (err) {
-      console.warn(`[knowledge-store] search failed: ${err instanceof Error ? err.message : String(err)}`);
+      log.warn("search failed", { err: err instanceof Error ? err.message : String(err) });
       return [];
     }
   }

--- a/src/knowledge/research-store.ts
+++ b/src/knowledge/research-store.ts
@@ -21,6 +21,9 @@ import { mkdirSync, existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import * as sqliteVec from "sqlite-vec";
 import { gatewayEmbed as embed } from "../services/embeddings/gateway-embed.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("research-store");
 
 /** What a chunk represents — drives filtering + how the agent reads it back. */
 export type ResearchKind = "paper" | "finding" | "digest" | "model_release";
@@ -96,7 +99,7 @@ export class ResearchStore {
           END;
         `);
       } catch (err) {
-        console.warn(`[research-store] FTS5 unavailable: ${err instanceof Error ? err.message : String(err)}`);
+        log.warn("FTS5 unavailable", { err: err instanceof Error ? err.message : String(err) });
       }
 
       // sqlite-vec — the semantic half. If the extension won't load, we run
@@ -109,18 +112,18 @@ export class ResearchStore {
         // vectors survive ordinary restarts.
         const existing = this.db.query<{ sql: string }, []>(`SELECT sql FROM sqlite_master WHERE name='research_vec'`).get();
         if (existing && !existing.sql.includes(`float[${EMBED_DIM}]`)) {
-          console.warn(`[research-store] research_vec dimension changed → rebuilding as float[${EMBED_DIM}]`);
+          log.warn(`research_vec dimension changed → rebuilding as float[${EMBED_DIM}]`);
           this.db.exec(`DROP TABLE research_vec`);
         }
         this.db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS research_vec USING vec0(embedding float[${EMBED_DIM}])`);
         this.vecAvailable = true;
       } catch (err) {
-        console.warn(`[research-store] sqlite-vec unavailable — keyword-only: ${err instanceof Error ? err.message : String(err)}`);
+        log.warn("sqlite-vec unavailable — keyword-only", { err: err instanceof Error ? err.message : String(err) });
         this.vecAvailable = false;
       }
-      console.log(`[research-store] DB ready: ${this.dbPath} (vec=${this.vecAvailable}, dim=${EMBED_DIM})`);
+      log.info(`DB ready: ${this.dbPath} (vec=${this.vecAvailable}, dim=${EMBED_DIM})`);
     } catch (err) {
-      console.error(`[research-store] DB init failed: ${err instanceof Error ? err.message : String(err)}`);
+      log.error("DB init failed", { err: err instanceof Error ? err.message : String(err) });
       this.db = null;
     }
   }
@@ -146,7 +149,7 @@ export class ResearchStore {
       if (this.vecAvailable) await this._embedInto(id, `${input.title ?? ""}\n${input.content}`.trim());
       return id;
     } catch (err) {
-      console.warn(`[research-store] addChunk failed: ${err instanceof Error ? err.message : String(err)}`);
+      log.warn("addChunk failed", { err: err instanceof Error ? err.message : String(err) });
       return null;
     }
   }
@@ -158,7 +161,7 @@ export class ResearchStore {
       const blob = new Uint8Array(new Float32Array(vec).buffer);
       this.db!.query(`INSERT INTO research_vec(rowid, embedding) VALUES (?, ?)`).run(id, blob);
     } catch (err) {
-      console.warn(`[research-store] vector insert failed for ${id}: ${err instanceof Error ? err.message : String(err)}`);
+      log.warn(`vector insert failed for ${id}`, { err: err instanceof Error ? err.message : String(err) });
     }
   }
 

--- a/src/services/codebase/symbol-fetcher.ts
+++ b/src/services/codebase/symbol-fetcher.ts
@@ -8,6 +8,9 @@
 
 import type { ExtractedSymbol } from "../diff/symbol-extractor.ts";
 import { HttpClient } from "../http-client.ts";
+import { logger } from "../../../lib/log.ts";
+
+const log = logger("symbol-fetcher");
 
 const CONTEXT_LINES = 10; // lines before and after the symbol definition
 
@@ -62,7 +65,7 @@ export async function fetchSymbolContext(
       repo: `${owner}/${repo}`,
     };
   } catch (err) {
-    console.error(`[symbol-fetcher] fetchSymbolContext error for ${filePath}:`, err);
+    log.error(`fetchSymbolContext error for ${filePath}`, { err });
     return null;
   }
 }

--- a/src/services/diff/symbol-extractor.ts
+++ b/src/services/diff/symbol-extractor.ts
@@ -9,6 +9,9 @@ import { extractTypeScriptSymbols } from "./symbols/typescript.ts";
 import { extractPythonSymbols } from "./symbols/python.ts";
 import { extractGoSymbols } from "./symbols/go.ts";
 import type { DiffFile } from "./chunker.ts";
+import { logger } from "../../../lib/log.ts";
+
+const log = logger("symbol-extractor");
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -46,7 +49,7 @@ export function extractSymbols(file: DiffFile): ExtractedSymbol[] {
 
   if (language === "unknown") {
     const ext = file.path.split(".").pop() ?? "unknown";
-    console.warn(`[symbol-extractor] Unsupported language extension .${ext} for ${file.path} — skipping pattern extraction`);
+    log.warn(`Unsupported language extension .${ext} for ${file.path} — skipping pattern extraction`);
     return [];
   }
 

--- a/src/services/embeddings/gateway-embed.ts
+++ b/src/services/embeddings/gateway-embed.ts
@@ -11,6 +11,10 @@
  * search rather than blocking ingestion.
  */
 
+import { logger } from "../../../lib/log.ts";
+
+const log = logger("gateway-embed");
+
 const GATEWAY_URL = process.env.LLM_GATEWAY_URL ?? process.env.OPENAI_BASE_URL ?? "http://gateway:4000/v1";
 const API_KEY = process.env.OPENAI_API_KEY ?? "";
 const EMBED_MODEL = process.env.RESEARCH_EMBED_MODEL ?? "text-embedding-3-small";
@@ -35,18 +39,18 @@ export async function gatewayEmbed(text: string): Promise<number[] | null> {
       signal: controller.signal,
     });
     if (!res.ok) {
-      console.error(`[gateway-embed] failed ${res.status}: ${(await res.text()).slice(0, 200)}`);
+      log.error(`failed ${res.status}: ${(await res.text()).slice(0, 200)}`);
       return null;
     }
     const data = (await res.json()) as EmbeddingsResponse;
     const vec = data.data?.[0]?.embedding;
     if (!Array.isArray(vec) || vec.length === 0) {
-      console.error("[gateway-embed] empty embedding in response");
+      log.error("empty embedding in response");
       return null;
     }
     return vec;
   } catch (err) {
-    console.error("[gateway-embed] error:", err instanceof Error ? err.message : String(err));
+    log.error("error", { err: err instanceof Error ? err.message : String(err) });
     return null;
   } finally {
     clearTimeout(timer);

--- a/src/services/embeddings/ollama-client.ts
+++ b/src/services/embeddings/ollama-client.ts
@@ -7,6 +7,10 @@
  * Model:    OLLAMA_EMBED_MODEL env var (default: nomic-embed-text)
  */
 
+import { logger } from "../../../lib/log.ts";
+
+const log = logger("ollama");
+
 const OLLAMA_URL = process.env.OLLAMA_URL ?? "http://ollama:11434";
 const EMBED_MODEL = process.env.OLLAMA_EMBED_MODEL ?? "nomic-embed-text";
 const TIMEOUT_MS = 30_000; // embeddings can take a few seconds
@@ -32,19 +36,19 @@ export async function embed(text: string): Promise<number[] | null> {
     });
 
     if (!res.ok) {
-      console.error(`[ollama] embed failed ${res.status}: ${await res.text()}`);
+      log.error(`embed failed ${res.status}: ${await res.text()}`);
       return null;
     }
 
     const data = await res.json() as OllamaEmbedResponse;
     if (!Array.isArray(data.embedding) || data.embedding.length === 0) {
-      console.error("[ollama] embed returned empty embedding");
+      log.error("embed returned empty embedding");
       return null;
     }
 
     return data.embedding;
   } catch (err) {
-    console.error("[ollama] embed error:", err);
+    log.error("embed error", { err });
     return null;
   } finally {
     clearTimeout(timer);
@@ -70,7 +74,7 @@ export async function embedMany(
       // Alert if failure rate exceeds 10%
       const total = results.length + failureCount;
       if (total >= 10 && failureCount / total > 0.1) {
-        console.warn(`[ollama] High embedding failure rate: ${failureCount}/${total}`);
+        log.warn(`High embedding failure rate: ${failureCount}/${total}`);
       }
     }
   }

--- a/src/services/github/diff-fetcher.ts
+++ b/src/services/github/diff-fetcher.ts
@@ -4,6 +4,9 @@
  */
 
 import { HttpClient } from "../http-client.ts";
+import { logger } from "../../../lib/log.ts";
+
+const log = logger("diff-fetcher");
 
 const GITHUB_API = "https://api.github.com";
 const USER_AGENT = "protoWorkstacean/1.0";
@@ -65,12 +68,12 @@ export async function fetchPRDiff(meta: PRMetadata, token: string): Promise<stri
       headers: { Accept: "application/vnd.github.diff" },
     });
     if (!resp.ok) {
-      console.error(`[diff-fetcher] fetchPRDiff failed ${resp.status}`);
+      log.error(`fetchPRDiff failed ${resp.status}`);
       return "";
     }
     return await resp.text();
   } catch (err) {
-    console.error("[diff-fetcher] fetchPRDiff error:", err);
+    log.error("fetchPRDiff error", { err });
     return "";
   }
 }
@@ -102,7 +105,7 @@ export async function fetchReviewComments(
       isQuinn: (c.user?.login ?? "").includes("quinn"),
     }));
   } catch (err) {
-    console.error("[diff-fetcher] fetchReviewComments error:", err);
+    log.error("fetchReviewComments error", { err });
     return [];
   }
 }
@@ -132,7 +135,7 @@ export async function fetchReviewDecision(
     if (!decisive.length) return "COMMENT";
     return decisive[0].state === "APPROVED" ? "APPROVE" : "REQUEST_CHANGES";
   } catch (err) {
-    console.error("[diff-fetcher] fetchReviewDecision error:", err);
+    log.error("fetchReviewDecision error", { err });
     return "PENDING";
   }
 }

--- a/src/services/qdrant/client.ts
+++ b/src/services/qdrant/client.ts
@@ -8,6 +8,9 @@
  */
 
 import { HttpClient } from "../http-client.ts";
+import { logger } from "../../../lib/log.ts";
+
+const log = logger("qdrant");
 
 const QDRANT_URL = process.env.QDRANT_URL ?? "http://qdrant:6333";
 const TIMEOUT_MS = 5_000;
@@ -60,10 +63,10 @@ export async function ensureCollection(
       return true;
     }
     const text = await res.text();
-    console.error(`[qdrant] ensureCollection(${name}) failed ${res.status}: ${text}`);
+    log.error(`ensureCollection(${name}) failed ${res.status}: ${text}`);
     return false;
   } catch (err) {
-    console.error(`[qdrant] ensureCollection(${name}) error:`, err);
+    log.error(`ensureCollection(${name}) error`, { err });
     return false;
   }
 }
@@ -101,10 +104,10 @@ export async function upsertPoints(
     });
     if (res.ok) return true;
     const text = await res.text();
-    console.error(`[qdrant] upsertPoints(${collection}) failed ${res.status}: ${text}`);
+    log.error(`upsertPoints(${collection}) failed ${res.status}: ${text}`);
     return false;
   } catch (err) {
-    console.error(`[qdrant] upsertPoints(${collection}) error:`, err);
+    log.error(`upsertPoints(${collection}) error`, { err });
     return false;
   }
 }
@@ -135,13 +138,13 @@ export async function searchPoints(
     });
     if (!res.ok) {
       const text = await res.text();
-      console.error(`[qdrant] search(${collection}) failed ${res.status}: ${text}`);
+      log.error(`search(${collection}) failed ${res.status}: ${text}`);
       return [];
     }
     const data = await res.json() as { result?: QdrantSearchResult[] };
     return data.result ?? [];
   } catch (err) {
-    console.error(`[qdrant] search(${collection}) error:`, err);
+    log.error(`search(${collection}) error`, { err });
     return [];
   }
 }

--- a/src/services/qdrant/code-patterns-indexer.ts
+++ b/src/services/qdrant/code-patterns-indexer.ts
@@ -10,6 +10,9 @@ import { upsertPoints } from "./client.ts";
 import { COLLECTION_CODE_PATTERNS } from "./collections.ts";
 import { embed } from "../embeddings/ollama-client.ts";
 import type { SymbolContext } from "../codebase/symbol-fetcher.ts";
+import { logger } from "../../../lib/log.ts";
+
+const log = logger("code-patterns-indexer");
 
 /**
  * Index symbol contexts into quinn-code-patterns.
@@ -27,7 +30,7 @@ export async function indexCodePatterns(symbolContexts: SymbolContext[]): Promis
       failures++;
       const total = indexed + failures;
       if (total >= 10 && failures / total > 0.1) {
-        console.warn(`[code-patterns-indexer] High embedding failure rate: ${failures}/${total}`);
+        log.warn(`High embedding failure rate: ${failures}/${total}`);
       }
       continue;
     }
@@ -52,7 +55,7 @@ export async function indexCodePatterns(symbolContexts: SymbolContext[]): Promis
     if (success) indexed++;
   }
 
-  console.log(`[code-patterns-indexer] ${indexed} symbol contexts indexed, ${failures} failed`);
+  log.info(`${indexed} symbol contexts indexed, ${failures} failed`);
   return indexed;
 }
 

--- a/src/services/qdrant/collections.ts
+++ b/src/services/qdrant/collections.ts
@@ -10,6 +10,9 @@
  */
 
 import { ensureCollection } from "./client.ts";
+import { logger } from "../../../lib/log.ts";
+
+const log = logger("qdrant");
 
 // Vector dimension must match the configured Ollama embedding model.
 // nomic-embed-text produces 768-dimensional vectors.
@@ -43,9 +46,9 @@ export async function initializeCollections(): Promise<boolean> {
   const allReady = results.every(r => r);
 
   if (allReady) {
-    console.log("[qdrant] Collections initialized: quinn-pr-history, quinn-code-patterns, quinn-review-learnings");
+    log.info("Collections initialized: quinn-pr-history, quinn-code-patterns, quinn-review-learnings");
   } else {
-    console.warn("[qdrant] One or more collections failed to initialize — vector context will be unavailable");
+    log.warn("One or more collections failed to initialize — vector context will be unavailable");
   }
 
   return allReady;

--- a/src/services/qdrant/pr-history-indexer.ts
+++ b/src/services/qdrant/pr-history-indexer.ts
@@ -11,6 +11,9 @@ import { COLLECTION_PR_HISTORY } from "./collections.ts";
 import { embed } from "../embeddings/ollama-client.ts";
 import type { DiffChunk } from "../diff/chunker.ts";
 import type { PRMetadata, ReviewDecision } from "../github/diff-fetcher.ts";
+import { logger } from "../../../lib/log.ts";
+
+const log = logger("pr-history-indexer");
 
 export interface PRHistoryRecord {
   meta: PRMetadata;
@@ -38,7 +41,7 @@ export async function indexPRHistory(record: PRHistoryRecord): Promise<number> {
       failures++;
       const total = indexed + failures;
       if (total >= 10 && failures / total > 0.1) {
-        console.warn(`[pr-history-indexer] High embedding failure rate: ${failures}/${total}`);
+        log.warn(`High embedding failure rate: ${failures}/${total}`);
       }
       continue;
     }
@@ -67,7 +70,7 @@ export async function indexPRHistory(record: PRHistoryRecord): Promise<number> {
     if (success) indexed++;
   }
 
-  console.log(`[pr-history-indexer] PR #${meta.prNumber} ${meta.owner}/${meta.repo}: ${indexed} chunks indexed, ${failures} failed`);
+  log.info(`PR #${meta.prNumber} ${meta.owner}/${meta.repo}: ${indexed} chunks indexed, ${failures} failed`);
   return indexed;
 }
 

--- a/src/services/reviews/dismissal-tracker.ts
+++ b/src/services/reviews/dismissal-tracker.ts
@@ -7,6 +7,9 @@
  */
 
 import { recordDismissalEvent } from "../qdrant/review-learnings-indexer.ts";
+import { logger } from "../../../lib/log.ts";
+
+const log = logger("dismissal-tracker");
 
 export interface CommentResponseEvent {
   repo: string;
@@ -42,12 +45,12 @@ export async function trackCommentResponse(event: CommentResponseEvent): Promise
       reason: event.reason,
     });
 
-    console.log(
-      `[dismissal-tracker] ${event.dismissed ? "Dismissed" : "Approved"} pattern in ${event.repo} (${fileType})` +
+    log.info(
+      `${event.dismissed ? "Dismissed" : "Approved"} pattern in ${event.repo} (${fileType})` +
       (event.reason ? `: ${event.reason}` : ""),
     );
   } catch (err) {
-    console.error("[dismissal-tracker] Failed to record comment response:", err);
+    log.error("Failed to record comment response", { err });
     // Non-fatal — learning loop failure must not block review
   }
 }

--- a/src/services/reviews/review-pipeline.ts
+++ b/src/services/reviews/review-pipeline.ts
@@ -22,6 +22,9 @@ import { assembleReviewPrompt } from "./quinn-review-prompt.ts";
 import { checkHealth } from "../qdrant/client.ts";
 import type { AssembledPrompt } from "./quinn-review-prompt.ts";
 import type { CodebaseContext } from "./context-formatter.ts";
+import { logger } from "../../../lib/log.ts";
+
+const log = logger("review-pipeline");
 
 export interface PipelineInput {
   repo: string;
@@ -66,10 +69,10 @@ export async function runReviewPipeline(input: PipelineInput): Promise<PipelineR
         context = { pastDecisions, similarPatterns };
       }
     } catch (err) {
-      console.warn("[review-pipeline] Qdrant context retrieval failed — proceeding with diff-only review:", err);
+      log.warn("Qdrant context retrieval failed — proceeding with diff-only review", { err });
     }
   } else {
-    console.warn("[review-pipeline] Qdrant unavailable — proceeding with diff-only review");
+    log.warn("Qdrant unavailable — proceeding with diff-only review");
   }
 
   const assembled = assembleReviewPrompt({
@@ -82,8 +85,8 @@ export async function runReviewPipeline(input: PipelineInput): Promise<PipelineR
     promptBudget: input.promptBudget,
   });
 
-  console.log(
-    `[review-pipeline] PR #${prNumber} ${repo}: ` +
+  log.info(
+    `PR #${prNumber} ${repo}: ` +
     `${filePaths.length} files, ${symbols.length} symbols, ` +
     `context=${assembled.hasContext}, tokens=${assembled.totalTokens}`,
   );

--- a/src/storage/push-notification-store.ts
+++ b/src/storage/push-notification-store.ts
@@ -36,6 +36,9 @@ import { existsSync, mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import type { TaskPushNotificationConfig } from "@a2a-js/sdk";
 import type { PushNotificationStore, ServerCallContext } from "@a2a-js/sdk/server";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("push-notification-store");
 
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
 
@@ -86,9 +89,9 @@ export class SqlitePushNotificationStore implements PushNotificationStore {
       // Cold-start purge — a process that's been off for days shouldn't
       // surface stale configs on its first load() call.
       this._purgeExpired();
-      console.log(`[push-store] Ready at ${this.dbPath} (ttl=${this.ttlMs}ms)`);
+      log.info(`Ready at ${this.dbPath} (ttl=${this.ttlMs}ms)`);
     } catch (err) {
-      console.error("[push-store] Init failed — push-notification persistence disabled:", err);
+      log.error("Init failed — push-notification persistence disabled", { err });
       this.db = null;
     }
   }
@@ -118,7 +121,7 @@ export class SqlitePushNotificationStore implements PushNotificationStore {
       // between INSERT and DELETE.
       this._purgeExpired(now);
     } catch (err) {
-      console.error(`[push-store] save() failed for task ${taskId.slice(0, 8)}…:`, err);
+      log.error(`save() failed for task ${taskId.slice(0, 8)}…`, { err });
     }
   }
 
@@ -136,7 +139,7 @@ export class SqlitePushNotificationStore implements PushNotificationStore {
         .all(taskId, now);
       return rows.map(r => JSON.parse(r.config_json) as TaskPushNotificationConfig);
     } catch (err) {
-      console.error(`[push-store] load() failed for task ${taskId.slice(0, 8)}…:`, err);
+      log.error(`load() failed for task ${taskId.slice(0, 8)}…`, { err });
       return [];
     }
   }
@@ -153,7 +156,7 @@ export class SqlitePushNotificationStore implements PushNotificationStore {
         this.db.run(`DELETE FROM push_notifications WHERE task_id = ?`, [taskId]);
       }
     } catch (err) {
-      console.error(`[push-store] delete() failed for task ${taskId.slice(0, 8)}…:`, err);
+      log.error(`delete() failed for task ${taskId.slice(0, 8)}…`, { err });
     }
   }
 

--- a/src/telemetry/langfuse-tracer.ts
+++ b/src/telemetry/langfuse-tracer.ts
@@ -19,6 +19,9 @@
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { LangfuseSpanProcessor } from "@langfuse/otel";
 import { setLangfuseTracerProvider } from "@langfuse/tracing";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("langfuse");
 
 let initialized = false;
 let activeProvider: NodeTracerProvider | null = null;
@@ -55,7 +58,7 @@ export async function shutdownLangfuseTracer(): Promise<void> {
   try {
     await activeProvider.shutdown();
   } catch (err) {
-    console.warn("[langfuse] tracer shutdown/flush failed:", err);
+    log.warn("tracer shutdown/flush failed", { err });
   } finally {
     activeProvider = null;
     initialized = false;

--- a/src/telemetry/telemetry-service.ts
+++ b/src/telemetry/telemetry-service.ts
@@ -16,6 +16,9 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync, existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("telemetry");
 
 export type TelemetryKind = "goal" | "action";
 
@@ -57,7 +60,7 @@ export class TelemetryService {
         try {
           mkdirSync(dir, { recursive: true });
         } catch (mkErr) {
-          console.error("[telemetry] Cannot create data dir — counters disabled:", mkErr);
+          log.error("Cannot create data dir — counters disabled", { err: mkErr });
           this.db = null;
           return;
         }
@@ -80,9 +83,9 @@ export class TelemetryService {
         CREATE INDEX IF NOT EXISTS idx_telemetry_kind_id
           ON telemetry_counters(kind, id);
       `);
-      console.log(`[telemetry] Ready at ${this.dbPath}`);
+      log.info(`Ready at ${this.dbPath}`);
     } catch (err) {
-      console.error("[telemetry] Init failed — counters disabled:", err);
+      log.error("Init failed — counters disabled", { err });
       this.db = null;
     }
   }
@@ -106,7 +109,7 @@ export class TelemetryService {
       );
     } catch (err) {
       // Swallow — telemetry must never break the caller.
-      console.warn("[telemetry] bump failed:", err);
+      log.warn("bump failed", { err });
     }
   }
 
@@ -127,7 +130,7 @@ export class TelemetryService {
         stmt.run(kind, id, event);
       }
     } catch (err) {
-      console.warn("[telemetry] registerKnown failed:", err);
+      log.warn("registerKnown failed", { err });
     }
   }
 
@@ -153,7 +156,7 @@ export class TelemetryService {
         )
         .all();
     } catch (err) {
-      console.warn("[telemetry] snapshot failed:", err);
+      log.warn("snapshot failed", { err });
       return [];
     }
   }


### PR DESCRIPTION
## What

**Slice 5** of the `console.*` → `lib/log.ts` sweep (after #818 spine, #823 integration core, #824 discord, #825 google). Converts the `src/` **data + infra layer**.

**22 files, 0 remaining `console.*`:**
- `src/knowledge/*` — research/knowledge/conversation stores, `ceremonyOutcomes`, `conversation-harvester`, `fleet-state`
- `src/services/*` — qdrant client + indexers, embeddings (ollama/gateway), github `diff-fetcher`, reviews pipeline + `dismissal-tracker`, diff/codebase symbol extractors
- `src/telemetry/*` — `telemetry-service`, `langfuse-tracer`
- `src/storage/push-notification-store`, `src/executor/{task-tracker-store, skill-ab-test-plugin}`

Same convention as prior slices (tag→component, level-mapped, trailing `err`→`{ err }`, sentences inline). Pure stores/services — no output-sink fallbacks; no logic changes.

## Verification

- Full suite green under **both** dev and **`NODE_ENV=production`** (image-build gate): **1080 pass / 0 fail**
- `tsc --noEmit` + biome lint clean

## Remaining (final slice)

**Slice 6** — `src/` plugins/api/webhooks/mcp/loaders/integrations/misc (~30 files). Includes the two files whose tests spy on `console` (`src/api/a2a-server.ts`, `src/integrations/discord/CeremonyNotifier.ts`) — those get handled with care (the CeremonyNotifier "no webhook → console" path is an intentional output sink that stays). CLI/debug terminal-UX files stay `console`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)