### PR TITLE
fix(quinn): stop the pending-CI busy-wait that thrashes pr_review to no verdict

### DIFF
--- a/src/api/__tests__/pr-inspector-check-ci-format.test.ts
+++ b/src/api/__tests__/pr-inspector-check-ci-format.test.ts
@@ -1,0 +1,46 @@
+/**
+ * check_ci result formatting — the pending-CI comment-and-exit directive.
+ *
+ * Quinn busy-waited on pending CI (re-polling check_ci until the ReAct
+ * recursion limit → no verdict; live: ORBIS#436, a release PR). The result now
+ * tells her to comment once and stop when any check is non-terminal.
+ */
+import { describe, expect, test } from "bun:test";
+import { formatCheckCiResult } from "../pr-inspector.ts";
+
+describe("formatCheckCiResult", () => {
+  test("all terminal → lists checks, NO wait/exit directive", () => {
+    const out = formatCheckCiResult(42, "deadbeefcafe", [
+      { name: "test", status: "completed", conclusion: "success" },
+      { name: "lint", status: "completed", conclusion: "success" },
+    ]);
+    expect(out).toContain("test: success");
+    expect(out).toContain("lint: success");
+    expect(out).not.toContain("Non-terminal CI");
+    expect(out).not.toMatch(/comment once/i);
+  });
+
+  test("any pending check → comment-and-stop directive naming the pending checks", () => {
+    const out = formatCheckCiResult(436, "abc1234", [
+      { name: "ruff", status: "completed", conclusion: "success" },
+      { name: "build", status: "in_progress", conclusion: null },
+      { name: "e2e", status: "queued", conclusion: null },
+    ]);
+    expect(out).toContain("ruff: success");
+    expect(out).toContain("build: in_progress");
+    expect(out).toContain("Non-terminal CI");
+    expect(out).toContain("2 check(s) still running");
+    expect(out).toContain("build");
+    expect(out).toContain("e2e");
+    // the load-bearing instructions
+    expect(out).toMatch(/review_comment/);
+    expect(out).toMatch(/Do not call check_ci again/i);
+    expect(out).toMatch(/comment once, then stop/i);
+  });
+
+  test("no checks → terminal-by-definition message, no directive", () => {
+    const out = formatCheckCiResult(7, "0123456", []);
+    expect(out).toContain("No CI checks found");
+    expect(out).not.toContain("Non-terminal CI");
+  });
+});

--- a/src/api/pr-inspector.ts
+++ b/src/api/pr-inspector.ts
@@ -248,11 +248,37 @@ async function checkCi(owner: string, name: string, pr: number): Promise<string>
     throw err;
   }
   const { headSha, runs } = result;
+  return formatCheckCiResult(pr, headSha, runs);
+}
+
+/**
+ * Format the `check_ci` result for Quinn. When any check is non-terminal the
+ * result carries an explicit comment-and-exit directive.
+ *
+ * Without it Quinn busy-waits: she re-polls `check_ci` waiting for terminal CI
+ * and burns the whole ReAct turn budget → recursion limit → no verdict (live:
+ * ORBIS#436, a release PR whose CI runs long; the #843 escalation paged the
+ * operator). There is nothing to wait for on this pass — the CI-completion
+ * re-dispatch plus deterministic approve-on-green deliver the formal verdict
+ * once checks settle. So the right move on pending CI is: comment once, stop.
+ */
+export function formatCheckCiResult(pr: number, headSha: string, runs: CheckRun[]): string {
   if (runs.length === 0) return `No CI checks found for PR#${pr} (head ${headSha.slice(0, 7)}).`;
   const lines = [`**CI Checks for PR#${pr}** (head ${headSha.slice(0, 7)}):`];
   for (const c of runs) {
     const state = c.conclusion ?? c.status;
     lines.push(`- ${c.name}: ${state}`);
+  }
+  const pending = pendingCheckNames(runs);
+  if (pending.length > 0) {
+    lines.push("");
+    lines.push(
+      `⏳ Non-terminal CI — ${pending.length} check(s) still running (${pending.join(", ")}). ` +
+        `Submit your findings now with review_comment (non-blocking), then return your one-line ` +
+        `confirmation to END the review. Do not call check_ci again to wait: a CI-completion event ` +
+        `re-dispatches you for the formal PASS/FAIL once checks settle, and the merge loop auto-approves ` +
+        `on terminal-green. Nothing to wait for on this pass — comment once, then stop.`,
+    );
   }
   return lines.join("\n");
 }

