### PR TITLE
[github] quinn pr_review: a re-review that resolves the blocker returns COMMENTED (WARN) — doesn't clear the 

### DIFF
--- a/lib/plugins/__tests__/github-approve-on-green.test.ts
+++ b/lib/plugins/__tests__/github-approve-on-green.test.ts
@@ -1,11 +1,12 @@
 /**
- * Deterministic approve-on-terminal-green (#748).
+ * Deterministic approve-on-terminal-green (#748, #848).
  *
  * Quinn never reliably chooses review_approve on the CI-completion re-dispatch,
  * so the merge-on-green gate never opens. `_handleCiCompletion` now posts a
  * formal APPROVE programmatically when CI is terminal-GREEN and Quinn's latest
- * review is a held COMMENT. These tests cover the pure decision gates plus the
- * orchestration's fire / fall-through behavior with a stubbed GitHub API.
+ * review is a held COMMENT (no blockers) OR a prior CHANGES_REQUESTED (blocker
+ * resolved). These tests cover the pure decision gates plus the orchestration's
+ * fire / fall-through behavior with a stubbed GitHub API.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
@@ -155,12 +156,15 @@ describe("_handleCiCompletion — deterministic approve-on-green", () => {
     expect(captured.approvePosts[0]!.commit_id).toBe(SHA);
   });
 
-  test("(b) terminal-green + prior CHANGES_REQUESTED → no approve (falls through)", async () => {
+  test("(b) terminal-green + prior CHANGES_REQUESTED → posts formal APPROVE (blocker resolved, #848)", async () => {
     const captured = await runCiCompletion({
       reviews: [{ user: { login: "protoquinn[bot]" }, state: "CHANGES_REQUESTED" }],
       checkRuns: [{ status: "completed", conclusion: "success" }],
     });
-    expect(captured.approvePosts.length).toBe(0);
+    expect(captured.approvePosts.length).toBe(1);
+    expect(captured.approvePosts[0]!.event).toBe("APPROVE");
+    expect(captured.approvePosts[0]!.commit_id).toBe(SHA);
+    expect(captured.approvePosts[0]!.body).toContain("blocker resolved");
   });
 
   test("(c) terminal-green + no prior Quinn review → no blind approve (falls through)", async () => {
@@ -174,6 +178,17 @@ describe("_handleCiCompletion — deterministic approve-on-green", () => {
   test("(d) terminal but RED + prior COMMENTED → no approve (falls through)", async () => {
     const captured = await runCiCompletion({
       reviews: [{ user: { login: "protoquinn[bot]" }, state: "COMMENTED" }],
+      checkRuns: [
+        { status: "completed", conclusion: "success" },
+        { status: "completed", conclusion: "failure" },
+      ],
+    });
+    expect(captured.approvePosts.length).toBe(0);
+  });
+
+  test("(f) terminal but RED + prior CHANGES_REQUESTED → no approve (blocker not resolved)", async () => {
+    const captured = await runCiCompletion({
+      reviews: [{ user: { login: "protoquinn[bot]" }, state: "CHANGES_REQUESTED" }],
       checkRuns: [
         { status: "completed", conclusion: "success" },
         { status: "completed", conclusion: "failure" },

--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -1049,18 +1049,22 @@ export class GitHubPlugin implements Plugin {
         continue;
       }
 
-      // ── Deterministic approve-on-terminal-green (#748) ───────────────────────
+      // ── Deterministic approve-on-terminal-green (#748, #848) ─────────────────
       // Quinn reliably re-COMMENTs instead of choosing review_approve, so the
       // merge-on-green gate never opens (approvedCount stays 0). When CI is
       // terminal-GREEN and Quinn's latest review is a held COMMENT (no blockers),
       // post the formal APPROVE programmatically rather than re-prompting the LLM.
       //
-      // Fail closed: only the COMMENTED-latest + all-green case auto-approves.
-      // CHANGES_REQUESTED (blockers), an already-APPROVED PR, no prior Quinn
-      // review, or any non-green / unverifiable CI state falls through to the
-      // unchanged LLM re-dispatch below.
+      // A prior CHANGES_REQUESTED + now-green is also auto-approved: the blocker
+      // Quinn raised (typically failing CI) is resolved, so the re-review maps to
+      // PASS, not WARN. Without this, Quinn returns COMMENTED, which does NOT
+      // dismiss the prior CHANGES_REQUESTED → PR stuck in merge-limbo (#848).
+      //
+      // Fail closed: an already-APPROVED PR, no prior Quinn review, or any
+      // non-green / unverifiable CI state falls through to the unchanged LLM
+      // re-dispatch below.
       const latestState = quinnLatestReviewState(reviews ?? undefined);
-      if (latestState === "COMMENTED" && (await this._ciGreen(getToken, owner, repo, headSha))) {
+      if ((latestState === "COMMENTED" || latestState === "CHANGES_REQUESTED") && (await this._ciGreen(getToken, owner, repo, headSha))) {
         // Collapse co-arriving terminal webhooks. GitHub fires check_suite,
         // workflow_run, and check_run completions near-simultaneously; each runs
         // _handleCiCompletion concurrently and reads `reviews` before any has
@@ -1081,18 +1085,21 @@ export class GitHubPlugin implements Plugin {
         this.recentDispatches.set(approveKey, Date.now());
         try {
           const submitter = new GitHubReviewSubmitter(getToken);
+          const isResolvedBlocker = latestState === "CHANGES_REQUESTED";
           await submitter.submitReview(
             owner,
             repo,
             number,
             headSha,
             "APPROVE",
-            "CI terminal-green, no blockers on prior review — auto-approving on green (#748).",
+            isResolvedBlocker
+              ? "CI terminal-green, prior blocker resolved — auto-approving on green (#848)."
+              : "CI terminal-green, no blockers on prior review — auto-approving on green (#748).",
             [],
           );
           log.info(
             `CI-completion (${event}): auto-approved ${owner}/${repo}#${number} @${headSha.slice(0, 7)} ` +
-              `(terminal-green, prior Quinn review COMMENTED) — #748`,
+              `(terminal-green, prior Quinn review ${latestState}${isResolvedBlocker ? ", blocker resolved" : ""})`,
           );
 
           // ── Enable native auto-merge (squash) for one-off PRs ──────────────


### PR DESCRIPTION
## Summary

# [github] quinn pr_review: a re-review that resolves the blocker returns COMMENTED (WARN) — doesn't clear the 

## Situation
This feature was requested but PRD generation encountered an issue.

## Problem
quinn pr_review: a re-review that resolves the blocker returns COMMENTED (WARN) — doesn't clear the prior CHANGES_REQUESTED → PR stuck in merge-limbo

## Observed (2026-06-06, protoWorkstacean #848)
1. Quinn reviewed #848, CI red (failing tests) → **CHANGES_REQUESTED** (correct).
2. The bug wa...

Closes #854

---
*Created automatically by Automaker*

<!-- automaker:owner instance=ef15d09b-b02a-4f05-bb57-fcc898070dd7 team= created=2026-06-06T23:24:33.106Z -->