### PR TITLE
feat(o11y): attribute Quinn review failures to their PR

### DIFF
--- a/scripts/quinn-review-eval.ts
+++ b/scripts/quinn-review-eval.ts
@@ -87,9 +87,10 @@ for (const [t, n] of Object.entries(s.toolUse.toolFrequency).sort((a, b) => b[1]
 }
 
 if (s.perRepo.length) {
-  console.log("\nPER-REPO (top 8)");
-  for (const r of s.perRepo.slice(0, 8)) {
-    console.log(`  ${r.repo.padEnd(32)} ${r.reviews} reviews  (A${r.approve}/C${r.comment}/RC${r.requestChanges})`);
+  console.log("\nPER-REPO (top 10)");
+  for (const r of s.perRepo.slice(0, 10)) {
+    const fail = r.failures ? `  FAIL ${r.failures}` : "";
+    console.log(`  ${r.repo.padEnd(32)} ${r.reviews} reviews  (A${r.approve}/C${r.comment}/RC${r.requestChanges})${fail}`);
   }
 }
 console.log("");

--- a/src/event-bus/payloads.ts
+++ b/src/event-bus/payloads.ts
@@ -412,6 +412,13 @@ export interface AutonomousOutcomePayload {
    * the default rate otherwise.
    */
   model?: string;
+  /**
+   * GitHub PR coordinates when the dispatch originated from a PR (auto-review).
+   * Lets failure analysis attribute a stuck review to a specific PR — without
+   * this a recursion-limit/timeout review emits no quinn.review.submitted and
+   * carried no traceable parentId, so it was invisible per-PR (#843 follow-up).
+   */
+  github?: { owner: string; repo: string; number: number };
   /** World-state delta produced by this task — populated in Arc 4/5. */
   effectDelta?: Record<string, unknown>;
 }

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -316,6 +316,15 @@ export class SkillDispatcherPlugin implements Plugin {
 
     const rawContent = typeof payload.content === "string" ? payload.content : undefined;
 
+    // GitHub PR coordinates, when this dispatch came from an auto-review. Stamped
+    // onto every autonomous.outcome so a failed (recursion-limit/timeout) review —
+    // which emits no quinn.review.submitted — is still attributable to its PR.
+    const ghDispatch = payload.github as { owner?: unknown; repo?: unknown; number?: unknown } | undefined;
+    const githubCoords =
+      typeof ghDispatch?.owner === "string" && typeof ghDispatch?.repo === "string" && typeof ghDispatch?.number === "number"
+        ? { owner: ghDispatch.owner, repo: ghDispatch.repo, number: ghDispatch.number }
+        : undefined;
+
     const agentName = targets[0] ?? "";
 
     const req: SkillRequest = {
@@ -400,6 +409,7 @@ export class SkillDispatcherPlugin implements Plugin {
               text: content,
               durationMs: Date.now() - dispatchedAt,
               model: requestedModel,
+              github: githubCoords,
             });
 
             const gh = payload.github as { title?: string; owner?: string; repo?: string; number?: number; url?: string } | undefined;
@@ -482,6 +492,7 @@ export class SkillDispatcherPlugin implements Plugin {
           usage: result.data?.usage,
           durationMs: Date.now() - dispatchedAt,
           model: requestedModel,
+          github: githubCoords,
         });
       } else {
         // Log a preview of the response so we can see what the executor actually
@@ -582,6 +593,7 @@ export class SkillDispatcherPlugin implements Plugin {
           usage: result.data?.usage,
           durationMs,
           model: requestedModel,
+          github: githubCoords,
         });
       }
 
