### PR TITLE
fix(github): gate CHANGES_REQUESTED auto-approve on resolved review threads (#858)

### DIFF
--- a/lib/plugins/__tests__/github-approve-on-green.test.ts
+++ b/lib/plugins/__tests__/github-approve-on-green.test.ts
@@ -81,6 +81,12 @@ interface StubOpts {
   /** Returns the check-runs body, or a 403 Response to simulate the CiAccessError path. */
   checkRuns?: Array<Record<string, unknown>>;
   checkRunsStatus?: number; // default 200
+  /**
+   * Review-thread resolution for the GraphQL gate (#858):
+   *   true  → an unresolved thread remains, false → all resolved/none,
+   *   null  → GraphQL errors (unknown). Default false (no unresolved threads).
+   */
+  threadsUnresolved?: boolean | null;
 }
 
 /** Records every POST .../reviews submission so a test can assert the APPROVE. */
@@ -119,6 +125,13 @@ function stubFetch(opts: StubOpts): Captured {
       if (status !== 200) return json({ message: "Forbidden" }, status);
       return json({ check_runs: opts.checkRuns ?? [] });
     }
+    // GraphQL review-thread resolution (#858 gate for CHANGES_REQUESTED)
+    if (url.includes("/graphql") && method === "POST") {
+      const u = opts.threadsUnresolved === undefined ? false : opts.threadsUnresolved;
+      if (u === null) return json({ message: "error" }, 500); // unknown
+      const nodes = u ? [{ isResolved: false }] : [{ isResolved: true }];
+      return json({ data: { repository: { pullRequest: { reviewThreads: { nodes } } } } });
+    }
     // APPROVE submission (POST .../reviews) via GitHubReviewSubmitter
     if (url.includes(`/pulls/${PR}/reviews`) && method === "POST") {
       captured.approvePosts.push(JSON.parse(String(init?.body ?? "{}")));
@@ -156,15 +169,34 @@ describe("_handleCiCompletion — deterministic approve-on-green", () => {
     expect(captured.approvePosts[0]!.commit_id).toBe(SHA);
   });
 
-  test("(b) terminal-green + prior CHANGES_REQUESTED → posts formal APPROVE (blocker resolved, #848)", async () => {
+  test("(b) terminal-green + prior CHANGES_REQUESTED + no unresolved threads → APPROVE (blocker resolved, #848/#858)", async () => {
     const captured = await runCiCompletion({
       reviews: [{ user: { login: "protoquinn[bot]" }, state: "CHANGES_REQUESTED" }],
       checkRuns: [{ status: "completed", conclusion: "success" }],
+      threadsUnresolved: false,
     });
     expect(captured.approvePosts.length).toBe(1);
     expect(captured.approvePosts[0]!.event).toBe("APPROVE");
     expect(captured.approvePosts[0]!.commit_id).toBe(SHA);
     expect(captured.approvePosts[0]!.body).toContain("blocker resolved");
+  });
+
+  test("(b2) terminal-green + prior CHANGES_REQUESTED + UNRESOLVED thread → no approve (#858 — code concern remains)", async () => {
+    const captured = await runCiCompletion({
+      reviews: [{ user: { login: "protoquinn[bot]" }, state: "CHANGES_REQUESTED" }],
+      checkRuns: [{ status: "completed", conclusion: "success" }],
+      threadsUnresolved: true,
+    });
+    expect(captured.approvePosts.length).toBe(0); // a real concern → don't auto-clear
+  });
+
+  test("(b3) terminal-green + prior CHANGES_REQUESTED + thread state unknown → no approve (#858 fail-safe)", async () => {
+    const captured = await runCiCompletion({
+      reviews: [{ user: { login: "protoquinn[bot]" }, state: "CHANGES_REQUESTED" }],
+      checkRuns: [{ status: "completed", conclusion: "success" }],
+      threadsUnresolved: null,
+    });
+    expect(captured.approvePosts.length).toBe(0); // unknown → conservative, defer to re-review
   });
 
   test("(c) terminal-green + no prior Quinn review → no blind approve (falls through)", async () => {

--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -1064,7 +1064,32 @@ export class GitHubPlugin implements Plugin {
       // non-green / unverifiable CI state falls through to the unchanged LLM
       // re-dispatch below.
       const latestState = quinnLatestReviewState(reviews ?? undefined);
+      let autoApprove = false;
+      let isResolvedBlocker = false;
       if ((latestState === "COMMENTED" || latestState === "CHANGES_REQUESTED") && (await this._ciGreen(getToken, owner, repo, headSha))) {
+        if (latestState === "CHANGES_REQUESTED") {
+          // A prior block only clears when the *requested change is in* — not
+          // on CI-green alone. A code finding (auth bypass, data-loss, logic
+          // bug) leaves an unresolved review thread that green CI doesn't
+          // resolve; a CI-only block leaves none. Gate on unresolved threads
+          // (#858). Fail safe: unknown thread state → don't auto-clear; defer
+          // to the LLM re-review below.
+          const unresolved = await this._hasUnresolvedReviewThreads(getToken, owner, repo, number);
+          if (unresolved === false) {
+            autoApprove = true;
+            isResolvedBlocker = true;
+          } else {
+            log.info(
+              `CI-completion (${event}): ${owner}/${repo}#${number} prior CHANGES_REQUESTED + green but ` +
+                `${unresolved === null ? "review-thread state unverifiable" : "unresolved review threads remain"} ` +
+                `— not auto-clearing the block, deferring to re-review (#858)`,
+            );
+          }
+        } else {
+          autoApprove = true;
+        }
+      }
+      if (autoApprove) {
         // Collapse co-arriving terminal webhooks. GitHub fires check_suite,
         // workflow_run, and check_run completions near-simultaneously; each runs
         // _handleCiCompletion concurrently and reads `reviews` before any has
@@ -1085,7 +1110,6 @@ export class GitHubPlugin implements Plugin {
         this.recentDispatches.set(approveKey, Date.now());
         try {
           const submitter = new GitHubReviewSubmitter(getToken);
-          const isResolvedBlocker = latestState === "CHANGES_REQUESTED";
           await submitter.submitReview(
             owner,
             repo,
@@ -1210,6 +1234,46 @@ export class GitHubPlugin implements Plugin {
       | { check_runs?: Array<Record<string, unknown>> }
       | null;
     return allChecksGreen(data?.check_runs);
+  }
+
+  /**
+   * True if the PR has any unresolved review thread. Used to decide whether a
+   * prior CHANGES_REQUESTED is actually resolved before auto-clearing it on
+   * green (#858) — a code finding leaves an unresolved thread; a CI-only block
+   * leaves none. Thread-resolution state is GraphQL-only (REST doesn't expose
+   * it). Returns null when it can't be determined (auth/network/GraphQL error),
+   * and the caller treats null as "don't auto-clear" (fail safe).
+   */
+  private async _hasUnresolvedReviewThreads(
+    getToken: (owner: string, repo: string) => Promise<string>,
+    owner: string,
+    repo: string,
+    number: number,
+  ): Promise<boolean | null> {
+    try {
+      const token = await getToken(owner, repo);
+      const query =
+        "query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){" +
+        "pullRequest(number:$num){reviewThreads(first:100){nodes{isResolved}}}}}";
+      const resp = await fetch("https://api.github.com/graphql", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          "User-Agent": "protoWorkstacean/1.0",
+        },
+        body: JSON.stringify({ query, variables: { owner, repo, num: number } }),
+      });
+      if (!resp.ok) return null;
+      const json = (await resp.json()) as {
+        data?: { repository?: { pullRequest?: { reviewThreads?: { nodes?: Array<{ isResolved?: boolean }> } } } };
+      };
+      const nodes = json.data?.repository?.pullRequest?.reviewThreads?.nodes;
+      if (!Array.isArray(nodes)) return null;
+      return nodes.some((n) => n?.isResolved === false);
+    } catch {
+      return null;
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #858. Follow-up hardening to #856 (flagged during the queue-clearing sweep).

## The residual edge (#856)
#856 made approve-on-green also clear a prior `CHANGES_REQUESTED` once CI is terminal-green — but keyed **purely on CI color**. A `CHANGES_REQUESTED` raised for a **code finding** (auth bypass, data-loss, logic bug), not a CI failure, would also auto-approve (and auto-merge) once CI is green, even though green CI doesn't resolve a code finding.

## Fix — gate on unresolved review threads
The clean discriminator is orthogonal to CI: **a code finding leaves an unresolved review thread; a CI-only block leaves none.** (Body-severity can't separate them — a CI typecheck FAIL is tagged `CRITICAL` too.) This is exactly #854's stated-but-omitted third condition: *"the requested change is present."*

For a prior `CHANGES_REQUESTED` + terminal-green:
- **no unresolved threads** → requested change is in → auto-approve (clears the block; #854 stays fixed).
- **unresolved threads remain** → a concern stands → do **not** auto-approve; fall through to LLM re-review.
- **thread state unknown** (GraphQL error) → fail safe; don't auto-clear a block.

The `COMMENTED`→approve path (no prior block) is unchanged. Thread resolution is GraphQL-only (`reviewThreads.isResolved`); `_hasUnresolvedReviewThreads` returns `null` on any failure and the caller treats `null` as "don't clear".

## Verification
- approve-on-green suite extended: (b) resolved→APPROVE, **(b2)** unresolved→no approve, **(b3)** unknown→no approve.
- `bun test`: **1127 pass, 0 fail** (incl. `NODE_ENV=production`); `tsc` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)