### PR TITLE
feat(digest): deliver as a plain markdown message + emit real structure

### DIFF
--- a/src/integrations/discord/CeremonyNotifier.ts
+++ b/src/integrations/discord/CeremonyNotifier.ts
@@ -1,13 +1,15 @@
 /**
  * CeremonyNotifier — sends ceremony execution outcomes to Discord.
  *
- * Uses the DISCORD_CEREMONY_WEBHOOK_URL environment variable by default.
- * Per-ceremony notifyChannel overrides are resolved to webhook URLs via
- * DISCORD_WEBHOOK_{CHANNEL_SLUG_UPPERCASE} env vars, e.g.
- * DISCORD_WEBHOOK_GENERAL for notifyChannel: "general".
+ * Delivers the outcome as a plain MARKDOWN MESSAGE (Discord renders headers,
+ * bullets, and blank lines in message content), not an embed — embeds cramped
+ * multi-line digests. The skill's result IS the message body; a small `-#`
+ * subtext line carries the ceremony/run metadata. Long results split across
+ * messages at Discord's 2000-char content cap.
  *
- * Falls back to console logging on missing config or network error.
- * Discord notifications are always non-blocking.
+ * Webhook resolution: explicit `webhookEnv` wins, else `notifyChannel` →
+ * DISCORD_WEBHOOK_<SLUG>, else DISCORD_CEREMONY_WEBHOOK_URL. Falls back to
+ * console when none is configured. Always non-blocking.
  */
 
 import type { CeremonyOutcome } from "../../plugins/CeremonyPlugin.types.ts";
@@ -15,26 +17,18 @@ import { logger } from "../../../lib/log.ts";
 
 const log = logger("ceremony-notifier");
 
-const STATUS_COLORS: Record<string, number> = {
-  success: 0x2ecc71,  // green
-  failure: 0xe74c3c,  // red
-  timeout: 0xf39c12,  // orange
-};
+// Discord caps a message's `content` at 2000 chars; chunk under that with room
+// for the trailing metadata line appended to the last chunk.
+const MSG_CHUNK = 1850;
 
-// Discord embed limits. A description holds 4096 chars (vs a field's 1024), and
-// a single message may carry ≤10 embeds whose text sums to ≤6000 chars. Long
-// results are chunked into description-embeds and split across messages.
-const DESC_CHUNK = 3500;        // headroom under the 4096 description cap
-const MAX_EMBEDS_PER_MSG = 10;
-const MAX_CHARS_PER_MSG = 6000;
-
-type Embed = Record<string, unknown>;
+const STATUS_EMOJI: Record<string, string> = { success: "✅", timeout: "⏱️" };
 
 /**
- * Split text into chunks ≤ `size`, preferring line boundaries so markdown/bullets
- * aren't cut mid-line. A single over-long line is hard-split. Always ≥1 chunk.
+ * Split text into chunks ≤ `size`, preferring line boundaries so markdown
+ * (headers/bullets) isn't cut mid-line. A single over-long line is hard-split.
+ * Always returns ≥1 chunk.
  */
