### PR TITLE
[github] Stale GitHub issues: no issue close/comment/label tooling — triage can open but never resolve

### DIFF
--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -548,6 +548,197 @@ export function createRoutes(ctx: ApiContext): Route[] {
   // Aggregate open issue counts per repo for issue-tracking dashboards.
   // Polls `/repos/{repo}/issues?state=open` and classifies by label priority.
 
+  /** Shared guard: reject mutations on repos not in the project registry. */
+  function requireManagedRepo(repo: string): Response | null {
+    const managed = repos();
+    if (!managed.includes(repo)) {
+      return Response.json(
+        { success: false, error: `Repo "${repo}" is not in the project registry` },
+        { status: 403 },
+      );
+    }
+    return null;
+  }
+
+  /** Shared guard: reject if API key configured but doesn't match. */
+  function requireApiKey(req: Request): Response | null {
+    if (ctx.apiKey && req.headers.get("X-API-Key") !== ctx.apiKey) {
+      return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+    }
+    return null;
+  }
+
+  async function handleCloseIssue(req: Request): Promise<Response> {
+    const authErr = requireApiKey(req);
+    if (authErr) return authErr;
+    if (!GITHUB_TOKEN) return Response.json({ success: false, error: "GITHUB_TOKEN not set" }, { status: 500 });
+
+    let body: Record<string, unknown>;
+    try { body = (await req.json()) as Record<string, unknown>; }
+    catch { return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 }); }
+
+    const repo = body.repo as string | undefined;
+    const number = body.number as number | undefined;
+    const comment = body.comment as string | undefined;
+    const reason = (body.reason as "completed" | "not_planned") ?? "completed";
+
+    if (!repo || typeof number !== "number") {
+      return Response.json({ success: false, error: "repo and number are required" }, { status: 400 });
+    }
+
+    const forbidden = requireManagedRepo(repo);
+    if (forbidden) return forbidden;
+
+    try {
+      // Post explanatory comment first (non-fatal if it fails)
+      if (comment && comment.trim()) {
+        try {
+          const commentResp = await ghHttp.fetch(
+            `https://api.github.com/repos/${repo}/issues/${number}/comments`,
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Accept: "application/vnd.github+json",
+                Authorization: `Bearer ${GITHUB_TOKEN}`,
+                "X-GitHub-Api-Version": "2022-11-28",
+              },
+              body: JSON.stringify({ body: comment }),
+            },
+          );
+          if (!commentResp.ok) {
+            log.warn(`close_issue: comment failed (${commentResp.status}), proceeding with close`);
+          }
+        } catch (e) {
+          log.warn(`close_issue: comment failed (${String(e).slice(0, 200)}), proceeding with close`);
+        }
+      }
+
+      const closeBody: Record<string, unknown> = { state: "closed", state_reason: reason };
+      const resp = await ghHttp.fetch(`https://api.github.com/repos/${repo}/issues/${number}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/vnd.github+json",
+          Authorization: `Bearer ${GITHUB_TOKEN}`,
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+        body: JSON.stringify(closeBody),
+      });
+
+      if (!resp.ok) {
+        const errText = await resp.text().catch(() => "(no body)");
+        return Response.json({ success: false, error: `GitHub API: ${resp.status} ${errText}` }, { status: resp.status });
+      }
+
+      return Response.json({
+        success: true,
+        data: { repo, number, reason },
+      });
+    } catch (e) {
+      return Response.json({ success: false, error: String(e) }, { status: 502 });
+    }
+  }
+
+  async function handleCommentIssue(req: Request): Promise<Response> {
+    const authErr = requireApiKey(req);
+    if (authErr) return authErr;
+    if (!GITHUB_TOKEN) return Response.json({ success: false, error: "GITHUB_TOKEN not set" }, { status: 500 });
+
+    let body: Record<string, unknown>;
+    try { body = (await req.json()) as Record<string, unknown>; }
+    catch { return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 }); }
+
+    const repo = body.repo as string | undefined;
+    const number = body.number as number | undefined;
+    const body_ = body.body as string | undefined;
+
+    if (!repo || typeof number !== "number" || !body_) {
+      return Response.json({ success: false, error: "repo, number, and body are required" }, { status: 400 });
+    }
+
+    const forbidden = requireManagedRepo(repo);
+    if (forbidden) return forbidden;
+
+    try {
+      const resp = await ghHttp.fetch(
+        `https://api.github.com/repos/${repo}/issues/${number}/comments`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/vnd.github+json",
+            Authorization: `Bearer ${GITHUB_TOKEN}`,
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+          body: JSON.stringify({ body: body_ }),
+        },
+      );
+
+      if (!resp.ok) {
+        const errText = await resp.text().catch(() => "(no body)");
+        return Response.json({ success: false, error: `GitHub API: ${resp.status} ${errText}` }, { status: resp.status });
+      }
+
+      const result = await resp.json() as { html_url: string };
+      return Response.json({
+        success: true,
+        data: { repo, number, html_url: result.html_url },
+      });
+    } catch (e) {
+      return Response.json({ success: false, error: String(e) }, { status: 502 });
+    }
+  }
+
+  async function handleLabelIssue(req: Request): Promise<Response> {
+    const authErr = requireApiKey(req);
+    if (authErr) return authErr;
+    if (!GITHUB_TOKEN) return Response.json({ success: false, error: "GITHUB_TOKEN not set" }, { status: 500 });
+
+    let body: Record<string, unknown>;
+    try { body = (await req.json()) as Record<string, unknown>; }
+    catch { return Response.json({ success: false, error: "Invalid JSON" }, { status: 400 }); }
+
+    const repo = body.repo as string | undefined;
+    const number = body.number as number | undefined;
+    const labels = body.labels as string[] | undefined;
+
+    if (!repo || typeof number !== "number" || !labels) {
+      return Response.json({ success: false, error: "repo, number, and labels are required" }, { status: 400 });
+    }
+
+    const forbidden = requireManagedRepo(repo);
+    if (forbidden) return forbidden;
+
+    try {
+      const resp = await ghHttp.fetch(
+        `https://api.github.com/repos/${repo}/issues/${number}/labels`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/vnd.github+json",
+            Authorization: `Bearer ${GITHUB_TOKEN}`,
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+          body: JSON.stringify({ names: labels }),
+        },
+      );
+
+      if (!resp.ok) {
+        const errText = await resp.text().catch(() => "(no body)");
+        return Response.json({ success: false, error: `GitHub API: ${resp.status} ${errText}` }, { status: resp.status });
+      }
+
+      return Response.json({
+        success: true,
+        data: { repo, number, labels },
+      });
+    } catch (e) {
+      return Response.json({ success: false, error: String(e) }, { status: 502 });
+    }
+  }
+
   async function handleGetGithubIssues(): Promise<Response> {
     const repoList = repos();
     if (!repoList.length || !GITHUB_TOKEN) return Response.json({
@@ -713,5 +904,8 @@ export function createRoutes(ctx: ApiContext): Route[] {
     { method: "GET",  path: "/api/github-issues",      handler: () => handleGetGithubIssues() },
     { method: "GET",  path: "/api/recent-activity",    handler: (req) => handleGetRecentActivity(req) },
     { method: "POST", path: "/api/github/issues",      handler: (req) => handleCreateIssue(req) },
+    { method: "POST", path: "/api/github/issues/close",      handler: (req) => handleCloseIssue(req) },
+    { method: "POST", path: "/api/github/issues/comment",    handler: (req) => handleCommentIssue(req) },
+    { method: "POST", path: "/api/github/issues/label",      handler: (req) => handleLabelIssue(req) },
   ];
 }

--- a/src/api/linear.ts
+++ b/src/api/linear.ts
@@ -19,6 +19,7 @@ import type { Route, ApiContext } from "./types.ts";
 import { LinearClient, type LinearPriority } from "../../lib/linear-client.ts";
 import { getLinearAvaTokenManager } from "../../lib/linear/ava-oauth-token-manager.ts";
 import { LinearAgentActivityClient } from "../../lib/linear/agent-activity-client.ts";
+import { normalizeIssueTitle as normalizeLinearTitle } from "./github.ts";
 import { logger } from "../../lib/log.ts";
 
 const log = logger("api-linear");
@@ -168,6 +169,44 @@ export function createRoutes(ctx: ApiContext): Route[] {
           return Response.json({ success: false, error: `invalid priority — must be one of urgent/high/medium/low/none` }, { status: 400 });
         }
         return withClient(async (c) => {
+          // ── Dedup guard ──────────────────────────────────────────────────────
+          // Port of the GitHub title-normalized dedup. Search for recent open
+          // issues in the same team with a matching normalized title. Like the
+          // GitHub path, this prevents any future ceremony/loop wired to this
+          // endpoint from duplicating every run.
+          const wantTitle = normalizeLinearTitle(input.title!);
+          try {
+            const recent = await c.listIssues({
+              teamKey: input.teamKey!,
+              max: 50,
+            });
+            const dedupWindowMs = 6 * 60 * 60 * 1000;
+            const now = Date.now();
+            const match = recent.find((i) => {
+              if (normalizeLinearTitle(i.title) !== wantTitle) return false;
+              // Only block on open issues, or recently created closed issues
+              if (i.state.toLowerCase() !== "cancelled" && i.state.toLowerCase() !== "done") return true;
+              const age = now - new Date(i.updatedAt).getTime();
+              return age < dedupWindowMs;
+            });
+            if (match) {
+              log.info(
+                `linear create dedup: skipping "${input.title}" — existing ${match.identifier} (${match.state}) matches`,
+              );
+              return {
+                id: match.id,
+                teamKey: input.teamKey,
+                title: input.title,
+                deduped: true,
+                existingIdentifier: match.identifier,
+                existingState: match.state,
+              };
+            }
+          } catch (e) {
+            // Dedup is best-effort — proceed with create on failure
+            log.warn(`linear create dedup lookup failed (proceeding): ${String(e).slice(0, 200)}`);
+          }
+
           const id = await c.createIssue({
             teamKey: input.teamKey!,
             title: input.title!,

--- a/src/executor/executors/deep-agent-executor.ts
+++ b/src/executor/executors/deep-agent-executor.ts
@@ -402,6 +402,45 @@ export function createLangChainTools(toolNames: string[], http: HttpClient, corr
         }),
       },
     ),
+    close_github_issue: tool(
+      async (input) => JSON.stringify(await http.post("/api/github/issues/close", input)),
+      {
+        name: "close_github_issue",
+        description:
+          "Close an existing GitHub issue on a managed repo. Optionally posts a comment explaining the close. " +
+          "Use `reason: 'not_planned'` for stale, superseded, or resolved-differently closes. Default is 'completed'.",
+        schema: z.object({
+          repo: z.string().describe("Repository in owner/name format."),
+          number: z.number().int().describe("Issue number."),
+          comment: z.string().optional().describe("Explanatory comment posted before closing (recommended)."),
+          reason: z.enum(["completed", "not_planned"]).optional().describe("Close reason: 'completed' (default) or 'not_planned' (stale/superseded)."),
+        }),
+      },
+    ),
+    comment_github_issue: tool(
+      async (input) => JSON.stringify(await http.post("/api/github/issues/comment", input)),
+      {
+        name: "comment_github_issue",
+        description: "Post a comment on an existing GitHub issue.",
+        schema: z.object({
+          repo: z.string().describe("Repository in owner/name format."),
+          number: z.number().int().describe("Issue number."),
+          body: z.string().describe("Comment text."),
+        }),
+      },
+    ),
+    label_github_issue: tool(
+      async (input) => JSON.stringify(await http.post("/api/github/issues/label", input)),
+      {
+        name: "label_github_issue",
+        description: "Set (replace all) labels on an existing GitHub issue. Replaces any existing labels with the provided list.",
+        schema: z.object({
+          repo: z.string().describe("Repository in owner/name format."),
+          number: z.number().int().describe("Issue number."),
+          labels: z.array(z.string()).describe("Full list of labels to set (replaces existing)."),
+        }),
+      },
+    ),
     manage_cron: tool(
       async (input) => {
         if (input.action === "list") return JSON.stringify(await http.get("/api/ceremonies"));

--- a/workspace/agents/quinn.yaml
+++ b/workspace/agents/quinn.yaml
@@ -150,6 +150,9 @@ tools:
   - get_incidents
   # Issue filing + escalation
   - create_github_issue
+  - close_github_issue
+  - comment_github_issue
+  - label_github_issue
   - report_incident
   # Web search for verifying behavior against current library docs
   - searxng_search
@@ -453,6 +456,9 @@ skills:
       - pr_inspector
       - clawpatch_review
       - create_github_issue
+      - close_github_issue
+      - comment_github_issue
+      - label_github_issue
       - searxng_search
       - react
       - send_update
@@ -509,12 +515,12 @@ skills:
 
       ## Step 5 — Act
 
-      - Close stale issues with an explanation (use `create_github_issue`
-        — there's no separate close-issue tool yet; file a follow-up
-        ticket if needed and note in Observations)
-      - Comment on already_fixed issues with the commit that resolved them
-      - Label actionable issues with severity
-      - Flag duplicates with a link to the canonical issue
+      - **already_fixed**: Close the issue with `close_github_issue(repo, number, comment, reason='completed')`. The comment must cite the commit or PR that resolved it.
+      - **stale**: Close with `close_github_issue(repo, number, comment, reason='not_planned')`. Explain why (no activity, no reproduction steps, affected code removed).
+      - **actionable**: Label with `label_github_issue(repo, number, labels=[...])` using severity labels (e.g. `["bug", "high"]`). Comment with next steps if needed.
+      - **duplicate**: Comment on the duplicate with `comment_github_issue` linking to the canonical issue, then close it with `close_github_issue(reason='not_planned')`.
+
+      **Always use the dedicated tools** — `close_github_issue`, `comment_github_issue`, and `label_github_issue`. Do NOT file a follow-up ticket via `create_github_issue` to request a close — that's the cascade pattern from #556.
 
       ## Step 6 — Report
 


### PR DESCRIPTION
## Summary

# [github] Stale GitHub issues: no issue close/comment/label tooling — triage can open but never resolve

## Situation
This feature was requested but PRD generation encountered an issue.

## Problem
Stale GitHub issues: no issue close/comment/label tooling — triage can open but never resolve

## Stale-issue bug (verified on `origin/main`)

protoWorkstacean can **open** GitHub issues (`create_github_issue` tool → `POST /api/github/issues`, `src/api/github.ts`) but there is **no close, comment-on-...

Closes #784

---
*Created automatically by Automaker*

<!-- automaker:owner instance=ef15d09b-b02a-4f05-bb57-fcc898070dd7 team= created=2026-06-06T21:15:37.537Z -->