### PR TITLE
chore(logging): finish console→logger migration + lock in via noConsoleLog lint

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -40,7 +40,7 @@
         "noUnreachable": "error"
       },
       "suspicious": {
-        "noConsoleLog": "off",
+        "noConsoleLog": "error",
         "noExplicitAny": "warn",
         "noDoubleEquals": "error",
         "noFallthroughSwitchClause": "error"
@@ -63,7 +63,16 @@
       }
     },
     {
-      "include": ["src/api/**", "lib/**", "src/**"],
+      "include": [
+        "lib/log.ts",
+        "lib/plugins/cli.ts",
+        "lib/plugins/debug.ts",
+        "lib/plugins/onboarding.ts",
+        "lib/plugins/event-viewer.ts",
+        "lib/plugins/echo.ts",
+        "lib/conversation/conversation-tracer.ts",
+        "src/integrations/discord/CeremonyNotifier.ts"
+      ],
       "linter": {
         "rules": {
           "suspicious": {

--- a/lib/auth/agent-keys.ts
+++ b/lib/auth/agent-keys.ts
@@ -38,6 +38,9 @@
 import { existsSync, readFileSync, watchFile } from "node:fs";
 import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
+import { logger } from "../log.ts";
+
+const log = logger("agent-keys");
 
 export interface CallerIdentity {
   /** Set when the request was authenticated via an agent-scoped key. */
@@ -109,26 +112,26 @@ export class AgentKeyRegistry {
         if (!entry?.envKey) continue;
         const value = process.env[entry.envKey];
         if (!value) {
-          console.warn(
-            `[agent-keys] ${agentName}: env var "${entry.envKey}" is unset — skipping`,
+          log.warn(
+            `${agentName}: env var "${entry.envKey}" is unset — skipping`,
           );
           continue;
         }
         if (next.has(value)) {
-          console.warn(
-            `[agent-keys] duplicate key value detected — multiple agents share the same secret. Last write wins.`,
+          log.warn(
+            `duplicate key value detected — multiple agents share the same secret. Last write wins.`,
           );
         }
         next.set(value, agentName);
       }
       this.keyToAgent = next;
       if (next.size > 0) {
-        console.log(
-          `[agent-keys] Loaded ${next.size} per-agent key(s): ${this.agentNames().join(", ")}`,
+        log.info(
+          `Loaded ${next.size} per-agent key(s): ${this.agentNames().join(", ")}`,
         );
       }
     } catch (err) {
-      console.error(`[agent-keys] Failed to parse ${this.yamlPath}:`, err);
+      log.error(`Failed to parse ${this.yamlPath}`, { err });
     }
   }
 }

--- a/lib/channels/channel-registry.ts
+++ b/lib/channels/channel-registry.ts
@@ -11,6 +11,9 @@
 import { readFileSync, existsSync, watchFile, unwatchFile } from "node:fs";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import type { Channel, ChannelsYaml } from "../types/channels.ts";
+import { logger } from "../log.ts";
+
+const log = logger("channel-registry");
 
 export type { Channel };
 
@@ -158,7 +161,7 @@ export class ChannelRegistry {
     const { writeFileSync } = require("node:fs") as typeof import("node:fs");
     writeFileSync(this.filePath, stringifyYaml(yaml), "utf8");
     this._buildIndex(updated);
-    console.log(`[channel-registry] Added channel "${channel.id}" (${channel.platform})`);
+    log.info(`Added channel "${channel.id}" (${channel.platform})`);
   }
 
   // ── Hot-reload ────────────────────────────────────────────────────────────────
@@ -171,7 +174,7 @@ export class ChannelRegistry {
       this.reloadDebounce = setTimeout(() => {
         this.reloadDebounce = null;
         this._load();
-        console.log(`[channel-registry] Reloaded — ${this.channels.length} channel(s)`);
+        log.info(`Reloaded — ${this.channels.length} channel(s)`);
       }, 300);
     });
   }
@@ -202,7 +205,7 @@ export class ChannelRegistry {
       const parsed = parseYaml(raw) as ChannelsYaml;
       this._buildIndex(parsed.channels ?? []);
     } catch (err) {
-      console.error(`[channel-registry] Failed to load ${this.filePath}:`, err);
+      log.error(`Failed to load ${this.filePath}`, { err });
     }
   }
 
@@ -224,8 +227,8 @@ export class ChannelRegistry {
           // A duplicate (project, kind) means notifications could route to
           // either channel depending on file order — surface it loudly rather
           // than silently overwriting. Keep the first; operator fixes the dup.
-          console.warn(
-            `[channel-registry] duplicate project binding "${key}" — channel "${existing.id}" already owns it; ` +
+          log.warn(
+            `duplicate project binding "${key}" — channel "${existing.id}" already owns it; ` +
               `ignoring "${ch.id}". Remove one from channels.yaml.`,
           );
         } else {

--- a/lib/checkout-cache.ts
+++ b/lib/checkout-cache.ts
@@ -36,6 +36,9 @@ import {
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { logger } from "./log.ts";
+
+const log = logger("checkout-cache");
 
 const DEFAULT_CHECKOUT_ROOT =
   process.env["CLAWPATCH_CHECKOUT_ROOT"] ??
@@ -145,13 +148,13 @@ export class CheckoutCache {
       if (age < this.cfg.ttlMs) {
         const now = new Date();
         utimesSync(dir, now, now);
-        console.log(
-          `[checkout-cache] hit ${repo}@${sha.slice(0, 7)} (age ${(age / 60_000).toFixed(1)}m)`,
+        log.info(
+          `hit ${repo}@${sha.slice(0, 7)} (age ${(age / 60_000).toFixed(1)}m)`,
         );
         return dir;
       }
-      console.log(
-        `[checkout-cache] stale ${repo}@${sha.slice(0, 7)} (age ${(age / 60_000).toFixed(1)}m > ttl) — re-fetching`,
+      log.info(
+        `stale ${repo}@${sha.slice(0, 7)} (age ${(age / 60_000).toFixed(1)}m > ttl) — re-fetching`,
       );
       rmSync(dir, { recursive: true, force: true });
     }
@@ -166,8 +169,8 @@ export class CheckoutCache {
       );
     }
     await this._extract(tarball, dir, repo, sha);
-    console.log(
-      `[checkout-cache] miss ${repo}@${sha.slice(0, 7)} extracted (${tarball.byteLength} bytes)`,
+    log.info(
+      `miss ${repo}@${sha.slice(0, 7)} extracted (${tarball.byteLength} bytes)`,
     );
     return dir;
   }
@@ -224,8 +227,8 @@ export class CheckoutCache {
     }
 
     if (evicted > 0) {
-      console.log(
-        `[checkout-cache] pruned ${evicted} entr${evicted === 1 ? "y" : "ies"} (${bytesFreed} bytes)`,
+      log.info(
+        `pruned ${evicted} entr${evicted === 1 ? "y" : "ies"} (${bytesFreed} bytes)`,
       );
     }
     return { evicted, bytesFreed };

--- a/lib/conversation/conversation-manager.ts
+++ b/lib/conversation/conversation-manager.ts
@@ -12,6 +12,10 @@
  *   manager.end(channelId, userId)  // terminate explicitly
  */
 
+import { logger } from "../log.ts";
+
+const log = logger("conversation");
+
 export interface ConversationEntry {
   conversationId: string;
   channelId: string;
@@ -112,8 +116,8 @@ export class ConversationManager {
     for (const [key, entry] of this.conversations) {
       if (now - entry.lastActivity >= entry.timeoutMs) {
         this.conversations.delete(key);
-        console.log(
-          `[conversation] Conversation ${entry.conversationId} timed out ` +
+        log.info(
+          `Conversation ${entry.conversationId} timed out ` +
           `(${entry.turnNumber} turn(s), user ${entry.userId} in channel ${entry.channelId})`,
         );
         this.onTimeout?.(entry);

--- a/lib/conversation/conversation-tracer.ts
+++ b/lib/conversation/conversation-tracer.ts
@@ -15,6 +15,10 @@
  *   endTrace()   — when conversation times out or is closed
  */
 
+import { logger } from "../log.ts";
+
+const log = logger("conversation-tracer");
+
 interface LangfuseConfig {
   publicKey: string;
   secretKey: string;
@@ -44,7 +48,7 @@ export class ConversationTracer {
       this.config = { publicKey, secretKey, host };
     } else {
       this.config = null;
-      console.info("[conversation-tracer] LANGFUSE keys not set — tracing disabled");
+      log.info("LANGFUSE keys not set — tracing disabled");
     }
   }
 
@@ -79,7 +83,7 @@ export class ConversationTracer {
         },
       }]);
     } catch (err) {
-      console.error("[conversation-tracer] startTrace error:", err);
+      log.error("startTrace error", { err });
     }
   }
 
@@ -119,7 +123,7 @@ export class ConversationTracer {
         },
       }]);
     } catch (err) {
-      console.error(`[conversation-tracer] traceTurn error (turn ${data.turnNumber}):`, err);
+      log.error(`traceTurn error (turn ${data.turnNumber})`, { err });
     }
   }
 
@@ -155,7 +159,7 @@ export class ConversationTracer {
         },
       }]);
     } catch (err) {
-      console.error("[conversation-tracer] endTrace error:", err);
+      log.error("endTrace error", { err });
     }
   }
 

