### PR TITLE
chore: drop dead ollama refs (follow-up to #864)

### DIFF
--- a/docs/how-to/use-quinn-pr-review.md
+++ b/docs/how-to/use-quinn-pr-review.md
@@ -7,7 +7,7 @@ _This is a how-to guide. It covers webhook setup, triggering PR review, and unde
 
 ---
 
-Quinn reviews pull requests and issues via GitHub webhook. It uses codebase-wide vector search (Qdrant + Ollama) to provide context-aware reviews informed by past PR decisions and code patterns.
+Quinn reviews pull requests and issues via GitHub webhook. It uses codebase-wide vector search (Qdrant + gateway qwen3-embedding) to provide context-aware reviews informed by past PR decisions and code patterns.
 
 ---
 
@@ -21,8 +21,8 @@ Quinn reviews pull requests and issues via GitHub webhook. It uses codebase-wide
 | `GITHUB_APP_ID` | For bot comments | GitHub App ID — Quinn posts as `protoquinn[bot]` |
 | `GITHUB_APP_PRIVATE_KEY` | For bot comments | GitHub App private key (PKCS#1 PEM) |
 | `QDRANT_URL` | For vector context | `http://qdrant:6333` |
-| `OLLAMA_URL` | For embeddings | `http://ollama:11434` |
-| `OLLAMA_EMBED_MODEL` | For embeddings | `nomic-embed-text` |
+| `EMBED_MODEL` | For embeddings | `qwen3-embedding` |
+| `LLM_GATEWAY_URL` | For embeddings | `http://gateway:4000/v1` |
 
 ---
 

--- a/docs/reference/config-files.md
+++ b/docs/reference/config-files.md
@@ -66,8 +66,8 @@ _This is a reference doc. It covers all `workspace/*.yaml` schemas and environme
 |----------|----------|-------------|
 | `QDRANT_URL` | Yes (for vector) | `http://qdrant:6333` |
 | `QDRANT_VECTOR_SIZE` | No | Embedding dimensions (default: `768`) |
-| `OLLAMA_URL` | Yes (for embeddings) | `http://ollama:11434` |
-| `OLLAMA_EMBED_MODEL` | No | Embedding model (default: `nomic-embed-text`) |
+| `EMBED_MODEL` | No | Gateway embedding model (default: `qwen3-embedding`) |
+| `LLM_GATEWAY_URL` | No | Gateway base URL (default: `http://gateway:4000/v1`) |
 
 ### Scheduler Plugin
 

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -115,8 +115,8 @@ Every variable recognised by protoWorkstacean is declared in the zod `EnvSchema`
 
 | Variable | Required? | Description |
 |---|---|---|
-| `OLLAMA_EMBED_MODEL` | optional | — |
-| `OLLAMA_URL` | optional | — |
+| `EMBED_MODEL` | optional | — |
+| `LLM_GATEWAY_URL` | optional | — |
 | `QDRANT_URL` | optional | — |
 | `QDRANT_VECTOR_SIZE` | optional | — |
 | `REDIS_URL` | optional | — |

--- a/scripts/agent-rollcall.sh
+++ b/scripts/agent-rollcall.sh
@@ -44,7 +44,6 @@ INFRA=(
   "graphiti::container:Graphiti (Knowledge Graph)"
   "open-webui:3000:http:Open WebUI"
   "vllm:8000:http:vLLM Inference"
-  "ollama:11434:http:Ollama"
   "langfuse-web:3001:http:Langfuse"
   "caddy::container:Caddy (TLS Proxy)"
   "cloudflared::container:Cloudflared (Tunnel)"

--- a/src/knowledge/research-store.ts
+++ b/src/knowledge/research-store.ts
@@ -7,7 +7,7 @@
  * two ranked lists with Reciprocal Rank Fusion — the combination that, per
  * protoResearcher, fixes the failure modes of either signal alone.
  *
- * Embeddings come from the existing Ollama client. The vector half is
+ * Embeddings come from the gateway (qwen3-embedding via gateway-embed.ts). The vector half is
  * best-effort: if the embedding service is down (embed returns null) we simply
  * store the chunk without a vector and degrade to keyword-only search, never
  * blocking ingestion. Same file as the rest of the knowledge layer.


### PR DESCRIPTION
Cleanup after #864 (embeddings → gateway qwen3-embedding). Removes the now-false-failing `ollama:11434` health check from agent-rollcall, fixes the stale research-store comment, and updates docs (`OLLAMA_*` → `EMBED_MODEL`/`LLM_GATEWAY_URL`/qwen3-embedding). No runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)