### PR TITLE
feat(canvas): WS-3b — live dispatch animation from flow.item.* (+ fix targetAgent wiring)

### DIFF
--- a/dashboard/src/components/SystemGraph.tsx
+++ b/dashboard/src/components/SystemGraph.tsx
@@ -34,6 +34,7 @@ import MessageDrawer, { type DrawerMessage } from "./MessageDrawer.tsx";
 import QuinnVerdictCounters from "./QuinnVerdictCounters.tsx";
 import LatencyHistogram from "./LatencyHistogram.tsx";
 import { architecturalLayout } from "../lib/layout.ts";
+import { applyFlowDispatch, type FlowDispatchItem } from "../lib/flow-dispatch.ts";
 
 /** Ring-buffer cap for per-topic history shown in the edge drawer. */
 const TOPIC_HISTORY_CAP = 20;
@@ -127,9 +128,11 @@ interface BuildArgs {
   agents: AgentRuntimeEntry[];
   agentActivity: Map<string, AgentActivityState>;
   activeEdges: Set<string>;
+  /** Agent names with a live dispatch, folded from flow.item.* (WS-3b). */
+  inFlight: Set<string>;
 }
 
-function buildGraph({ plugins, agents, agentActivity, activeEdges }: BuildArgs): { nodes: Node[]; edges: Edge[] } {
+function buildGraph({ plugins, agents, agentActivity, activeEdges, inFlight }: BuildArgs): { nodes: Node[]; edges: Edge[] } {
   const nodes: Node[] = [];
   const edges: Edge[] = [];
 
@@ -210,18 +213,26 @@ function buildGraph({ plugins, agents, agentActivity, activeEdges }: BuildArgs):
   }
 
   // 6. Agent → agent-runtime / skill-broker plugin edges. Each agent's
-  // dispatch flows through one of those plugins; render an edge so the
-  // animation reaches the agent node when activity is live.
+  // dispatch flows through one of those plugins; the edge animates while a
+  // dispatch to that agent is in-flight. The live signal is flow.item.* (the
+  // hub's authoritative dispatch lifecycle), so a dispatch out to a distributed
+  // A2A agent animates exactly like an in-process one — both flow through the
+  // hub. A2A edges are dashed, matching the "lives elsewhere" idiom.
   for (const a of agents) {
     const hostPlugin = a.type === "a2a" ? "skill-broker" : "agent-runtime";
     if (!plugins.find((p) => p.name === hostPlugin)) continue;
-    const live = agentActivity.get(a.name)?.status === "running";
+    const live = inFlight.has(a.name);
+    const remote = a.type === "a2a";
     edges.push({
       id: `agent-${a.name}->${hostPlugin}`,
       source: `plugin-${hostPlugin}`,
       target: `agent-${a.name}`,
       animated: live,
-      style: { stroke: live ? "var(--text-success)" : "var(--border-default)", strokeWidth: live ? 2 : 1 },
+      style: {
+        stroke: live ? "var(--text-success)" : "var(--border-default)",
+        strokeWidth: live ? 2 : 1,
+        strokeDasharray: remote ? "5 4" : undefined,
+      },
     });
   }
 
@@ -345,6 +356,9 @@ export default function SystemGraph() {
   const [agents, setAgents] = useState<AgentRuntimeEntry[]>([]);
   const [agentActivity, setAgentActivity] = useState<Map<string, AgentActivityState>>(new Map());
   const [activeEdges, setActiveEdges] = useState<Set<string>>(new Set());
+  // Agent names with a live dispatch, folded from flow.item.* (WS-3b). Drives
+  // the host→agent edge animation uniformly across builtin + a2a tiers.
+  const [inFlight, setInFlight] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
   // Per-topic ring buffer of recent WS-observed messages. Lives in a ref
   // (not state) because every WS frame would otherwise re-trigger the
@@ -411,10 +425,17 @@ export default function SystemGraph() {
             timestamp?: number;
           };
           if (!msg.topic) return;
-          // Agent activity → state machine
+          // Agent activity → state machine (in-process node internals: skill + tools)
           if (msg.topic.startsWith("agent.runtime.activity.")) {
             const ev = msg.payload as AgentActivityEvent;
             setAgentActivity((cur) => applyActivity(cur, ev));
+          }
+          // Dispatch lifecycle → in-flight set (the authoritative, tier-agnostic
+          // signal driving the host→agent edge animation).
+          if (msg.topic.startsWith("flow.item.")) {
+            const topic = msg.topic;
+            const item = msg.payload as FlowDispatchItem;
+            setInFlight((cur) => applyFlowDispatch(cur, topic, item));
           }
           // Per-topic ring buffer for D3's edge drawer. Cap at TOPIC_HISTORY_CAP.
           const buf = topicHistoryRef.current.get(msg.topic) ?? [];
@@ -468,9 +489,9 @@ export default function SystemGraph() {
 
   const { nodes, edges } = useMemo(
     () => topology
-      ? buildGraph({ plugins: topology, agents, agentActivity, activeEdges })
+      ? buildGraph({ plugins: topology, agents, agentActivity, activeEdges, inFlight })
       : { nodes: [], edges: [] },
-    [topology, agents, agentActivity, activeEdges],
+    [topology, agents, agentActivity, activeEdges, inFlight],
   );
 
   // ALL hooks must run before any conditional return (Rules of Hooks). This

--- a/dashboard/src/lib/__tests__/flow-dispatch.test.ts
+++ b/dashboard/src/lib/__tests__/flow-dispatch.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from "bun:test";
+import { applyFlowDispatch } from "../flow-dispatch.ts";
+
+const created = (agent?: string) => ({ status: "active" as const, stage: "dispatched" as const, meta: { targetAgent: agent } });
+
+describe("applyFlowDispatch", () => {
+  test("flow.item.created with a target agent adds it to the in-flight set", () => {
+    const out = applyFlowDispatch(new Set(), "flow.item.created", created("roxy"));
+    expect([...out]).toEqual(["roxy"]);
+  });
+
+  test("flow.item.completed removes the agent", () => {
+    const live = new Set(["roxy", "quinn"]);
+    const out = applyFlowDispatch(live, "flow.item.completed", { status: "complete", stage: "done", meta: { targetAgent: "roxy" } });
+    expect([...out].sort()).toEqual(["quinn"]);
+  });
+
+  test("a blocked/error update is terminal — removes the agent", () => {
+    const live = new Set(["quinn"]);
+    const out = applyFlowDispatch(live, "flow.item.updated", { status: "blocked", stage: "error", meta: { targetAgent: "quinn" } });
+    expect(out.has("quinn")).toBe(false);
+  });
+
+  test("an active update keeps the agent in-flight", () => {
+    const live = new Set(["quinn"]);
+    const out = applyFlowDispatch(live, "flow.item.updated", { status: "active", stage: "running", meta: { targetAgent: "quinn" } });
+    expect(out.has("quinn")).toBe(true);
+  });
+
+  test("a2a and builtin dispatches are tracked identically (both flow through the hub)", () => {
+    let s = new Set<string>();
+    s = applyFlowDispatch(s, "flow.item.created", created("quinn")); // builtin
+    s = applyFlowDispatch(s, "flow.item.created", created("roxy")); // a2a
+    expect([...s].sort()).toEqual(["quinn", "roxy"]);
+  });
+
+  test("events without a target agent are inert (same reference, no churn)", () => {
+    const live = new Set(["roxy"]);
+    expect(applyFlowDispatch(live, "flow.item.created", created(undefined))).toBe(live);
+    expect(applyFlowDispatch(live, "flow.item.created", created(""))).toBe(live);
+    expect(applyFlowDispatch(live, "flow.item.created", { meta: {} })).toBe(live);
+  });
+
+  test("idempotent: re-adding a tracked agent / removing an absent one returns the same reference", () => {
+    const live = new Set(["roxy"]);
+    expect(applyFlowDispatch(live, "flow.item.created", created("roxy"))).toBe(live);
+    expect(applyFlowDispatch(live, "flow.item.completed", { status: "complete", meta: { targetAgent: "absent" } })).toBe(live);
+  });
+});

--- a/dashboard/src/lib/flow-dispatch.ts
+++ b/dashboard/src/lib/flow-dispatch.ts
@@ -1,0 +1,50 @@
+/**
+ * In-flight dispatch tracking for the canvas (ADR-0008 WS-3b).
+ *
+ * The hub's authoritative dispatch signal is `flow.item.*` — every dispatch,
+ * builtin or A2A, flows through the SkillDispatcher and emits created → (updated)*
+ * → completed. We fold them into a set of agent names that currently have a live
+ * dispatch, so SystemGraph animates the host→agent edge uniformly across tiers
+ * (a dispatch to a distributed A2A agent animates the same as an in-process one —
+ * it all flows through the one hub).
+ */
+
+export interface FlowDispatchItem {
+  status?: "active" | "blocked" | "complete";
+  stage?: "dispatched" | "running" | "error" | "done";
+  meta?: { targetAgent?: unknown };
+}
+
+/** A flow.item.* event is terminal on completion or error. */
+function isTerminal(topic: string, item: FlowDispatchItem): boolean {
+  return (
+    topic === "flow.item.completed"
+    || item.status === "complete"
+    || item.status === "blocked"
+    || item.stage === "done"
+    || item.stage === "error"
+  );
+}
+
+/**
+ * Fold one `flow.item.*` event into the in-flight set. Returns the SAME set
+ * reference when nothing changed (so React can bail out of a re-render), a new
+ * set otherwise. Events without a non-empty string `targetAgent`
+ * (function/ceremony dispatches) are inert.
+ */
+export function applyFlowDispatch(current: Set<string>, topic: string, item: FlowDispatchItem): Set<string> {
+  const agent = item?.meta?.targetAgent;
+  if (typeof agent !== "string" || agent === "") return current;
+
+  if (isTerminal(topic, item)) {
+    if (!current.has(agent)) return current;
+    const next = new Set(current);
+    next.delete(agent);
+    return next;
+  }
+
+  if (current.has(agent)) return current;
+  const next = new Set(current);
+  next.add(agent);
+  return next;
+}

--- a/src/executor/__tests__/skill-dispatcher-plugin.test.ts
+++ b/src/executor/__tests__/skill-dispatcher-plugin.test.ts
@@ -85,6 +85,24 @@ describe("SkillDispatcherPlugin", () => {
     expect((reply!.payload as Record<string, unknown>).error).toBeUndefined();
   });
 
+  it("flow.item.created carries the target agent (canvas attribution + Executions filter)", async () => {
+    registry.register(
+      "some_skill",
+      new FunctionExecutor(async (req: SkillRequest): Promise<SkillResult> => ({ text: "ok", isError: false, correlationId: req.correlationId })),
+      { agentName: "ava" },
+    );
+    bus.publish("agent.skill.request", makeMsg({ payload: { skill: "some_skill", targets: ["ava"] }, reply: { topic: "reply.t" } }));
+    await new Promise((r) => setTimeout(r, 10));
+
+    const created = bus.published.find((m) => m.topic === "flow.item.created");
+    expect(created).toBeDefined();
+    const meta = (created!.payload as { meta?: Record<string, unknown> }).meta;
+    expect(meta?.targetAgent).toBe("ava");
+
+    const completed = bus.published.find((m) => m.topic === "flow.item.completed");
+    expect((completed!.payload as { meta?: Record<string, unknown> }).meta?.targetAgent).toBe("ava");
+  });
+
   it("publishes error response when no executor found", async () => {
     const msg = makeMsg({ reply: { topic: "reply.test" } });
     bus.publish("agent.skill.request", msg);

--- a/src/executor/skill-dispatcher-plugin.ts
+++ b/src/executor/skill-dispatcher-plugin.ts
@@ -362,7 +362,7 @@ export class SkillDispatcherPlugin implements Plugin {
       stage: "dispatched",
       createdAt: dispatchedAt,
       startedAt: dispatchedAt,
-      meta: { skill, executorType: executor.type },
+      meta: { skill, executorType: executor.type, targetAgent: targets[0] },
     });
 
     // Live agent telemetry — the /system dashboard subscribes to
@@ -467,7 +467,7 @@ export class SkillDispatcherPlugin implements Plugin {
           id: flowItemId,
           status: "active",
           stage: "running",
-          meta: { skill, taskId, taskState, trackedBy: "task-tracker" },
+          meta: { skill, taskId, taskState, trackedBy: "task-tracker", targetAgent: targets[0] },
         });
         // Don't publish a response — tracker will do it. Still fall through to
         // finally block so activeExecutions gets cleaned up.
@@ -489,7 +489,7 @@ export class SkillDispatcherPlugin implements Plugin {
           id: flowItemId,
           status: "blocked",
           stage: "error",
-          meta: { skill, error: result.text },
+          meta: { skill, error: result.text, targetAgent: targets[0] },
         });
         this._publishAutonomousOutcome({
           correlationId,
@@ -585,6 +585,7 @@ export class SkillDispatcherPlugin implements Plugin {
           meta: {
             skill,
             executorType: executor.type,
+            targetAgent: targets[0],
             durationMs,
             inputTokens: result.data?.usage?.input_tokens,
             outputTokens: result.data?.usage?.output_tokens,
@@ -644,7 +645,7 @@ export class SkillDispatcherPlugin implements Plugin {
         id: flowItemId,
         status: "blocked",
         stage: "error",
-        meta: { skill, error: errorMsg },
+        meta: { skill, error: errorMsg, targetAgent: targets[0] },
       });
       this._publishAutonomousOutcome({
         correlationId,


### PR DESCRIPTION
## What

The **WS-3 keystone** (ADR-0008 P1): the canvas animates a dispatch traveling to its target agent — uniformly for `builtin` and `a2a`, because every dispatch flows through the one hub.

## Fixes a latent wiring bug (the foundation)

The flow store reads `meta.targetAgent`, but the `SkillDispatcher`'s `flow.item.*` events only emitted `{skill, executorType}` — **never the target agent**. So `FlowRecord.targetAgent` was always `null`:
- the Executions **"Target" column was always `—`**, and
- the **#875 graph→Executions linkage never matched** (clicking an agent node showed nothing).

The dispatcher now stamps `targetAgent: targets[0]` on **every** `flow.item` meta (created / updated / completed / error). That repair is also exactly the attribution the canvas needs.

## Canvas — `SystemGraph`

- New **pure reducer** `applyFlowDispatch` (in `lib/flow-dispatch.ts`) folds `flow.item.*` into an in-flight set of agent names: created/active → add; completed/blocked/error → remove; events with no `targetAgent` are inert (same-reference, no re-render churn).
- The **host→agent edge animates while a dispatch to that agent is in-flight**, driven by `flow.item.*` — the hub's authoritative dispatch lifecycle — rather than the best-effort activity telemetry. **A2A edges are dashed** (the "lives elsewhere" idiom). A dispatch out to `roxy@steamdeck` animates exactly like an in-process one.

## Acceptance (the demo)

A real dispatch to an in-process agent **and** one out to a distributed A2A agent both animate live on one canvas, drawn from the one bus — ✅ same code path, both via `flow.item.*`.

## Tests

- Backend: `flow.item.created`/`completed` carry `targetAgent` (concrete `FunctionExecutor`, **no mocks** per CLAUDE.md guideline).
- Frontend: 7 `applyFlowDispatch` cases (add/remove/terminal/inert/idempotent/tier-agnostic).
- Backend 202 executor + 51 knowledge/flow-store tests green · dashboard `tsc` + `vite build` + 27 tests green.

## Follow-up in WS-3

- **WS-3c** — node-click → right-panel inspector (recent skills, tool-calls, last flow item, jump to `SkillTrace`) in the WS-2 dock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)