### PR TITLE
feat(quinn): review hardening — anti-thrash, eval harness, clawpatch gating

### DIFF
--- a/docs/explanation/code-review-agent-design.md
+++ b/docs/explanation/code-review-agent-design.md
@@ -1,0 +1,160 @@
+---
+title: Designing the Code-Review Agent (Quinn)
+---
+
+# Designing the code-review agent (Quinn)
+
+This is a due-diligence benchmark of our in-process PR-review agent, **Quinn**,
+against the state of the art (2025–2026), plus a prioritized roadmap. It pairs
+external research with live observability pulled from `events.db`.
+
+Quinn is a LangGraph ReAct DeepAgent. On every PR she runs `pr_inspector`
+(CI status + CodeRabbit threads + diff summary), optionally runs `clawpatch_review`
+(our AST/structural review fork), produces a `VERDICT`, and submits a formal GitHub
+review (`APPROVE` / `COMMENT` / `REQUEST_CHANGES`) that feeds the auto-merge-on-green
+loop.
+
+## Live baseline (events.db, ~7 days)
+
+| Metric | Value |
+| --- | --- |
+| pr_review runs | 1,523 (~217/day) |
+| Completed | 1,498 (98.4%) |
+| Failed | 25 (1.6%) — **24 of 25 are "Recursion limit of 37 reached"**, 1 timeout |
+| Verdict mix | COMMENT 51% · APPROVE 43% · REQUEST_CHANGES 2.6% |
+| Tool-calls / review | median 3, p90 4, max 15 |
+| Tool frequency | `pr_inspector` 4,590 · `react` 94 · **`clawpatch_review` 83** · `send_update` 48 |
+| clawpatch usage | **~5% of reviews** |
+| Latency | avg ~44s, max ~7 min (the thrash tail) |
+
+Two facts stand out: Quinn is effectively a **diff-only reviewer 95% of the time**
+(clawpatch, her structural pass, rarely fires), and her only meaningful failure mode
+is the **recursion-limit thrash that produces no verdict** and stalls the PR.
+
+## What the field does
+
+### Architecture — diff-only vs whole-repo context
+
+The biggest quality lever. [Greptile](https://www.greptile.com/agent) indexes the
+whole repo into a graph (parses the AST, recursively generates per-node docstrings,
+embeds them) and runs a swarm of agents doing **multi-hop investigation** — tracing
+dependencies, checking git history, following references across files (v3 built on the
+Claude Agent SDK). [Benchmarks](https://www.greptile.com/benchmarks) put graph-context
+Greptile at **82% catch rate vs CodeRabbit's 44%** (diff-only). Systemic, cross-file
+bugs are exactly where diff-only reviewers fail.
+
+**Quinn's `clawpatch` is the structural analog — but at 5% usage it is not the
+engine.** The tools that win run structural analysis as the *default* pass.
+
+### Multi-agent specialization
+
+[Cloudflare's production system](https://blog.cloudflare.com/ai-code-review/)
+(48,095 MRs / 30 days) runs **seven scoped reviewers** (security, performance, code
+quality, docs, release, compliance) + a coordinator, *"rather than relying on one model
+with a massive, generic prompt."* Quinn is one ReAct agent wearing all hats.
+
+### Noise reduction — the #1 complaint
+
+Cloudflare's clearest lesson: *"telling an LLM what NOT to do is where the actual prompt
+engineering value resides."* Without explicit don't-flag lists they got *"a firehose of
+speculative theoretical warnings developers learn to ignore."* Their coordinator runs a
+**reasonableness filter** dropping *"speculative issues, nitpicks, false positives, and
+convention-contradicted findings,"* and **reads source to verify** when uncertain.
+Best-in-class tools hold [5–15% false-positive rates](https://www.propelcode.ai/blog/ai-code-review-false-positives-reducing-noise)
+with per-type tolerances ([security <3%, style <2%](https://www.codeant.ai/blogs/ai-code-review-false-positives)).
+
+**Quinn is ahead of the field on grounding** — her Step 2c rule (*every HIGH/CRITICAL on
+an external reference must rest on a fetched EXISTS/MISSING fact, else it's a Gap*) is the
+"read source to verify" discipline, formalized. She lacks an explicit **"what NOT to
+flag"** list (see the prompt-policy decision below).
+
+### Comment-vs-block policy
+
+Cloudflare biases *explicitly toward approval*: clean/trivial → approve; suggestion-level
+→ approve-with-comments; only **critical/safety** → block. Quinn's
+PASS→approve / WARN→comment / FAIL→request_changes maps almost exactly, and her live
+distribution (COMMENT 51%, REQUEST_CHANGES 2.6%) confirms the correct bias. **Keep this.**
+
+### Convergence — timeouts, not turn-limits
+
+Cloudflare uses **per-task 5 min (10 for code quality), a 25 min overall cap, and a 60s
+inactivity kill** plus heartbeat logs — and budget exhaustion still yields a *result*.
+Quinn instead hits a raw LangGraph recursion cap (maxTurns=18 → 37 steps) and fails to
+**nothing**, leaving the PR stuck. This is her clearest defect.
+
+### Memory — recall → review → retain
+
+Real but young. Cloudflare's production form is **re-review memory**: on re-review the
+coordinator gets *"the full text of its last review comment and a list of inline DiffNote
+comments… along with their resolution status,"* auto-resolves fixed findings, respects
+"won't fix," reconsiders on "I disagree." Per-repo conventions ride in
+[AGENTS.md injected into prompts](https://blog.buildbetter.ai/agents-md-complete-guide-for-engineering-teams-in-2026/).
+A simpler [recall/retain loop](https://dev.to/abhiramcdivakaran/building-a-code-review-agent-that-learns-from-every-decision-5a4c)
+stores `PR# | file | comment | developer-action` and suppresses repeatedly-rejected
+suggestion types. **Honest caveat:** measured benefit is mostly *qualitative*
+(*"the first review is average; the tenth is meaningfully better"*) — no published
+precision/recall gains. Memory is a trust/consistency play, not a proven accuracy
+multiplier.
+
+**Quinn is fully stateless.** The highest-value memory is **re-review memory**, not a
+fancy KB — she re-reviews the same PR from scratch every CI cycle, which both wastes
+turns and is a prime cause of the recursion thrash.
+
+### Evaluation
+
+The field measures with **bug-hits vs valid-suggestions vs noise**
+([CR-Bench / CR-Evaluator](https://arxiv.org/pdf/2603.11078)), **signal-to-noise ratio**
+as a trust proxy, and **suggestion-acceptance rate**. Precision is the universal hard
+part (some tools <10%). Quinn has no eval harness — but we already log
+`quinn.review.submitted` + `autonomous.outcome.*pr_review` + GitHub resolution state, so
+the raw material exists.
+
+## Prioritized roadmap
+
+**P0 — fix the stuck mode**
+1. **Never fail to nothing.** On budget exhaustion (recursion limit / timeout) in a
+   `pr_review` run, force-emit a terminal **COMMENT** ("review incomplete — out of budget;
+   partial findings below") instead of a hard error. Removes the ~1.6% of PRs that get no
+   verdict and stall the merge loop.
+2. **Make clawpatch deterministic, not discretionary.** Trigger it on objective signals
+   (diff > N files / > N lines, or sensitive paths) rather than the model's "is this
+   non-trivial?" judgement, which is under-firing it (5%).
+
+**P1 — re-review memory**
+3. Before a re-review, recall Quinn's own prior verdict + which findings are resolved
+   (Cloudflare's re-review contract). Cuts duplicate comments, tokens, and thrash.
+
+**P2 — repo conventions + eval**
+4. Per-repo conventions via AGENTS.md-style injected context, or wire Quinn into the
+   existing `AgentMemory` flywheel (she's the one core agent without a `memory:` block)
+   with a `review_finding` domain. Set expectations honestly (consistency, not precision).
+5. Stand up an **eval harness** from data we already emit: per-finding resolution rate,
+   SNR, verdict-vs-merge accuracy. Arguably do this *first* as the baseline.
+
+**Keep (already at/above field):** the Step 2c grounding rule, deterministic
+VERDICT→action mapping with CI-terminal gating (409→comment), approval-biased rubric,
+self-review safety rail.
+
+## Prompt-policy decision: "what NOT to flag"
+
+The field's highest-ROI noise lever is an explicit **don't-flag exclusion list**. Our
+house rule is *"prompts — no negative reinforcement / positive framing only."* These
+appear to conflict.
+
+**Decision:** carve the exception. The no-negative-reinforcement rule targets *behavioral
+coaching* of the agent ("never be lazy", "don't hallucinate") — which degrades into
+nagging. A **scope-exclusion list** ("the following finding categories are out of scope
+for this review") is *specification*, not behavioral reinforcement: it defines the task
+boundary the same way a function signature does. Review agents are the case where naming
+the out-of-scope set is the single biggest signal-quality win, so Quinn's `pr_review`
+prompt carries an explicit out-of-scope list. This is a deliberate, scoped exception, not
+a repeal of the house rule.
+
+## Sources
+
+- [Greptile — agent architecture](https://www.greptile.com/agent) · [benchmarks](https://www.greptile.com/benchmarks) · [Greptile vs CodeRabbit](https://www.greptile.com/greptile-vs-coderabbit)
+- [Cloudflare — Orchestrating AI Code Review at scale](https://blog.cloudflare.com/ai-code-review/)
+- [Propel — reducing AI code-review false positives](https://www.propelcode.ai/blog/ai-code-review-false-positives-reducing-noise) · [CodeAnt — FP tolerances](https://www.codeant.ai/blogs/ai-code-review-false-positives)
+- [Building a code-review agent that learns from every decision](https://dev.to/abhiramcdivakaran/building-a-code-review-agent-that-learns-from-every-decision-5a4c) · [AGENTS.md guide](https://blog.buildbetter.ai/agents-md-complete-guide-for-engineering-teams-in-2026/)
+- [CR-Bench — evaluating real-world utility of AI code-review agents](https://arxiv.org/pdf/2603.11078)
+- [Qodo PR-Agent — compression strategy](https://qodo-merge-docs.qodo.ai/core-abilities/compression_strategy/) · [State of AI Code Review Tools 2025](https://www.devtoolsacademy.com/blog/state-of-ai-code-review-tools-2025/)

--- a/lib/plugins/__tests__/github-review-fallback.test.ts
+++ b/lib/plugins/__tests__/github-review-fallback.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Anti-thrash: budget-exhausted PR reviews (recursion limit / timeout) produce
+ * no verdict. Rather than fail to silence, the github-outbound reply handler
+ * escalates to a human and deliberately does NOT post a COMMENT (a COMMENTED
+ * state would let approve-on-green auto-approve an unreviewed PR).
+ *
+ * Covers the pure gate plus the handler's escalate-vs-comment branch with a
+ * stubbed GitHub API. See docs/explanation/code-review-agent-design.md.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { isReviewBudgetExhausted, GitHubPlugin } from "../github.ts";
+import { InMemoryEventBus } from "../../bus.ts";
+import { ProjectRegistry } from "../../../src/plugins/project-registry.ts";
+
+describe("isReviewBudgetExhausted", () => {
+  test("true for recursion-limit + timeout signatures", () => {
+    expect(isReviewBudgetExhausted("Recursion limit of 37 reached without hitting a stop condition. You can...")).toBe(true);
+    expect(isReviewBudgetExhausted("The operation timed out.")).toBe(true);
+    expect(isReviewBudgetExhausted("The operation was aborted")).toBe(true);
+  });
+  test("false for a real verdict or empty/undefined", () => {
+    expect(isReviewBudgetExhausted("Submitted COMMENT review on protoLabsAI/ORBIS#253.")).toBe(false);
+    expect(isReviewBudgetExhausted("")).toBe(false);
+    expect(isReviewBudgetExhausted(undefined)).toBe(false);
+  });
+});
+
+const PENDING = { owner: "protoLabsAI", repo: "ORBIS", number: 253 };
+
+function drive(plugin: GitHubPlugin, payload: Record<string, unknown>, bus: InMemoryEventBus) {
+  return (plugin as unknown as {
+    _handleOutboundReply: (
+      pending: typeof PENDING,
+      cid: string,
+      payload: Record<string, unknown>,
+      bus: InMemoryEventBus,
+      getToken: () => Promise<string>,
+    ) => Promise<void>;
+  })._handleOutboundReply(PENDING, "cid-1", payload, bus, async () => "fake-token");
+}
+
+const origFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = origFetch; });
+
+describe("_handleOutboundReply — budget-exhaustion escalation", () => {
+  test("recursion-limit error → escalates to operator, posts NO comment", async () => {
+    const commentPosts: string[] = [];
+    globalThis.fetch = (async (url: string) => {
+      commentPosts.push(String(url));
+      return new Response("{}", { status: 201 });
+    }) as unknown as typeof fetch;
+
+    const bus = new InMemoryEventBus();
+    const escalations: Record<string, unknown>[] = [];
+    bus.subscribe("operator.message.request", "test", (m) => { escalations.push(m.payload as Record<string, unknown>); });
+
+    const plugin = new GitHubPlugin("/tmp/nonexistent-ws", new ProjectRegistry());
+    await drive(plugin, { error: "Recursion limit of 37 reached without hitting a stop condition." }, bus);
+
+    expect(escalations.length).toBe(1);
+    expect(escalations[0]!.type).toBe("operator_message_request");
+    expect(String(escalations[0]!.message)).toContain("protoLabsAI/ORBIS#253");
+    expect(escalations[0]!.from).toBe("github");
+    expect(commentPosts.length).toBe(0); // never posts a review/comment
+  });
+
+  test("normal content reply → posts a comment, no escalation", async () => {
+    const commentPosts: string[] = [];
+    globalThis.fetch = (async (url: string) => {
+      commentPosts.push(String(url));
+      return new Response("{}", { status: 201 });
+    }) as unknown as typeof fetch;
+
+    const bus = new InMemoryEventBus();
+    const escalations: unknown[] = [];
+    bus.subscribe("operator.message.request", "test", (m) => { escalations.push(m.payload); });
+
+    const plugin = new GitHubPlugin("/tmp/nonexistent-ws", new ProjectRegistry());
+    await drive(plugin, { content: "VERDICT: PASS — looks good." }, bus);
+
+    expect(escalations.length).toBe(0);
+    expect(commentPosts.length).toBe(1);
+  });
+
+  test("empty reply → no comment, no escalation", async () => {
+    let fetched = false;
+    globalThis.fetch = (async () => { fetched = true; return new Response("{}", { status: 201 }); }) as unknown as typeof fetch;
+    const bus = new InMemoryEventBus();
+    const escalations: unknown[] = [];
+    bus.subscribe("operator.message.request", "test", (m) => { escalations.push(m.payload); });
+
+    const plugin = new GitHubPlugin("/tmp/nonexistent-ws", new ProjectRegistry());
+    await drive(plugin, { content: "" }, bus);
+
+    expect(escalations.length).toBe(0);
+    expect(fetched).toBe(false);
+  });
+});

--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -247,6 +247,27 @@ export function quinnLatestReviewState(
 }
 
 /**
+ * Detect a budget-exhausted PR review: the agent's ReAct loop hit its turn
+ * ceiling ("Recursion limit of N reached…") or the run timed out before it
+ * produced a formal verdict. ~1.6% of pr_review runs end this way (see
+ * docs/explanation/code-review-agent-design.md) and historically left the PR
+ * silently unreviewed. We escalate these to a human rather than fail to
+ * nothing — and deliberately do NOT synthesize a COMMENT review, because a
+ * COMMENTED state would let the approve-on-green path (#748) auto-approve a PR
+ * that was never actually reviewed.
+ */
+export function isReviewBudgetExhausted(error: string | undefined): boolean {
+  const m = (error ?? "").toLowerCase();
+  if (!m) return false;
+  return (
+    m.includes("recursion limit") ||
+    m.includes("timed out") ||
+    m.includes("operation was aborted") ||
+    m.includes("without hitting a stop condition")
+  );
+}
+
+/**
  * Normalize a GitHub `release` webhook payload into a ReleasePublishedPayload,
  * or null when it isn't a published release worth surfacing (wrong action,
  * missing owner/repo/tag). Exported for unit testing; called from
@@ -456,11 +477,7 @@ export class GitHubPlugin implements Plugin {
       if (!pending) return;
       pendingComments.delete(correlationId);
 
-      const content = String((msg.payload as Record<string, unknown>).content ?? "").trim();
-      if (!content) return;
-      if (/^Skill ".+" completed by \w+$/i.test(content)) return;
-
-      await this._postComment(getToken, pending, content);
+      await this._handleOutboundReply(pending, correlationId, msg.payload as Record<string, unknown>, bus, getToken);
     });
 
     // ── Inbound: webhook HTTP server ─────────────────────────────────────────
@@ -955,6 +972,53 @@ export class GitHubPlugin implements Plugin {
    * The dispatcher's `@sha7` cooldown (#437) is the backstop against any
    * residual burst from the two event types arriving together.
    */
+  /**
+   * Process a skill reply bound for a GitHub PR (the `message.outbound.github.#`
+   * subscriber body — extracted so the budget-exhaustion path is unit-testable
+   * by driving it directly). On a normal reply, post the agent's content as a
+   * PR comment. On a budget-exhausted review (recursion limit / timeout, no
+   * verdict), escalate to a human instead of failing silently — and never post
+   * it as a review, since a COMMENTED state would let approve-on-green (#748)
+   * auto-approve a PR that was never actually reviewed.
+   */
+  private async _handleOutboundReply(
+    pending: PendingComment,
+    correlationId: string,
+    payload: Record<string, unknown>,
+    bus: EventBus,
+    getToken: (owner: string, repo: string) => Promise<string>,
+  ): Promise<void> {
+    const error = typeof payload.error === "string" ? payload.error : undefined;
+
+    if (isReviewBudgetExhausted(error)) {
+      const slug = `${pending.owner}/${pending.repo}#${pending.number}`;
+      log.warn(`pr_review budget-exhausted for ${slug} — escalating to operator (no verdict produced): ${error}`);
+      bus.publish("operator.message.request", {
+        id: crypto.randomUUID(),
+        correlationId,
+        topic: "operator.message.request",
+        timestamp: Date.now(),
+        payload: {
+          type: "operator_message_request",
+          message:
+            `Quinn could not finish reviewing ${slug} — the review ran out of budget ` +
+            `(${error}) and produced no verdict. The PR is unreviewed; it needs a human ` +
+            `review or a re-run. https://github.com/${pending.owner}/${pending.repo}/pull/${pending.number}`,
+          urgency: "normal",
+          topic: `pr-review-incomplete/${slug}`,
+          from: "github",
+        },
+      });
+      return;
+    }
+
+    const content = String(payload.content ?? "").trim();
+    if (!content) return;
+    if (/^Skill ".+" completed by \w+$/i.test(content)) return;
+
+    await this._postComment(getToken, pending, content);
+  }
+
   private async _handleCiCompletion(
     event: string,
     payload: Record<string, unknown>,

--- a/scripts/quinn-review-eval.ts
+++ b/scripts/quinn-review-eval.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env bun
+/**
+ * quinn-review-eval — print the PR-review measurement baseline from events.db.
+ *
+ *   bun scripts/quinn-review-eval.ts [path-to-events.db]
+ *
+ * Defaults to $WORKSTACEAN_DATA_DIR/events.db, else ./data/events.db. Read-only.
+ * Pure aggregation lives in src/knowledge/quinn-review-eval.ts (unit-tested);
+ * this is just the reader + pretty-printer.
+ */
+import { Database } from "bun:sqlite";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { computeQuinnReviewStats, type EvalEvent } from "../src/knowledge/quinn-review-eval.ts";
+
+const dbPath =
+  process.argv[2] ||
+  join(process.env.WORKSTACEAN_DATA_DIR || "./data", "events.db");
+
+if (!existsSync(dbPath)) {
+  console.error(`events.db not found at ${dbPath} — pass a path or set WORKSTACEAN_DATA_DIR.`);
+  process.exit(1);
+}
+
+const db = new Database(dbPath, { readonly: true });
+
+const rows = db
+  .query(
+    `SELECT topic, payload, correlation_id, timestamp FROM events
+     WHERE topic LIKE 'autonomous.outcome.%pr_review'
+        OR topic = 'agent.runtime.activity.tool.call'
+        OR topic = 'quinn.review.submitted'`,
+  )
+  .all() as { topic: string; payload: string; correlation_id: string; timestamp: number }[];
+
+const events: EvalEvent[] = [];
+for (const r of rows) {
+  let env: { payload?: Record<string, unknown> };
+  try {
+    env = JSON.parse(r.payload);
+  } catch {
+    continue;
+  }
+  events.push({
+    topic: r.topic,
+    ts: r.timestamp,
+    correlationId: r.correlation_id,
+    body: env.payload ?? {},
+  });
+}
+
+const s = computeQuinnReviewStats(events);
+const pct = (x: number) => `${(x * 100).toFixed(1)}%`;
+const days = s.window.days.toFixed(1);
+
+console.log(`\nQuinn PR-review eval — ${dbPath}`);
+console.log(`window: ${days} days  (${rows.length} events scanned)\n`);
+
+console.log("OUTCOMES");
+console.log(`  runs:        ${s.outcomes.total}`);
+console.log(`  completed:   ${s.outcomes.completed} (${pct(s.outcomes.completionRate)})`);
+console.log(`  failed:      ${s.outcomes.failed}`);
+for (const [mode, n] of Object.entries(s.outcomes.failureModes).sort((a, b) => b[1] - a[1])) {
+  console.log(`     ${mode.padEnd(16)} ${n}`);
+}
+
+if (s.latencyMs) {
+  console.log("\nLATENCY (ms, success)");
+  console.log(`  min ${s.latencyMs.min}  median ${s.latencyMs.median}  p90 ${s.latencyMs.p90}  max ${s.latencyMs.max}  avg ${s.latencyMs.avg}`);
+}
+
+console.log("\nVERDICTS (formal reviews)");
+const v = s.verdicts;
+const vt = v.total || 1;
+console.log(`  APPROVE          ${v.APPROVE} (${pct(v.APPROVE / vt)})`);
+console.log(`  COMMENT          ${v.COMMENT} (${pct(v.COMMENT / vt)})`);
+console.log(`  REQUEST_CHANGES  ${v.REQUEST_CHANGES} (${pct(v.REQUEST_CHANGES / vt)})`);
+
+console.log("\nTOOL USE");
+console.log(`  reviews profiled:  ${s.toolUse.reviewsProfiled}`);
+console.log(`  clawpatch used in: ${s.toolUse.clawpatchReviews} (${pct(s.toolUse.clawpatchRate)})`);
+if (s.toolUse.callsPerReview) {
+  console.log(`  tool-calls/review: median ${s.toolUse.callsPerReview.median}  p90 ${s.toolUse.callsPerReview.p90}  max ${s.toolUse.callsPerReview.max}`);
+}
+for (const [t, n] of Object.entries(s.toolUse.toolFrequency).sort((a, b) => b[1] - a[1]).slice(0, 8)) {
+  console.log(`     ${t.padEnd(20)} ${n}`);
+}
+
+if (s.perRepo.length) {
+  console.log("\nPER-REPO (top 8)");
+  for (const r of s.perRepo.slice(0, 8)) {
+    console.log(`  ${r.repo.padEnd(32)} ${r.reviews} reviews  (A${r.approve}/C${r.comment}/RC${r.requestChanges})`);
+  }
+}
+console.log("");
+
+db.close();

--- a/src/knowledge/__tests__/quinn-review-eval.test.ts
+++ b/src/knowledge/__tests__/quinn-review-eval.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import { classifyFailure, computeQuinnReviewStats, type EvalEvent } from "../quinn-review-eval.ts";
+
+const T0 = 1_780_000_000_000;
+
+function outcome(success: boolean, opts: { ms?: number; error?: string; ts?: number } = {}): EvalEvent {
+  return {
+    topic: "autonomous.outcome.user.pr_review",
+    ts: opts.ts ?? T0,
+    correlationId: crypto.randomUUID(),
+    body: {
+      skill: "pr_review",
+      success,
+      taskState: success ? "completed" : "failed",
+      durationMs: opts.ms,
+      ...(opts.error ? { error: opts.error } : {}),
+    },
+  };
+}
+
+function toolCall(cid: string, toolNames: string[], ts = T0): EvalEvent {
+  return {
+    topic: "agent.runtime.activity.tool.call",
+    ts,
+    correlationId: cid,
+    body: { type: "tool.call", agentName: "quinn", skill: "pr_review", toolNames },
+  };
+}
+
+function submitted(owner: string, repo: string, event: string, ts = T0): EvalEvent {
+  return {
+    topic: "quinn.review.submitted",
+    ts,
+    correlationId: crypto.randomUUID(),
+    body: { owner, repo, prNumber: 1, event, prUrl: "u", bodyPreview: "b" },
+  };
+}
+
+describe("classifyFailure", () => {
+  test("buckets the known stuck modes", () => {
+    expect(classifyFailure("Recursion limit of 37 reached without hitting a stop condition")).toBe("recursion_limit");
+    expect(classifyFailure("The operation timed out.")).toBe("timeout");
+    expect(classifyFailure("GitHub API 429 rate limit")).toBe("rate_limit");
+    expect(classifyFailure("circuit breaker open")).toBe("circuit_open");
+    expect(classifyFailure("something else entirely")).toBe("other");
+    expect(classifyFailure(undefined)).toBe("unknown");
+    expect(classifyFailure("")).toBe("unknown");
+  });
+});
+
+describe("computeQuinnReviewStats", () => {
+  test("completion rate and failure-mode breakdown", () => {
+    const events = [
+      outcome(true, { ms: 1000 }),
+      outcome(true, { ms: 3000 }),
+      outcome(true, { ms: 5000 }),
+      outcome(false, { error: "Recursion limit of 37 reached without hitting a stop condition" }),
+      outcome(false, { error: "The operation timed out." }),
+    ];
+    const s = computeQuinnReviewStats(events);
+    expect(s.outcomes.total).toBe(5);
+    expect(s.outcomes.completed).toBe(3);
+    expect(s.outcomes.failed).toBe(2);
+    expect(s.outcomes.completionRate).toBeCloseTo(0.6, 5);
+    expect(s.outcomes.failureModes.recursion_limit).toBe(1);
+    expect(s.outcomes.failureModes.timeout).toBe(1);
+  });
+
+  test("latency percentiles from successful runs only", () => {
+    const events = [1000, 2000, 3000, 4000, 5000].map((ms) => outcome(true, { ms }));
+    const s = computeQuinnReviewStats(events);
+    expect(s.latencyMs).not.toBeNull();
+    expect(s.latencyMs!.min).toBe(1000);
+    expect(s.latencyMs!.max).toBe(5000);
+    expect(s.latencyMs!.avg).toBe(3000);
+    expect(s.latencyMs!.median).toBe(3000);
+  });
+
+  test("clawpatch rate uses the longest (final) tool sequence per review", () => {
+    const cidA = "a";
+    const cidB = "b";
+    const events = [
+      // review A: cumulative frames, final includes clawpatch
+      toolCall(cidA, ["pr_inspector"]),
+      toolCall(cidA, ["pr_inspector", "pr_inspector", "clawpatch_review"]),
+      // review B: never uses clawpatch
+      toolCall(cidB, ["pr_inspector", "pr_inspector", "pr_inspector"]),
+    ];
+    const s = computeQuinnReviewStats(events);
+    expect(s.toolUse.reviewsProfiled).toBe(2);
+    expect(s.toolUse.clawpatchReviews).toBe(1);
+    expect(s.toolUse.clawpatchRate).toBeCloseTo(0.5, 5);
+    expect(s.toolUse.toolFrequency.pr_inspector).toBe(5); // 2 from A's final + 3 from B
+    expect(s.toolUse.callsPerReview!.max).toBe(3);
+  });
+
+  test("verdict mix and per-repo from quinn.review.submitted", () => {
+    const events = [
+      submitted("protoLabsAI", "ORBIS", "COMMENT"),
+      submitted("protoLabsAI", "ORBIS", "APPROVE"),
+      submitted("protoLabsAI", "protoWorkstacean", "REQUEST_CHANGES"),
+      submitted("protoLabsAI", "ORBIS", "APPROVE"),
+    ];
+    const s = computeQuinnReviewStats(events);
+    expect(s.verdicts.APPROVE).toBe(2);
+    expect(s.verdicts.COMMENT).toBe(1);
+    expect(s.verdicts.REQUEST_CHANGES).toBe(1);
+    expect(s.verdicts.total).toBe(4);
+    expect(s.perRepo[0].repo).toBe("protoLabsAI/ORBIS");
+    expect(s.perRepo[0].reviews).toBe(3);
+    expect(s.perRepo[0].approve).toBe(2);
+  });
+
+  test("empty input degrades cleanly", () => {
+    const s = computeQuinnReviewStats([]);
+    expect(s.outcomes.total).toBe(0);
+    expect(s.outcomes.completionRate).toBe(0);
+    expect(s.latencyMs).toBeNull();
+    expect(s.toolUse.callsPerReview).toBeNull();
+    expect(s.perRepo).toEqual([]);
+  });
+
+  test("window spans min/max event timestamps", () => {
+    const s = computeQuinnReviewStats([
+      outcome(true, { ms: 1, ts: T0 }),
+      outcome(true, { ms: 1, ts: T0 + 2 * 86_400_000 }),
+    ]);
+    expect(s.window.from).toBe(T0);
+    expect(s.window.to).toBe(T0 + 2 * 86_400_000);
+    expect(s.window.days).toBeCloseTo(2, 5);
+  });
+});

--- a/src/knowledge/quinn-review-eval.ts
+++ b/src/knowledge/quinn-review-eval.ts
@@ -1,0 +1,190 @@
+/**
+ * Quinn review-eval — a measurement baseline for the PR-review agent.
+ *
+ * Pure aggregation over bus events already persisted in events.db. No DB or IO
+ * here so it unit-tests against synthetic events; `scripts/quinn-review-eval.ts`
+ * is the thin reader that feeds it real rows.
+ *
+ * The field measures review agents by signal-to-noise, not raw volume
+ * (CR-Bench / CR-Evaluator): beneficial findings vs noise, verdict mix, and —
+ * critically for us — the rate at which a review fails to produce ANY verdict.
+ * See docs/explanation/code-review-agent-design.md.
+ *
+ * Inputs are normalized events: the inner bus payload (`envelope.payload`) plus
+ * topic/ts/correlationId. Consumes three topics:
+ *   - autonomous.outcome.*.pr_review        → completion / failure-mode / latency
+ *   - agent.runtime.activity.tool.call       → tool profile + clawpatch usage
+ *   - quinn.review.submitted                 → formal verdict mix + per-repo
+ */
+
+export interface EvalEvent {
+  topic: string;
+  /** epoch ms */
+  ts: number;
+  correlationId: string;
+  /** the inner bus payload (envelope.payload), already JSON-parsed */
+  body: Record<string, unknown>;
+}
+
+export interface QuinnReviewStats {
+  window: { from: number | null; to: number | null; days: number };
+  outcomes: {
+    total: number;
+    completed: number;
+    failed: number;
+    completionRate: number;
+    /** failure messages bucketed — the "where she gets stuck" view */
+    failureModes: Record<string, number>;
+  };
+  verdicts: {
+    /** formal GitHub reviews from quinn.review.submitted */
+    APPROVE: number;
+    COMMENT: number;
+    REQUEST_CHANGES: number;
+    total: number;
+  };
+  latencyMs: { min: number; median: number; p90: number; max: number; avg: number } | null;
+  toolUse: {
+    reviewsProfiled: number;
+    clawpatchReviews: number;
+    clawpatchRate: number;
+    callsPerReview: { median: number; p90: number; max: number } | null;
+    toolFrequency: Record<string, number>;
+  };
+  perRepo: Array<{ repo: string; reviews: number; approve: number; comment: number; requestChanges: number }>;
+}
+
+const PR_REVIEW_OUTCOME = /^autonomous\.outcome\..*\.pr_review$/;
+
+/** Bucket a failure message into a stable, low-cardinality mode label. */
+export function classifyFailure(message: string | undefined): string {
+  const m = (message ?? "").toLowerCase();
+  if (!m) return "unknown";
+  if (m.includes("recursion limit")) return "recursion_limit";
+  if (m.includes("timed out") || m.includes("timeout") || m.includes("aborted")) return "timeout";
+  if (m.includes("rate limit") || m.includes("429")) return "rate_limit";
+  if (m.includes("circuit")) return "circuit_open";
+  return "other";
+}
+
+function pct(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.floor(sorted.length * p));
+  return sorted[idx];
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+function num(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+export function computeQuinnReviewStats(events: EvalEvent[]): QuinnReviewStats {
+  let from: number | null = null;
+  let to: number | null = null;
+
+  // ── outcomes ──────────────────────────────────────────────────────────────
+  let completed = 0;
+  let failed = 0;
+  const failureModes: Record<string, number> = {};
+  const latencies: number[] = [];
+
+  // ── tool use (final toolNames per correlationId wins — the array is cumulative)
+  const finalTools = new Map<string, string[]>();
+
+  // ── verdicts / per-repo (from quinn.review.submitted) ──────────────────────
+  const verdicts = { APPROVE: 0, COMMENT: 0, REQUEST_CHANGES: 0 };
+  const repoMap = new Map<string, { reviews: number; approve: number; comment: number; requestChanges: number }>();
+
+  for (const e of events) {
+    if (e.ts) {
+      from = from === null ? e.ts : Math.min(from, e.ts);
+      to = to === null ? e.ts : Math.max(to, e.ts);
+    }
+
+    if (PR_REVIEW_OUTCOME.test(e.topic)) {
+      const success = e.body.success === true;
+      if (success) {
+        completed++;
+        const d = num(e.body.durationMs);
+        if (d !== undefined) latencies.push(d);
+      } else {
+        failed++;
+        const mode = classifyFailure(str(e.body.error) ?? str(e.body.textPreview));
+        failureModes[mode] = (failureModes[mode] ?? 0) + 1;
+      }
+      continue;
+    }
+
+    if (e.topic === "agent.runtime.activity.tool.call" && e.body.skill === "pr_review") {
+      const tn = Array.isArray(e.body.toolNames) ? (e.body.toolNames as unknown[]).filter((x): x is string => typeof x === "string") : [];
+      const prev = finalTools.get(e.correlationId);
+      if (!prev || tn.length > prev.length) finalTools.set(e.correlationId, tn);
+      continue;
+    }
+
+    if (e.topic === "quinn.review.submitted") {
+      const event = str(e.body.event);
+      const repo = `${str(e.body.owner) ?? "?"}/${str(e.body.repo) ?? "?"}`;
+      const r = repoMap.get(repo) ?? { reviews: 0, approve: 0, comment: 0, requestChanges: 0 };
+      r.reviews++;
+      if (event === "APPROVE") { verdicts.APPROVE++; r.approve++; }
+      else if (event === "COMMENT") { verdicts.COMMENT++; r.comment++; }
+      else if (event === "REQUEST_CHANGES") { verdicts.REQUEST_CHANGES++; r.requestChanges++; }
+      repoMap.set(repo, r);
+      continue;
+    }
+  }
+
+  const total = completed + failed;
+
+  latencies.sort((a, b) => a - b);
+  const latencyMs = latencies.length
+    ? {
+        min: latencies[0],
+        median: pct(latencies, 0.5),
+        p90: pct(latencies, 0.9),
+        max: latencies[latencies.length - 1],
+        avg: Math.round(latencies.reduce((s, x) => s + x, 0) / latencies.length),
+      }
+    : null;
+
+  const toolFrequency: Record<string, number> = {};
+  const lens: number[] = [];
+  let clawpatch = 0;
+  for (const seq of finalTools.values()) {
+    lens.push(seq.length);
+    for (const t of seq) toolFrequency[t] = (toolFrequency[t] ?? 0) + 1;
+    if (seq.some((t) => t.includes("clawpatch"))) clawpatch++;
+  }
+  lens.sort((a, b) => a - b);
+  const reviewsProfiled = finalTools.size;
+
+  return {
+    window: {
+      from,
+      to,
+      days: from !== null && to !== null ? Math.max(0, (to - from) / 86_400_000) : 0,
+    },
+    outcomes: {
+      total,
+      completed,
+      failed,
+      completionRate: total ? completed / total : 0,
+      failureModes,
+    },
+    verdicts: { ...verdicts, total: verdicts.APPROVE + verdicts.COMMENT + verdicts.REQUEST_CHANGES },
+    latencyMs,
+    toolUse: {
+      reviewsProfiled,
+      clawpatchReviews: clawpatch,
+      clawpatchRate: reviewsProfiled ? clawpatch / reviewsProfiled : 0,
+      callsPerReview: lens.length ? { median: pct(lens, 0.5), p90: pct(lens, 0.9), max: lens[lens.length - 1] } : null,
+      toolFrequency,
+    },
+    perRepo: [...repoMap.entries()]
+      .map(([repo, r]) => ({ repo, reviews: r.reviews, approve: r.approve, comment: r.comment, requestChanges: r.requestChanges }))
+      .sort((a, b) => b.reviews - a.reviews),
+  };
+}

--- a/workspace/agents/quinn.yaml
+++ b/workspace/agents/quinn.yaml
@@ -230,9 +230,25 @@ skills:
 
       ## Step 2b — Structural review (clawpatch)
 
-      For PRs with non-trivial code changes, also call:
+      Structural review is the default, not the exception. Run:
 
       - `clawpatch_review(repo='owner/name', since='<pr-base>')`
+
+      whenever the `diff_summary` from Step 2 shows ANY of these objective
+      triggers:
+
+      - the diff touches **more than 3 files**, OR
+      - the diff changes **more than ~120 lines** total, OR
+      - any changed path is **security-relevant**: auth, session, token,
+        crypto, payment/billing, a database migration, CI/CD or infra
+        (`.github/`, Dockerfile, compose), or a public API surface.
+
+      Only a genuinely small, contained diff (a few files, a short patch,
+      no sensitive paths — docs, a copy tweak, a config bump) skips
+      clawpatch. When in doubt, run it: the structural pass is the part of
+      the review the diff alone cannot give you, and skipping it is how
+      cross-file bugs slip through. A skipped structural pass on a diff that
+      hit a trigger is a Gap — note it.
 
       Use the PR's base branch (typically `main` or `dev`) as the
       `since` arg so clawpatch only reviews features touched by this PR.
@@ -289,6 +305,31 @@ skills:
       reference must rest on an EXISTS/MISSING fact you actually fetched, or
       it is a Gap, not a severity. Internal-plausibility reasoning ("this
       probably won't resolve") is a Gap until verified.
+
+      ## Step 2d — Scope: what is out of scope for this review
+
+      A review is only as trusted as its signal-to-noise ratio. Findings
+      below the bar train the team to ignore you. Keep these categories OUT
+      of your review entirely — they are out of scope, not low-severity:
+
+      - **Style and formatting** the linter/formatter already owns
+        (spacing, import order, quote style, line length). The toolchain
+        enforces these; restating them is noise.
+      - **Theoretical risks that need unlikely preconditions** — a failure
+        mode that requires an attacker who already has the keys, or an input
+        the type system makes impossible. If the precondition can't happen,
+        the finding isn't real.
+      - **Subjective preferences** dressed as defects ("I'd have used a map
+        here") when the code is correct and readable as written.
+      - **Speculation about code you did not read.** If you can't cite the
+        file:line, it is a Gap, not a finding.
+      - **Findings the PR's own description or an existing CodeRabbit thread
+        already covers** — don't re-litigate a resolved thread.
+
+      Raise a finding when it is correct, grounded in evidence you fetched,
+      and actionable by the author on this PR. Everything else is out of
+      scope. This is task scope, not timidity: a precise review is a louder
+      signal than an exhaustive one.
 
       ## Step 3 — Apply the rubric
 


### PR DESCRIPTION
## Why

A check-in on Quinn (our in-process PR reviewer) paired a due-diligence review of how the field builds code-review agents (Greptile, Cloudflare, Qodo) with live o11y from `events.db`. Two concrete gaps surfaced:

- **~1.6% of reviews hard-fail on the LangGraph recursion limit** (`"Recursion limit of 37 reached…"`) and produce **no verdict** — the PR is left silently unreviewed.
- **clawpatch (her AST/structural pass) fires on only ~5% of PRs** — she's effectively a diff-only reviewer, the architecture the field has moved away from.

This PR addresses both and stands up measurement so we can prove future changes help.

## Changes

**Anti-thrash escalation (P0)** — `lib/plugins/github.ts`
A budget-exhausted review (recursion limit / timeout) now escalates to the operator via `operator.message.request` instead of failing to silence. It deliberately does **not** synthesize a COMMENT review — a `COMMENTED` state would let approve-on-green (#748) auto-approve a PR that was never actually reviewed. New pure gate `isReviewBudgetExhausted` + extracted `_handleOutboundReply`, unit-tested with a stubbed GitHub API (escalate-vs-comment-vs-noop branches).

**Eval harness (P0)** — `src/knowledge/quinn-review-eval.ts` + `scripts/quinn-review-eval.ts`
Pure, unit-tested aggregation over `events.db`: verdict mix, completion/failure-mode breakdown, clawpatch rate, latency, tool profile, per-repo. Run: `bun scripts/quinn-review-eval.ts [events.db]`. This is the baseline. Live snapshot today: 1494 runs, 98.5% complete, 22/23 failures = recursion_limit, clawpatch 5.6%, formal verdicts 81.7% COMMENT.

**clawpatch gating** — `workspace/agents/quinn.yaml`
The `pr_review` prompt now triggers the structural pass on objective signals (>3 files / >120 lines / security-relevant paths) instead of the model's "is this non-trivial?" judgement, which was under-firing it.

**Prompt policy** — `workspace/agents/quinn.yaml`
Added an explicit out-of-scope ("what NOT to flag") list — the field's highest-ROI noise lever (Cloudflare). Scoped exception to the no-negative-reinforcement house rule (task specification, not behavioral coaching); rationale in the doc.

**Doc** — `docs/explanation/code-review-agent-design.md`
The full benchmark vs the field + prioritized roadmap (P1 re-review memory, P2 repo-convention memory + eval were left as follow-ups).

## Verification
- `bun test`: **1110 pass, 0 fail** (incl. `NODE_ENV=production`)
- `bunx tsc --noEmit` clean; `bun run lint` clean on changed files
- Eval harness validated against the live `events.db` snapshot

## Deploy notes
`quinn.yaml` hot-reloads (no restart). `github.ts` ships via the image (watchtower). Docs publish via `docs-deploy.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive design documentation for Quinn PR-review agent, including performance metrics and architectural analysis.

* **New Features**
  * Automatic escalation to human reviewers when review analysis budget is exhausted, preventing stuck PRs.
  * Enhanced review scope with explicit guidelines on excluded categories (style, theoretical risks, subjective preferences).

* **Improvements**
  * Added performance monitoring and metrics tracking for review outcomes and failure modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->