### PR TITLE
fix(canvas): Executions row keyboard-a11y + URL-encode (CodeRabbit on #873)

### DIFF
--- a/dashboard/src/components/Executions.tsx
+++ b/dashboard/src/components/Executions.tsx
@@ -151,10 +151,19 @@ export default function Executions() {
           <tbody>
             {visible.map((f) => {
               const t = tier(f.executorType);
+              const openTrace = () => navigate(`/trace?correlationId=${encodeURIComponent(correlationIdOf(f.id))}`);
               return (
                 <tr
                   key={f.id}
-                  onClick={() => navigate(`/trace?correlationId=${correlationIdOf(f.id)}`)}
+                  role="button"
+                  tabIndex={0}
+                  onClick={openTrace}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      openTrace();
+                    }
+                  }}
                   style={{ borderTop: "1px solid var(--border)", cursor: "pointer" }}
                   title={f.errorPreview ?? `View trace for ${correlationIdOf(f.id)}`}
                 >


### PR DESCRIPTION
Addresses the 2 CodeRabbit comments on #873 (which auto-merged on green before the read-before-merge gate could hold it):
- **Keyboard accessibility (Major):** the drill-down `<tr onClick>` was mouse-only — added `role="button"`, `tabIndex={0}`, and `Enter`/`Space` → open trace.
- **URL-encode (Minor):** `encodeURIComponent` the `correlationId` in the trace link.

dashboard-only; `tsc` + `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Execution table rows now support keyboard navigation. Press Enter or Space to navigate to trace pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->