### PR TITLE
feat(researcher): cite sources in the digest + make discord_scan_feed configurable

### DIFF
--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -10,7 +10,7 @@ Every variable recognised by protoWorkstacean is declared in the zod `EnvSchema`
 
 - **62** variables declared in `EnvSchema`
 - **0** required (no `.optional()`); the rest are optional
-- **34** variable(s) read via `process.env` at runtime but **not** in `EnvSchema` (see [Read directly (not in EnvSchema)](#read-directly-not-in-envschema))
+- **35** variable(s) read via `process.env` at runtime but **not** in `EnvSchema` (see [Read directly (not in EnvSchema)](#read-directly-not-in-envschema))
 
 ## Core / runtime
 
@@ -165,6 +165,7 @@ These variables are read via `process.env` somewhere in `src/` or `lib/` but are
 | `QUINN_DISCORD_TOKEN` | `lib/types/channels.ts` |
 | `RESEARCH_EMBED_DIM` | `src/knowledge/research-store.ts` |
 | `RESEARCH_EMBED_MODEL` | `src/services/embeddings/gateway-embed.ts` |
+| `RESEARCH_FEED_CHANNEL_ID` | `src/executor/executors/deep-agent-executor.ts` |
 | `SEARXNG_URL` | `src/executor/executors/deep-agent-executor.ts` |
 | `WORKSTACEAN_AGENT_BOT_LOGINS` | `lib/plugins/github.ts` |
 | `WORKSTACEAN_DISPATCH_DROP_ESCALATION_COOLDOWN_MS` | `src/plugins/dispatch-drop-escalator-plugin.ts` |

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -614,8 +614,15 @@ export function createLangChainTools(toolNames: string[], http: HttpClient, corr
       async (input) => {
         const token = process.env.DISCORD_BOT_TOKEN;
         if (!token) return JSON.stringify({ error: "DISCORD_BOT_TOKEN not set" });
+        // Default to the configured research-feed channel when the caller omits
+        // one — the agent doesn't know channel IDs, so without this it can never
+        // use the feed. Operator sets RESEARCH_FEED_CHANNEL_ID to enable it.
+        const channelId = input.channelId ?? process.env.RESEARCH_FEED_CHANNEL_ID;
+        if (!channelId) {
+          return JSON.stringify({ error: "no feed channel — set RESEARCH_FEED_CHANNEL_ID or pass channelId", scanned: 0, links: [] });
+        }
         try {
-          const res = await fetch(`https://discord.com/api/v10/channels/${input.channelId}/messages?limit=${input.limit ?? 30}`, {
+          const res = await fetch(`https://discord.com/api/v10/channels/${channelId}/messages?limit=${input.limit ?? 30}`, {
             headers: { Authorization: `Bot ${token}` },
           });
           if (!res.ok) return JSON.stringify({ error: `Discord ${res.status}` });
@@ -633,9 +640,9 @@ export function createLangChainTools(toolNames: string[], http: HttpClient, corr
       },
       {
         name: "discord_scan_feed",
-        description: "Scan a Discord channel's recent messages and extract + classify shared links (arxiv, huggingface, github, video, web) — the team's research feed.",
+        description: "Scan the team's research-feed Discord channel for shared links (arxiv, huggingface, github, video, web). Omit channelId to use the configured feed (RESEARCH_FEED_CHANNEL_ID).",
         schema: z.object({
-          channelId: z.string().describe("Discord channel ID to scan."),
+          channelId: z.string().optional().describe("Discord channel ID to scan. Omit to use the configured research feed."),
           limit: z.number().optional().describe("Messages to scan (default 30, max 100)."),
         }),
       },

--- a/workspace/agents/researcher.yaml
+++ b/workspace/agents/researcher.yaml
@@ -72,6 +72,25 @@ skills:
   - name: research_digest
     description: >
       Produce a digest of recent AI/ML developments — scan the sources, pull the
-      notable papers/models/releases, synthesize the highlights, and store the
-      digest (kind: digest) for recall + publishing.
+      notable papers/models/releases, synthesize the highlights WITH SOURCE
+      CITATIONS, and store the digest (kind: digest) for recall + publishing.
     keywords: [research_digest, digest, weekly research, research report, roundup]
+    systemPromptOverride: |
+      Produce the weekly AI/ML research digest. Run your standard loop first:
+      recall (`research_search`) → gather (`huggingface_search`,
+      `github_trending`, `discord_scan_feed`, `searxng_search`) → ingest the
+      keepers (`research_ingest`) → then write the digest.
+
+      Grounding is non-negotiable — this posts publicly to the research channel:
+      - EVERY model, paper, and release you mention carries an inline source
+        link `[name](url)` taken from the tool results. No source link → leave
+        it out. Do not fill gaps from your own prior knowledge.
+      - State a status (Released / Expected / Delayed / Rumored) ONLY when a
+        source explicitly says so. Otherwise describe what the source claims and
+        link it — never assert "Released" on your own.
+      - Prefer primary sources (papers, repos, model cards, official posts) over
+        secondary coverage.
+
+      Format: lead with the 2–3 biggest signals, then group under **Models**,
+      **Papers**, **Tools/Repos** — each item one line with its link. Keep it
+      tight. Your final reply IS the message posted to the research channel.


### PR DESCRIPTION
From the researcher smoke test:

## 1. Digest now cites sources
The interactive `deep_research` grounds every claim with inline source links (Reuters/arXiv URLs), but `research_digest` dropped that rigor — it asserted statuses like "GPT-5.5 ✅ Released" with no source. Added a `systemPromptOverride` to `research_digest`: **every model/paper/release carries an inline `[name](url)`**, statuses (Released/Expected/Delayed) only when a source explicitly says so, primary sources preferred. Same grounding bar as `deep_research`.

## 2. discord_scan_feed is now usable
It required a `channelId` the agent had no way to know, so the Discord-feed source was never scanned. Now `channelId` is **optional and defaults to `RESEARCH_FEED_CHANNEL_ID`** — the agent can scan the team's feed once the operator sets that env. Until then it returns a clear "no feed channel" notice (graceful). (Tool description + env docs updated.)

**Operator action to enable the feed:** set `RESEARCH_FEED_CHANNEL_ID` to the research-feed Discord channel ID in the workstacean container env (Infisical/homelab-iac). Optional — everything else (HF/GitHub/web/arxiv) works without it.

## Verification
- Full suite green under **both** dev and `NODE_ENV=production`: **1093 pass / 0 fail**; tsc + biome clean; env docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)