### PR TITLE
feat(canvas): WS-3a — tier-tag canvas nodes builtin vs a2a, with remote host

### DIFF
--- a/dashboard/src/components/AgentNode.tsx
+++ b/dashboard/src/components/AgentNode.tsx
@@ -25,6 +25,8 @@ export interface AgentActivityState {
 export interface AgentNodeData {
   label: string;
   type: string; // "deep-agent" | "a2a" | "function"
+  /** A2A only: endpoint host[:port] (e.g. "roxy:7870") — where the remote node lives. */
+  host?: string;
   activity?: AgentActivityState;
 }
 
@@ -35,11 +37,10 @@ const STATUS_COLOR: Record<AgentStatus, string> = {
   error: "var(--text-danger)",       // GitHub red
 };
 
-const TYPE_LABEL: Record<string, string> = {
-  "deep-agent": "DeepAgent",
-  a2a: "A2A",
-  function: "function",
-};
+/** Tier tag (ADR-0008): in-process `builtin` vs distributed `a2a`. */
+function tierLabel(type: string): string {
+  return type === "a2a" ? "a2a" : "builtin";
+}
 
 function relativeTime(ms: number): string {
   const delta = Date.now() - ms;
@@ -53,13 +54,17 @@ export default function AgentNode({ data }: { data: AgentNodeData }) {
   const activity = data.activity;
   const status: AgentStatus = activity?.status ?? "idle";
   const statusColor = STATUS_COLOR[status];
+  // Remote (A2A) nodes get a dashed border — the same "lives elsewhere" idiom
+  // the graph already uses for service + api-route nodes — so tier reads at a
+  // glance even when idle.
+  const isRemote = data.type === "a2a";
 
   return (
     <div
       style={{
         background: "var(--bg-canvas)",
         color: "var(--text-primary)",
-        border: `1px solid ${statusColor}`,
+        border: `1px ${isRemote ? "dashed" : "solid"} ${statusColor}`,
         borderRadius: 8,
         padding: 10,
         minWidth: 220,
@@ -79,12 +84,12 @@ export default function AgentNode({ data }: { data: AgentNodeData }) {
           style={{
             fontSize: 9,
             padding: "1px 5px",
-            border: "1px solid var(--border-default)",
+            border: `1px ${isRemote ? "dashed" : "solid"} var(--border-default)`,
             borderRadius: 3,
-            color: "var(--text-secondary)",
+            color: isRemote ? "var(--accent-fg)" : "var(--text-secondary)",
           }}
         >
-          {TYPE_LABEL[data.type] ?? data.type}
+          {tierLabel(data.type)}
         </span>
         <span style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 4 }}>
           <span
@@ -99,6 +104,13 @@ export default function AgentNode({ data }: { data: AgentNodeData }) {
           <span style={{ fontSize: 10, color: statusColor }}>{status}</span>
         </span>
       </div>
+
+      {/* Remote host — where the distributed A2A node lives */}
+      {isRemote && data.host && (
+        <div style={{ fontSize: 10, color: "var(--text-secondary)", marginBottom: 4 }}>
+          <span style={{ color: "var(--accent-fg)" }}>⤳</span> {data.host}
+        </div>
+      )}
 
       {/* Current skill */}
       {activity?.currentSkill && (

--- a/dashboard/src/components/SystemGraph.tsx
+++ b/dashboard/src/components/SystemGraph.tsx
@@ -52,6 +52,8 @@ interface AgentRuntimeEntry {
   name: string;
   type: string;
   skills: string[];
+  /** A2A only: endpoint host[:port] from /api/agents/runtime. */
+  host?: string;
 }
 
 interface AgentActivityEvent {
@@ -137,7 +139,7 @@ function buildGraph({ plugins, agents, agentActivity, activeEdges }: BuildArgs):
       id: `agent-${a.name}`,
       type: "agent",
       position: PLACEHOLDER_POS,
-      data: { label: a.name, type: a.type, activity: agentActivity.get(a.name) },
+      data: { label: a.name, type: a.type, host: a.host, activity: agentActivity.get(a.name) },
     });
   });
 

--- a/src/api/__tests__/agents-runtime.test.ts
+++ b/src/api/__tests__/agents-runtime.test.ts
@@ -1,0 +1,80 @@
+/**
+ * /api/agents/runtime host derivation (ADR-0008 WS-3a). The canvas tags A2A
+ * nodes with where they live; the host comes from the declared yaml url and
+ * must survive both the pending-discovery and registry-discovered paths.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { ExecutorRegistry } from "../../executor/executor-registry.ts";
+import type { IExecutor, SkillRequest, SkillResult } from "../../executor/types.ts";
+import { collectFleetAgents, hostFromUrl } from "../agents-runtime.ts";
+import type { ApiContext } from "../types.ts";
+
+function a2aExecutor(): IExecutor {
+  return {
+    type: "a2a",
+    execute: mock(async (req: SkillRequest): Promise<SkillResult> => ({ text: "", isError: false, correlationId: req.correlationId })),
+  };
+}
+function deepAgentExecutor(): IExecutor {
+  return {
+    type: "deep-agent",
+    execute: mock(async (req: SkillRequest): Promise<SkillResult> => ({ text: "", isError: false, correlationId: req.correlationId })),
+  };
+}
+
+describe("hostFromUrl", () => {
+  test("derives host:port from an A2A url", () => {
+    expect(hostFromUrl("http://roxy:7870/a2a")).toBe("roxy:7870");
+  });
+  test("keeps the bare host when the port is the scheme default", () => {
+    expect(hostFromUrl("http://frank/a2a")).toBe("frank");
+  });
+  test("undefined / empty / unparseable → undefined", () => {
+    expect(hostFromUrl(undefined)).toBeUndefined();
+    expect(hostFromUrl("")).toBeUndefined();
+    expect(hostFromUrl("roxy:7870")).toBeUndefined(); // no scheme → not a URL
+  });
+});
+
+describe("collectFleetAgents host attachment", () => {
+  let root: string;
+  let registry: ExecutorRegistry;
+  let ctx: ApiContext;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "agents-runtime-"));
+    mkdirSync(join(root, "agents.d"));
+    writeFileSync(join(root, "agents.d", "roxy.yaml"), "name: roxy\nurl: http://roxy:7870/a2a\n");
+    registry = new ExecutorRegistry();
+    ctx = { workspaceDir: root, bus: new InMemoryEventBus(), plugins: [], executorRegistry: registry };
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  test("declared-but-undiscovered A2A agent carries host + pendingDiscovery", () => {
+    const roxy = collectFleetAgents(ctx).find((a) => a.name === "roxy");
+    expect(roxy).toBeDefined();
+    expect(roxy?.type).toBe("a2a");
+    expect(roxy?.host).toBe("roxy:7870");
+    expect(roxy?.pendingDiscovery).toBe(true);
+  });
+
+  test("registry-discovered A2A agent keeps host, drops pendingDiscovery", () => {
+    registry.register("portfolio_sitrep", a2aExecutor(), { agentName: "roxy" });
+    const roxy = collectFleetAgents(ctx).find((a) => a.name === "roxy");
+    expect(roxy?.host).toBe("roxy:7870");
+    expect(roxy?.skills).toEqual(["portfolio_sitrep"]);
+    expect(roxy?.pendingDiscovery).toBeUndefined();
+  });
+
+  test("builtin (deep-agent) agents have no host", () => {
+    registry.register("pr_review", deepAgentExecutor(), { agentName: "quinn" });
+    const quinn = collectFleetAgents(ctx).find((a) => a.name === "quinn");
+    expect(quinn?.type).toBe("deep-agent");
+    expect(quinn?.host).toBeUndefined();
+  });
+});

--- a/src/api/__tests__/agents-runtime.test.ts
+++ b/src/api/__tests__/agents-runtime.test.ts
@@ -4,7 +4,7 @@
  * must survive both the pending-discovery and registry-discovered paths.
  */
 
-import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -17,13 +17,13 @@ import type { ApiContext } from "../types.ts";
 function a2aExecutor(): IExecutor {
   return {
     type: "a2a",
-    execute: mock(async (req: SkillRequest): Promise<SkillResult> => ({ text: "", isError: false, correlationId: req.correlationId })),
+    execute: async (req: SkillRequest): Promise<SkillResult> => ({ text: "", isError: false, correlationId: req.correlationId }),
   };
 }
 function deepAgentExecutor(): IExecutor {
   return {
     type: "deep-agent",
-    execute: mock(async (req: SkillRequest): Promise<SkillResult> => ({ text: "", isError: false, correlationId: req.correlationId })),
+    execute: async (req: SkillRequest): Promise<SkillResult> => ({ text: "", isError: false, correlationId: req.correlationId }),
   };
 }
 

--- a/src/api/agents-runtime.ts
+++ b/src/api/agents-runtime.ts
@@ -22,7 +22,7 @@
  *     data: {
  *       agents: [
  *         { name: "quinn", type: "deep-agent", skills: ["pr_review", ...] },
- *         { name: "protomaker", type: "a2a", skills: [...], pendingDiscovery: false },
+ *         { name: "roxy", type: "a2a", skills: [...], host: "roxy:7870" },
  *         { name: "function", type: "function", skills: ["alert.*", ...] },
  *         ...
  *       ]
@@ -41,6 +41,8 @@ export interface AgentSummary {
   skills: string[];
   /** True iff this agent is known from yaml but hasn't registered any skill yet (A2A card discovery in flight). */
   pendingDiscovery?: boolean;
+  /** For A2A agents: the endpoint host[:port] (e.g. "roxy:7870"), derived from the yaml url. The canvas tags remote nodes with where they live. */
+  host?: string;
 }
 
 interface YamlAgent {
@@ -50,19 +52,34 @@ interface YamlAgent {
 }
 
 /**
- * Names of A2A agents declared on disk: the hand-maintained agents.yaml plus
- * each control-plane-managed agents.d/*.yaml (ADR-0004 P3). These may not be in
- * the registry yet (card discovery in flight) but should render eagerly.
+ * Endpoint host[:port] from an A2A url, or undefined if absent/unparseable.
+ * `http://roxy:7870/a2a` → `roxy:7870`. The default-port case keeps the bare
+ * host. Pure — unit-tested directly; the canvas shows this on A2A nodes.
  */
-function loadDeclaredA2aNames(workspaceDir: string): string[] {
-  const names: string[] = [];
+export function hostFromUrl(url?: string): string | undefined {
+  if (!url) return undefined;
+  try {
+    return new URL(url).host || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * A2A agents declared on disk (name + endpoint host): the hand-maintained
+ * agents.yaml plus each control-plane-managed agents.d/*.yaml (ADR-0004 P3).
+ * These may not be in the registry yet (card discovery in flight) but should
+ * render eagerly, and their host is known statically from the yaml url.
+ */
+function loadDeclaredA2aAgents(workspaceDir: string): Array<{ name: string; host?: string }> {
+  const agents: Array<{ name: string; host?: string }> = [];
 
   const yamlPath = join(workspaceDir, "agents.yaml");
   if (existsSync(yamlPath)) {
     try {
       const parsed = parseYaml(readFileSync(yamlPath, "utf8")) as { agents?: YamlAgent[] };
       for (const a of Array.isArray(parsed?.agents) ? parsed.agents : []) {
-        if (a?.name) names.push(a.name);
+        if (a?.name) agents.push({ name: a.name, host: hostFromUrl(a.url) });
       }
     } catch {
       // Tolerate parse errors — the live registry view is still useful and an
@@ -75,14 +92,14 @@ function loadDeclaredA2aNames(workspaceDir: string): string[] {
     for (const file of readdirSync(dir).filter((f) => f.endsWith(".yaml"))) {
       try {
         const parsed = parseYaml(readFileSync(join(dir, file), "utf8")) as YamlAgent;
-        if (parsed?.name) names.push(parsed.name);
+        if (parsed?.name) agents.push({ name: parsed.name, host: hostFromUrl(parsed.url) });
       } catch {
         // skip an unparseable managed file
       }
     }
   }
 
-  return names;
+  return agents;
 }
 
 /**
@@ -104,8 +121,11 @@ export function collectFleetAgents(ctx: ApiContext): AgentSummary[] {
 
   // Merge declared A2A agents. If already in the registry (discovered /
   // in-process), the registry wins; otherwise mark pendingDiscovery so the
-  // dashboard renders a node with no skills yet.
-  for (const name of loadDeclaredA2aNames(ctx.workspaceDir)) {
+  // dashboard renders a node with no skills yet. Either way the yaml is the
+  // source of truth for the endpoint host.
+  const declared = loadDeclaredA2aAgents(ctx.workspaceDir);
+  const hostByName = new Map(declared.map((d) => [d.name, d.host]));
+  for (const { name } of declared) {
     if (byKey.has(name)) continue;
     byKey.set(name, { type: "a2a", skills: new Set() });
   }
@@ -114,8 +134,10 @@ export function collectFleetAgents(ctx: ApiContext): AgentSummary[] {
     .map(([name, { type, skills }]) => {
       const skillList = [...skills].sort();
       const summary: AgentSummary = { name, type, skills: skillList };
-      if (type === "a2a" && skillList.length === 0) {
-        summary.pendingDiscovery = true;
+      if (type === "a2a") {
+        const host = hostByName.get(name);
+        if (host) summary.host = host;
+        if (skillList.length === 0) summary.pendingDiscovery = true;
       }
       return summary;
     })


### PR DESCRIPTION
## What

First slice of the **WS-3 keystone** (ADR-0008 P1): make `SystemGraph` nodes **tier-aware** — in-process `builtin` vs distributed `a2a`, with the remote node's host shown.

## Backend — `/api/agents/runtime`

- `AgentSummary` gains **`host?`**: the A2A endpoint `host[:port]` (e.g. `roxy:7870`), derived from the declared yaml `url` via a new pure `hostFromUrl` helper.
- Host survives **both** code paths: declared-but-undiscovered (`pendingDiscovery`) and registry-discovered. Builtin agents carry no host.

## Frontend — `AgentNode` + `SystemGraph`

- **Tier badge**: `builtin` vs `a2a` (replaces the old DeepAgent/A2A/function label with the ADR-0008 tier vocabulary).
- **A2A nodes get a dashed border** — the same "lives elsewhere" idiom the graph already uses for service + api-route nodes — so tier reads at a glance even when idle.
- A2A nodes show their **host** (`⤳ roxy:7870`).

## Tests

6 new (`src/api/__tests__/agents-runtime.test.ts`): `hostFromUrl` cases + `collectFleetAgents` host attachment across the pending / discovered / builtin paths.

## Verification

- `bun test` new file: 6/6 · control-plane + agents-crud: 13/13 still green
- dashboard `tsc` + `vite build` clean · 20/20 dashboard tests
- (the one biome warning is the pre-existing `topicMatches` nested ternary, untouched)

## Next in WS-3

- **WS-3b** — live dispatch animation from `flow.item.*` (the demo: in-process + A2A dispatch animate on one canvas).
- **WS-3c** — node-click → right-panel inspector (lands in the WS-2 dock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard shows remote (A2A) agents with distinct tier labels, dashed border styling, and an optional remote host line in node headers.
  * Agent runtime summaries now include optional host information so remote agents display their endpoint where available.

* **Tests**
  * Added tests covering host extraction and fleet-agent host attachment and discovery behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->