### PR TITLE
[github] Unbounded in-memory state on the dispatch hot path (process-lifetime leaks)

### DIFF
--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -164,6 +164,9 @@ export class SkillDispatcherPlugin implements Plugin {
    */
   private readonly lastDispatchAt = new Map<string, number>();
 
+  /** Counter for periodic sweep of expired cooldown keys. */
+  private _cooldownDispatchesSinceSweep = 0;
+
   constructor(
     private readonly registry: ExecutorRegistry,
     workspaceDir: string,
@@ -267,9 +270,10 @@ export class SkillDispatcherPlugin implements Plugin {
     const cooldownMs = cooldownMsFor(skill);
     if (cooldownMs > 0) {
       const key = cooldownKeyFor(skill, payload as Record<string, unknown>);
+      const now = Date.now();
       const last = this.lastDispatchAt.get(key);
-      if (last !== undefined && Date.now() - last < cooldownMs) {
-        const elapsed = Date.now() - last;
+      if (last !== undefined && now - last < cooldownMs) {
+        const elapsed = now - last;
         const remaining = cooldownMs - elapsed;
         this.activeExecutions.delete(correlationId);
         const dropMsg = `Cooldown drop: "${key}" dispatched ${elapsed}ms ago (window=${cooldownMs}ms, ${remaining}ms remaining)`;
@@ -284,7 +288,15 @@ export class SkillDispatcherPlugin implements Plugin {
         this._publishResponse(replyTopic, correlationId, undefined, `Cooldown: ${key} (${remaining}ms remaining)`);
         return;
       }
-      this.lastDispatchAt.set(key, Date.now());
+      // Lazy-evict: if the stored timestamp is older than the cooldown window,
+      // the key is no longer useful — delete it to prevent unbounded growth.
+      if (last !== undefined && now - last >= cooldownMs) {
+        this.lastDispatchAt.delete(key);
+      }
+      this.lastDispatchAt.set(key, now);
+      // Sweep: periodically purge any expired keys across the entire map.
+      // Runs at most once per 100 dispatches to avoid O(N) scan on every hit.
+      this._maybeSweepCooldownMap();
     }
 
     log.info(
@@ -889,5 +901,32 @@ export class SkillDispatcherPlugin implements Plugin {
       timestamp: Date.now(),
       payload,
     });
+  }
+
+  /**
+   * Periodically sweep the cooldown map to remove expired keys.
+   * Runs after every 100 cooldown-gated dispatches to prevent unbounded growth.
+   * Max cooldown is 60s (security_triage default), so any key older than that
+   * is safe to evict regardless of which skill it belongs to.
+   */
+  private _maybeSweepCooldownMap(): void {
+    this._cooldownDispatchesSinceSweep++;
+    if (this._cooldownDispatchesSinceSweep < 100) return;
+    this._cooldownDispatchesSinceSweep = 0;
+
+    const now = Date.now();
+    // Max cooldown across all shipped skills is 60s (security_triage).
+    // Any key older than that is expired for every possible skill.
+    const maxCooldownMs = 60_000;
+    let pruned = 0;
+    for (const [key, last] of this.lastDispatchAt) {
+      if (now - last >= maxCooldownMs) {
+        this.lastDispatchAt.delete(key);
+        pruned++;
+      }
+    }
+    if (pruned > 0) {
+      log.info(`cooldown sweep: pruned ${pruned} expired key(s), ${this.lastDispatchAt.size} remaining`);
+    }
   }
 }

--- a/src/executor/task-tracker.ts
+++ b/src/executor/task-tracker.ts
@@ -413,6 +413,11 @@ export class TaskTracker {
         );
       }
     }
+
+    // Evict immediately after extraction — the set entry has served its
+    // idempotency purpose and serves no further role. This prevents unbounded
+    // growth across the process lifetime.
+    this.publishedDeltaTaskIds.delete(taskId);
   }
 
   private _publishResponse(

--- a/src/plugins/CeremonyPlugin.ts
+++ b/src/plugins/CeremonyPlugin.ts
@@ -375,6 +375,12 @@ export class CeremonyPlugin implements Plugin {
       const skillRequestTopic = "agent.skill.request";
       const replyTopic = `agent.skill.response.${context.runId}`;
 
+      // Always use a timeout to guarantee the subscription is torn down.
+      // Without a timeout, ceremonies that set no timeoutMs leak one bus
+      // subscription and a dangling promise per cron tick when no response
+      // is published to the reply topic.
+      const timeoutMs = ceremony.timeoutMs ?? 10 * 60_000; // default: 10 min
+
       const skillResult = await new Promise<string | null>((resolve) => {
         let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -396,13 +402,11 @@ export class CeremonyPlugin implements Plugin {
           resolve(payload?.content ?? null);
         });
 
-        // Set up per-ceremony timeout only if configured
-        if (ceremony.timeoutMs !== undefined) {
-          timeoutTimer = setTimeout(() => {
-            this.bus?.unsubscribe(subId);
-            resolve(null);
-          }, ceremony.timeoutMs);
-        }
+        // Always arm a timeout to guarantee the subscription is torn down.
+        timeoutTimer = setTimeout(() => {
+          this.bus?.unsubscribe(subId);
+          resolve(null);
+        }, timeoutMs);
 
         // Publish skill request
         this.bus!.publish(skillRequestTopic, {
@@ -424,10 +428,10 @@ export class CeremonyPlugin implements Plugin {
         });
       });
 
-      if (skillResult === null && !error && ceremony.timeoutMs !== undefined) {
-        // Per-ceremony timeout fired
+      if (skillResult === null && !error) {
+        // Timeout fired — subscription resolved with null
         status = "timeout";
-        error = `Skill dispatch timed out after ${ceremony.timeoutMs / 1000}s`;
+        error = `Skill dispatch timed out after ${timeoutMs / 1000}s`;
         log.warn(`Skill dispatch timeout for ${ceremony.id} (run ${context.runId})`);
       }
     } catch (err) {

--- a/src/plugins/dispatch-drop-escalator-plugin.ts
+++ b/src/plugins/dispatch-drop-escalator-plugin.ts
@@ -98,6 +98,14 @@ export class DispatchDropEscalatorPlugin implements Plugin {
     record.lastPayload = payload;
     // Prune outside the rolling window. Bounded — never more than threshold+a-few entries.
     record.timestamps = record.timestamps.filter(t => now - t < this.windowMs);
+
+    // Delete the key if no timestamps remain — prevents unbounded growth
+    // for drop keys that fire once and never recur.
+    if (record.timestamps.length === 0) {
+      this.drops.delete(key);
+      return;
+    }
+
     record.timestamps.push(now);
     this.drops.set(key, record);
 
@@ -107,6 +115,10 @@ export class DispatchDropEscalatorPlugin implements Plugin {
     if (lastEscalation !== undefined && now - lastEscalation < this.escalationCooldownMs) return;
 
     this.lastEscalatedAt.set(key, now);
+
+    // Lazy-evict expired escalation cooldown keys.
+    this._sweepLastEscalatedAt(now);
+
     this._escalate(key, record);
   }
 
@@ -174,6 +186,15 @@ export class DispatchDropEscalatorPlugin implements Plugin {
         return "Caller published agent.skill.request with no skill field — bug in the caller.";
       default:
         return `Unknown reason: ${reason}`;
+    }
+  }
+
+  /** Purge escalation-cooldown keys whose window has elapsed. */
+  private _sweepLastEscalatedAt(now: number): void {
+    for (const [key, ts] of this.lastEscalatedAt) {
+      if (now - ts >= this.escalationCooldownMs) {
+        this.lastEscalatedAt.delete(key);
+      }
     }
   }
 }

--- a/src/plugins/dispatch-drop-escalator-plugin.ts
+++ b/src/plugins/dispatch-drop-escalator-plugin.ts
@@ -96,18 +96,17 @@ export class DispatchDropEscalatorPlugin implements Plugin {
 
     const record = this.drops.get(key) ?? { timestamps: [], lastPayload: payload };
     record.lastPayload = payload;
-    // Prune outside the rolling window. Bounded — never more than threshold+a-few entries.
+    // Prune this key's drops outside the rolling window, then record the current one.
+    // (Record BEFORE the threshold check — the previous order returned on the empty
+    // fresh-key array and never counted ANY drop, so no storm ever escalated.)
     record.timestamps = record.timestamps.filter(t => now - t < this.windowMs);
-
-    // Delete the key if no timestamps remain — prevents unbounded growth
-    // for drop keys that fire once and never recur.
-    if (record.timestamps.length === 0) {
-      this.drops.delete(key);
-      return;
-    }
-
     record.timestamps.push(now);
     this.drops.set(key, record);
+
+    // Bound the map: evict OTHER keys whose drops have all aged out of the window —
+    // one-shot drop keys that never recur would otherwise linger forever. Drops are
+    // rare (dispatch failures only), so this O(keys) sweep is cheap on this path.
+    this._sweepDrops(now);
 
     if (record.timestamps.length < this.threshold) return;
 
@@ -186,6 +185,14 @@ export class DispatchDropEscalatorPlugin implements Plugin {
         return "Caller published agent.skill.request with no skill field — bug in the caller.";
       default:
         return `Unknown reason: ${reason}`;
+    }
+  }
+
+  /** Purge drop keys whose timestamps have all aged out of the window (memory bound). */
+  private _sweepDrops(now: number): void {
+    for (const [k, rec] of this.drops) {
+      rec.timestamps = rec.timestamps.filter(t => now - t < this.windowMs);
+      if (rec.timestamps.length === 0) this.drops.delete(k);
     }
   }
 


### PR DESCRIPTION
## Summary

# [github] Unbounded in-memory state on the dispatch hot path (process-lifetime leaks)

## Situation
This feature was requested but PRD generation encountered an issue.

## Problem
Unbounded in-memory state on the dispatch hot path (process-lifetime leaks)

## Leak audit (verified on `origin/main`)

Several in-memory containers on the hottest (webhook-driven) path grow for the entire process lifetime with **no eviction** — they leak slowly across a long-running deploy. All keyed by high-cardinal...

Closes #785

---
*Created automatically by Automaker*

<!-- automaker:owner instance=ef15d09b-b02a-4f05-bb57-fcc898070dd7 team= created=2026-06-06T21:22:20.886Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed skill completion response timeout enforcement to ensure proper handling of timed-out operations

* **Performance & Stability**
  * Improved memory management in task tracking to prevent unbounded growth during extended operations
  * Optimized dispatch and escalation handlers with enhanced state cleanup and lazy eviction of expired data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->