### PR TITLE
chore(lint): upgrade biome 1.9.4 → 2.4.16 + noConsole (full console lock-in)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,85 +1,83 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-  "files": {
-    "ignoreUnknown": true,
-    "ignore": [
-      "node_modules",
-      "dist",
-      "out",
-      "docs/.vitepress/dist",
-      "docs/.vitepress/cache",
-      "docs/node_modules",
-      ".automaker",
-      "data",
-      "workspace/ceremonies",
-      "**/*.yaml",
-      "**/*.yml",
-      "**/*.md"
-    ]
-  },
-  "organizeImports": {
-    "enabled": false
-  },
-  "formatter": {
-    "enabled": false
-  },
-  "linter": {
-    "enabled": true,
-    "rules": {
-      "recommended": false,
-      "complexity": {
-        "noUselessTernary": "error"
-      },
-      "style": {
-        "useConst": "error",
-        "useShorthandAssign": "error"
-      },
-      "correctness": {
-        "noUnusedImports": "warn",
-        "noConstAssign": "error",
-        "noUnreachable": "error"
-      },
-      "suspicious": {
-        "noConsoleLog": "error",
-        "noExplicitAny": "warn",
-        "noDoubleEquals": "error",
-        "noFallthroughSwitchClause": "error"
-      },
-      "nursery": {
-        "noNestedTernary": "warn"
-      }
-    }
-  },
-  "overrides": [
-    {
-      "include": ["**/*.test.ts", "**/__tests__/**"],
-      "linter": {
-        "rules": {
-          "suspicious": {
-            "noConsoleLog": "off",
-            "noExplicitAny": "off"
-          }
-        }
-      }
-    },
-    {
-      "include": [
-        "lib/log.ts",
-        "lib/plugins/cli.ts",
-        "lib/plugins/debug.ts",
-        "lib/plugins/onboarding.ts",
-        "lib/plugins/event-viewer.ts",
-        "lib/plugins/echo.ts",
-        "lib/conversation/conversation-tracer.ts",
-        "src/integrations/discord/CeremonyNotifier.ts"
-      ],
-      "linter": {
-        "rules": {
-          "suspicious": {
-            "noConsoleLog": "off"
-          }
-        }
-      }
-    }
-  ]
+	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"files": {
+		"ignoreUnknown": true,
+		"includes": [
+			"**",
+			"!**/node_modules",
+			"!**/dist",
+			"!**/out",
+			"!**/docs/.vitepress/dist",
+			"!**/docs/.vitepress/cache",
+			"!**/docs/node_modules",
+			"!**/.automaker",
+			"!**/data",
+			"!**/workspace/ceremonies",
+			"!**/*.yaml",
+			"!**/*.yml",
+			"!**/*.md"
+		]
+	},
+	"assist": { "actions": { "source": { "organizeImports": "off" } } },
+	"formatter": {
+		"enabled": false
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": false,
+			"complexity": {
+				"noUselessTernary": "error"
+			},
+			"style": {
+				"useConst": "error",
+				"useShorthandAssign": "error",
+				"noNestedTernary": "warn"
+			},
+			"correctness": {
+				"noUnusedImports": "warn",
+				"noConstAssign": "error",
+				"noUnreachable": "error"
+			},
+			"suspicious": {
+				"noExplicitAny": "warn",
+				"noDoubleEquals": "error",
+				"noFallthroughSwitchClause": "error",
+				"noConsole": "error"
+			},
+			"nursery": {}
+		}
+	},
+	"overrides": [
+		{
+			"includes": ["**/*.test.ts", "**/__tests__/**"],
+			"linter": {
+				"rules": {
+					"suspicious": {
+						"noExplicitAny": "off",
+						"noConsole": "off"
+					}
+				}
+			}
+		},
+		{
+			"includes": [
+				"**/lib/log.ts",
+				"**/lib/plugins/cli.ts",
+				"**/lib/plugins/debug.ts",
+				"**/lib/plugins/onboarding.ts",
+				"**/lib/plugins/event-viewer.ts",
+				"**/lib/plugins/echo.ts",
+				"**/lib/conversation/conversation-tracer.ts",
+				"**/src/integrations/discord/CeremonyNotifier.ts"
+			],
+			"linter": {
+				"rules": {
+					"suspicious": {
+						"noConsole": "off"
+					}
+				}
+			}
+		}
+	]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
         "zod": "^3.25.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "^1.9.4",
+        "@biomejs/biome": "2.4.16",
         "@types/bun": "latest",
         "typescript": "~5.7",
       },
@@ -114,23 +114,23 @@
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
-    "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.16", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.16", "@biomejs/cli-darwin-x64": "2.4.16", "@biomejs/cli-linux-arm64": "2.4.16", "@biomejs/cli-linux-arm64-musl": "2.4.16", "@biomejs/cli-linux-x64": "2.4.16", "@biomejs/cli-linux-x64-musl": "2.4.16", "@biomejs/cli-win32-arm64": "2.4.16", "@biomejs/cli-win32-x64": "2.4.16" }, "bin": { "biome": "bin/biome" } }, "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@1.9.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@1.9.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "zod": "^3.25.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.9.4",
+    "@biomejs/biome": "2.4.16",
     "@types/bun": "latest",
     "typescript": "~5.7"
   },


### PR DESCRIPTION
## What

Upgrades biome **1.9.4 → 2.4.16** and swaps `noConsoleLog` → `noConsole`, closing the limitation flagged in #828: 1.9.4's `noConsoleLog` only caught `console.log`, so `console.warn`/`console.error` regressions slipped through. Biome 2.x's stable **`noConsole`** covers **all** `console.*` methods.

- `biome migrate` converted the config to the 2.x schema (`files.include`→`includes` with `!` negation, `organizeImports`→`assist.actions`, `noNestedTernary` promoted nursery→style)
- `noConsole: "error"` with **no `allow` list** → forbids `console.log` *and* `warn`/`error`/`info`/`debug` outside the allowlist
- the intentional-keep allowlist + the tests override carry over unchanged (`noConsole: off`)

## Verification

- `bun run lint` exits **0** (0 errors; 41 pre-existing nursery/any warnings)
- **Proved the new coverage:** injecting `console.warn` into a non-allowlisted file now **fails** lint (1 error) — something `noConsoleLog` could not catch
- Full suite **1080 pass / 0 fail**
- No CI biome pin to bump (lint runs via `bun run lint` on the node_modules binary); biome pinned exact (`2.4.16`) for reproducible CI linting

With this, the console→logger migration is fully locked in — *any* `console.*` outside the documented sinks/terminal-UX allowlist fails CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)