--- a/lib/dm/dm-accumulator.ts
+++ b/lib/dm/dm-accumulator.ts
@@ -13,6 +13,9 @@
  */
 
 import type { ContextMailbox } from "./context-mailbox.ts";
+import { logger } from "../log.ts";
+
+const log = logger("dm-accumulator");
 
 /**
  * Minimal subset of Discord.js Message used by the accumulator.
@@ -149,10 +152,7 @@ export class DmAccumulator {
     entry: Omit<AccumulatorEntry, "timer">,
     err: unknown,
   ): void {
-    console.error(
-      `[dm-accumulator] Flush error for ${conversationId}:`,
-      err instanceof Error ? err.message : err,
-    );
+    log.error(`Flush error for ${conversationId}`, { err });
 
     // Fallback: push to mailbox so messages aren't lost
     if (this.fallbackMailbox) {
@@ -165,8 +165,8 @@ export class DmAccumulator {
         sender: entry.userId,
         receivedAt: Date.now(),
       });
-      console.log(
-        `[dm-accumulator] Pushed ${entry.contents.length} message(s) to mailbox fallback for ${conversationId}`,
+      log.info(
+        `Pushed ${entry.contents.length} message(s) to mailbox fallback for ${conversationId}`,
       );
     }
   }

--- a/lib/fleet/fleet-config.ts
+++ b/lib/fleet/fleet-config.ts
@@ -19,6 +19,9 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
+import { logger } from "../log.ts";
+
+const log = logger("fleet");
 
 export interface FleetConfig {
   /** Default target for untargeted inbound requests + the OpenAI-compat chat alias. */
