### PR TITLE
[github] FeatureRemediationPlugin never clears its tracker on feature recovery — `feature.unblocked` has no e

### DIFF
--- a/lib/plugins/__tests__/feature-remediation.test.ts
+++ b/lib/plugins/__tests__/feature-remediation.test.ts
@@ -164,7 +164,7 @@ describe("FeatureRemediationPlugin", () => {
     plugin.uninstall();
   });
 
-  it("clears the tracker on feature.unblocked so a re-block gets a fresh budget", () => {
+  it("clears the tracker on feature.completed so a re-block gets a fresh budget", () => {
     const bus = new InMemoryEventBus();
     const clock = fakeClock();
     const plugin = new FeatureRemediationPlugin({ now: clock.now });
@@ -174,16 +174,41 @@ describe("FeatureRemediationPlugin", () => {
     publishBlocked(bus, blocked({ kind: "ci_failure" }));
     expect(dispatches).toHaveLength(1);
 
-    // Feature recovered.
-    bus.publish("feature.unblocked", {
+    // Feature recovered — feature.completed is the event protoMaker actually emits.
+    bus.publish("feature.completed", {
       id: crypto.randomUUID(),
       correlationId: crypto.randomUUID(),
-      topic: "feature.unblocked",
+      topic: "feature.completed",
       timestamp: 0,
       payload: blocked(),
     });
 
     // Re-block immediately — fresh budget means an immediate dispatch (no cooldown carryover).
+    publishBlocked(bus, blocked({ kind: "ci_failure" }));
+    expect(dispatches).toHaveLength(2);
+    plugin.uninstall();
+  });
+
+  it("clears the tracker on feature.failed so a re-block gets a fresh budget", () => {
+    const bus = new InMemoryEventBus();
+    const clock = fakeClock();
+    const plugin = new FeatureRemediationPlugin({ now: clock.now });
+    plugin.install(bus);
+    const dispatches = capture(bus, "agent.skill.request");
+
+    publishBlocked(bus, blocked({ kind: "ci_failure" }));
+    expect(dispatches).toHaveLength(1);
+
+    // Feature failed — also clears the tracker.
+    bus.publish("feature.failed", {
+      id: crypto.randomUUID(),
+      correlationId: crypto.randomUUID(),
+      topic: "feature.failed",
+      timestamp: 0,
+      payload: blocked(),
+    });
+
+    // Re-block immediately — fresh budget.
     publishBlocked(bus, blocked({ kind: "ci_failure" }));
     expect(dispatches).toHaveLength(2);
     plugin.uninstall();

--- a/lib/plugins/feature-remediation.ts
+++ b/lib/plugins/feature-remediation.ts
@@ -82,11 +82,19 @@ export class FeatureRemediationPlugin implements Plugin {
   install(bus: EventBus): void {
     this.bus = bus;
     this.subscriptionIds.push(bus.subscribe("feature.blocked", this.name, (msg) => this._onBlocked(msg)));
-    // A recovered feature clears its tracker so a later re-block starts fresh.
-    this.subscriptionIds.push(bus.subscribe("feature.unblocked", this.name, (msg) => {
+
+    // Terminal or recovery signals — clear the tracker so a later re-block
+    // starts with a fresh attempt budget.  `feature.completed` and
+    // `feature.failed` are the actual events protoMaker emits today;
+    // `feature.unblocked` is kept for when protoMaker adds that emitter.
+    const evict = (msg: BusMessage) => {
       const p = msg.payload as FeatureBlockedPayload;
       this.tracked.delete(this._key(p));
-    }));
+    };
+    this.subscriptionIds.push(bus.subscribe("feature.unblocked", this.name, evict));
+    this.subscriptionIds.push(bus.subscribe("feature.completed", this.name, evict));
+    this.subscriptionIds.push(bus.subscribe("feature.failed", this.name, evict));
+
     this.sweepTimer = setInterval(() => this._sweep(), ENTRY_TTL_MS);
     this.sweepTimer.unref?.();
     log.info("installed — routing feature.blocked");


### PR DESCRIPTION
## Summary

# [github] FeatureRemediationPlugin never clears its tracker on feature recovery — `feature.unblocked` has no e

## Situation
This feature was requested but PRD generation encountered an issue.

## Problem
FeatureRemediationPlugin never clears its tracker on feature recovery — `feature.unblocked` has no emitter

## Stale-state bug (verified on `origin/main`)

`FeatureRemediationPlugin` keeps a per-feature `tracked` map of `{attempts, escalated, lastAttemptAt, lastSeenAt}` (`lib/plugins/feature-r...

Closes #783

---
*Created automatically by Automaker*

<!-- automaker:owner instance=ef15d09b-b02a-4f05-bb57-fcc898070dd7 team= created=2026-06-06T20:40:10.869Z -->