### PR TITLE
fix(researcher): discord_scan_feed reads Components V2 (the actual feed format)

### DIFF
--- a/src/executor/__tests__/deep-agent-discord-feed.test.ts
+++ b/src/executor/__tests__/deep-agent-discord-feed.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { extractDiscordFeedLinks, classifyFeedLink } from "../executors/deep-agent-executor.ts";
+
+describe("classifyFeedLink", () => {
+  test("buckets by host", () => {
+    expect(classifyFeedLink("https://arxiv.org/abs/2604.1")).toBe("arxiv");
+    expect(classifyFeedLink("https://huggingface.co/models")).toBe("huggingface");
+    expect(classifyFeedLink("https://github.com/a/b")).toBe("github");
+    expect(classifyFeedLink("https://youtu.be/x")).toBe("video");
+    expect(classifyFeedLink("https://openai.com/blog")).toBe("web");
+  });
+});
+
+describe("extractDiscordFeedLinks", () => {
+  test("Components V2 (MonitoRSS): pulls the button url + text-display headline", () => {
+    // Exact shape observed in the feed-ai-research channel.
+    const msg = {
+      content: "",
+      embeds: [],
+      author: { username: "MonitoRSS" },
+      flags: 32768,
+      components: [
+        {
+          type: 17,
+          components: [
+            { type: 10, content: "**Biodefense in the Intelligence Age**\nAn action plan for AI-powered biological resilience" },
+            { type: 1, components: [{ type: 2, style: 5, label: "View", url: "https://openai.com/index/biodefense-in-the-intelligence-age" }] },
+          ],
+        },
+      ],
+    };
+    const links = extractDiscordFeedLinks([msg]);
+    expect(links).toHaveLength(1);
+    expect(links[0]!.url).toBe("https://openai.com/index/biodefense-in-the-intelligence-age");
+    expect(links[0]!.type).toBe("web");
+    expect(links[0]!.from).toBe("MonitoRSS");
+    expect(links[0]!.title).toContain("Biodefense in the Intelligence Age");
+  });
+
+  test("still handles classic content + embed urls (v1)", () => {
+    const links = extractDiscordFeedLinks([
+      { content: "check https://arxiv.org/abs/2604.9 and https://github.com/x/y", author: { username: "matt" } },
+      { content: "", embeds: [{ url: "https://huggingface.co/m", title: "model" }], author: { username: "ava" } },
+    ]);
+    const urls = links.map((l) => l.url).sort();
+    expect(urls).toEqual([
+      "https://arxiv.org/abs/2604.9",
+      "https://github.com/x/y",
+      "https://huggingface.co/m",
+    ]);
+    expect(links.find((l) => l.url.includes("arxiv"))!.type).toBe("arxiv");
+  });
+
+  test("dedupes within a message + tolerates empty/missing", () => {
+    expect(extractDiscordFeedLinks([])).toEqual([]);
+    const links = extractDiscordFeedLinks([{ content: "https://a.com x https://a.com" }]);
+    expect(links).toHaveLength(1);
+  });
+});

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -28,6 +28,50 @@ const LANGFUSE_ENABLED = !!(process.env.LANGFUSE_PUBLIC_KEY && process.env.LANGF
 
 /** Sleep used by chat_with_agent's pending-result poller. */
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** Classify a shared link by host into the research feed's source buckets. */
+export function classifyFeedLink(u: string): string {
+  return /arxiv\.org/.test(u) ? "arxiv"
+    : /huggingface\.co/.test(u) ? "huggingface"
+    : /github\.com/.test(u) ? "github"
+    : /(youtube\.com|youtu\.be)/.test(u) ? "video"
+    : "web";
+}
+
+/**
+ * Extract shared links from Discord messages — handles plain `content`, classic
+ * `embeds`, AND Components V2 (`type:17` container / `type:10` text-display /
+ * `type:2` button `url`). RSS bots like MonitoRSS now post via Components V2, so
+ * their links live in `components`, not content/embeds — walk the whole message
+ * tree. Returns each unique URL with its source bucket + the message's headline
+ * (the first text-display) as context. Pure + exported for testing.
+ */
+export function extractDiscordFeedLinks(
+  messages: Array<Record<string, unknown>>,
+): Array<{ url: string; type: string; title?: string; from?: string }> {
+  const urlRe = /https?:\/\/[^\s<>")]+/g;
+  const out: Array<{ url: string; type: string; title?: string; from?: string }> = [];
+  for (const m of messages ?? []) {
+    const from = ((m.author as Record<string, unknown> | undefined)?.username as string) || undefined;
+    const urls = new Set<string>();
+    const texts: string[] = [];
+    const walk = (o: unknown): void => {
+      if (typeof o === "string") {
+        for (const u of o.match(urlRe) ?? []) urls.add(u);
+      } else if (Array.isArray(o)) {
+        for (const v of o) walk(v);
+      } else if (o && typeof o === "object") {
+        const rec = o as Record<string, unknown>;
+        if (rec.type === 10 && typeof rec.content === "string") texts.push(rec.content.replace(/\s+/g, " ").trim());
+        for (const v of Object.values(rec)) walk(v);
+      }
+    };
+    walk(m);
+    const title = texts.find((t) => t.length > 0)?.slice(0, 140);
+    for (const u of urls) out.push({ url: u, type: classifyFeedLink(u), title, from });
+  }
+  return out;
+}
 /** chat_with_agent polls a pending A2A result this often, up to this budget,
  *  before handing back the pending marker. Slow skills (recon, pentest) finish
  *  well inside this; it just bounds the wait so a stuck task can't pin the tool.
@@ -626,15 +670,9 @@ export function createLangChainTools(toolNames: string[], http: HttpClient, corr
             headers: { Authorization: `Bot ${token}` },
           });
           if (!res.ok) return JSON.stringify({ error: `Discord ${res.status}` });
-          const msgs = (await res.json()) as Array<{ content?: string; embeds?: Array<{ url?: string; title?: string }>; author?: { username?: string } }>;
-          const urlRe = /https?:\/\/[^\s<>")]+/g;
-          const classify = (u: string): string =>
-            /arxiv\.org/.test(u) ? "arxiv" : /huggingface\.co/.test(u) ? "huggingface" : /github\.com/.test(u) ? "github" : /(youtube|youtu\.be)/.test(u) ? "video" : "web";
-          const links: Array<{ url: string; type: string; from?: string }> = [];
-          for (const m of msgs) {
-            for (const u of (m.content ?? "").match(urlRe) ?? []) links.push({ url: u, type: classify(u), from: m.author?.username });
-            for (const e of m.embeds ?? []) if (e.url) links.push({ url: e.url, type: classify(e.url), from: m.author?.username });
-          }
+          const msgs = (await res.json()) as Array<Record<string, unknown>>;
+          // Handles content + embeds + Components V2 (what MonitoRSS posts).
+          const links = extractDiscordFeedLinks(msgs);
           return JSON.stringify({ scanned: msgs.length, links: links.slice(0, 50) });
         } catch (e) { return JSON.stringify({ error: e instanceof Error ? e.message : String(e) }); }
       },


### PR DESCRIPTION
Wiring `discord_scan_feed` to the **`feed-ai-research`** channel (`1469054764833701942`) surfaced that it extracted **zero links**.

## Why
The channel is fed by **MonitoRSS**, which posts via Discord **Components V2** (`type:17` container → `type:10` text-display → `type:2` button with the `url`). The tool only scanned `content` + `embeds` — both **empty** under Components V2 — so the article links (which live in `components`) were invisible. The bot reads the components fine, so it's *not* a Message-Content-intent issue.

## Fix
New pure exported **`extractDiscordFeedLinks(messages)`** walks the whole message tree (`content` + `embeds` + `components`), dedupes URLs per message, classifies by host, and attaches the text-display headline as the link `title`. `discord_scan_feed` now uses it (keeps the `RESEARCH_FEED_CHANNEL_ID` default).

## Verification
- 4 tests including the **exact MonitoRSS Components-V2 shape** captured from the live channel → pulls the button URL + headline
- Full suite green under **both** dev and `NODE_ENV=production`: **1097 pass / 0 fail**; tsc + biome clean

Paired with setting `RESEARCH_FEED_CHANNEL_ID=1469054764833701942` (homelab-iac), this makes the Discord-feed source actually work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)