### PR TITLE
feat(canvas): graph→executions drill-down — agent node click filters the dispatch log

### DIFF
--- a/dashboard/src/components/Executions.tsx
+++ b/dashboard/src/components/Executions.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { getFlows, type FlowRecord } from "../lib/api";
 
 const POLL_INTERVAL = 10_000;
@@ -58,10 +58,20 @@ function fmtAge(ts: number | null): string {
 
 export default function Executions() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  // `?target=<agent>` arrives from a SystemGraph agent-node click — land the
+  // page pre-filtered to that agent's dispatches.
+  const target = searchParams.get("target");
   const [flows, setFlows] = useState<FlowRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState<StatusFilter>("all");
+
+  const clearTarget = () => {
+    const next = new URLSearchParams(searchParams);
+    next.delete("target");
+    setSearchParams(next, { replace: true });
+  };
 
   async function refresh(force = false) {
     try {
@@ -91,7 +101,11 @@ export default function Executions() {
     acc[k] = (acc[k] ?? 0) + 1;
     return acc;
   }, {});
-  const visible = filter === "all" ? flows : flows.filter((f) => f.status === filter);
+  const visible = flows.filter((f) => {
+    if (filter !== "all" && f.status !== filter) return false;
+    if (target && f.targetAgent !== target) return false;
+    return true;
+  });
 
   return (
     <div style={{ padding: 16 }}>
@@ -100,6 +114,28 @@ export default function Executions() {
         <span style={{ fontSize: 12, color: "var(--text-muted)", fontFamily: "var(--font-mono, monospace)" }}>
           {flows.length} flows · {counts.complete ?? 0} complete · {counts.active ?? 0} active · {counts.blocked ?? 0} blocked
         </span>
+        {target && (
+          <button
+            onClick={clearTarget}
+            title="Clear agent filter"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+              fontSize: 11,
+              fontFamily: "var(--font-mono, monospace)",
+              padding: "3px 8px",
+              borderRadius: 5,
+              border: "1px solid var(--border)",
+              background: "var(--bg-hover, rgba(255,255,255,0.06))",
+              color: "var(--text, #ededed)",
+              cursor: "pointer",
+            }}
+          >
+            target: {target}
+            <span style={{ color: "var(--text-muted)" }}>×</span>
+          </button>
+        )}
         <div style={{ display: "flex", gap: 4, marginLeft: "auto" }}>
           {STATUS_FILTERS.map((s) => (
             <button
@@ -133,7 +169,9 @@ export default function Executions() {
       )}
 
       {!error && flows.length > 0 && visible.length === 0 && (
-        <div style={{ color: "var(--text-muted)", padding: 48, textAlign: "center" }}>No {filter} dispatches.</div>
+        <div style={{ color: "var(--text-muted)", padding: 48, textAlign: "center" }}>
+          No {filter === "all" ? "" : `${filter} `}dispatches{target ? ` for ${target}` : ""}.
+        </div>
       )}
 
       {visible.length > 0 && (

--- a/dashboard/src/components/SystemGraph.tsx
+++ b/dashboard/src/components/SystemGraph.tsx
@@ -25,6 +25,7 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { ReactFlow, Background, Controls, type Edge, type Node } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import AgentNode, { type AgentActivityState } from "./AgentNode.tsx";
@@ -337,6 +338,7 @@ function applyActivity(state: Map<string, AgentActivityState>, ev: AgentActivity
 const NODE_TYPES = { agent: AgentNode, service: ServiceNode };
 
 export default function SystemGraph() {
+  const navigate = useNavigate();
   const [topology, setTopology] = useState<PluginTopologyEntry[] | null>(null);
   const [agents, setAgents] = useState<AgentRuntimeEntry[]>([]);
   const [agentActivity, setAgentActivity] = useState<Map<string, AgentActivityState>>(new Map());
@@ -496,6 +498,15 @@ export default function SystemGraph() {
         nodeTypes={NODE_TYPES}
         fitView
         minZoom={0.2}
+        onNodeClick={(_evt: unknown, node: Node) => {
+          // Agent nodes (id `agent-<name>`) drill into the execution log
+          // pre-filtered to that agent's dispatches. Plugin/service/api-route
+          // nodes have no execution view — those clicks are inert.
+          if (node.id.startsWith("agent-")) {
+            const agent = node.id.slice("agent-".length);
+            navigate(`/executions?target=${encodeURIComponent(agent)}`);
+          }
+        }}
         onEdgeClick={(_evt: unknown, edge: Edge) => {
           // Edges built from publisher → subscriber carry their topic as the
           // edge label. Static plugin → service edges have no topic — those


### PR DESCRIPTION
## What

SystemGraph agent nodes (`/system`) become clickable: a click navigates to `/executions?target=<agent>`, landing the execution log pre-filtered to that agent's dispatches. Closes the graph→Executions linkage (ADR-0008 P1) — the observability spine now connects the live topology view to the durable dispatch log.

## Detail

**`SystemGraph.tsx`** — added `onNodeClick`: agent nodes (`id` = `agent-<name>`) navigate to `/executions?target=<encoded name>`. Plugin / service / `api-routes` node clicks are inert (no execution view for them). Edge-click drawer behaviour unchanged.

**`Executions.tsx`** — reads `?target=` via `useSearchParams`, AND-combines it with the status filter (`visible = status-match AND target-match`), and renders a clearable `target: <agent>` chip (`setSearchParams(..., { replace: true })` — no history spam). Empty states name the target.

## Notes

- Held until #874 merged to avoid an `Executions.tsx` parallel-edit collision (per the canvas plan).
- `target` matches `FlowRecord.targetAgent`; an agent with no recorded dispatches shows the target-named empty state.

## Verification

- `tsc --noEmit` clean
- `vite build` clean (chunk-size warning pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filter executions by target agent—click agent nodes in the system graph to view their executions
  * Added UI control to clear the agent filter
  * Updated empty-state messaging to reflect active filter selections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->