### PR TITLE
feat(control-plane): durable A2A registrations across redeploys (#850)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { SignalPlugin } from "../lib/plugins/signal";
 import { SchedulerPlugin } from "../lib/plugins/scheduler";
 import { A2ADeliveryPlugin } from "../lib/plugins/a2a-delivery";
 import { ControlPlaneRegistrarPlugin } from "./plugins/control-plane-registrar-plugin.ts";
+import { RegistrationStore } from "./storage/registration-store.ts";
 import type { Plugin, } from "../lib/types";
 import { parseEnv } from "./config/env.ts";
 import { isProductionLike, safeKeyEqual } from "../lib/runtime-env.ts";
@@ -153,7 +154,9 @@ const corePlugins: Plugin[] = [
   new SchedulerPlugin(dataDir),
   new A2ADeliveryPlugin(workspaceDir),
   // ADR-0004 P2: sole writer of workspace config for control-plane command.* mutations.
-  new ControlPlaneRegistrarPlugin(workspaceDir),
+  // Backed by a durable RegistrationStore so API-driven a2a registrations
+  // survive a redeploy (the agents.d/ clone is ephemeral) — #850.
+  new ControlPlaneRegistrarPlugin(workspaceDir, new RegistrationStore(`${dataDir}/registrations.db`)),
 ];
 
 for (const plugin of corePlugins) {

--- a/src/plugins/__tests__/control-plane-registrar-persistence.test.ts
+++ b/src/plugins/__tests__/control-plane-registrar-persistence.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Durable a2a registrations (#850): a registration made via the control-plane
+ * API must survive a redeploy that wipes the ephemeral agents.d/ clone.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ControlPlaneRegistrarPlugin } from "../control-plane-registrar-plugin.ts";
+import { RegistrationStore } from "../../storage/registration-store.ts";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+
+const roots: string[] = [];
+function scratch() {
+  const base = mkdtempSync(join(tmpdir(), "cpr-"));
+  roots.push(base);
+  const workspace = join(base, "workspace");
+  mkdirSync(join(workspace, "agents.d"), { recursive: true });
+  return { workspace, dbPath: join(base, "registrations.db"), agentsd: join(workspace, "agents.d") };
+}
+afterEach(() => {
+  for (const r of roots.splice(0)) rmSync(r, { recursive: true, force: true });
+});
+
+function upsert(bus: InMemoryEventBus, name: string, file: string, yaml: string) {
+  bus.publish("command.a2a.upsert", {
+    id: crypto.randomUUID(),
+    correlationId: crypto.randomUUID(),
+    topic: "command.a2a.upsert",
+    timestamp: 0,
+    payload: { name, file, yaml },
+  });
+}
+
+describe("ControlPlaneRegistrar — durable a2a registrations", () => {
+  test("upsert writes agents.d/ AND persists to the store", () => {
+    const { workspace, dbPath, agentsd } = scratch();
+    const store = new RegistrationStore(dbPath);
+    const bus = new InMemoryEventBus();
+    const reg = new ControlPlaneRegistrarPlugin(workspace, store);
+    reg.install(bus);
+    const file = join(agentsd, "roxy.yaml");
+    upsert(bus, "roxy", file, "name: roxy\nurl: http://roxy:7870\n");
+
+    expect(existsSync(file)).toBe(true);
+    expect(store.all("a2a").map((r) => r.name)).toEqual(["roxy"]);
+    store.close();
+  });
+
+  test("redeploy: a wiped agents.d/ is re-materialized from the store on boot", () => {
+    const { workspace, dbPath, agentsd } = scratch();
+    const store = new RegistrationStore(dbPath);
+
+    // First boot — register roxy via the API path.
+    const bus1 = new InMemoryEventBus();
+    const reg1 = new ControlPlaneRegistrarPlugin(workspace, store);
+    reg1.install(bus1);
+    const file = join(agentsd, "roxy.yaml");
+    upsert(bus1, "roxy", file, "name: roxy\nurl: http://roxy:7870\n");
+    expect(existsSync(file)).toBe(true);
+
+    // Redeploy from a fresh clone — the ephemeral agents.d/ is wiped.
+    rmSync(agentsd, { recursive: true, force: true });
+    expect(existsSync(file)).toBe(false);
+
+    // Second boot with the SAME durable store — install() re-materializes.
+    const reg2 = new ControlPlaneRegistrarPlugin(workspace, store);
+    reg2.install(new InMemoryEventBus());
+
+    expect(existsSync(file)).toBe(true);
+    expect(readFileSync(file, "utf8")).toContain("roxy:7870");
+    store.close();
+  });
+
+  test("remove deletes the file AND forgets it in the store (no zombie re-materialize)", () => {
+    const { workspace, dbPath, agentsd } = scratch();
+    const store = new RegistrationStore(dbPath);
+    const bus = new InMemoryEventBus();
+    const reg = new ControlPlaneRegistrarPlugin(workspace, store);
+    reg.install(bus);
+    const file = join(agentsd, "roxy.yaml");
+
+    upsert(bus, "roxy", file, "name: roxy\n");
+    expect(store.all("a2a")).toHaveLength(1);
+
+    bus.publish("command.a2a.remove", {
+      id: crypto.randomUUID(),
+      correlationId: crypto.randomUUID(),
+      topic: "command.a2a.remove",
+      timestamp: 0,
+      payload: { name: "roxy", file },
+    });
+    expect(existsSync(file)).toBe(false);
+    expect(store.all("a2a")).toEqual([]);
+
+    // A subsequent boot must NOT resurrect the removed registration.
+    rmSync(agentsd, { recursive: true, force: true });
+    new ControlPlaneRegistrarPlugin(workspace, store).install(new InMemoryEventBus());
+    expect(existsSync(file)).toBe(false);
+    store.close();
+  });
+
+  test("no store → behaves exactly as before (ephemeral only, no throw)", () => {
+    const { workspace, agentsd } = scratch();
+    const bus = new InMemoryEventBus();
+    const reg = new ControlPlaneRegistrarPlugin(workspace); // no store
+    reg.install(bus);
+    const file = join(agentsd, "roxy.yaml");
+    upsert(bus, "roxy", file, "name: roxy\n");
+    expect(existsSync(file)).toBe(true); // still writes the cache
+  });
+});

--- a/src/plugins/control-plane-registrar-plugin.ts
+++ b/src/plugins/control-plane-registrar-plugin.ts
@@ -18,8 +18,9 @@
  */
 
 import { writeFileSync, renameSync, unlinkSync, existsSync, mkdirSync } from "node:fs";
-import { resolve, dirname } from "node:path";
+import { resolve, dirname, join } from "node:path";
 import type { Plugin, EventBus, BusMessage } from "../../lib/types.ts";
+import type { RegistrationStore } from "../storage/registration-store.ts";
 import { logger } from "../../lib/log.ts";
 
 const log = logger("control-plane-registrar");
@@ -35,13 +36,27 @@ export class ControlPlaneRegistrarPlugin implements Plugin {
   private readonly mcpServersRoot: string; // workspace/mcp-servers.d/ — MCP servers (P4, ADR-0005)
   private subscriptionIds: string[] = [];
 
-  constructor(workspaceDir: string) {
+  /**
+   * Durable store for runtime-written registrations (#850). Optional: when
+   * absent the registrar behaves exactly as before (ephemeral agents.d/ only).
+   * Only the `agents.d/` (a2a) root is persisted — `workspace/agents/` is
+   * git-tracked and has a durable home already.
+   */
+  private readonly store: RegistrationStore | undefined;
+
+  constructor(workspaceDir: string, store?: RegistrationStore) {
     this.agentsRoot = resolve(workspaceDir, "agents");
     this.agentsdRoot = resolve(workspaceDir, "agents.d");
     this.mcpServersRoot = resolve(workspaceDir, "mcp-servers.d");
+    this.store = store;
   }
 
   install(bus: EventBus): void {
+    // Re-materialize durable registrations into the (possibly freshly-cloned,
+    // empty) agents.d/ cache BEFORE SkillBroker loads it. Registrar installs
+    // ahead of the broker in src/index.ts, so this closes the redeploy gap.
+    this._rematerialize();
+
     this.subscriptionIds.push(
       bus.subscribe("command.agent.upsert", this.name, (msg) => this._write(this.agentsRoot, msg)),
       bus.subscribe("command.agent.remove", this.name, (msg) => this._delete(this.agentsRoot, msg)),
@@ -50,6 +65,35 @@ export class ControlPlaneRegistrarPlugin implements Plugin {
       bus.subscribe("command.mcp.upsert", this.name, (msg) => this._write(this.mcpServersRoot, msg)),
       bus.subscribe("command.mcp.remove", this.name, (msg) => this._delete(this.mcpServersRoot, msg)),
     );
+  }
+
+  /** "a2a" for the agents.d/ root (the persisted kind); undefined otherwise. */
+  private _persistKind(root: string): string | undefined {
+    return root === this.agentsdRoot ? "a2a" : undefined;
+  }
+
+  /**
+   * Restore persisted a2a registrations to agents.d/ on boot. Only writes files
+   * that are missing — an already-present file (normal restart, files survived)
+   * is left untouched. On a fresh clone, agents.d/ is empty, so every stored
+   * registration is rewritten and the broker picks them up.
+   */
+  private _rematerialize(): void {
+    if (!this.store) return;
+    let restored = 0;
+    for (const reg of this.store.all("a2a")) {
+      const file = join(this.agentsdRoot, `${reg.name}.yaml`);
+      if (this._safe(file, this.agentsdRoot) !== file) continue;
+      if (existsSync(file)) continue;
+      try {
+        if (!existsSync(this.agentsdRoot)) mkdirSync(this.agentsdRoot, { recursive: true });
+        writeFileSync(file, reg.yaml, "utf8");
+        restored++;
+      } catch (err) {
+        log.error(`rematerialize "${reg.name}" failed`, { err });
+      }
+    }
+    if (restored > 0) log.info(`restored ${restored} durable a2a registration(s) to agents.d/`);
   }
 
   uninstall(): void {
@@ -78,6 +122,9 @@ export class ControlPlaneRegistrarPlugin implements Plugin {
       writeFileSync(tmp, p.yaml, "utf8");
       renameSync(tmp, file);
       log.info(`wrote "${p.name}" → ${file}`);
+      // Persist to the durable store so the registration survives a redeploy.
+      const kind = this._persistKind(root);
+      if (kind && p.name) this.store?.upsert(kind, p.name, p.yaml);
     } catch (err) {
       log.error(`write "${p.name}" failed`, { err });
     }
@@ -90,6 +137,8 @@ export class ControlPlaneRegistrarPlugin implements Plugin {
     try {
       if (existsSync(file)) unlinkSync(file);
       log.info(`removed "${p.name}" → ${file}`);
+      const kind = this._persistKind(root);
+      if (kind && p.name) this.store?.remove(kind, p.name);
     } catch (err) {
       log.error(`remove "${p.name}" failed`, { err });
     }

--- a/src/storage/__tests__/registration-store.test.ts
+++ b/src/storage/__tests__/registration-store.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { RegistrationStore } from "../registration-store.ts";
+
+const dirs: string[] = [];
+function tmpDb(): string {
+  const d = mkdtempSync(join(tmpdir(), "reg-store-"));
+  dirs.push(d);
+  return join(d, "registrations.db");
+}
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe("RegistrationStore", () => {
+  test("upsert + all round-trips by kind", () => {
+    const s = new RegistrationStore(tmpDb());
+    s.upsert("a2a", "roxy", "name: roxy\nurl: http://roxy:7870\n");
+    s.upsert("a2a", "jon", "name: jon\n");
+    s.upsert("mcp", "fs", "name: fs\n");
+
+    const a2a = s.all("a2a");
+    expect(a2a.map((r) => r.name)).toEqual(["jon", "roxy"]); // ORDER BY name
+    expect(a2a.find((r) => r.name === "roxy")!.yaml).toContain("roxy:7870");
+    expect(s.all("mcp").map((r) => r.name)).toEqual(["fs"]);
+    s.close();
+  });
+
+  test("upsert replaces existing yaml (idempotent register)", () => {
+    const s = new RegistrationStore(tmpDb());
+    s.upsert("a2a", "roxy", "name: roxy\nv: 1\n");
+    s.upsert("a2a", "roxy", "name: roxy\nv: 2\n");
+    expect(s.all("a2a")).toHaveLength(1);
+    expect(s.all("a2a")[0].yaml).toContain("v: 2");
+    s.close();
+  });
+
+  test("remove forgets a registration", () => {
+    const s = new RegistrationStore(tmpDb());
+    s.upsert("a2a", "roxy", "name: roxy\n");
+    s.remove("a2a", "roxy");
+    expect(s.all("a2a")).toEqual([]);
+    s.close();
+  });
+
+  test("survives reopen (the whole point — durable across process restarts)", () => {
+    const path = tmpDb();
+    const s1 = new RegistrationStore(path);
+    s1.upsert("a2a", "roxy", "name: roxy\n");
+    s1.close();
+
+    const s2 = new RegistrationStore(path);
+    expect(s2.all("a2a").map((r) => r.name)).toEqual(["roxy"]);
+    s2.close();
+  });
+
+  test("remove of an absent key is a no-op", () => {
+    const s = new RegistrationStore(tmpDb());
+    s.remove("a2a", "nope"); // must not throw
+    expect(s.all("a2a")).toEqual([]);
+    s.close();
+  });
+});

--- a/src/storage/registration-store.ts
+++ b/src/storage/registration-store.ts
@@ -1,0 +1,121 @@
+/**
+ * RegistrationStore — durable home for control-plane-managed agent
+ * registrations (bun:sqlite, on the data volume).
+ *
+ * The write API (`POST /api/a2a-endpoints`) materializes a registration as a
+ * drop-in yaml file under `workspace/agents.d/`. But that lives in the
+ * *ephemeral* workspace clone — a redeploy from a fresh clone (or a `git
+ * clean`) wipes it, so an API-driven registration silently vanishes (#850).
+ *
+ * This store persists the same registration to `${dataDir}/registrations.db`
+ * (the durable volume that already holds events.db / knowledge.db / tasks.db).
+ * The `agents.d/` file becomes a cache: ControlPlaneRegistrarPlugin writes both
+ * on upsert, removes both on delete, and re-materializes the cache from this
+ * store on boot — so an API registration survives any number of redeploys
+ * without re-running `make register`.
+ *
+ * `kind` namespaces the runtime-written config roots (today: "a2a"; "mcp" is a
+ * trivial future addition). The git-tracked `workspace/agents/` root is NOT
+ * persisted here — those files have a durable home in git already.
+ *
+ * Degrades to a no-op when the DB is unavailable, exactly like the other
+ * sqlite-backed stores — a persistence outage must never block a live
+ * registration (the in-memory + agents.d/ path still works for the session).
+ */
+
+import { Database } from "bun:sqlite";
+import { existsSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("registration-store");
+
+export interface StoredRegistration {
+  name: string;
+  yaml: string;
+}
+
+export class RegistrationStore {
+  private db: Database | null = null;
+  private readonly dbPath: string;
+
+  constructor(dbPath: string) {
+    this.dbPath = resolve(dbPath);
+    this._init();
+  }
+
+  private _init(): void {
+    try {
+      const dir = dirname(this.dbPath);
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+      this.db = new Database(this.dbPath);
+      this.db.exec("PRAGMA journal_mode=WAL;");
+      this.db.exec("PRAGMA synchronous=NORMAL;");
+      this.db.exec("PRAGMA busy_timeout=5000;");
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS registrations (
+          kind       TEXT NOT NULL,
+          name       TEXT NOT NULL,
+          yaml       TEXT NOT NULL,
+          updated_at INTEGER NOT NULL,
+          PRIMARY KEY (kind, name)
+        );
+      `);
+      log.info(`Ready at ${this.dbPath}`);
+    } catch (err) {
+      log.error("Init failed — registration persistence disabled", { err });
+      this.db = null;
+    }
+  }
+
+  /** Persist (or replace) a registration's yaml. */
+  upsert(kind: string, name: string, yaml: string): void {
+    if (!this.db) return;
+    try {
+      this.db.run(
+        `INSERT INTO registrations (kind, name, yaml, updated_at)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT(kind, name) DO UPDATE SET
+           yaml = excluded.yaml,
+           updated_at = excluded.updated_at`,
+        [kind, name, yaml, Date.now()],
+      );
+    } catch (err) {
+      log.error(`upsert "${kind}/${name}" failed`, { err });
+    }
+  }
+
+  /** Forget a registration (it was unregistered via the API). */
+  remove(kind: string, name: string): void {
+    if (!this.db) return;
+    try {
+      this.db.run(`DELETE FROM registrations WHERE kind = ? AND name = ?`, [kind, name]);
+    } catch (err) {
+      log.error(`remove "${kind}/${name}" failed`, { err });
+    }
+  }
+
+  /** All persisted registrations of a kind — used to re-materialize the cache on boot. */
+  all(kind: string): StoredRegistration[] {
+    if (!this.db) return [];
+    try {
+      return this.db
+        .query<{ name: string; yaml: string }, [string]>(
+          `SELECT name, yaml FROM registrations WHERE kind = ? ORDER BY name`,
+        )
+        .all(kind);
+    } catch (err) {
+      log.error(`all("${kind}") failed`, { err });
+      return [];
+    }
+  }
+
+  close(): void {
+    try {
+      this.db?.close();
+    } catch {
+      // already closed / never opened
+    }
+    this.db = null;
+  }
+}


### PR DESCRIPTION
Closes #850.

## Why
`POST /api/a2a-endpoints` materialized registrations only to `workspace/agents.d/` in the **ephemeral** workspace clone. A redeploy from a fresh clone (or `git clean`) wiped them, so an API-driven registration silently vanished — hit live 2026-06-06: roxy registered, redeploy wiped it → `roxy.board-pulse` ceremony dropped with `No executor found for targets [roxy]` → the factory's review→merge half stalled.

## Change (durable DB; agents.d/ becomes a cache)
- **New `RegistrationStore`** — SQLite at `${dataDir}/registrations.db` (the durable volume that already holds events/knowledge/tasks DBs). `kind`-namespaced (`a2a` today; `mcp` is a one-line future add), fail-soft (degrades to no-op if the DB is unavailable).
- **`ControlPlaneRegistrarPlugin`** now:
  - writes the store **alongside** the `agents.d/` cache on `command.a2a.upsert`,
  - removes from **both** on `command.a2a.remove`,
  - **re-materializes** missing `agents.d/` files from the store in `install()` — which runs **before** SkillBroker loads `agents.d/` (verified ordering in `src/index.ts`), so a redeploy restores every registration with no re-run of `make register`.
- Only the `a2a` root is persisted — `workspace/agents/` is git-tracked and durable already. Store is optional (absent → unchanged ephemeral behavior).

## Scope
#849 made roxy durable *statically* (tracked `agents.yaml`); this is the general control-plane fix, after which the static entry is optional.

## Verification
- New tests: store round-trip/replace/remove/reopen-durability, and the registrar's **redeploy simulation** (wipe `agents.d/` → boot re-materializes), remove-no-zombie, and no-store fallback.
- `bun test`: **1125 pass, 0 fail** (incl. `NODE_ENV=production`); `tsc --noEmit` + `bun run lint` clean.

## Deploy note
Adds `registrations.db` on the existing data volume — no schema migration, no behavior change when the store is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)