### PR TITLE
feat(digest): lead with release notes, filter version-bump/housekeeping PRs

### DIFF
--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -73,13 +73,13 @@ Each row links to the route definition as `path:line` so jumping from this index
 
 | Method | Path | Source | Description |
 |---|---|---|---|
-| `GET` | `/api/branch-drift` | `src/api/github.ts:679` | — |
+| `GET` | `/api/branch-drift` | `src/api/github.ts:711` | — |
 
 ### `/api/branch-protection`
 
 | Method | Path | Source | Description |
 |---|---|---|---|
-| `GET` | `/api/branch-protection` | `src/api/github.ts:680` | — |
+| `GET` | `/api/branch-protection` | `src/api/github.ts:712` | — |
 
 ### `/api/bus`
 
@@ -108,7 +108,7 @@ Each row links to the route definition as `path:line` so jumping from this index
 
 | Method | Path | Source | Description |
 |---|---|---|---|
-| `GET` | `/api/ci-health` | `src/api/github.ts:677` | — |
+| `GET` | `/api/ci-health` | `src/api/github.ts:709` | — |
 
 ### `/api/clawpatch`
 
@@ -153,13 +153,13 @@ Each row links to the route definition as `path:line` so jumping from this index
 
 | Method | Path | Source | Description |
 |---|---|---|---|
-| `POST` | `/api/github/issues` | `src/api/github.ts:683` | — |
+| `POST` | `/api/github/issues` | `src/api/github.ts:715` | — |
 
 ### `/api/github-issues`
 
 | Method | Path | Source | Description |
 |---|---|---|---|
-| `GET` | `/api/github-issues` | `src/api/github.ts:681` | — |
+| `GET` | `/api/github-issues` | `src/api/github.ts:713` | — |
 
 ### `/api/google`
 
@@ -240,7 +240,7 @@ Each row links to the route definition as `path:line` so jumping from this index
 
 | Method | Path | Source | Description |
 |---|---|---|---|
-| `GET` | `/api/pr-pipeline` | `src/api/github.ts:678` | — |
+| `GET` | `/api/pr-pipeline` | `src/api/github.ts:710` | — |
 
 ### `/api/projects`
 
@@ -252,7 +252,7 @@ Each row links to the route definition as `path:line` so jumping from this index
 
 | Method | Path | Source | Description |
 |---|---|---|---|
-| `GET` | `/api/recent-activity` | `src/api/github.ts:682` | What shipped recently across the fleet — merged PRs + published releases in a trailing window (default 24h, `?hours=` 1..168). |
+| `GET` | `/api/recent-activity` | `src/api/github.ts:714` | What shipped recently across the fleet — published releases (with their curated notes) + substantive merged PRs in a trailing window (default 24h, `?hours=` 1..168). |
 
 ### `/api/research`
 

--- a/src/api/__tests__/github-housekeeping-pr.test.ts
+++ b/src/api/__tests__/github-housekeeping-pr.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { isHousekeepingPr } from "../github.ts";
+
+describe("isHousekeepingPr", () => {
+  test("flags release cuts + version bumps (the noise the digest must drop)", () => {
+    for (const t of [
+      "chore: release v0.8.2 (#830)",
+      "chore(release): bump to v0.8.1 (#821)",
+      "chore: bump to v0.8.2",
+      "chore(deps): bump zod from 3 to 4",
+      "build(deps): bump actions/checkout",
+      "Release v1.2.0",
+    ]) {
+      expect(isHousekeepingPr(t, "someone")).toBe(true);
+    }
+  });
+
+  test("flags automated agent commits", () => {
+    expect(isHousekeepingPr("chore: auto-commit agent progress before verification", "automaker")).toBe(true);
+  });
+
+  test("flags bot authors regardless of title", () => {
+    expect(isHousekeepingPr("feat: something real", "dependabot[bot]")).toBe(true);
+    expect(isHousekeepingPr("feat: something real", "dependabot")).toBe(true);
+    expect(isHousekeepingPr("feat: something real", "renovate")).toBe(true);
+  });
+
+  test("keeps substantive work (feat/fix/refactor/docs)", () => {
+    for (const t of [
+      "feat(ceremonies): daily-digest",
+      "fix(github): dedup approve-on-green",
+      "refactor: split the dispatcher",
+      "docs(handoff): 002",
+      "chore(logging): migrate discord subsystem", // a chore, but not release/bump/auto-commit
+    ]) {
+      expect(isHousekeepingPr(t, "josh")).toBe(false);
+    }
+  });
+
+  test("tolerates empty/missing inputs", () => {
+    expect(isHousekeepingPr("", "")).toBe(false);
+  });
+});

