### PR TITLE
fix(events-db): reclaim the 42 GB — migrate legacy auto_vacuum=NONE → INCREMENTAL

### DIFF
--- a/lib/plugins/__tests__/logger-redaction-retention.test.ts
+++ b/lib/plugins/__tests__/logger-redaction-retention.test.ts
@@ -2,8 +2,12 @@ import { describe, expect, test, afterEach } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Database } from "bun:sqlite";
 import { InMemoryEventBus } from "../../bus.ts";
 import { LoggerPlugin, redactSecrets } from "../logger.ts";
+
+const pragma = (db: Database, name: string): number =>
+  Number(Object.values(db.query(`PRAGMA ${name}`).get() as object)[0]);
 
 describe("redactSecrets (#801)", () => {
   test("masks secret-keyed fields, keeps everything else", () => {
@@ -59,5 +63,36 @@ describe("LoggerPlugin retention + redaction at rest", () => {
     expect(db.query("SELECT COUNT(*) n FROM events").get()).toEqual({ n: 0 });
 
     plugin.uninstall();
+  });
+});
+
+describe("LoggerPlugin events.db compaction (the 42 GB bug)", () => {
+  let dir: string;
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("migrates a legacy auto_vacuum=NONE db to INCREMENTAL + reclaims free pages on install", () => {
+    dir = mkdtempSync(join(tmpdir(), "logger-vac-"));
+    const path = join(dir, "events.db");
+
+    // Simulate the legacy state that grew to 42 GB: auto_vacuum=NONE (sqlite's
+    // default) with free pages left by deletes that NONE can't reclaim.
+    const seed = new Database(path);
+    seed.exec("PRAGMA auto_vacuum=NONE;");
+    seed.exec("CREATE TABLE junk (x TEXT)");
+    const ins = seed.prepare("INSERT INTO junk VALUES (?)");
+    seed.transaction(() => { for (let i = 0; i < 2000; i++) ins.run("x".repeat(400)); })();
+    seed.exec("DROP TABLE junk"); // → free pages the NONE db won't return
+    expect(pragma(seed, "auto_vacuum")).toBe(0);
+    expect(pragma(seed, "freelist_count")).toBeGreaterThan(0);
+    seed.close();
+
+    const plugin = new LoggerPlugin(dir);
+    plugin.install(new InMemoryEventBus()); // runs the one-time VACUUM migration
+    plugin.uninstall();
+
+    const check = new Database(path, { readonly: true });
+    expect(pragma(check, "auto_vacuum")).toBe(2); // INCREMENTAL — now incremental_vacuum works
+    expect(pragma(check, "freelist_count")).toBe(0); // free pages reclaimed
+    check.close();
   });
 });

--- a/lib/plugins/logger.ts
+++ b/lib/plugins/logger.ts
@@ -51,10 +51,26 @@ export class LoggerPlugin implements Plugin {
     this.db = new Database(`${this.dataDir}/events.db`);
     this.db.exec("PRAGMA journal_mode=WAL;");
     this.db.exec("PRAGMA busy_timeout=5000;");
-    // INCREMENTAL auto-vacuum so reclaimed space (after retention deletes) can
-    // be returned without a full locking VACUUM. Takes effect on a fresh DB; an
-    // existing one keeps its mode but retention still bounds row growth. (#801)
+    // INCREMENTAL auto-vacuum so retention deletes can return freed pages via
+    // `PRAGMA incremental_vacuum` (the hourly sweep) instead of a full locking
+    // VACUUM. CRITICAL: auto_vacuum can only change on an EXISTING db via a
+    // VACUUM rebuild — the PRAGMA alone is a no-op on a db created NONE. Legacy
+    // DBs (pre-#801) were stuck at NONE, so retention deleted rows but
+    // incremental_vacuum couldn't reclaim them and the file grew unbounded
+    // (observed: a 42 GB file holding 0.7 GB of live events). Migrate once:
+    // set INCREMENTAL, then VACUUM to apply it + reclaim. Runs on our own
+    // connection at install (before writes); ∝ LIVE data, which retention keeps
+    // small. After the first run auto_vacuum is 2, so this is skipped. (#801)
+    const avBefore = (this.db.query("PRAGMA auto_vacuum").get() as { auto_vacuum?: number } | undefined)?.auto_vacuum ?? 0;
     this.db.exec("PRAGMA auto_vacuum=INCREMENTAL;");
+    if (avBefore !== 2) {
+      log.warn(`events.db auto_vacuum=${avBefore} (not INCREMENTAL) — rebuilding once to reclaim free pages`);
+      try {
+        this.db.exec("VACUUM;");
+      } catch (err) {
+        log.error("events.db VACUUM migration failed (continuing — retention still bounds rows)", { err });
+      }
+    }
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS events (
         id TEXT NOT NULL,


### PR DESCRIPTION
## The 42 GB
Prod `events.db` was **42.7 GB on disk holding 0.7 GB of live events** — 42 GB of free pages never reclaimed.

## Root cause
`auto_vacuum` can only change on an **existing** sqlite db via a **VACUUM rebuild**. The db predated #801 and was created `auto_vacuum=NONE`, so:
- #801's `PRAGMA auto_vacuum=INCREMENTAL` on install was a **no-op** (existing db keeps its mode),
- so the retention sweep's `PRAGMA incremental_vacuum` was **also a no-op**.

Retention *was* deleting rows (7-day window — `events` held exactly 7 days / 150K rows), but the freed pages never returned → the file grew unbounded.

## Fix
On install: read the current `auto_vacuum` mode; if it isn't INCREMENTAL, set it and run a **one-time `VACUUM`** to apply the mode + reclaim. Runs on our own connection before writes; cost ∝ *live* data (small), so fast. After the first run the mode is INCREMENTAL → skipped, and the hourly sweep's `incremental_vacuum` now actually reclaims going forward. Fail-soft.

**Self-heals on next deploy** — watchtower recreates the container → install runs the migration → 42 GB reclaimed. No manual VACUUM / downtime needed (disk is at 75%, 224 GB free, so not an emergency).

## Verification
- New test: seeds a legacy `auto_vacuum=NONE` db with free pages → install → asserts mode becomes INCREMENTAL (2) and `freelist_count` → 0
- Full suite green under **both** dev and `NODE_ENV=production`: **1093 pass / 0 fail**; tsc + biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQLite database compaction to prevent excessive database growth.
  * Added one-time database rebuild during plugin installation to reclaim unused storage space.

* **Tests**
  * Added comprehensive test coverage for database compaction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->