### PR TITLE
feat: persist roxy's fleet registration + board-pulse ceremony (durable, tracked)

### DIFF
--- a/workspace/agents.yaml
+++ b/workspace/agents.yaml
@@ -67,9 +67,29 @@ agents:
       - message.inbound.discord.#
 
   # roxy — ProtoMaker Portfolio Manager (monitors + unblocks the protoMaker
-  # portfolio; read-only on code). Deliberately NOT registered here: she is
-  # control-plane-managed (ADR-0004), registered live to workspace/agents.d/roxy.yaml
-  # via POST /api/a2a-endpoints and re-registered idempotently on deploy by her own
-  # stack (homelab-iac/stacks/roxy). url http://roxy:7870/a2a on the shared network,
-  # auth ROXY_API_KEY. Do NOT add a roxy entry here — agents.d/ wins the dedup, so a
-  # hand entry would be shadowed, and two homes drift.
+  # portfolio; read-only on code). Registered STATICALLY here (like protopen) so the
+  # registration is DURABLE across redeploys.
+  #
+  # Previously this was control-plane-managed only (ADR-0004): `make register` in
+  # roxy's stack POSTs /api/a2a-endpoints, which writes workspace/agents.d/roxy.yaml.
+  # But agents.d/ lives in the runtime workspace clone — wiped on every WS redeploy
+  # from a fresh clone — so the registration silently vanished and ceremony dispatch
+  # failed with "No executor found for targets [roxy]". A tracked agents.yaml entry
+  # survives clone resets, exactly like protopen, and is the durable home.
+  #
+  # FOLLOW-UP: API-driven registrations (POST /api/a2a-endpoints) should ALSO persist
+  # across redeploys (durable store, not the ephemeral clone) — see the companion
+  # issue. Once that lands, the dynamic path is durable too and this static entry can
+  # be reconsidered (agents.d still wins the dedup if both exist).
+  - name: roxy
+    url: http://roxy:7870/a2a
+    auth:
+      scheme: bearer
+      credentialsEnv: ROXY_API_KEY
+    streaming: true
+    external: true
+    skills:
+      - portfolio_sitrep
+      - board_sweep
+      - project_decompose
+      - unblock_feature

--- a/workspace/ceremonies/roxy.board-pulse.yaml
+++ b/workspace/ceremonies/roxy.board-pulse.yaml
@@ -1,0 +1,19 @@
+id: roxy.board-pulse
+name: "Roxy Board Pulse"
+description: >
+  Hourly: dispatch board_sweep to roxy so she sweeps the fleet, keeps auto-mode
+  topped up on ready projects, and REACTS to board events — PR/CI → Quinn
+  pr_review, blocked/escalated → fix-or-escalate, stuck in_progress → steer/reset,
+  auto-mode paused → diagnose/restart, bug → Quinn bug_triage — then updates her
+  ledger. This is the review→merge half of the factory loop: it's why agent PRs
+  get reviewed + merged instead of piling up.
+
+  Targets ONLY roxy — never [all] (agents lacking board_sweep 404 at the
+  dispatcher, per the disabled agent-health/board.retro). Durable home is
+  protoWorkstacean#817; this lives in the deploy clone (hot-reloaded).
+schedule: "0 * * * *"
+skill: board_sweep
+targets:
+  - roxy
+notifyChannel: ""
+enabled: true


### PR DESCRIPTION
## Why
Roxy's WS executor registration and her recurring board-sweep ceremony both lived **only in the runtime workspace clone**:
- registration: `make register` (in roxy's stack) POSTs `/api/a2a-endpoints` → writes `workspace/agents.d/roxy.yaml`
- ceremony: hot-loaded `roxy.board-pulse.yaml`

Every WS redeploy from a fresh clone **wipes** both. Result: ceremony fires → `No executor found for targets [roxy]` → the factory's **review→merge half stalls** (agent PRs pile up, never dispatched to Quinn). Hit live today.

## Change (make both durable, like protopen)
- **`agents.yaml`** — static `roxy` entry (`bearer` / `ROXY_API_KEY`; skills incl. `board_sweep`). Tracked → survives clone resets. Replaces the "control-plane-managed, do NOT add here" comment, since that dynamic-only path is precisely what failed to persist. (If a dynamic `agents.d/roxy.yaml` ever co-exists, it still wins the dedup — no drift.)
- **`workspace/ceremonies/roxy.board-pulse.yaml`** — the hourly `board_sweep → roxy` ceremony (`targets: [roxy]` only, never `[all]`). Re-lands the ceremony from the closed/superseded #817, *cleanly* (no bundled code this time).

Verified live: with roxy re-registered + this ceremony, dispatch works (`board_sweep via a2a (targets: roxy)` → Roxy → `pr_review` → Quinn → first autonomous merge landed, protoCLI#364).

## Follow-up (companion issue)
API-driven registrations (`POST /api/a2a-endpoints`) should **persist across redeploys** on their own (durable store, not the ephemeral clone) — so the control-plane path is durable and a static entry isn't required. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)