--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -49,6 +49,22 @@ export function normalizeIssueTitle(title: string): string {
     .trim();
 }
 
+/**
+ * Housekeeping PRs the daily digest should COUNT but not enumerate — release
+ * cuts, version bumps, automated agent commits, and bot PRs. Keeps "what
+ * shipped" focused on substantive feat/fix work; the curated release notes
+ * (the release `body`) carry the real shipped story.
+ */
+export function isHousekeepingPr(title: string, author: string): boolean {
+  const t = (title ?? "").trim().toLowerCase();
+  const a = (author ?? "").toLowerCase();
+  if (a.endsWith("[bot]") || a === "dependabot" || a === "renovate") return true;
+  return (
+    /^(chore|build)(\([^)]*\))?:\s*(release\s+v|bump\b|version bump|auto-commit)/.test(t) ||
+    /^release\s+v?\d/.test(t)
+  );
+}
+
 export function createRoutes(ctx: ApiContext): Route[] {
   const repos = () => ctx.projectRegistry?.getGithubCoords() ?? [];
 
@@ -608,11 +624,14 @@ export function createRoutes(ctx: ApiContext): Route[] {
   }
 
   /**
-   * What shipped recently across the fleet — merged PRs + published releases in
-   * a trailing window (default 24h, `?hours=` 1..168). Backs the daily-digest
-   * ceremony's "yesterday's work" section; this is the same activity the release
-   * channel announces, sourced from GitHub directly so it doesn't depend on
-   * Discord formatting.
+   * What shipped recently across the fleet — published releases (with their
+   * curated notes) + substantive merged PRs in a trailing window (default 24h,
+   * `?hours=` 1..168). Backs the daily-digest's "yesterday's work" section.
+   *
+   * Release notes (the release `body`, themed by release-tools) are the primary
+   * "what shipped" signal. Merged PRs are split: substantive feat/fix work is
+   * enumerated, while housekeeping (release cuts, version bumps, auto-commits,
+   * bot PRs) is only COUNTED — so the digest isn't drowned in version-bump noise.
    */
   async function handleGetRecentActivity(req?: Request): Promise<Response> {
     const repoList = repos();
@@ -622,18 +641,20 @@ export function createRoutes(ctx: ApiContext): Route[] {
     const sinceIso = new Date(sinceMs).toISOString();
 
     if (!repoList.length) {
-      return Response.json({ since: sinceIso, hours, totalMergedPrs: 0, totalReleases: 0, repos: [] });
+      return Response.json({ since: sinceIso, hours, totalReleases: 0, totalMergedPrs: 0, totalHousekeepingPrs: 0, repos: [] });
     }
 
     const repoResults: Array<{
       repo: string;
+      releases: Array<{ tag: string; name: string; publishedAt: string; url: string; notes: string }>;
       mergedPrs: Array<{ number: number; title: string; author: string; mergedAt: string; url: string }>;
-      releases: Array<{ tag: string; name: string; publishedAt: string; url: string }>;
+      housekeepingCount: number;
     }> = [];
 
     for (const repo of repoList) {
       const mergedPrs: (typeof repoResults)[number]["mergedPrs"] = [];
       const releases: (typeof repoResults)[number]["releases"] = [];
+      let housekeepingCount = 0;
       try {
         // Closed PRs, most-recently-updated first; keep those MERGED in-window.
         // Unmerged-closed have a null merged_at → skipped.
@@ -642,7 +663,12 @@ export function createRoutes(ctx: ApiContext): Route[] {
         )) as Array<{ number: number; title: string; merged_at: string | null; html_url: string; user?: { login?: string } }>;
         for (const pr of prs) {
           if (!pr.merged_at || new Date(pr.merged_at).getTime() < sinceMs) continue;
-          mergedPrs.push({ number: pr.number, title: pr.title, author: pr.user?.login ?? "", mergedAt: pr.merged_at, url: pr.html_url });
+          const author = pr.user?.login ?? "";
+          if (isHousekeepingPr(pr.title, author)) {
+            housekeepingCount++;
+            continue;
+          }
+          mergedPrs.push({ number: pr.number, title: pr.title, author, mergedAt: pr.merged_at, url: pr.html_url });
         }
       } catch {
         // skip this repo's PR fetch on error — partial activity beats none
@@ -651,24 +677,30 @@ export function createRoutes(ctx: ApiContext): Route[] {
         const rels = (await ghApi(`/repos/${repo}/releases?per_page=10`)) as Array<{
           tag_name: string;
           name: string | null;
+          body: string | null;
           published_at: string | null;
           html_url: string;
         }>;
         for (const r of rels) {
           if (!r.published_at || new Date(r.published_at).getTime() < sinceMs) continue;
-          releases.push({ tag: r.tag_name, name: r.name ?? r.tag_name, publishedAt: r.published_at, url: r.html_url });
+          // The release body is the curated changelog; trim to keep the payload bounded.
+          const notes = (r.body ?? "").replace(/\r/g, "").trim().slice(0, 600);
+          releases.push({ tag: r.tag_name, name: r.name ?? r.tag_name, publishedAt: r.published_at, url: r.html_url, notes });
         }
       } catch {
         // skip this repo's release fetch on error
       }
-      if (mergedPrs.length || releases.length) repoResults.push({ repo, mergedPrs, releases });
+      if (mergedPrs.length || releases.length || housekeepingCount) {
+        repoResults.push({ repo, releases, mergedPrs, housekeepingCount });
+      }
     }
 
     return Response.json({
       since: sinceIso,
       hours,
-      totalMergedPrs: repoResults.reduce((s, r) => s + r.mergedPrs.length, 0),
       totalReleases: repoResults.reduce((s, r) => s + r.releases.length, 0),
+      totalMergedPrs: repoResults.reduce((s, r) => s + r.mergedPrs.length, 0),
+      totalHousekeepingPrs: repoResults.reduce((s, r) => s + r.housekeepingCount, 0),
       repos: repoResults,
     });
   }

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -381,8 +381,11 @@ skills:
       attention today.
 
       ## Gather (each call returns fleet-wide data once)
-      - `get_recent_activity` — what SHIPPED in the last 24h: merged PRs +
-        published releases per repo. This is "the work from the day before".
+      - `get_recent_activity` — what SHIPPED in the last 24h. Each repo carries:
+        `releases` (each with curated `notes` — the changelog), substantive
+        `mergedPrs` (feat/fix work), and a `housekeepingCount` (release/bump/
+        auto-commit/bot PRs already filtered out). Release `notes` are the
+        primary "what shipped" signal — summarize FROM them; don't list raw PRs.
       - `get_pr_pipeline` — open PRs with CI + Quinn's review state
         (approved = PASS, changes_requested = FAIL, pending = awaiting). The
         BLOCKERS are PRs in changes_requested or stuck on red CI.
@@ -393,8 +396,11 @@ skills:
 
       ## Write the digest — three sections, in this order
       Lead each section with a count, omit a section only if it's truly empty.
-        **Shipped (24h)** — releases first (`vX.Y.Z repo`), then a rolled-up
-        count of merged PRs per repo; name only the few most notable.
+        **Shipped (24h)** — lead with releases + a one-phrase theme from each
+        release's `notes` (`vX.Y.Z repo — <theme>`), then the few most notable
+        substantive PRs; roll the rest into counts (`+6 PRs across 3 repos`).
+        Never enumerate version-bump / housekeeping PRs — fold them into a
+        trailing `(+N housekeeping)` if worth noting at all.
         **Blockers** — one line each: PR # + repo + why (changes-requested,
         red CI, conflict), most urgent first.
         **Pipeline / fleet** — red mains, large drift, open incidents. One line each.


### PR DESCRIPTION
Follow-up to #832 — makes the daily digest's "what shipped" smart instead of feeding every merged PR.

## Problem
`/api/recent-activity` listed *every* merged PR, so `chore: release v0.8.2`, `chore: auto-commit…`, dependabot, etc. drowned the actual work.

## Fix
- **Release notes are the primary signal.** Each release now carries its `notes` (the release `body` — the themed changelog release-tools generates, which already excludes bump noise). The digest summarizes from those.
- **PR firehose filtered.** Merged PRs split into substantive `mergedPrs` (enumerated) vs `housekeepingCount` (release/bump/auto-commit/bot PRs — counted, not listed). New pure exported **`isHousekeepingPr(title, author)`** does the classification: bot authors (`*[bot]`, dependabot, renovate) + `chore|build` titles matching `release v` / `bump` / `auto-commit`. A `chore(logging):` PR is *kept* (substantive).
- Response adds per-repo `housekeepingCount` + `releases[].notes`, top-level `totalHousekeepingPrs`.
- **`daily_digest` prompt** updated: lead with releases + a one-phrase theme from each release's notes, roll PRs into counts, never enumerate bumps.

## Also answers: how the fleet is determined
The repos come from `projectRegistry.getGithubCoords()` — the **protoMaker** project registry (fetched via `PROTOMAKER_API_BASE` + `AUTOMAKER_API_KEY`, refreshed periodically), every registered project with a GitHub coord. Same source `pr-pipeline`/`ci-health` use; no separate list.

## Verification
- 5 new `isHousekeepingPr` tests; full suite green under **both** dev and `NODE_ENV=production`: **1086 pass / 0 fail**
- tsc + biome clean; `http-api.md` regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)