@@ -57,7 +60,7 @@ export function loadFleetConfig(workspaceDir: string = process.env.WORKSPACE_DIR
       reviewerBotLogins: Array.isArray(logins) && logins.length ? logins : FLEET_DEFAULTS.reviewerBotLogins,
     };
   } catch (e) {
-    console.warn("[fleet] failed to parse fleet.yaml — using defaults:", e);
+    log.warn("failed to parse fleet.yaml — using defaults", { err: e });
     return { ...FLEET_DEFAULTS };
   }
 }

--- a/lib/github-issues.ts
+++ b/lib/github-issues.ts
@@ -11,6 +11,9 @@
  */
 
 import { makeGitHubAuth } from "./github-auth.ts";
+import { logger } from "./log.ts";
+
+const log = logger("github-issues");
 
 export interface CloseIssueOpts {
   /** Comment posted before the close so observers see the rationale first. Best-effort. */
@@ -62,10 +65,10 @@ export async function closeIssue(
         body: JSON.stringify({ body: opts.comment }),
       });
       if (!c.ok) {
-        console.warn(`[github-issues] comment on ${owner}/${name}#${issueNumber} failed (proceeding to close): ${c.status}`);
+        log.warn(`comment on ${owner}/${name}#${issueNumber} failed (proceeding to close)`, { status: c.status });
       }
     } catch (e) {
-      console.warn(`[github-issues] comment on ${owner}/${name}#${issueNumber} threw (proceeding to close): ${String(e).slice(0, 200)}`);
+      log.warn(`comment on ${owner}/${name}#${issueNumber} threw (proceeding to close)`, { err: e });
     }
   }
 

--- a/lib/identity/identity-registry.ts
+++ b/lib/identity/identity-registry.ts
@@ -23,6 +23,9 @@ import { readFileSync, watchFile, unwatchFile } from "node:fs";
 import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
 import type { UserIdentity, UsersYaml } from "../types/users.ts";
+import { logger } from "../log.ts";
+
+const log = logger("identity");
 
 export class IdentityRegistry {
   private users: UserIdentity[] = [];
@@ -91,12 +94,12 @@ export class IdentityRegistry {
       const parsed = parseYaml(raw) as UsersYaml;
       this.users = parsed?.users ?? [];
       this._buildIndex();
-      console.log(`[identity] Loaded ${this.users.length} user identity(ies) from users.yaml`);
+      log.info(`Loaded ${this.users.length} user identity(ies) from users.yaml`);
     } catch (err: unknown) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-        console.info("[identity] No users.yaml found — identity resolution disabled");
+        log.info("No users.yaml found — identity resolution disabled");
       } else {
-        console.error("[identity] Error loading users.yaml:", err);
+        log.error("Error loading users.yaml", { err });
       }
       this.users = [];
       this.index.clear();