-export function chunkText(text: string, size: number = DESC_CHUNK): string[] {
+export function chunkText(text: string, size: number = MSG_CHUNK): string[] {
   const chunks: string[] = [];
   let cur = "";
   for (const line of (text ?? "").split("\n")) {
@@ -54,38 +48,26 @@ export function chunkText(text: string, size: number = DESC_CHUNK): string[] {
   return chunks.length ? chunks : [""];
 }
 
-/** Approximate Discord's per-message char budget for one embed (title + description + fields + footer). */
-export function embedTextLength(e: Embed): number {
-  let n = 0;
-  if (typeof e.title === "string") n += e.title.length;
-  if (typeof e.description === "string") n += e.description.length;
-  if (Array.isArray(e.fields)) {
-    for (const f of e.fields as Array<{ name?: string; value?: string }>) {
-      n += (f.name?.length ?? 0) + (f.value?.length ?? 0);
-    }
-  }
-  const footer = e.footer as { text?: string } | undefined;
-  if (footer?.text) n += footer.text.length;
-  return n;
-}
+/**
+ * Build the message content string(s) for an outcome — the markdown body plus a
+ * `-#` metadata subtext on the last message. Pure + exported for testing.
+ */
+export function buildContentMessages(outcome: CeremonyOutcome, ceremonyName: string): string[] {
+  const durationSec = (outcome.duration / 1000).toFixed(1);
+  const emoji = STATUS_EMOJI[outcome.status] ?? "❌";
+  const meta = `-# ${emoji} \`${outcome.ceremonyId}\` · ${outcome.skill} · ${durationSec}s · run ${outcome.runId.slice(0, 8)}`;
 
-/** Pack embeds into messages, each ≤10 embeds and ≤6000 total chars (one POST per message). */
-export function packEmbedsIntoMessages(embeds: Embed[]): Embed[][] {
-  const messages: Embed[][] = [];
-  let cur: Embed[] = [];
-  let curLen = 0;
-  for (const e of embeds) {
-    const len = embedTextLength(e);
-    if (cur.length && (cur.length >= MAX_EMBEDS_PER_MSG || curLen + len > MAX_CHARS_PER_MSG)) {
-      messages.push(cur);
-      cur = [];
-      curLen = 0;
-    }
-    cur.push(e);
-    curLen += len;
+  let body = (outcome.result ?? "").trim();
+  if (outcome.status !== "success") {
+    const head = `${emoji} **${ceremonyName}** — ${outcome.status}`;
+    const errBlock = outcome.error ? `\n\`\`\`\n${outcome.error.slice(0, 1500)}\n\`\`\`` : "";
+    body = body ? `${head}${errBlock}\n\n${body}` : `${head}${errBlock}`;
   }
-  if (cur.length) messages.push(cur);
-  return messages;
+  if (!body) body = `${emoji} **${ceremonyName}** — done`;
+
+  const chunks = chunkText(body, MSG_CHUNK);
+  chunks[chunks.length - 1] = `${chunks[chunks.length - 1]}\n${meta}`;
+  return chunks;
 }
 
 export class CeremonyNotifier {
@@ -99,8 +81,7 @@ export class CeremonyNotifier {
   }
 
   /**
-   * Send a ceremony outcome notification to Discord.
-   * If notifyChannel is provided, attempts to resolve a channel-specific webhook.
+   * Send a ceremony outcome to Discord as markdown message(s).
    * Returns true on success, false on fallback.
    */
   async notify(outcome: CeremonyOutcome, ceremonyName: string, notifyChannel?: string, webhookEnv?: string): Promise<boolean> {
@@ -111,16 +92,14 @@ export class CeremonyNotifier {
       return false;
     }
 
-    const messages = packEmbedsIntoMessages(this._buildEmbeds(outcome, ceremonyName));
-
     try {
-      // One POST per message; Discord caps each at 10 embeds / 6000 chars. Sent
-      // sequentially so multi-part digests arrive in order.
-      for (const embeds of messages) {
+      // One POST per message (Discord caps content at 2000 chars); sequential so
+      // a multi-part digest arrives in order.
+      for (const content of buildContentMessages(outcome, ceremonyName)) {
         const resp = await fetch(webhookUrl, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ embeds }),
+          body: JSON.stringify({ content }),
           signal: AbortSignal.timeout(10_000),
         });
         if (!resp.ok) {
@@ -158,45 +137,5 @@ export class CeremonyNotifier {
       `[ceremony-notifier:fallback] Ceremony "${ceremonyName}" (${outcome.ceremonyId}) ` +
       `${outcome.status.toUpperCase()} in ${durationSec}s — run ${outcome.runId}`,
     );
-  }
-
-  /**
-   * Build the embed(s) for an outcome. The result goes in the embed
-   * DESCRIPTION (4096 cap, renders markdown) rather than a 1024 field, and is
-   * chunked into continuation embeds when longer. The first embed carries the
-   * title + metadata fields; continuations carry only their description.
-   */
-  private _buildEmbeds(outcome: CeremonyOutcome, ceremonyName: string): Embed[] {
-    const color = STATUS_COLORS[outcome.status] ?? STATUS_COLORS.failure;
-    const durationSec = (outcome.duration / 1000).toFixed(1);
-    const ts = new Date(outcome.completedAt).toISOString();
-    const EMOJI_BY_STATUS: Record<string, string> = { success: "✅", timeout: "⏱️" };
-    const statusEmoji = EMOJI_BY_STATUS[outcome.status] ?? "❌";
-
-    const fields: Array<{ name: string; value: string; inline?: boolean }> = [
-      { name: "Ceremony", value: `\`${outcome.ceremonyId}\``, inline: true },
-      { name: "Skill", value: `\`${outcome.skill}\``, inline: true },
-      { name: "Duration", value: `${durationSec}s`, inline: true },
-      { name: "Targets", value: outcome.targets.join(", ").slice(0, 200) || "none", inline: false },
-    ];
-    if (outcome.error) {
-      fields.push({ name: "Error", value: `\`\`\`\n${outcome.error.slice(0, 400)}\n\`\`\`` });
-    }
-
-    const chunks = chunkText(outcome.result ?? "");
-    return chunks.map((chunk, i) => {
-      const first = i === 0;
-      const embed: Embed = { color, description: chunk };
-      if (first) {
-        embed.title = `${statusEmoji} Ceremony: ${ceremonyName}`;
-        embed.fields = fields;
-      }
-      // Timestamp + footer on the LAST embed so the run id closes the sequence.
-      if (i === chunks.length - 1) {
-        embed.timestamp = ts;
-        embed.footer = { text: `Run ID: ${outcome.runId} • protoWorkstacean` };
-      }
-      return embed;
-    });
   }
 }

--- a/src/integrations/discord/__tests__/CeremonyNotifier.test.ts
+++ b/src/integrations/discord/__tests__/CeremonyNotifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, spyOn } from "bun:test";
-import { CeremonyNotifier, chunkText, embedTextLength, packEmbedsIntoMessages } from "../CeremonyNotifier.ts";
+import { CeremonyNotifier, chunkText, buildContentMessages } from "../CeremonyNotifier.ts";
 import type { CeremonyOutcome } from "../../../plugins/CeremonyPlugin.types.ts";
 
 function makeOutcome(status: CeremonyOutcome["status"] = "success"): CeremonyOutcome {
@@ -109,44 +109,42 @@ describe("Discord ceremony notifications", () => {
     delete process.env.DISCORD_RESEARCH_WEBHOOK;
   });
 
-  test("long result goes in the embed DESCRIPTION (not a 1024 field), full text preserved", async () => {
+  test("result is sent as markdown message CONTENT (no embeds), full text preserved", async () => {
     process.env.DISCORD_WEBHOOK_GENERAL = "http://localhost:0/dev";
     const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(new Response("", { status: 204 }));
     const o = makeOutcome();
-    o.result = "x".repeat(2000); // > the old 1024 field cap, < one description chunk
+    o.result = "**Shipped**\n- repo a — thing\n- repo b — other";
 
     const ok = await new CeremonyNotifier(undefined).notify(o, "Daily Digest", "general");
     expect(ok).toBe(true);
     const body = JSON.parse((fetchSpy.mock.calls[0]![1] as RequestInit).body as string);
-    expect(body.embeds).toHaveLength(1);
-    expect(body.embeds[0].description).toBe(o.result); // full 2000 chars, untruncated
-    expect(body.embeds[0].fields.some((f: { name: string }) => f.name === "Result")).toBe(false);
+    expect(body.embeds).toBeUndefined(); // markdown message, not an embed
+    expect(body.content).toContain(o.result); // newlines/bullets preserved
+    expect(body.content).toContain("-#"); // metadata subtext line appended
 
     fetchSpy.mockRestore();
     delete process.env.DISCORD_WEBHOOK_GENERAL;
   });
 
-  test("very long result splits across multiple messages (≤10 embeds / ≤6000 chars each)", async () => {
+  test("very long result splits across multiple messages (≤2000 content chars each)", async () => {
     process.env.DISCORD_WEBHOOK_GENERAL = "http://localhost:0/dev";
     const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(new Response("", { status: 204 }));
     const o = makeOutcome();
-    o.result = "line\n".repeat(4000); // ~20k chars → several chunks → multiple messages
+    o.result = "line\n".repeat(2000); // ~10k chars → several content chunks → multiple POSTs
 
     const ok = await new CeremonyNotifier(undefined).notify(o, "Daily Digest", "general");
     expect(ok).toBe(true);
-    expect(fetchSpy.mock.calls.length).toBeGreaterThan(1); // multiple POSTs
+    expect(fetchSpy.mock.calls.length).toBeGreaterThan(1);
     for (const call of fetchSpy.mock.calls) {
       const body = JSON.parse((call[1] as RequestInit).body as string);
-      expect(body.embeds.length).toBeLessThanOrEqual(10);
-      const total = body.embeds.reduce((s: number, e: Record<string, unknown>) => s + embedTextLength(e), 0);
-      expect(total).toBeLessThanOrEqual(6000);
+      expect(body.content.length).toBeLessThanOrEqual(2000);
     }
     fetchSpy.mockRestore();
     delete process.env.DISCORD_WEBHOOK_GENERAL;
   });
 });
 
-describe("CeremonyNotifier chunk/pack helpers", () => {
+describe("CeremonyNotifier content helpers", () => {
   test("chunkText splits on line boundaries, ≥1 chunk, each ≤ size", () => {
     expect(chunkText("", 10)).toEqual([""]);
     expect(chunkText("short", 10)).toEqual(["short"]);
@@ -160,14 +158,24 @@ describe("CeremonyNotifier chunk/pack helpers", () => {
     expect(chunks.join("")).toBe("a".repeat(50));
   });
 
-  test("packEmbedsIntoMessages caps at 10 embeds and 6000 chars per message", () => {
-    const big = Array.from({ length: 15 }, () => ({ description: "z".repeat(1000) }));
-    const msgs = packEmbedsIntoMessages(big);
-    for (const m of msgs) {
-      expect(m.length).toBeLessThanOrEqual(10);
-      expect(m.reduce((s, e) => s + embedTextLength(e), 0)).toBeLessThanOrEqual(6000);
-    }
-    // 15 × 1000-char embeds → 6 per message (6000 cap) → 3 messages.
-    expect(msgs.length).toBe(3);
+  test("buildContentMessages: success → result body + metadata subtext, single message", () => {
+    const msgs = buildContentMessages(
+      { runId: "abcd1234ef", ceremonyId: "daily-digest", skill: "daily_digest", status: "success",
+        duration: 30000, targets: ["ava"], startedAt: 0, completedAt: 1, result: "☀️ digest body" } as never,
+      "Daily Fleet Digest",
+    );
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]).toContain("☀️ digest body");
+    expect(msgs[0]).toContain("-# ✅ `daily-digest` · daily_digest · 30.0s · run abcd1234");
+  });
+
+  test("buildContentMessages: failure → ❌ header + error block", () => {
+    const msgs = buildContentMessages(
+      { runId: "r1", ceremonyId: "c", skill: "s", status: "failure", duration: 1000,
+        targets: ["all"], startedAt: 0, completedAt: 1, error: "boom" } as never,
+      "Some Ceremony",
+    );
+    expect(msgs[0]).toContain("❌ **Some Ceremony** — failure");
+    expect(msgs[0]).toContain("```\nboom\n```");
   });
 });

--- a/workspace/agents/ava.yaml
+++ b/workspace/agents/ava.yaml
@@ -393,32 +393,39 @@ skills:
       - `get_branch_drift` — divergence signalling a stuck promotion.
       - `get_incidents` — open operational / security incidents.
 
-      ## Write it — three short sections
-      **Shipped** — the GENERAL IDEA of the day's work, NOT a play-by-play.
-      Synthesize across the fleet into a few themes — one line per repo that did
-      something notable (or fewer), naming the 1–2 standouts. Do NOT list
-      individual PRs or walk through each release; close with a single roll-up
-      like `(~70 PRs, 5 releases)`. Think "what you'd tell someone in the
-      hallway", not a changelog.
-      **Blockers** — what's stuck and why, most urgent first; one crisp line
-      each (repo + one-phrase reason). Omit the section if none.
-      **Pipeline / fleet** — red mains, big drift, open incidents; one line
-      each. Omit if none.
+      ## Write it — clean Discord markdown
+      It posts as a plain message, so USE REAL STRUCTURE — newlines, bold
+      headers on their own line, and bullet lists render. Format exactly like
+      this skeleton (mind the BLANK LINES between sections and one `- ` bullet
+      per item):
 
-      ## Style
-      Tight and scannable — read in ten seconds. Themes over specifics, verbs
-      over nouns. **Bold** the section labels (markdown renders). Keep the whole
-      thing well under ~1500 chars; shorter is better. End with `Else green.`
-      when blockers and pipeline/fleet are both clear.
+        ☀️ **Daily digest — <Mon D>**
 
-      Example shape:
-        ☀️ **Daily digest — <date>**
-        **Shipped** — workstacean: wrapped the console→logger migration + moved
-        the fleet to biome 2.0; protoContent: Content Cockpit PWA launch;
-        protoAgent: A2A 1.0 wire fixes. (~70 PRs, 5 releases.)
-        **Blockers** — protocli: PR #42 changes-requested 3d.
-        **Pipeline/fleet** — 🔴 protocontent main red; incident: gateway 5xx.
+        **Shipped**
+        - **<repo>** — <2–4 word themes of what it did; the standout first>
+        - **<repo>** — <themes>
+        _~<N> PRs · <M> releases_
+
+        **Blockers**
+        - <repo> — <one-phrase reason it's stuck>
+
+        **Pipeline / fleet**
+        - 🔴 <repo> — main red
+        - incident — <one phrase>
+
         Else green.
+
+      Rules:
+      - **Shipped** = the GENERAL IDEA, not a play-by-play. One bullet per repo
+        that did something notable (or fewer); name the 1–2 standouts; do NOT
+        list individual PRs or walk through releases — the `_~N PRs · M
+        releases_` roll-up line covers volume. "What you'd tell someone in the
+        hallway."
+      - **Blockers** / **Pipeline / fleet** — one crisp bullet each, most urgent
+        first. Omit the whole section (header included) when it's empty.
+      - `Else green.` only when both Blockers and Pipeline/fleet are clear.
+      - Themes over specifics, verbs over nouns. Whole thing well under ~1500
+        chars; shorter is better.
 
       ## Escalate
       If there's a genuine blocker or open incident, also call `msg_operator`


### PR DESCRIPTION
The digest came out as an unspaced wall — two causes, both fixed:

## 1. Embed → plain markdown message
Embeds compress multi-line content. `CeremonyNotifier` now posts the result as a plain markdown **message** (`content`), where Discord renders headers, bullets, and blank lines. The skill's result *is* the body; a small `-#` subtext line carries ceremony/skill/duration/run metadata. Long results split across messages at the 2000-char content cap. Removed the embed machinery (`_buildEmbeds`/`embedTextLength`/`packEmbedsIntoMessages`); kept `chunkText`, added pure `buildContentMessages`.

## 2. Prompt emits real structure
The `daily_digest` prompt now gives a concrete markdown **skeleton** — bold section headers on their own line, one `- ` bullet per repo, **blank lines between sections** — instead of the old inline run-on example. Shipped stays the synthesized "general idea" with a `_~N PRs · M releases_` roll-up.

Renders like:
```
☀️ **Daily digest — Jun 5**

**Shipped**
- **workstacean** — console→logger migration done; biome 2.0 fleet-wide; daily-digest live
- **protoAgent** — A2A 1.0 wire fixes

_~70 PRs · 5 releases_

**Blockers**
- protocli — PR #42 changes-requested 3d

Else green.
```

## Verification
- Full suite green under **both** dev and `NODE_ENV=production`: **1092 pass / 0 fail**; tsc + biome clean
- 13 `CeremonyNotifier` tests (content-shape, multi-message split ≤2000, `buildContentMessages` success/failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)