### PR TITLE
fix: backfilled CodeRabbit feedback (correlationId in escalations + fetchPrState null-safety)

### DIFF
--- a/lib/__tests__/github-pr-state.test.ts
+++ b/lib/__tests__/github-pr-state.test.ts
@@ -1,0 +1,38 @@
+/**
+ * fetchPrState — null-on-failure contract. A network error or malformed body
+ * must return null (not throw), because feature-remediation's escalation path
+ * relies on null meaning "unknown" rather than crashing.
+ */
+import { describe, expect, test } from "bun:test";
+import { fetchPrState } from "../github-pr-state.ts";
+
+const auth = async () => "fake-token";
+const ok = (body: unknown) =>
+  (async () => new Response(JSON.stringify(body), { status: 200 })) as unknown as typeof fetch;
+
+describe("fetchPrState — null on failure", () => {
+  test("happy path → PrState", async () => {
+    const r = await fetchPrState("o", "r", 1, { authGetter: auth, fetchImpl: ok({ state: "closed", merged: true }) });
+    expect(r).toEqual({ number: 1, state: "closed", merged: true });
+  });
+
+  test("fetch throws (network error) → null", async () => {
+    const fetchImpl = (async () => { throw new Error("ECONNREFUSED"); }) as unknown as typeof fetch;
+    expect(await fetchPrState("o", "r", 1, { authGetter: auth, fetchImpl })).toBeNull();
+  });
+
+  test("malformed body (json throws) → null", async () => {
+    const fetchImpl = (async () => new Response("<!DOCTYPE html>not json", { status: 200 })) as unknown as typeof fetch;
+    expect(await fetchPrState("o", "r", 1, { authGetter: auth, fetchImpl })).toBeNull();
+  });
+
+  test("non-ok response → null", async () => {
+    const fetchImpl = (async () => new Response("nope", { status: 503 })) as unknown as typeof fetch;
+    expect(await fetchPrState("o", "r", 1, { authGetter: auth, fetchImpl })).toBeNull();
+  });
+
+  test("auth throws → null", async () => {
+    const authGetter = async () => { throw new Error("no token"); };
+    expect(await fetchPrState("o", "r", 1, { authGetter, fetchImpl: ok({}) })).toBeNull();
+  });
+});

--- a/lib/github-pr-state.ts
+++ b/lib/github-pr-state.ts
@@ -59,17 +59,22 @@ export async function fetchPrState(
     return null;
   }
 
-  const resp = await doFetch(
-    `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}`,
-    { headers: ghHeaders(token) },
-  );
-
-  if (!resp.ok) return null;
-
-  const data = (await resp.json()) as Record<string, unknown>;
-  return {
-    number: prNumber,
-    state: (data.state as string | null) ?? null,
-    merged: Boolean(data.merged),
-  };
+  // Honor the null-on-failure contract: a network error (fetch throws) or a
+  // malformed body (json throws) must return null, not propagate into the
+  // caller's escalation path.
+  try {
+    const resp = await doFetch(
+      `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}`,
+      { headers: ghHeaders(token) },
+    );
+    if (!resp.ok) return null;
+    const data = (await resp.json()) as Record<string, unknown>;
+    return {
+      number: prNumber,
+      state: (data.state as string | null) ?? null,
+      merged: Boolean(data.merged),
+    };
+  } catch {
+    return null;
+  }
 }

--- a/lib/plugins/feature-remediation.ts
+++ b/lib/plugins/feature-remediation.ts
@@ -208,7 +208,11 @@ export class FeatureRemediationPlugin implements Plugin {
   /**
    * Check origin truth before escalating. If the linked PR has already merged,
    * suppress the escalation — the work shipped, the cap was just tripped by a
-   * long-but-successful run. Also skip if the feature is already done/archived.
+   * long-but-successful run.
+   *
+   * (A feature already marked done/archived with *no* merged PR isn't detectable
+   * from `feature.blocked` alone — that needs a board read, deferred. The
+   * merged-PR check covers the common shipped-work case.)
    *
    * Falls through to `_escalate` only when the work is genuinely incomplete.
    */
@@ -249,13 +253,15 @@ export class FeatureRemediationPlugin implements Plugin {
     ].join("\n");
     const urgency = HITL_KINDS.has(p.kind ?? "") ? "high" : "medium";
     log.warn(`STUCK → escalating to operator: ${p.featureId} (kind=${p.kind}) — ${why}`);
+    const correlationId = crypto.randomUUID();
     this.bus.publish("operator.message.request", {
       id: crypto.randomUUID(),
-      correlationId: crypto.randomUUID(),
+      correlationId,
       topic: "operator.message.request",
       timestamp: this.now(),
       payload: {
         type: "operator_message_request",
+        correlationId,
         message,
         urgency,
         topic: `feature-blocked/${project}/${p.featureId}`,

--- a/lib/plugins/github.ts
+++ b/lib/plugins/github.ts
@@ -1000,6 +1000,7 @@ export class GitHubPlugin implements Plugin {
         timestamp: Date.now(),
         payload: {
           type: "operator_message_request",
+          correlationId,
           message:
             `Quinn could not finish reviewing ${slug} — the review ran out of budget ` +
             `(${error}) and produced no verdict. The PR is unreviewed; it needs a human ` +


### PR DESCRIPTION
Backfill audit (the "do A" follow-up): the required **"CodeRabbit" check gates on review-*completion*, not comment-*resolution*** (`require_conversation_resolution: false`, CodeRabbit posts non-blocking `COMMENTED`), so earlier PRs merged with unaddressed comments. This fixes the verified-real 🟠 Major ones; false positives and low-impact items are triaged below.

## Fixed (verified real)
- **`operator.message.request` payload omitted `correlationId`** in *both* escalation sites (`github.ts` Quinn-budget-exhausted, `feature-remediation.ts` `_escalate`). `OperatorMessageRequest` requires it and operator-routing reads `req.correlationId` for failure-topic routing — it was `undefined`. (from #843/#855)
- **`fetchPrState` could throw despite its "null on failure" contract** — `doFetch()`/`resp.json()` weren't wrapped, so a network/JSON error would propagate into feature-remediation's escalation path. Now returns `null`. **+5 unit tests** (network-throw, malformed-json, non-ok, auth-throw, happy path). (from #855)
- **Docstring overclaim** — feature-remediation claimed done/archived suppression the code doesn't implement (no board read from `feature.blocked`); corrected to the merged-PR check it actually does. (from #855)

## Triaged, not fixed
- **#848 storm-escalator "🔴 CRIT"** — false positive: the drop is recorded (`push` + `set`) *before* the early return, so it's counted; the returns only gate escalation. That was literally the PR's fix.
- **#848 task-tracker immediate dedupe-eviction** — plausible but low-impact (`world.state.delta`, once-per-terminal); deferred rather than churn a sensitive file.
- **quinn-eval script payload-guard / epoch-zero** — operator script + never-happens edge; low stakes.

## Verification
- `bun test`: **1135 pass, 0 fail** (incl. `NODE_ENV=production`); tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for GitHub API requests to reliably return null on network failures, JSON parsing errors, or non-2xx responses.

* **Tests**
  * Added comprehensive test coverage for GitHub API state fetching.

* **Chores**
  * Refined correlation ID generation and messaging payloads for improved traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->