### PR TITLE
chore(logging): migrate remaining src/ to logger — console→logger sweep complete

### DIFF
--- a/src/agent-runtime/agent-definition-loader.ts
+++ b/src/agent-runtime/agent-definition-loader.ts
@@ -13,6 +13,9 @@ import { readdirSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
 import type { AgentDefinition, AgentRole, AgentSkillDefinition, JsonSchema, RawAgentYaml } from "./types.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("agent-runtime");
 
 const VALID_ROLES: AgentRole[] = [
   "orchestrator",
@@ -207,9 +210,7 @@ export function loadAgentEntries(workspaceDir: string): AgentEntry[] {
       const def = parseAgentYaml(raw, file);
       entries.push({ def, file: filePath });
     } catch (err) {
-      console.error(
-        `[agent-runtime] Skipping ${file}: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      log.error(`Skipping ${file}`, { err: err instanceof Error ? err.message : String(err) });
     }
   }
 

--- a/src/agent-runtime/agent-executor.ts
+++ b/src/agent-runtime/agent-executor.ts
@@ -28,6 +28,9 @@
 import { query, isSDKResultMessage } from "@protolabsai/sdk";
 import type { SDKResultMessageSuccess, SDKResultMessageError, ExtendedUsage } from "@protolabsai/sdk";
 import type { AgentDefinition } from "./types.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("agent-executor");
 
 export interface SkillProgressEvent {
   /** Discriminates between tool invocations and assistant text chunks. */
@@ -127,7 +130,7 @@ export class AgentExecutor {
         // use correlationId so LangFuse traces stay grouped under the same ID.
         ...(resume ? { resume } : { sessionId: correlationId }),
         cwd: cwd ?? process.cwd(),
-        stderr: (line: string) => console.error(`[agent:${this.agentDef.name}:stderr]`, line),
+        stderr: (line: string) => log.error("agent stderr", { agent: this.agentDef.name, line }),
         ...(this.agentDef.allowedTools?.length ? { allowedTools: this.agentDef.allowedTools } : {}),
         ...(this.agentDef.excludeTools?.length ? { excludeTools: this.agentDef.excludeTools } : {}),
         ...(Object.keys(env).length > 0 ? { env } : {}),

--- a/src/api/__tests__/a2a-server.test.ts
+++ b/src/api/__tests__/a2a-server.test.ts
@@ -207,7 +207,11 @@ describe("BusAgentExecutor (Phase 7)", () => {
       expect(requestPayload).toBeDefined();
       expect((requestPayload as { targets: string[] }).targets).toEqual(["ava"]);
       expect((requestPayload as { skill: string }).skill).toBe("chat");
-      expect(logCalls.some(l => l.includes("[a2a-server]") && l.includes("defaulting to helm [ava]"))).toBe(true);
+      // Assert on the message content, not the `[a2a-server]` tag: that tag is
+      // now the structured-logger component (rendered as a JSON field under the
+      // NODE_ENV=production build gate), so matching the literal would be
+      // env-dependent. The message text is stable across dev/json formats.
+      expect(logCalls.some(l => l.includes("defaulting to helm [ava]"))).toBe(true);
     } finally {
       console.log = origLog;
     }

--- a/src/api/a2a-server.ts
+++ b/src/api/a2a-server.ts
@@ -40,9 +40,12 @@ import { Role, TaskState, type Message } from "@a2a-js/sdk";
 import { textPart, partText, textArtifact, dataArtifact, emitToolCall, type ToolCallArtifactData } from "@protolabs/a2a";
 import type { Route, ApiContext } from "./types.ts";
 import type { BusMessage } from "../../lib/types.ts";
+import { logger } from "../../lib/log.ts";
 import { buildAgentCard } from "./agent-card.ts";
 import { getFleetConfig } from "../../lib/fleet/fleet-config.ts";
 import { SqlitePushNotificationStore } from "../storage/push-notification-store.ts";
+
+const log = logger("a2a-server");
 
 /**
  * Detect when an upstream payload looks like an HTML error page (usually the
@@ -147,7 +150,7 @@ class BusAgentExecutor implements AgentExecutor {
     if (explicitTargets.length === 0) {
       const helm = getFleetConfig().helm;
       targets = [helm];
-      console.log(`[a2a-server] no target specified, defaulting to helm [${helm}] for message/send`);
+      log.info(`no target specified, defaulting to helm [${helm}] for message/send`);
     } else {
       targets = explicitTargets;
     }
@@ -278,14 +281,14 @@ class BusAgentExecutor implements AgentExecutor {
         let errorText = rawError;
         let contentText = rawContent;
         if (rawError && looksLikeHtmlError(rawError)) {
-          console.warn(
-            `[a2a-server] upstream error payload contained HTML (taskId=${taskId.slice(0, 8)}…); sanitizing. Raw:\n${rawError}`,
+          log.warn(
+            `upstream error payload contained HTML (taskId=${taskId.slice(0, 8)}…); sanitizing. Raw:\n${rawError}`,
           );
           errorText = sanitizeHtmlError(rawError);
         }
         if (!errorText && rawContent && looksLikeHtmlError(rawContent)) {
-          console.warn(
-            `[a2a-server] upstream content payload contained HTML (taskId=${taskId.slice(0, 8)}…); treating as failure. Raw:\n${rawContent}`,
+          log.warn(
+            `upstream content payload contained HTML (taskId=${taskId.slice(0, 8)}…); treating as failure. Raw:\n${rawContent}`,
           );
           errorText = sanitizeHtmlError(rawContent);
           contentText = "";
@@ -408,7 +411,7 @@ class BusAgentExecutor implements AgentExecutor {
     await done;
     clearInterval(heartbeat);
     if (cancelled) {
-      console.log(`[a2a-server] Task ${taskId.slice(0, 8)}… canceled`);
+      log.info(`Task ${taskId.slice(0, 8)}… canceled`);
     }
   }
 

--- a/src/api/clawpatch.ts
+++ b/src/api/clawpatch.ts
@@ -38,6 +38,9 @@ import { makeGitHubAuth } from "../../lib/github-auth.ts";
 import type { Route, ApiContext } from "./types.ts";
 import type { ProjectRegistry } from "../plugins/project-registry.ts";
 import { safeKeyEqual } from "../../lib/runtime-env.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("clawpatch");
 
 /**
  * Where clawpatch persists `.clawpatch/` (features, findings, runs, reports,
@@ -93,7 +96,7 @@ function resolveDevOverridePath(repo: string): string | null {
     overrides = JSON.parse(raw) as Record<string, string>;
   } catch {
     // Bad JSON shouldn't break the route — log once and fall through to cache.
-    console.warn("[clawpatch] CLAWPATCH_REPO_PATH_MAP is not valid JSON — ignoring");
+    log.warn("CLAWPATCH_REPO_PATH_MAP is not valid JSON — ignoring");
     return null;
   }
   const path = overrides[repo];

--- a/src/api/discord.ts
+++ b/src/api/discord.ts
@@ -20,6 +20,9 @@
 
 import type { Route, ApiContext } from "./types.ts";
 import { pendingReplies, canSendProgress } from "../../lib/plugins/discord.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("discord-progress");
 
 function getDiscordClient(ctx: ApiContext) {
   const plugin = ctx.plugins.find(p => p.name === "discord") as any;
@@ -354,8 +357,9 @@ export function createRoutes(ctx: ApiContext): Route[] {
             await (pending.message.channel as any).send({ content });
             discordDelivered = true;
           } catch (e) {
-            console.warn(
-              `[discord/progress] Discord send failed for ${body.correlationId.slice(0, 8)}… (bus publish already succeeded): ${e instanceof Error ? e.message : String(e)}`,
+            log.warn(
+              `Discord send failed for ${body.correlationId.slice(0, 8)}… (bus publish already succeeded)`,
+              { err: e },
             );
           }
         }

--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -5,6 +5,9 @@
 
 import type { Route, ApiContext } from "./types.ts";
 import { HttpClient } from "../services/http-client.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("api-github");
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 
@@ -477,8 +480,8 @@ export function createRoutes(ctx: ApiContext): Route[] {
           return age < dedupWindowMs;
         });
         if (match) {
-          console.log(
-            `[github] create_github_issue dedup: skipping new "${title}" — ${match.state} ${repo}#${match.number} matches`,
+          log.info(
+            `create_github_issue dedup: skipping new "${title}" — ${match.state} ${repo}#${match.number} matches`,
           );
           return Response.json({
             success: true,
@@ -489,7 +492,7 @@ export function createRoutes(ctx: ApiContext): Route[] {
       } catch (e) {
         // Dedup is best-effort. Failing to query the listing shouldn't block
         // the create — log and proceed.
-        console.warn(`[github] create_github_issue dedup lookup failed (proceeding with create): ${String(e).slice(0, 200)}`);
+        log.warn(`create_github_issue dedup lookup failed (proceeding with create): ${String(e).slice(0, 200)}`);
       }
     }
 

--- a/src/api/linear-oauth.ts
+++ b/src/api/linear-oauth.ts
@@ -15,6 +15,9 @@
 
 import type { Route, ApiContext } from "./types.ts";
 import { getLinearAvaTokenManager } from "../../lib/linear/ava-oauth-token-manager.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("linear-ava-oauth");
 
 function htmlPage(title: string, body: string, status: number): Response {
   return new Response(
@@ -80,10 +83,10 @@ export function createRoutes(ctx: ApiContext): Route[] {
           await mgr.handleCallback(code, state);
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
-          console.error(`[linear-ava-oauth] callback failed: ${msg}`);
+          log.error("callback failed", { err });
           return htmlPage("Authorization failed", `<p>${msg}</p>`, 400);
         }
-        console.log("[linear-ava-oauth] authorized — refresh token captured; Ava can now post as herself.");
+        log.info("authorized — refresh token captured; Ava can now post as herself.");
         return htmlPage(
           "Ava is connected to Linear ✅",
           `<p>The agent token was captured and stored. Ava will now post as herself in Linear. You can close this tab.</p>`,

--- a/src/api/linear.ts
+++ b/src/api/linear.ts
@@ -19,6 +19,9 @@ import type { Route, ApiContext } from "./types.ts";
 import { LinearClient, type LinearPriority } from "../../lib/linear-client.ts";
 import { getLinearAvaTokenManager } from "../../lib/linear/ava-oauth-token-manager.ts";
 import { LinearAgentActivityClient } from "../../lib/linear/agent-activity-client.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("api-linear");
 
 /**
  * Post a comment authored AS Ava (actor=app token) when she's authorized,
@@ -34,7 +37,7 @@ async function postComment(dataDir: string, issueId: string, body: string): Prom
       await ava.createComment(issueId, body);
       return { as: "ava" };
     } catch (err) {
-      console.warn(`[api/linear] post-as-Ava comment failed on ${issueId} (${err instanceof Error ? err.message : String(err)}) — falling back to personal key`);
+      log.warn(`post-as-Ava comment failed on ${issueId} — falling back to personal key`, { err });
     }
   }
   const client = getClient();

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -11,6 +11,9 @@ import type { CallerIdentity } from "../../lib/auth/agent-keys.ts";
 import { getPendingHumanInput } from "./human-input.ts";
 import { safeKeyEqual, isPublishTopicDenied } from "../../lib/runtime-env.ts";
 import { metrics } from "../../lib/metrics.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("publish");
 
 /**
  * Probe whether the LLM gateway is REACHABLE for the readiness report.
@@ -144,7 +147,7 @@ export function createRoutes(ctx: ApiContext): Route[] {
     // never for forging agent.skill.request / operator.message.request /
     // inbound messages / scheduled triggers.
     if (isPublishTopicDenied(topic)) {
-      console.warn(`[publish] rejected denied topic "${topic}" from ${caller.agentName ?? "admin"}`);
+      log.warn(`rejected denied topic "${topic}" from ${caller.agentName ?? "admin"}`);
       return Response.json(
         { success: false, error: `Topic "${topic}" may not be published via /publish (internal control-plane topic)` },
         { status: 403 },

--- a/src/api/pr-inspector.ts
+++ b/src/api/pr-inspector.ts
@@ -30,6 +30,9 @@
 import type { Route, ApiContext } from "./types.ts";
 import { makeGitHubAuth } from "../../lib/github-auth.ts";
 import { REVIEW_TOPICS } from "../event-bus/topics.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("pr-inspector");
 
 // Resolve auth lazily + memoized on first use rather than at module load.
 // Module-load capture bound the getter to whatever env existed at import
@@ -313,8 +316,8 @@ async function guardTerminalCi(
   const pending = pendingCheckNames(runs);
   if (pending.length === 0) return null;
 
-  console.warn(
-    `[pr-inspector] CI-terminal guard: held ${verdict} on ${owner}/${name}#${pr} — ` +
+  log.warn(
+    `CI-terminal guard: held ${verdict} on ${owner}/${name}#${pr} — ` +
       `${pending.length} check(s) still running: ${pending.slice(0, 8).join(", ")}`,
   );
   const verb = verdict === "APPROVE" ? "approval" : "change-request";
@@ -442,9 +445,7 @@ function publishReviewSubmitted(
       },
     });
   } catch (err) {
-    console.warn(
-      `[pr-inspector] failed to publish quinn.review.submitted: ${err instanceof Error ? err.message : err}`,
-    );
+    log.warn("failed to publish quinn.review.submitted", { err });
   }
 }
 
@@ -511,7 +512,7 @@ async function setPrState(
     try {
       await postIssueComment(owner, name, pr, comment);
     } catch (e) {
-      console.warn(`[pr-inspector] comment-then-close: comment failed (proceeding): ${String(e).slice(0, 300)}`);
+      log.warn(`comment-then-close: comment failed (proceeding): ${String(e).slice(0, 300)}`);
     }
   }
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -22,6 +22,9 @@
  */
 
 import { z } from "zod";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("env");
 
 // ── Schema ────────────────────────────────────────────────────────────────────
 // All vars are optional strings — the system degrades gracefully when optional
@@ -161,8 +164,8 @@ export function parseEnv(raw: NodeJS.ProcessEnv = process.env): Env {
     const issues = result.error.issues
       .map((i) => `  ${i.path.join(".")}: ${i.message}`)
       .join("\n");
-    console.error(
-      `[env] Invalid environment configuration — fix the following and restart:\n${issues}`,
+    log.error(
+      `Invalid environment configuration — fix the following and restart:\n${issues}`,
     );
     process.exit(1);
   }

--- a/src/diff/validateComments.ts
+++ b/src/diff/validateComments.ts
@@ -8,6 +8,9 @@
  */
 
 import type { LLMComment, ValidatedComment, AnnotatedHunk } from "./types.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("validate-comments");
 
 /**
  * Check if a given line number falls within any hunk for the specified file.
@@ -78,8 +81,8 @@ export function validateComments(
     // Validate line_end is within hunk bounds
     const endHunk = findHunkForLine(path, line_end, hunks);
     if (!endHunk) {
-      console.warn(
-        `[validateComments] Dropping comment: ${path}:${line_end} is outside hunk bounds or on a deleted line`,
+      log.warn(
+        `Dropping comment: ${path}:${line_end} is outside hunk bounds or on a deleted line`,
       );
       continue;
     }
@@ -101,8 +104,8 @@ export function validateComments(
     const startHunk = findHunkForLine(path, line_start, hunks);
     if (!startHunk) {
       // Start line is invalid — fall back to single-line at line_end
-      console.warn(
-        `[validateComments] Multi-line comment ${path}:${line_start}-${line_end}: start line outside bounds, falling back to single-line at ${line_end}`,
+      log.warn(
+        `Multi-line comment ${path}:${line_start}-${line_end}: start line outside bounds, falling back to single-line at ${line_end}`,
       );
       validated.push({
         path,
@@ -117,8 +120,8 @@ export function validateComments(
 
     // Check if start and end are in different hunks — split into single-line at end
     if (startHunk !== endHunk) {
-      console.warn(
-        `[validateComments] Multi-line comment ${path}:${line_start}-${line_end} spans multiple hunks, splitting to single-line at ${line_end}`,
+      log.warn(
+        `Multi-line comment ${path}:${line_start}-${line_end} spans multiple hunks, splitting to single-line at ${line_end}`,
       );
       validated.push({
         path,

--- a/src/event-bus/history-recorder.ts
+++ b/src/event-bus/history-recorder.ts
@@ -24,6 +24,9 @@
  */
 
 import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("bus-history-recorder");
 
 const DEFAULT_MAX_EVENTS = 10_000;
 const DEFAULT_TTL_MS = 30 * 60 * 1000;
@@ -142,8 +145,8 @@ export class BusHistoryRecorderPlugin implements Plugin {
     this.subscriptionId = bus.subscribe("#", this.name, msg => this.recorder.record(msg));
     this.pruneTimer = setInterval(() => this.recorder.prune(), PRUNE_INTERVAL_MS);
     if (typeof this.pruneTimer.unref === "function") this.pruneTimer.unref();
-    console.log(
-      `[bus-history-recorder] installed (cap=${this.recorder.stats().capacity}, ttlMs=${this.recorder.stats().ttlMs})`,
+    log.info(
+      `installed (cap=${this.recorder.stats().capacity}, ttlMs=${this.recorder.stats().ttlMs})`,
     );
   }
 

--- a/src/event-bus/payloads.ts
+++ b/src/event-bus/payloads.ts
@@ -221,7 +221,7 @@ export type DispatchDropReason = "no_skill" | "target_unresolved" | "cooldown";
 export interface DispatchDroppedPayload {
   reason: DispatchDropReason;
   correlationId: string;
-  /** The dispatcher's human-readable drop message — same content as the console.warn line. */
+  /** The dispatcher's human-readable drop message — same content as the log.warn line. */
   message: string;
   /** Skill name (absent only when reason="no_skill"). */
   skill?: string;

--- a/src/event-bus/skill-response-cache.ts
+++ b/src/event-bus/skill-response-cache.ts
@@ -20,6 +20,9 @@
 
 import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
 import type { AgentSkillResponsePayload } from "./payloads.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("skill-response-cache");
 
 const DEFAULT_TTL_MS = 15 * 60 * 1000;
 const DEFAULT_MAX_ENTRIES = 5_000;
@@ -114,8 +117,8 @@ export class SkillResponseCachePlugin implements Plugin {
     this.subscriptionId = bus.subscribe(RESPONSE_TOPIC_WILDCARD, this.name, (msg) => this.cache.record(msg));
     this.pruneTimer = setInterval(() => this.cache.prune(), PRUNE_INTERVAL_MS);
     if (typeof this.pruneTimer.unref === "function") this.pruneTimer.unref();
-    console.log(
-      `[skill-response-cache] installed (maxEntries=${this.cache.stats().maxEntries}, ttlMs=${this.cache.stats().ttlMs})`,
+    log.info(
+      `installed (maxEntries=${this.cache.stats().maxEntries}, ttlMs=${this.cache.stats().ttlMs})`,
     );
   }
 

--- a/src/github/reviewSubmitter.ts
+++ b/src/github/reviewSubmitter.ts
@@ -20,6 +20,9 @@ import type {
 import { toGitHubComment } from "./types.ts";
 import type { ValidatedComment } from "../diff/types.ts";
 import { HttpClient } from "../services/http-client.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("review-submitter");
 
 const GITHUB_API_BASE = "https://api.github.com";
 const USER_AGENT = "protoWorkstacean/1.0";
@@ -95,11 +98,10 @@ export class GitHubReviewSubmitter {
 
       if (res.status === 422) {
         // Log all submitted comments for debugging, then fail fast — do NOT retry
-        console.error(
-          "[reviewSubmitter] 422 Validation Error — submitted comments:",
-          JSON.stringify(githubComments, null, 2),
-        );
-        console.error("[reviewSubmitter] GitHub response:", responseBody);
+        log.error("422 Validation Error — submitted comments", {
+          comments: JSON.stringify(githubComments, null, 2),
+        });
+        log.error("GitHub response", { responseBody });
         throw new Error(
           `[reviewSubmitter] GitHub API 422 validation error on review submission. ` +
           `Comments: ${githubComments.length}. Error: ${responseBody}`,
@@ -113,8 +115,8 @@ export class GitHubReviewSubmitter {
 
     const data = await res.json() as { id: number };
 
-    console.log(
-      `[reviewSubmitter] Review #${data.id} submitted on ${owner}/${repo}#${prNumber} — ` +
+    log.info(
+      `Review #${data.id} submitted on ${owner}/${repo}#${prNumber} — ` +
       `${event}, ${githubComments.length} inline comment(s)`,
     );
 

--- a/src/integrations/discord/CeremonyNotifier.ts
+++ b/src/integrations/discord/CeremonyNotifier.ts
@@ -11,6 +11,9 @@
  */
 
 import type { CeremonyOutcome } from "../../plugins/CeremonyPlugin.types.ts";
+import { logger } from "../../../lib/log.ts";
+
+const log = logger("ceremony-notifier");
 
 const STATUS_COLORS: Record<string, number> = {
   success: 0x2ecc71,  // green
@@ -24,7 +27,7 @@ export class CeremonyNotifier {
   constructor(webhookUrl?: string) {
     this.defaultWebhookUrl = webhookUrl ?? process.env.DISCORD_CEREMONY_WEBHOOK_URL ?? null;
     if (!this.defaultWebhookUrl) {
-      console.info("[ceremony-notifier] DISCORD_CEREMONY_WEBHOOK_URL not set — using console fallback");
+      log.info("DISCORD_CEREMONY_WEBHOOK_URL not set — using console fallback");
     }
   }
 
@@ -58,7 +61,7 @@ export class CeremonyNotifier {
 
       return true;
     } catch (err) {
-      console.error("[ceremony-notifier] Discord integration error:", err);
+      log.error("Discord integration error", { err });
       this._logFallback(outcome, ceremonyName);
       return false;
     }
@@ -77,6 +80,10 @@ export class CeremonyNotifier {
   }
 
   private _logFallback(outcome: CeremonyOutcome, ceremonyName: string): void {
+    // Intentional console output sink: when no Discord webhook is configured,
+    // the ceremony outcome is delivered to stdout. This is the fallback
+    // *delivery channel*, not operational logging — kept on console so the
+    // payload stays a stable, parse-friendly single line (a2a/ops tail it).
     const durationSec = (outcome.duration / 1000).toFixed(1);
     console.log(
       `[ceremony-notifier:fallback] Ceremony "${ceremonyName}" (${outcome.ceremonyId}) ` +

--- a/src/loaders/ceremonyYamlLoader.ts
+++ b/src/loaders/ceremonyYamlLoader.ts
@@ -10,6 +10,9 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 import type { Ceremony } from "../plugins/CeremonyPlugin.types.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("ceremony-loader");
 
 export interface LoadedCeremonies {
   ceremonies: Ceremony[];
@@ -83,7 +86,7 @@ export class CeremonyYamlLoader {
         (f) => f.endsWith(".yaml") || f.endsWith(".yml")
       );
     } catch (err) {
-      console.error(`[ceremony-loader] Failed to read directory ${dir}:`, err);
+      log.error(`Failed to read directory ${dir}`, { err });
       return [];
     }
 
@@ -105,14 +108,14 @@ export class CeremonyYamlLoader {
       const parsed = parseYaml(raw) as unknown;
       return this._validate(parsed, source, filePath);
     } catch (err) {
-      console.error(`[ceremony-loader] Failed to parse ${filePath}:`, err);
+      log.error(`Failed to parse ${filePath}`, { err });
       return null;
     }
   }
 
   private _validate(raw: unknown, source: string, filePath: string): Ceremony | null {
     if (!raw || typeof raw !== "object") {
-      console.warn(`[ceremony-loader] Invalid ceremony YAML at ${filePath}: not an object`);
+      log.warn(`Invalid ceremony YAML at ${filePath}: not an object`);
       return null;
     }
 
@@ -126,23 +129,23 @@ export class CeremonyYamlLoader {
     // _reloadChangedCeremonies path, which couldn't see a disappearing entry.
 
     if (typeof c.id !== "string" || !c.id) {
-      console.warn(`[ceremony-loader] Skipping ${filePath} (${source}): missing required 'id' field`);
+      log.warn(`Skipping ${filePath} (${source}): missing required 'id' field`);
       return null;
     }
     if (typeof c.name !== "string" || !c.name) {
-      console.warn(`[ceremony-loader] Skipping ${filePath} (${source}): missing required 'name' field`);
+      log.warn(`Skipping ${filePath} (${source}): missing required 'name' field`);
       return null;
     }
     if (typeof c.schedule !== "string" || !c.schedule) {
-      console.warn(`[ceremony-loader] Skipping ${filePath} (${source}): missing required 'schedule' field`);
+      log.warn(`Skipping ${filePath} (${source}): missing required 'schedule' field`);
       return null;
     }
     if (typeof c.skill !== "string" || !c.skill) {
-      console.warn(`[ceremony-loader] Skipping ${filePath} (${source}): missing required 'skill' field`);
+      log.warn(`Skipping ${filePath} (${source}): missing required 'skill' field`);
       return null;
     }
     if (!Array.isArray(c.targets) || c.targets.length === 0) {
-      console.warn(`[ceremony-loader] Skipping ${filePath} (${source}): 'targets' must be a non-empty array`);
+      log.warn(`Skipping ${filePath} (${source}): 'targets' must be a non-empty array`);
       return null;
     }
 

--- a/src/mcp/mcp-client-plugin.ts
+++ b/src/mcp/mcp-client-plugin.ts
@@ -28,6 +28,9 @@ import type { ExecutorRegistry } from "../executor/executor-registry.ts";
 import type { McpServerDef } from "./types.ts";
 import { McpExecutor } from "./mcp-executor.ts";
 import { resolveServerConfig, connectMcp, toolAllowed, mcpEnabled } from "./mcp-connect.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("mcp-client");
 
 /** The registry skill name for an MCP tool — namespaced by server to avoid collisions. */
 export function mcpSkillName(serverName: string, toolName: string): string {
@@ -54,7 +57,7 @@ export class McpClientPlugin implements Plugin {
     this.bus = bus;
     const defs = this._loadServers();
     for (const def of defs) this._registerServer(def);
-    console.log(`[mcp-client] Reconciling ${defs.length} MCP server(s) from mcp-servers.d/ (tools connect async)`);
+    log.info(`Reconciling ${defs.length} MCP server(s) from mcp-servers.d/ (tools connect async)`);
 
     bus.subscribe("command.mcp.upsert", this.name, (msg: BusMessage) => {
       const entry = (msg.payload as { entry?: McpServerDef })?.entry;
@@ -78,7 +81,7 @@ export class McpClientPlugin implements Plugin {
   private _registerServer(def: McpServerDef): void {
     void this._unregisterServer(def.name).then(() => {
       if (!mcpEnabled(def)) {
-        console.log(`[mcp-client] "${def.name}" registered but disabled (trust=${def.trust ?? "community"}) — set enabled:true to connect`);
+        log.info(`"${def.name}" registered but disabled (trust=${def.trust ?? "community"}) — set enabled:true to connect`);
         return;
       }
       return this._connectAndRegister(def);
@@ -101,12 +104,12 @@ export class McpClientPlugin implements Plugin {
         });
         registered++;
       }
-      console.log(`[mcp-client] "${def.name}" connected — registered ${registered}/${tools.length} tool(s)`);
+      log.info(`"${def.name}" connected — registered ${registered}/${tools.length} tool(s)`);
     } catch (err) {
       // Loud failure at the boundary (per feedback_fail_fast_and_loud): a server
       // that won't connect registers no tools, and silence would hide it.
       this.clients.delete(def.name);
-      console.warn(`[mcp-client] "${def.name}" connect failed — no tools registered: ${err instanceof Error ? err.message : err}`);
+      log.warn(`"${def.name}" connect failed — no tools registered`, { err: err instanceof Error ? err.message : err });
     }
   }
 
@@ -119,7 +122,7 @@ export class McpClientPlugin implements Plugin {
     if (client) {
       this.clients.delete(name);
       await client.close().catch(() => {});
-      console.log(`[mcp-client] - MCP server "${name}" disconnected + unregistered`);
+      log.info(`MCP server "${name}" disconnected + unregistered`);
     }
   }
 
@@ -134,9 +137,9 @@ export class McpClientPlugin implements Plugin {
         try {
           const def = parseYaml(readFileSync(join(dir, f), "utf8")) as McpServerDef;
           if (def?.name) out.push(def);
-          else console.warn(`[mcp-client] mcp-servers.d/${f}: missing name — skipped`);
+          else log.warn(`mcp-servers.d/${f}: missing name — skipped`);
         } catch (err) {
-          console.error(`[mcp-client] Skipping mcp-servers.d/${f}: ${err instanceof Error ? err.message : String(err)}`);
+          log.error(`Skipping mcp-servers.d/${f}`, { err: err instanceof Error ? err.message : String(err) });
         }
       }
     } catch { /* dir vanished mid-scan */ }

--- a/src/plugins/agent-fleet-health-plugin.ts
+++ b/src/plugins/agent-fleet-health-plugin.ts
@@ -27,6 +27,9 @@ import type { AutonomousOutcomePayload } from "../event-bus/payloads.ts";
 import type { ExecutorRegistry } from "../executor/executor-registry.ts";
 import { MODEL_RATES } from "../../lib/types/budget.ts";
 import type { FleetStateRepository, OutcomeRecord as PersistedOutcomeRecord } from "../knowledge/fleet-state.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("fleet-health");
 
 const WINDOW_MS = 24 * 60 * 60 * 1_000; // 24 hours
 const WINDOW_1H_MS = 60 * 60 * 1_000; // 1 hour
@@ -54,8 +57,8 @@ function _ratesFor(model: string | undefined): { input: number; output: number }
   if (rates) return rates;
   if (!_warnedUnknownModels.has(model)) {
     _warnedUnknownModels.add(model);
-    console.warn(
-      `[agent-fleet-health] No MODEL_RATES entry for "${model}" — using default rate. ` +
+    log.warn(
+      `No MODEL_RATES entry for "${model}" — using default rate. ` +
         `Add the model to lib/types/budget.ts MODEL_RATES table for accurate cost attribution.`,
     );
   }
@@ -198,7 +201,7 @@ export class AgentFleetHealthPlugin implements Plugin {
       const records = this.fleetStateRepo.hydrateRecords(24);
       for (const r of records) this._addToWindow(r);
       if (records.length > 0) {
-        console.log(`[agent-fleet-health] hydrated ${records.length} records from knowledge.db`);
+        log.info(`hydrated ${records.length} records from knowledge.db`);
       }
     }
 
@@ -209,7 +212,7 @@ export class AgentFleetHealthPlugin implements Plugin {
         this._record(p);
       }),
     );
-    console.log("[agent-fleet-health] Installed — aggregating autonomous.outcome.#");
+    log.info("Installed — aggregating autonomous.outcome.#");
   }
 
   uninstall(): void {
@@ -352,8 +355,8 @@ export class AgentFleetHealthPlugin implements Plugin {
       // without flooding on every outcome.
       if (!this.seenSyntheticActors.has(p.systemActor)) {
         this.seenSyntheticActors.add(p.systemActor);
-        console.warn(
-          `[agent-fleet-health] synthetic_actor_filtered systemActor=${p.systemActor} ` +
+        log.warn(
+          `synthetic_actor_filtered systemActor=${p.systemActor} ` +
             `skill=${p.skill} — not in ExecutorRegistry; aggregating under systemActors[] ` +
             `instead of agents[]. Fix source so it doesn't masquerade as an agent.`,
         );

--- a/src/plugins/alert-skill-executor-plugin.ts
+++ b/src/plugins/alert-skill-executor-plugin.ts
@@ -22,6 +22,9 @@ import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
 import type { ExecutorRegistry } from "../executor/executor-registry.ts";
 import type { SkillRequest, SkillResult } from "../executor/types.ts";
 import { FunctionExecutor } from "../executor/executors/function-executor.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("alert-skill-executor");
 
 /**
  * Every `alert.*` skill in workspace/actions.yaml that has no other handler.
@@ -79,8 +82,8 @@ export class AlertSkillExecutorPlugin implements Plugin {
       const executor = new FunctionExecutor(async (req) => this._execute(req, entry));
       this.registry.register(entry.skill, executor, { priority: 5 });
     }
-    console.log(
-      `[alert-skill-executor] Registered ${ALERT_SKILLS.length} alert executor(s): ${ALERT_SKILLS.map(a => a.skill).join(", ")}`,
+    log.info(
+      `Registered ${ALERT_SKILLS.length} alert executor(s): ${ALERT_SKILLS.map(a => a.skill).join(", ")}`,
     );
   }
 

--- a/src/plugins/ceremony-skill-executor-plugin.ts
+++ b/src/plugins/ceremony-skill-executor-plugin.ts
@@ -28,6 +28,9 @@ import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
 import type { ExecutorRegistry } from "../executor/executor-registry.ts";
 import type { SkillRequest, SkillResult } from "../executor/types.ts";
 import { FunctionExecutor } from "../executor/executors/function-executor.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("ceremony-skill-executor");
 
 /**
  * Action id (== skill name on agent.skill.request) → ceremony id to trigger.
@@ -69,8 +72,8 @@ export class CeremonySkillExecutorPlugin implements Plugin {
       const executor = new FunctionExecutor(async (req) => this._execute(req, entry));
       this.registry.register(entry.skill, executor, { priority: 5 });
     }
-    console.log(
-      `[ceremony-skill-executor] Registered ${CEREMONY_SKILLS.length} ceremony executor(s): ${CEREMONY_SKILLS.map(c => c.skill).join(", ")}`,
+    log.info(
+      `Registered ${CEREMONY_SKILLS.length} ceremony executor(s): ${CEREMONY_SKILLS.map(c => c.skill).join(", ")}`,
     );
   }
 

--- a/src/plugins/clawpatch-cache-cleanup-skill-executor-plugin.ts
+++ b/src/plugins/clawpatch-cache-cleanup-skill-executor-plugin.ts
@@ -17,6 +17,10 @@ import type { SkillRequest, SkillResult } from "../executor/types.ts";
 import { FunctionExecutor } from "../executor/executors/function-executor.ts";
 import { CheckoutCache } from "../../lib/checkout-cache.ts";
 import { makeGitHubAuth } from "../../lib/github-auth.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("clawpatch-cache-cleanup-skill-executor");
+const cleanupLog = logger("clawpatch-cache-cleanup");
 
 export class ClawpatchCacheCleanupSkillExecutorPlugin implements Plugin {
   readonly name = "clawpatch-cache-cleanup-skill-executor";
@@ -42,9 +46,7 @@ export class ClawpatchCacheCleanupSkillExecutorPlugin implements Plugin {
     });
     const executor = new FunctionExecutor(async (req) => this._execute(req));
     this.registry.register("ceremony.clawpatch_cache_cleanup", executor, { priority: 5 });
-    console.log(
-      "[clawpatch-cache-cleanup-skill-executor] Registered ceremony.clawpatch_cache_cleanup",
-    );
+    log.info("Registered ceremony.clawpatch_cache_cleanup");
   }
 
   uninstall(): void {
@@ -63,8 +65,8 @@ export class ClawpatchCacheCleanupSkillExecutorPlugin implements Plugin {
     try {
       const { evicted, bytesFreed } = await this._cache.prune();
       const durationMs = Date.now() - startedAt;
-      console.log(
-        `[clawpatch-cache-cleanup] pruned ${evicted} entr${evicted === 1 ? "y" : "ies"} ` +
+      cleanupLog.info(
+        `pruned ${evicted} entr${evicted === 1 ? "y" : "ies"} ` +
           `(${bytesFreed} bytes) in ${durationMs}ms`,
       );
       return {

--- a/src/plugins/control-plane-registrar-plugin.ts
+++ b/src/plugins/control-plane-registrar-plugin.ts
@@ -20,6 +20,9 @@
 import { writeFileSync, renameSync, unlinkSync, existsSync, mkdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("control-plane-registrar");
 
 export class ControlPlaneRegistrarPlugin implements Plugin {
   name = "control-plane-registrar";
@@ -58,7 +61,7 @@ export class ControlPlaneRegistrarPlugin implements Plugin {
     if (!file) return null;
     const resolved = resolve(file);
     if (dirname(resolved) !== root) {
-      console.warn(`[control-plane] refusing write outside ${root}: ${file}`);
+      log.warn(`refusing write outside ${root}: ${file}`);
       return null;
     }
     return resolved;
@@ -74,9 +77,9 @@ export class ControlPlaneRegistrarPlugin implements Plugin {
       const tmp = `${file}.tmp-${msg.id}`;
       writeFileSync(tmp, p.yaml, "utf8");
       renameSync(tmp, file);
-      console.log(`[control-plane] wrote "${p.name}" → ${file}`);
+      log.info(`wrote "${p.name}" → ${file}`);
     } catch (err) {
-      console.error(`[control-plane] write "${p.name}" failed: ${err instanceof Error ? err.message : String(err)}`);
+      log.error(`write "${p.name}" failed`, { err });
     }
   }
 
@@ -86,9 +89,9 @@ export class ControlPlaneRegistrarPlugin implements Plugin {
     if (!file) return;
     try {
       if (existsSync(file)) unlinkSync(file);
-      console.log(`[control-plane] removed "${p.name}" → ${file}`);
+      log.info(`removed "${p.name}" → ${file}`);
     } catch (err) {
-      console.error(`[control-plane] remove "${p.name}" failed: ${err instanceof Error ? err.message : String(err)}`);
+      log.error(`remove "${p.name}" failed`, { err });
     }
   }
 }

--- a/src/plugins/dispatch-drop-escalator-plugin.ts
+++ b/src/plugins/dispatch-drop-escalator-plugin.ts
@@ -24,6 +24,9 @@
 
 import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
 import type { DispatchDroppedPayload } from "../event-bus/payloads.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("dispatch-drop-escalator");
 
 /** Drops in this rolling window count toward the storm threshold. */
 const STORM_WINDOW_MS_DEFAULT = 10 * 60_000;
@@ -68,8 +71,8 @@ export class DispatchDropEscalatorPlugin implements Plugin {
     this.subscriptionId = bus.subscribe("dispatch.dropped.#", this.name, (msg: BusMessage) => {
       this._onDrop(msg);
     });
-    console.log(
-      `[dispatch-drop-escalator] Installed — threshold=${this.threshold} drops / ` +
+    log.info(
+      `Installed — threshold=${this.threshold} drops / ` +
         `${Math.round(this.windowMs / 60_000)}min, escalationCooldown=${Math.round(this.escalationCooldownMs / 60_000)}min`,
     );
   }
@@ -156,8 +159,8 @@ export class DispatchDropEscalatorPlugin implements Plugin {
       },
     });
 
-    console.warn(
-      `[dispatch-drop-escalator] STORM → escalating: ${key} (${count} drops in ${ageMin}min)`,
+    log.warn(
+      `STORM → escalating: ${key} (${count} drops in ${ageMin}min)`,
     );
   }
 

--- a/src/plugins/fleet-alerts-evaluator-plugin.ts
+++ b/src/plugins/fleet-alerts-evaluator-plugin.ts
@@ -41,6 +41,9 @@ import type { ExecutorRegistry } from "../executor/executor-registry.ts";
 import type { SkillRequest, SkillResult } from "../executor/types.ts";
 import type { AgentFleetHealthPlugin, FleetHealthSnapshot } from "./agent-fleet-health-plugin.ts";
 import { FunctionExecutor } from "../executor/executors/function-executor.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("fleet-alerts-evaluator");
 
 /** Minimum interval between firing the same alert skill (env: WORKSTACEAN_FLEET_ALERT_COOLDOWN_MS). */
 const ALERT_COOLDOWN_MS_DEFAULT = 15 * 60_000;
@@ -85,8 +88,8 @@ export class FleetAlertsEvaluatorPlugin implements Plugin {
     this.bus = bus;
     const executor = new FunctionExecutor(async (req: SkillRequest) => this._execute(req));
     this.registry.register("evaluate_fleet_thresholds", executor, { priority: 5 });
-    console.log(
-      `[fleet-alerts-evaluator] Installed — failureRate1h>${this.failureRateThreshold}, ` +
+    log.info(
+      `Installed — failureRate1h>${this.failureRateThreshold}, ` +
         `dailyBudget=$${this.dailyBudgetUsd}, alertCooldown=${Math.round(this.cooldownMs / 60_000)}min`,
     );
   }
@@ -208,8 +211,8 @@ export class FleetAlertsEvaluatorPlugin implements Plugin {
       },
     } as BusMessage);
 
-    console.log(
-      `[fleet-alerts-evaluator] DISPATCH ${violation.alertSkill}: ${violation.metric}=${violation.value} > ${violation.threshold} — ${violation.detail}`,
+    log.info(
+      `DISPATCH ${violation.alertSkill}: ${violation.metric}=${violation.value} > ${violation.threshold} — ${violation.detail}`,
     );
   }
 }

--- a/src/plugins/project-registry.ts
+++ b/src/plugins/project-registry.ts
@@ -28,6 +28,9 @@
 
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("project-registry");
 
 const DEFAULT_PROTOMAKER_BASE = "http://protomaker-server:3008";
 const DEFAULT_REFRESH_INTERVAL_MS = 5 * 60_000;
@@ -99,13 +102,13 @@ export class ProjectRegistry {
     if (this.refreshTimer) return;
     this.refreshTimer = setInterval(() => void this._refresh(), this.refreshIntervalMs);
     if (!this.apiKey) {
-      console.warn(
-        `[project-registry] AUTOMAKER_API_KEY not set — protoMaker will reject every refresh with 401. ` +
+      log.warn(
+        `AUTOMAKER_API_KEY not set — protoMaker will reject every refresh with 401. ` +
           `Set the env var (workstacean reads protoMaker's own auth key under that name) or pass apiKey in options.`,
       );
     }
-    console.log(
-      `[project-registry] Started — apiBase=${this.apiBase}, ` +
+    log.info(
+      `Started — apiBase=${this.apiBase}, ` +
         `auth=${this.apiKey ? "configured" : "MISSING"}, ` +
         `refresh=${Math.round(this.refreshIntervalMs / 60_000)}min, ` +
         `${this.projects.length} project(s) loaded`,
@@ -173,15 +176,15 @@ export class ProjectRegistry {
       this.projects = dedupeBySlug(raw.map((p) => this._enrichProject(p)));
       this.lastRefreshAt = Date.now();
       this.lastError = undefined;
-      console.log(
-        `[project-registry] Refreshed: ${this.projects.length} project(s) — ` +
+      log.info(
+        `Refreshed: ${this.projects.length} project(s) — ` +
           this.projects.map((p) => p.slug).join(", "),
       );
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.lastError = msg;
-      console.warn(
-        `[project-registry] Refresh failed (${this.apiBase}): ${msg} — ` +
+      log.warn(
+        `Refresh failed (${this.apiBase}): ${msg} — ` +
           `keeping ${this.projects.length} stale project(s) in memory`,
       );
     }
@@ -268,8 +271,8 @@ export function dedupeBySlug(projects: RegistryProject[]): RegistryProject[] {
   const out: RegistryProject[] = [];
   for (const p of projects) {
     if (seen.has(p.slug)) {
-      console.warn(
-        `[project-registry] duplicate slug "${p.slug}" — keeping the first project, ` +
+      log.warn(
+        `duplicate slug "${p.slug}" — keeping the first project, ` +
           `dropping "${p.name}" (${p.path}). Rename one in protoMaker to disambiguate.`,
       );
       continue;

--- a/src/plugins/quinn-review-notifier-plugin.ts
+++ b/src/plugins/quinn-review-notifier-plugin.ts
@@ -27,6 +27,9 @@
 
 import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
 import { REVIEW_TOPICS } from "../event-bus/topics.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("quinn-review-notifier");
 
 interface QuinnReviewSubmittedPayload {
   owner: string;
@@ -56,7 +59,7 @@ export class QuinnReviewNotifierPlugin implements Plugin {
       (msg) => this._handle(msg),
     );
     this.subscriptionIds.push(subId);
-    console.log("[quinn-review-notifier] installed — REQUEST_CHANGES verdicts will fire Discord alerts");
+    log.info("installed — REQUEST_CHANGES verdicts will fire Discord alerts");
   }
 
   uninstall(): void {
@@ -72,8 +75,8 @@ export class QuinnReviewNotifierPlugin implements Plugin {
     const payload = (msg.payload ?? {}) as Partial<QuinnReviewSubmittedPayload>;
     if (payload.event !== "REQUEST_CHANGES") return;
     if (!payload.owner || !payload.repo || !payload.prNumber) {
-      console.warn(
-        `[quinn-review-notifier] dropping malformed REQUEST_CHANGES event — missing owner/repo/prNumber`,
+      log.warn(
+        `dropping malformed REQUEST_CHANGES event — missing owner/repo/prNumber`,
       );
       return;
     }
@@ -111,11 +114,9 @@ export class QuinnReviewNotifierPlugin implements Plugin {
 
     try {
       this.bus.publish("message.outbound.discord.alert", alertMsg);
-      console.log(`[quinn-review-notifier] REQUEST_CHANGES on ${prRef} → discord.alert`);
+      log.info(`REQUEST_CHANGES on ${prRef} → discord.alert`);
     } catch (err) {
-      console.warn(
-        `[quinn-review-notifier] failed to publish discord.alert for ${prRef}: ${err instanceof Error ? err.message : err}`,
-      );
+      log.warn(`failed to publish discord.alert for ${prRef}`, { err });
     }
   }
 }

--- a/src/utils/env-interpolation.ts
+++ b/src/utils/env-interpolation.ts
@@ -1,3 +1,7 @@
+import { logger } from "../../lib/log.ts";
+
+const log = logger("env-interpolation");
+
 /**
  * Interpolate ${ENV_VAR} placeholders in a string.
  * Unresolved variables are left as-is and a warning is emitted.
@@ -6,7 +10,7 @@ export function resolveEnvVars(str: string, context?: string): string {
   return str.replace(/\$\{([^}]+)\}/g, (match, name: string) => {
     const val = process.env[name];
     if (val === undefined) {
-      console.warn(`[${context ?? "env"}] Unresolved env var: \${${name}}`);
+      log.warn(`Unresolved env var: \${${name}}`, { context: context ?? "env" });
       return match;
     }
     return val;

--- a/src/webhooks/github-comment-response.ts
+++ b/src/webhooks/github-comment-response.ts
@@ -11,6 +11,9 @@
  */
 
 import { trackCommentResponse, isDismissalResponse } from "../services/reviews/dismissal-tracker.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("github-comment-response");
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -86,8 +89,8 @@ export async function handleCommentResponse(
     reason: dismissed ? responseBody.slice(0, 200) : undefined,
   });
 
-  console.log(
-    `[github-comment-response] Comment response on ${repoSlug}#${payload.pull_request.number} ` +
+  log.info(
+    `Comment response on ${repoSlug}#${payload.pull_request.number} ` +
     `by @${author}: ${dismissed ? "dismissed" : "engaged"}`,
   );
 }
@@ -117,8 +120,8 @@ export async function handleReviewDismissal(
     reason: reason.slice(0, 200),
   });
 
-  console.log(
-    `[github-comment-response] Review dismissed on ${repoSlug}#${payload.pull_request.number}` +
+  log.info(
+    `Review dismissed on ${repoSlug}#${payload.pull_request.number}` +
     (reason ? `: ${reason}` : ""),
   );
 }

--- a/src/webhooks/github-pr-merge.ts
+++ b/src/webhooks/github-pr-merge.ts
@@ -20,6 +20,9 @@ import { fetchSymbolContexts } from "../services/codebase/symbol-fetcher.ts";
 import { indexPRHistory } from "../services/qdrant/pr-history-indexer.ts";
 import { indexCodePatterns } from "../services/qdrant/code-patterns-indexer.ts";
 import type { PRMetadata } from "../services/github/diff-fetcher.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("github-pr-merge");
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -61,7 +64,7 @@ export async function handlePRMerge(
   const repo = payload.repository.name;
   const prNumber = pr.number;
 
-  console.log(`[github-pr-merge] Processing merged PR #${prNumber} in ${owner}/${repo}`);
+  log.info(`Processing merged PR #${prNumber} in ${owner}/${repo}`);
 
   const token = await getToken(owner, repo);
 
@@ -83,7 +86,7 @@ export async function handlePRMerge(
   ]);
 
   if (!diff) {
-    console.warn(`[github-pr-merge] Empty diff for PR #${prNumber} — skipping indexing`);
+    log.warn(`Empty diff for PR #${prNumber} — skipping indexing`);
     return;
   }
 
@@ -108,8 +111,8 @@ export async function handlePRMerge(
     }
   }
 
-  console.log(
-    `[github-pr-merge] Indexed PR #${prNumber} ${owner}/${repo}: ` +
+  log.info(
+    `Indexed PR #${prNumber} ${owner}/${repo}: ` +
     `${chunks.length} chunks, ${symbols.length} symbols, decision=${decision}`,
   );
 }


### PR DESCRIPTION
## What — the final slice

**Slice 6** of the `console.*` → `lib/log.ts` sweep, after #818 (spine), #823 (integration core), #824 (discord), #825 (google), #826 (data layer). Converts the remaining `src/` operational logging — **this completes the migration.**

**32 files:** `src/plugins/*` (registries, control-plane registrar, notifiers, fleet-health, evaluators, skill executors), `src/api/*` + `src/webhooks/*`, `src/mcp/mcp-client`, `src/loaders/ceremonyYamlLoader`, `src/github/reviewSubmitter`, `src/diff/validateComments`, `src/event-bus/*`, `src/config/env`, `src/utils/*`, `src/agent-runtime/*` loaders.

## Two console-spy-coupled files handled by hand

- **`src/api/a2a-server.ts`** — migrated all 4 sites; updated the one test assertion that matched the literal `[a2a-server]` tag (now a JSON `component` field under the prod build gate) to match the stable **message text** instead. The `<!DOCTYPE` warn assertions are env-independent (the substring survives JSON) → unchanged.
- **`src/integrations/discord/CeremonyNotifier.ts`** — migrated the diagnostic + error lines; **kept** `_logFallback`'s `console.log`. That's the intentional **output sink** (no webhook → deliver the ceremony outcome to stdout as a stable, parse-friendly line), not operational logging. Documented with a comment; its test passes unchanged.

## Verification

- Full suite green under **both** dev and **`NODE_ENV=production`** (the image-build gate PR CI doesn't exercise): **1080 pass / 0 fail**
- `tsc --noEmit` + biome lint clean
- The only `console.*` left in the changed set are intentional (the CeremonyNotifier sink + the a2a-server test's own spy machinery).

## Sweep complete 🎉

After slices #818 + #823–#826 + this, the remaining `console.*` across `src`/`lib` are **by design**: `debug.ts` (the `DebugPlugin` console interceptor), `cli.ts`/`onboarding.ts`/`event-viewer.ts`/`echo.ts` (terminal UX), the CeremonyNotifier fallback sink, and `lib/log.ts`'s own sinks. The `noConsoleLog` lint rule the handoff suggested could now be turned on (scoped to exclude those) to keep it from regressing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)