@@ -116,7 +119,7 @@ export class IdentityRegistry {
 
   private _watch(): void {
     watchFile(this.filePath, { interval: 2000 }, () => {
-      console.log("[identity] users.yaml changed — reloading");
+      log.info("users.yaml changed — reloading");
       this._load();
     });
   }

--- a/lib/linear/ava-oauth-token-manager.ts
+++ b/lib/linear/ava-oauth-token-manager.ts
@@ -23,6 +23,9 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { logger } from "../log.ts";
+
+const log = logger("linear-ava-oauth");
 
 const AUTHORIZE_URL = "https://linear.app/oauth/authorize";
 const TOKEN_URL = "https://api.linear.app/oauth/token";
@@ -226,7 +229,7 @@ export class LinearAvaTokenManager {
       }
     } catch (err) {
       // Corrupt file shouldn't crash boot — surface loudly, start unauthorized.
-      console.warn(`[linear-ava-oauth] failed to load ${this.filePath}: ${err instanceof Error ? err.message : String(err)}`);
+      log.warn(`failed to load ${this.filePath}`, { err });
       this.tokens = null;
     }
   }

--- a/lib/plugins/app-alert.ts
+++ b/lib/plugins/app-alert.ts
@@ -46,7 +46,7 @@ export class AppAlertPlugin implements Plugin {
   install(bus: EventBus): void {
     this.bus = bus;
     this.subId = bus.subscribe("system.error", this.name, (m) => { void this._onError(m); });
-    console.log(`[app-alert] installed — system.error → ops webhook${this.webhookUrl ? "" : " (no DISCORD_OPS_WEBHOOK_URL; logging only)"}`);
+    log.info(`installed — system.error → ops webhook${this.webhookUrl ? "" : " (no DISCORD_OPS_WEBHOOK_URL; logging only)"}`);
   }
 
   uninstall(): void {


### PR DESCRIPTION
## Locks in the console→logger sweep — and closes a gap I'd missed

### 1. Closed the migration gap
The 6 prior slices (#818, #823–827) were organized around `lib/plugins/*` and `src/*` and **missed a cluster of `lib/` non-plugin files** still on `console.*`. Migrated them (~28 sites):
`lib/identity/identity-registry`, `lib/checkout-cache`, `lib/channels/channel-registry`, `lib/auth/agent-keys`, `lib/dm/dm-accumulator`, `lib/linear/ava-oauth-token-manager`, `lib/fleet/fleet-config`, `lib/conversation/{conversation-manager,conversation-tracer}`, `lib/github-issues`, `lib/plugins/app-alert`.

`conversation-tracer` keeps its three `[…:fallback]` `console.log` **output sinks** (no Langfuse → deliver the trace to stdout — same pattern as `CeremonyNotifier`); its `console.info` + `console.error` migrate.

### 2. Locked it in
`biome.json`: `suspicious/noConsoleLog` flipped **off → error**, and the broad `src/**`/`lib/**` escape-hatch override (which disabled it *during* the migration) replaced with a **minimal allowlist** of files that intentionally keep `console.*`:

| File(s) | Why |
|---|---|
| `lib/log.ts` | the logger's own sinks |
| `lib/plugins/{cli,onboarding,event-viewer,echo}` | terminal UX |
| `lib/plugins/debug` | `DebugPlugin` *intercepts* `console.*` to republish on the bus |
| `lib/conversation/conversation-tracer`, `src/integrations/discord/CeremonyNotifier` | no-backend fallback output sinks |

Tests keep their existing console-off override.

### Verification
- `bun run lint` exits **0** (rule active, 0 errors — 42 pre-existing nursery/any warnings unchanged)
- **Proved it fires:** injecting a stray `console.log` into a non-allowlisted file → lint fails (1 error); allowlisted sinks stay exempt
- Full suite green under **both** dev and **`NODE_ENV=production`**: **1080 pass / 0 fail**; `tsc` clean

### Limitation (follow-up)
biome 1.9.4 has no `noConsole` rule — only `noConsoleLog` — so this gates `console.log` specifically (the common debugging-regression vector). `console.warn`/`console.error` aren't linted until a biome 2.x upgrade brings `noConsole`. Tracked as a follow-up; not worth the 2.x config-churn right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)