### PR TITLE
chore(ceremonies): daily-digest posts to the shared dev channel

### DIFF
--- a/workspace/ceremonies/daily-digest.yaml
+++ b/workspace/ceremonies/daily-digest.yaml
@@ -17,8 +17,8 @@ timezone: America/Los_Angeles
 skill: daily_digest
 targets:
   - ava
-# Resolves to DISCORD_WEBHOOK_PROTOWORKSTACEAN_DEV (slug -> DISCORD_WEBHOOK_<SLUG>).
-notifyChannel: "protoworkstacean-dev"
+# Single shared dev channel (no per-project split) -> DISCORD_WEBHOOK_DEV.
+notifyChannel: "dev"
 # LLM digest + fleet-wide GitHub reads — bound it so a hung run can't wedge.
 timeoutMs: 300000
 enabled: true


### PR DESCRIPTION
Points the daily-digest `notifyChannel` at the single shared dev webhook (`DISCORD_WEBHOOK_DEV`) instead of the per-project `protoworkstacean-dev` slug — no longer separating dev channels per project. Config-only (hot-reloads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)