--- a/workspace/agents/quinn.yaml
+++ b/workspace/agents/quinn.yaml
@@ -366,14 +366,21 @@ skills:
 
       **A formal verdict needs terminal CI.** A PASS or FAIL reflects the
       PR's settled state, so submit `review_approve` / `review_request_changes`
-      once every check has completed. While `check_ci` still shows a
-      `queued` or `in_progress` check, record your findings with
-      `review_comment` (non-blocking) and let the formal verdict land on a
-      later pass once checks are terminal — a "broken CI" FAIL means a
-      check that *completed* with a failure conclusion, not one still
-      running. pr_inspector enforces this: an approve / request-changes
-      call while CI is pending returns a 409 asking you to comment instead,
-      so a re-review after checks finish is the clean path.
+      once every check has completed. A "broken CI" FAIL means a check that
+      *completed* with a failure conclusion, not one still running. pr_inspector
+      enforces this: an approve / request-changes call while CI is pending
+      returns a 409 asking you to comment instead.
+
+      **Pending CI → comment once, then stop. Never wait.** The moment
+      `check_ci` shows any `queued` / `in_progress` check, submit a single
+      `review_comment` with the findings you have and return your one-line
+      confirmation — that ends this review. Do not call `check_ci` again to
+      see if CI finished, and do not loop waiting for it. There is nothing to
+      wait for: when checks settle, a CI-completion event re-dispatches you for
+      the formal PASS/FAIL, and the merge loop auto-approves a clean PR on
+      terminal-green without you. Re-polling pending CI is the one way a simple
+      review runs out of turns and produces no verdict — so on pending CI you
+      take exactly one action (comment) and finish.
 
       **CI you cannot access is a Gap, not a broken-CI FAIL.** When
       `check_ci` reports CI as inaccessible (HTTP 403 — a fork PR, a repo


### PR DESCRIPTION
## What this fixes
The recursion-limit `pr_review` failures (the ones the #843 escalation pages about; the parked `ws-1ny` lever-decision). **Root cause, now attributable thanks to #844:** on a PR whose CI is still running, Quinn re-polls `check_ci` waiting for terminal CI and burns her whole 18-turn ReAct budget → recursion limit → **no verdict** → operator page.

Live case dissected: **ORBIS#436**, a trivial `chore: release v0.2.123` version-bump PR. Trace from `events.db`:
- 3 real tool calls (`check_ci`, `coderabbit_threads`, `diff_summary`),
- then narration `"Waiting on CI for ORBIS#436 (ruff passed, 4 checks still in progress)"` followed by a **loop of `running pr_inspector`** until the cap.

So it's not big diffs (clawpatch territory) — it's **busy-waiting on pending CI** on *any* slow-CI PR.

## Fix — two layers
**Tool result (strongest lever — it's in-context exactly when she decides):** `check_ci` now appends a comment-and-exit directive when any check is non-terminal — *"submit `review_comment`, return your confirmation, END the review; do not call `check_ci` again to wait."* (`formatCheckCiResult`, extracted + unit-tested.)

**Prompt (`quinn.yaml` Step 4):** *"Pending CI → comment once, then stop. Never wait."* Names re-polling pending CI as the one way a simple review runs out of turns.

There's genuinely nothing to wait for on the pre-CI pass: the CI-completion re-dispatch delivers the formal PASS/FAIL, and approve-on-green (#748/#856/#858) lands a clean PR on terminal-green without her.

## Verification
- New unit tests: terminal → no directive, any-pending → comment-and-stop directive naming the pending checks, no-checks → terminal-by-definition.
- `bun test`: **1130 pass, 0 fail** (incl. `NODE_ENV=production`); `tsc` + lint clean.

## Deploy
`quinn.yaml` hot-reloads; `pr-inspector.ts` ships via the image. After deploy, watch `autonomous.outcome.*pr_review` failures — `scripts/quinn-review-eval.ts` should show the recursion_limit mode drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)