@@ -634,6 +646,7 @@ export class SkillDispatcherPlugin implements Plugin {
         text: errorMsg,
         durationMs: Date.now() - dispatchedAt,
         model: requestedModel,
+        github: githubCoords,
       });
       this._publishResponse(replyTopic, correlationId, undefined, errorMsg);
     } finally {
@@ -697,6 +710,7 @@ export class SkillDispatcherPlugin implements Plugin {
     usage?: AutonomousOutcomePayload["usage"];
     durationMs: number;
     model?: string;
+    github?: { owner: string; repo: string; number: number };
   }): void {
     if (!this.bus) return;
     // Prometheus metrics — the single per-outcome chokepoint (#800). Labels are
@@ -718,6 +732,7 @@ export class SkillDispatcherPlugin implements Plugin {
       usage: opts.usage,
       durationMs: opts.durationMs,
       model: opts.model,
+      github: opts.github,
     };
     this.bus.publish(topic, {
       id: crypto.randomUUID(),

--- a/src/knowledge/__tests__/quinn-review-eval.test.ts
+++ b/src/knowledge/__tests__/quinn-review-eval.test.ts
@@ -3,7 +3,10 @@ import { classifyFailure, computeQuinnReviewStats, type EvalEvent } from "../qui
 
 const T0 = 1_780_000_000_000;
 
-function outcome(success: boolean, opts: { ms?: number; error?: string; ts?: number } = {}): EvalEvent {
+function outcome(
+  success: boolean,
+  opts: { ms?: number; error?: string; ts?: number; github?: { owner: string; repo: string; number: number } } = {},
+): EvalEvent {
   return {
     topic: "autonomous.outcome.user.pr_review",
     ts: opts.ts ?? T0,
@@ -14,6 +17,7 @@ function outcome(success: boolean, opts: { ms?: number; error?: string; ts?: num
       taskState: success ? "completed" : "failed",
       durationMs: opts.ms,
       ...(opts.error ? { error: opts.error } : {}),
+      ...(opts.github ? { github: opts.github } : {}),
     },
   };
 }
@@ -109,6 +113,23 @@ describe("computeQuinnReviewStats", () => {
     expect(s.perRepo[0].repo).toBe("protoLabsAI/ORBIS");
     expect(s.perRepo[0].reviews).toBe(3);
     expect(s.perRepo[0].approve).toBe(2);
+  });
+
+  test("failed reviews attribute to their repo via github coords (failure-only repo appears)", () => {
+    const events = [
+      submitted("protoLabsAI", "ORBIS", "COMMENT"),
+      // a stuck review in a repo with no submitted verdict — must still surface
+      outcome(false, { error: "Recursion limit of 37 reached", github: { owner: "protoLabsAI", repo: "protoMaker", number: 9 } }),
+      outcome(false, { error: "The operation timed out.", github: { owner: "protoLabsAI", repo: "protoMaker", number: 12 } }),
+      outcome(false, { error: "Recursion limit of 37 reached", github: { owner: "protoLabsAI", repo: "ORBIS", number: 5 } }),
+    ];
+    const s = computeQuinnReviewStats(events);
+    const byRepo = Object.fromEntries(s.perRepo.map((r) => [r.repo, r]));
+    expect(byRepo["protoLabsAI/protoMaker"].failures).toBe(2);
+    expect(byRepo["protoLabsAI/protoMaker"].reviews).toBe(0); // no formal verdict, failure-only
+    expect(byRepo["protoLabsAI/ORBIS"].failures).toBe(1);
+    expect(byRepo["protoLabsAI/ORBIS"].reviews).toBe(1);
+    expect(s.outcomes.failed).toBe(3);
   });
 
   test("empty input degrades cleanly", () => {

--- a/src/knowledge/quinn-review-eval.ts
+++ b/src/knowledge/quinn-review-eval.ts
@@ -51,7 +51,7 @@ export interface QuinnReviewStats {
     callsPerReview: { median: number; p90: number; max: number } | null;
     toolFrequency: Record<string, number>;
   };
-  perRepo: Array<{ repo: string; reviews: number; approve: number; comment: number; requestChanges: number }>;
+  perRepo: Array<{ repo: string; reviews: number; approve: number; comment: number; requestChanges: number; failures: number }>;
 }
 
 const PR_REVIEW_OUTCOME = /^autonomous\.outcome\..*\.pr_review$/;
@@ -96,6 +96,8 @@ export function computeQuinnReviewStats(events: EvalEvent[]): QuinnReviewStats {
   // ── verdicts / per-repo (from quinn.review.submitted) ──────────────────────
   const verdicts = { APPROVE: 0, COMMENT: 0, REQUEST_CHANGES: 0 };
   const repoMap = new Map<string, { reviews: number; approve: number; comment: number; requestChanges: number }>();
+  // ── failure attribution per repo (from the outcome's github coords) ────────
+  const repoFailures = new Map<string, number>();
 
   for (const e of events) {
     if (e.ts) {
@@ -113,6 +115,11 @@ export function computeQuinnReviewStats(events: EvalEvent[]): QuinnReviewStats {
         failed++;
         const mode = classifyFailure(str(e.body.error) ?? str(e.body.textPreview));
         failureModes[mode] = (failureModes[mode] ?? 0) + 1;
+        const gh = e.body.github as { owner?: unknown; repo?: unknown } | undefined;
+        if (typeof gh?.owner === "string" && typeof gh?.repo === "string") {
+          const repo = `${gh.owner}/${gh.repo}`;
+          repoFailures.set(repo, (repoFailures.get(repo) ?? 0) + 1);
+        }
       }
       continue;
     }
@@ -183,8 +190,11 @@ export function computeQuinnReviewStats(events: EvalEvent[]): QuinnReviewStats {
       callsPerReview: lens.length ? { median: pct(lens, 0.5), p90: pct(lens, 0.9), max: lens[lens.length - 1] } : null,
       toolFrequency,
     },
-    perRepo: [...repoMap.entries()]
-      .map(([repo, r]) => ({ repo, reviews: r.reviews, approve: r.approve, comment: r.comment, requestChanges: r.requestChanges }))
-      .sort((a, b) => b.reviews - a.reviews),
+    perRepo: [...new Set([...repoMap.keys(), ...repoFailures.keys()])]
+      .map((repo) => {
+        const r = repoMap.get(repo) ?? { reviews: 0, approve: 0, comment: 0, requestChanges: 0 };
+        return { repo, reviews: r.reviews, approve: r.approve, comment: r.comment, requestChanges: r.requestChanges, failures: repoFailures.get(repo) ?? 0 };
+      })
+      .sort((a, b) => b.reviews + b.failures - (a.reviews + a.failures)),
   };
 }


### PR DESCRIPTION
## Why

Follow-up to #843. Diagnosing *where* Quinn gets stuck hit a wall: **all 23 recursion-limit / timeout review failures had an empty `parent_id`** and emit no `quinn.review.submitted` (no review was submitted), so they were **untraceable to a PR**. The failures we most want to analyze were invisible per-repo.

## Change

Stamp the dispatch's GitHub coordinates (`{owner, repo, number}`) onto every `autonomous.outcome.*` event. The eval harness then attributes failures per repo (failure-only repos surface too), turning "which repos/PRs thrash?" from a dead end into a data question.

- `payloads.ts` — `AutonomousOutcomePayload.github`
- `skill-dispatcher-plugin.ts` — extract `githubCoords` once from `payload.github`, stamp all 4 outcome emit sites (success + error + A2A-async + throw)
- `quinn-review-eval.ts` — per-repo `failures` count; unions failure-only repos into `perRepo`
- `scripts/quinn-review-eval.ts` — PER-REPO line shows `FAIL n`

Additive payload field; no behavior change to dispatch. Helps **future** failures (historical ones stay untraceable), so the next data-driven call (re-review memory vs the clawpatch gating already shipped) can rest on real attribution.

## Verification
- `bun test`: **1111 pass, 0 fail** (incl. `NODE_ENV=production`)
- `tsc --noEmit` + `bun run lint` clean
- New unit test covers per-repo failure attribution incl. a failure-only repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved failure attribution: Failures are now properly tracked and assigned to their originating repositories, improving visibility into code quality and review outcomes
  * Enhanced repository metrics: Per-repository reports now include failure counts alongside review verdict statistics for more complete metrics
  * Better failure visibility: Repositories with failures are now clearly indicated in summary reports for easier identification and analysis
  * Expanded reports: Reports now showcase the top 10 repositories rather than fewer, giving broader visibility into project status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->