### PR TITLE
feat(a2a/chat): returnImmediately flag — non-blocking for slow skills

### DIFF
--- a/src/api/__tests__/ava-tools.test.ts
+++ b/src/api/__tests__/ava-tools.test.ts
@@ -116,6 +116,36 @@ describe("/api/a2a/chat (bus round-trip)", () => {
     expect(json.data.pollUrl).toBe(`/api/a2a/task/${json.data.correlationId}`);
   });
 
+  test("returnImmediately:true hands back the poll handle now, without waiting for the reply", async () => {
+    // A reply WOULD arrive synchronously, but returnImmediately must not block on
+    // it — it dispatches and returns the poll handle, so slow skills never wedge.
+    let dispatched = false;
+    autoReply(bus, () => {
+      dispatched = true;
+      return { content: "the answer", taskState: "completed" };
+    });
+    const { chat } = routesFor({ bus, executorRegistry: fakeRegistry(["researcher"]) });
+
+    const resp = await chat(
+      new Request("http://x/api/a2a/chat", {
+        method: "POST",
+        body: JSON.stringify({
+          agent: "researcher", skill: "deep_research", message: "slow query",
+          returnImmediately: true, contextId: "conv-9",
+        }),
+      }),
+      {},
+    );
+    const json = (await resp.json()) as { success: boolean; data: Record<string, unknown> };
+    expect(resp.status).toBe(200);
+    expect(dispatched).toBe(true); // the skill WAS dispatched
+    expect(json.data.pending).toBe(true); // ...but we got a poll handle, not the answer
+    expect(json.data.response).toBeNull();
+    expect(json.data.taskState).toBe("submitted");
+    expect(json.data.contextId).toBe("conv-9");
+    expect(json.data.pollUrl).toBe(`/api/a2a/task/${json.data.correlationId}`);
+  });
+
   test("404 when no executor is registered for the agent", async () => {
     const { chat } = routesFor({ bus, executorRegistry: fakeRegistry([]) });
     const resp = await chat(

--- a/src/api/ava-tools.ts
+++ b/src/api/ava-tools.ts
@@ -60,11 +60,16 @@ export function createRoutes(ctx: ApiContext): Route[] {
   /**
    * POST /api/a2a/chat — multi-turn conversation with an agent over the bus.
    *
-   * Body: { agent, message, contextId?, skill?, done?, dispatcherAgent? }
+   * Body: { agent, message, contextId?, skill?, done?, dispatcherAgent?,
+   *   returnImmediately? }
    * Returns on completion: { success, data: { response, contextId?, taskId?,
    *   taskState, correlationId, agent, usage?, costUsd?, confidence?, durationMs? } }
-   * Returns on timeout: { success, data: { pending: true, response: null,
-   *   taskState: "working", correlationId, contextId?, agent, pollUrl } }
+   * Returns on timeout OR returnImmediately:true: { success, data: { pending: true,
+   *   response: null, taskState, correlationId, contextId?, agent, pollUrl } }
+   *
+   * returnImmediately:true (A2A SendMessageConfiguration) dispatches and returns
+   * the poll handle right away instead of blocking up to the reply timeout —
+   * use it for slow skills (deep_research) so a synchronous caller never wedges.
    *
    * When done=true, the response omits contextId/taskId to signal conversation end.
    */
@@ -86,6 +91,11 @@ export function createRoutes(ctx: ApiContext): Route[] {
     const skill = (body.skill as string) || "chat";
     const done = body.done === true;
     const dispatcherAgent = typeof body.dispatcherAgent === "string" ? body.dispatcherAgent : undefined;
+    // A2A SendMessageConfiguration.returnImmediately: hand back a poll handle
+    // now instead of blocking up to the reply timeout. For slow skills
+    // (deep_research, research_digest) this stops a synchronous caller from
+    // wedging on the 30s timeout — they poll the task endpoint for the result.
+    const returnImmediately = body.returnImmediately === true;
 
     if (!agent || !message) {
       return Response.json(
@@ -126,8 +136,11 @@ export function createRoutes(ctx: ApiContext): Route[] {
     }
 
     // Listen for the terminal result BEFORE dispatching so a fast inline
-    // completion can't fire before we're subscribed.
-    const replyPromise = awaitSkillResponse(ctx.bus, correlationId, replyTimeoutMs());
+    // completion can't fire before we're subscribed. Skipped when the caller
+    // opted into an immediate poll-handle response (nothing to await).
+    const replyPromise = returnImmediately
+      ? undefined
+      : awaitSkillResponse(ctx.bus, correlationId, replyTimeoutMs());
 
     ctx.bus.publish("agent.skill.request", {
       id: crypto.randomUUID(),
@@ -143,7 +156,25 @@ export function createRoutes(ctx: ApiContext): Route[] {
       },
     });
 
-    const reply = await replyPromise;
+    // Dispatched — hand back the poll handle now. The result lands on the same
+    // poll endpoint (GET /api/a2a/task/{correlationId}) when the task finishes.
+    if (returnImmediately) {
+      return Response.json({
+        success: true,
+        data: {
+          pending: true,
+          response: null,
+          taskState: "submitted",
+          correlationId,
+          ...(done ? {} : { contextId: conversationId }),
+          agent,
+          pollUrl: `/api/a2a/task/${correlationId}`,
+        },
+      });
+    }
+
+    // Block up to the reply timeout (replyPromise is defined on this path).
+    const reply = await replyPromise!;
 
     // Timed out — task is still running. TaskTracker will deliver the result to
     // the reply topic + an autonomous.outcome event when it finishes; the caller


### PR DESCRIPTION
Follow-up to the researcher smoke test: `/api/a2a/chat` **blocks** on the terminal reply up to `A2A_CHAT_REPLY_TIMEOUT_MS` (**30s**) before falling back to a poll handle. A ~27s skill like `deep_research` lands right at that edge, so a synchronous client with a ~30s timeout gets an empty **HTTP 000**.

## Fix
Add **`returnImmediately`** (A2A `SendMessageConfiguration` semantics): when `true`, the handler dispatches the skill and returns the poll handle **immediately** (`pending: true`, `taskState: "submitted"`, `pollUrl`) instead of awaiting. The result lands on the same `GET /api/a2a/task/{correlationId}` when the task finishes.

Default behavior (block up to the reply timeout, then poll-fallback) is unchanged — callers of slow skills opt in. This is the spec-aligned sync/async control (our own A2A-maturity notes: "returnImmediately already answers sync/async — the caller decides").

```bash
curl -XPOST .../api/a2a/chat -d '{"agent":"researcher","skill":"deep_research","message":"…","returnImmediately":true}'
# → { pending:true, taskState:"submitted", pollUrl:"/api/a2a/task/<cid>" }  (instant)
```

## Verification
- New test: `returnImmediately:true` returns the poll handle even when a reply is available (proves it dispatches but doesn't block)
- Full suite green under **both** dev and `NODE_ENV=production`: **1098 pass / 0 fail**; tsc + biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `/api/a2a/chat` endpoint now supports immediate return mode, responding with a pending status and poll URL instead of blocking until completion.

* **Tests**
  * Added test coverage for the immediate return mode behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->