### PR TITLE
feat(canvas): WS-3c — node-click inspector (composes tier, activity, last flow, trace)

### DIFF
--- a/dashboard/src/components/NodeInspector.tsx
+++ b/dashboard/src/components/NodeInspector.tsx
@@ -1,0 +1,197 @@
+/**
+ * NodeInspector — slide-in right panel for a single agent node, opened by
+ * clicking an agent in SystemGraph (ADR-0008 WS-3c).
+ *
+ * Composes the whole canvas into one in-context view:
+ *   - tier (builtin / a2a) + remote host        (WS-3a)
+ *   - live status + current skill + tool-calls   (agent.runtime.activity.*)
+ *   - the agent's last flow item                 (flow store, via WS-3b's
+ *     targetAgent fix) with a jump to /trace
+ *   - a drill-out to /executions?target=<agent>  (WS-875)
+ *
+ * Self-contained like MessageDrawer: fixed right overlay, own <style>, closes
+ * on backdrop click or Esc. Plain <a> links match the MessageDrawer idiom.
+ */
+
+import { useEffect, useState } from "react";
+import type { AgentActivityState } from "./AgentNode.tsx";
+import { getFlows, type FlowRecord } from "../lib/api";
+
+export interface InspectorNode {
+  name: string;
+  type: string;
+  host?: string;
+  activity?: AgentActivityState;
+}
+
+interface Props {
+  node: InspectorNode;
+  onClose: () => void;
+}
+
+const tierLabel = (type: string) => (type === "a2a" ? "a2a" : "builtin");
+
+function relativeTime(ms: number): string {
+  const delta = Date.now() - ms;
+  if (delta < 1000) return "just now";
+  if (delta < 60_000) return `${Math.floor(delta / 1000)}s ago`;
+  if (delta < 3_600_000) return `${Math.floor(delta / 60_000)}m ago`;
+  return `${Math.floor(delta / 3_600_000)}h ago`;
+}
+
+function fmtDuration(ms: number | null): string {
+  if (ms == null) return "—";
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${(ms / 60_000).toFixed(1)}m`;
+}
+
+/** The flow id is `skill-<correlationId>` — strip the prefix for the trace link. */
+const correlationIdOf = (flowId: string) => (flowId.startsWith("skill-") ? flowId.slice("skill-".length) : flowId);
+
+export default function NodeInspector({ node, onClose }: Props) {
+  const activity = node.activity;
+  const isRemote = node.type === "a2a";
+  const [lastFlow, setLastFlow] = useState<FlowRecord | null>(null);
+  const [flowState, setFlowState] = useState<"loading" | "ready" | "error">("loading");
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  // The agent's most-recent flow item (now that flow.item.* carries targetAgent).
+  useEffect(() => {
+    let cancelled = false;
+    setFlowState("loading");
+    setLastFlow(null);
+    getFlows(true)
+      .then((data) => {
+        if (cancelled) return;
+        const mine = (data.flows ?? []).filter((f) => f.targetAgent === node.name);
+        // /api/flows is newest-first; take the first match.
+        setLastFlow(mine[0] ?? null);
+        setFlowState("ready");
+      })
+      .catch(() => {
+        if (!cancelled) setFlowState("error");
+      });
+    return () => { cancelled = true; };
+  }, [node.name]);
+
+  const status = activity?.status ?? "idle";
+  const traceHref = lastFlow ? `/trace?correlationId=${encodeURIComponent(correlationIdOf(lastFlow.id))}` : null;
+
+  return (
+    <>
+      <style>{STYLE}</style>
+      <div className="ni-backdrop" onClick={onClose} />
+      <aside className="ni-panel" role="dialog" aria-label={`Inspector for ${node.name}`}>
+        <header className="ni-header">
+          <div>
+            <h3 className="ni-title">{node.name}</h3>
+            <p className="ni-sub">
+              <span className={`ni-tier ni-tier--${isRemote ? "a2a" : "builtin"}`}>{tierLabel(node.type)}</span>
+              {isRemote && node.host && <span className="ni-host">⤳ {node.host}</span>}
+              <span className={`ni-status ni-status--${status}`}>{status}</span>
+            </p>
+          </div>
+          <button className="ni-close" onClick={onClose} aria-label="Close">×</button>
+        </header>
+
+        <div className="ni-body">
+          {/* Live activity */}
+          <section className="ni-section">
+            <div className="ni-label">Live</div>
+            {activity?.currentSkill ? (
+              <div className="ni-row">
+                skill <span className="ni-strong">{activity.currentSkill}</span>
+                {activity.startedAt && status === "running" && <span className="ni-dim"> · {relativeTime(activity.startedAt)}</span>}
+              </div>
+            ) : (
+              <div className="ni-dim">No live skill.</div>
+            )}
+            {activity && activity.toolCalls.length > 0 && (
+              <ul className="ni-tools">
+                {activity.toolCalls.slice(0, 5).map((c, i) => (
+                  <li key={i}>
+                    <span className="ni-tool-mark">↳</span> <span className="ni-strong">{c.tools.join(", ")}</span>
+                    <span className="ni-dim"> {relativeTime(c.timestamp)}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {status === "error" && activity?.errorMessage && <div className="ni-err">⚠ {activity.errorMessage}</div>}
+          </section>
+
+          {/* Last flow item */}
+          <section className="ni-section">
+            <div className="ni-label">Last dispatch</div>
+            {flowState === "loading" && <div className="ni-dim">Loading…</div>}
+            {flowState === "error" && <div className="ni-dim">Flow store unavailable.</div>}
+            {flowState === "ready" && !lastFlow && <div className="ni-dim">No recorded dispatches for {node.name}.</div>}
+            {flowState === "ready" && lastFlow && (
+              <div className="ni-flow">
+                <div className="ni-row">
+                  <span className={`ni-pill ni-pill--${lastFlow.status ?? "unknown"}`}>{lastFlow.status ?? "—"}</span>
+                  <span className="ni-strong">{lastFlow.skill ?? "—"}</span>
+                </div>
+                <div className="ni-dim">
+                  {fmtDuration(lastFlow.durationMs)} · {lastFlow.createdAt ? relativeTime(lastFlow.createdAt) : "—"}
+                </div>
+                {traceHref && <a className="ni-link" href={traceHref}>Open trace →</a>}
+              </div>
+            )}
+          </section>
+        </div>
+
+        <footer className="ni-footer">
+          <a className="ni-link" href={`/executions?target=${encodeURIComponent(node.name)}`}>View all executions →</a>
+        </footer>
+      </aside>
+    </>
+  );
+}
+
+const STYLE = `
+  .ni-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.35); z-index: 100; }
+  .ni-panel {
+    position: fixed; top: 0; right: 0; height: 100vh; width: 380px; max-width: 90vw;
+    background: var(--bg-canvas); border-left: 1px solid var(--border-default); color: var(--text-primary);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    z-index: 101; display: flex; flex-direction: column; box-shadow: -8px 0 24px rgba(0,0,0,0.5);
+  }
+  .ni-header { display: flex; align-items: flex-start; justify-content: space-between; padding: 1rem 1.25rem 0.75rem; border-bottom: 1px solid var(--border-muted); }
+  .ni-title { margin: 0; font-size: 1rem; color: var(--text-primary); word-break: break-all; }
+  .ni-sub { margin: 0.4rem 0 0; display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+  .ni-tier { font-size: 0.7rem; padding: 1px 6px; border-radius: 3px; border: 1px solid var(--border-default); }
+  .ni-tier--a2a { color: var(--accent-fg); border-style: dashed; }
+  .ni-tier--builtin { color: var(--text-secondary); }
+  .ni-host { font-size: 0.75rem; color: var(--text-secondary); }
+  .ni-status { font-size: 0.72rem; margin-left: auto; }
+  .ni-status--running { color: var(--text-success); }
+  .ni-status--error { color: var(--text-danger); }
+  .ni-status--completed { color: var(--accent-fg); }
+  .ni-status--idle { color: var(--text-secondary); }
+  .ni-body { flex: 1; overflow-y: auto; padding: 0.5rem 1.25rem; }
+  .ni-section { padding: 0.85rem 0; border-bottom: 1px dashed var(--border-muted); }
+  .ni-label { font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-secondary); margin-bottom: 0.5rem; }
+  .ni-row { display: flex; align-items: center; gap: 0.4rem; font-size: 0.8rem; margin-bottom: 0.25rem; }
+  .ni-strong { color: var(--text-primary); }
+  .ni-dim { color: var(--text-secondary); font-size: 0.76rem; }
+  .ni-tools { list-style: none; padding: 0; margin: 0.4rem 0 0; }
+  .ni-tools li { font-size: 0.76rem; color: var(--text-secondary); line-height: 1.5; }
+  .ni-tool-mark { color: var(--text-success); }
+  .ni-err { margin-top: 0.4rem; color: var(--text-danger); font-size: 0.76rem; }
+  .ni-flow { display: flex; flex-direction: column; gap: 0.3rem; }
+  .ni-pill { font-size: 0.7rem; padding: 1px 6px; border-radius: 3px; background: var(--bg-default); }
+  .ni-pill--complete { color: var(--text-success); }
+  .ni-pill--active { color: var(--text-warning); }
+  .ni-pill--blocked { color: var(--text-danger); }
+  .ni-link { color: var(--accent-fg); text-decoration: none; font-size: 0.78rem; }
+  .ni-link:hover { text-decoration: underline; }
+  .ni-footer { padding: 0.85rem 1.25rem; border-top: 1px solid var(--border-muted); }
+`;

--- a/dashboard/src/components/SystemGraph.tsx
+++ b/dashboard/src/components/SystemGraph.tsx
@@ -25,12 +25,12 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import { ReactFlow, Background, Controls, type Edge, type Node } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import AgentNode, { type AgentActivityState } from "./AgentNode.tsx";
 import ServiceNode from "./ServiceNode.tsx";
 import MessageDrawer, { type DrawerMessage } from "./MessageDrawer.tsx";
+import NodeInspector, { type InspectorNode } from "./NodeInspector.tsx";
 import QuinnVerdictCounters from "./QuinnVerdictCounters.tsx";
 import LatencyHistogram from "./LatencyHistogram.tsx";
 import { architecturalLayout } from "../lib/layout.ts";
@@ -351,7 +351,6 @@ function applyActivity(state: Map<string, AgentActivityState>, ev: AgentActivity
 const NODE_TYPES = { agent: AgentNode, service: ServiceNode };
 
 export default function SystemGraph() {
-  const navigate = useNavigate();
   const [topology, setTopology] = useState<PluginTopologyEntry[] | null>(null);
   const [agents, setAgents] = useState<AgentRuntimeEntry[]>([]);
   const [agentActivity, setAgentActivity] = useState<Map<string, AgentActivityState>>(new Map());
@@ -360,6 +359,9 @@ export default function SystemGraph() {
   // the host→agent edge animation uniformly across builtin + a2a tiers.
   const [inFlight, setInFlight] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
+  // Agent name whose inspector is open (WS-3c). Mutually exclusive with the
+  // edge MessageDrawer.
+  const [openNode, setOpenNode] = useState<string | null>(null);
   // Per-topic ring buffer of recent WS-observed messages. Lives in a ref
   // (not state) because every WS frame would otherwise re-trigger the
   // whole graph rebuild — we only need to re-render when the operator
@@ -513,6 +515,11 @@ export default function SystemGraph() {
     return <div style={{ padding: 24, color: "var(--text-secondary)" }}>loading topology…</div>;
   }
 
+  const inspectorAgent = openNode ? agents.find((a) => a.name === openNode) : undefined;
+  const inspectorNode: InspectorNode | null = openNode
+    ? { name: openNode, type: inspectorAgent?.type ?? "deep-agent", host: inspectorAgent?.host, activity: agentActivity.get(openNode) }
+    : null;
+
   return (
     <div style={{ width: "100%", height: "calc(100vh - 64px)", background: "var(--bg-canvas)", position: "relative" }}>
       <ReactFlow
@@ -522,12 +529,13 @@ export default function SystemGraph() {
         fitView
         minZoom={0.2}
         onNodeClick={(_evt: unknown, node: Node) => {
-          // Agent nodes (id `agent-<name>`) drill into the execution log
-          // pre-filtered to that agent's dispatches. Plugin/service/api-route
-          // nodes have no execution view — those clicks are inert.
+          // Agent nodes (id `agent-<name>`) open the in-context inspector
+          // (tier, host, live activity, last flow item, links out to
+          // /executions + /trace). Plugin/service/api-route nodes have no
+          // inspector — those clicks are inert.
           if (node.id.startsWith("agent-")) {
-            const agent = node.id.slice("agent-".length);
-            navigate(`/executions?target=${encodeURIComponent(agent)}`);
+            setOpenNode(node.id.slice("agent-".length));
+            setOpenTopic(null); // inspector + edge drawer are mutually exclusive
           }
         }}
         onEdgeClick={(_evt: unknown, edge: Edge) => {
@@ -535,7 +543,10 @@ export default function SystemGraph() {
           // edge label. Static plugin → service edges have no topic — those
           // skip the drawer.
           const topic = typeof edge.label === "string" ? edge.label : null;
-          if (topic) setOpenTopic(topic);
+          if (topic) {
+            setOpenTopic(topic);
+            setOpenNode(null);
+          }
         }}
       >
         <Background color="var(--bg-subtle)" gap={16} />
@@ -549,6 +560,9 @@ export default function SystemGraph() {
           messages={drawerMessages}
           onClose={() => setOpenTopic(null)}
         />
+      )}
+      {inspectorNode && (
+        <NodeInspector node={inspectorNode} onClose={() => setOpenNode(null)} />
       )}
     </div>
   );


### PR DESCRIPTION
## What

Completes the **WS-3 keystone** (ADR-0008 P1). Clicking an agent node opens **`NodeInspector`** — a slide-in right panel (mirroring the `MessageDrawer` idiom) that pulls the whole canvas into one in-context view.

## The inspector composes every prior slice

- **tier** (builtin / a2a) + **remote host** — WS-3a (#877)
- **live status + current skill + recent tool-calls** — from `agent.runtime.activity.*`
- **the agent's last flow item** (skill · status · duration · age) — from the flow store, now reachable because WS-3b (#878) fixed `targetAgent` — with **"Open trace →"** into `/trace?correlationId=`
- **"View all executions →"** drill-out to `/executions?target=` — preserves the #875 linkage

## SystemGraph wiring

- Agent-node click now **opens the inspector** instead of navigating straight to `/executions` (that drill-out lives inside the inspector as a link).
- Inspector and the edge `MessageDrawer` are **mutually exclusive** (opening one closes the other).
- Dropped the now-unused `useNavigate`.

## Verification

- `tsc --noEmit` clean · `vite build` clean (chunk-size warning pre-existing)
- `bun test` — 27/27 dashboard tests pass
- (lone biome warning is the pre-existing `topicMatches` nested ternary, untouched)

## P1 status

WS-1 ✅ · WS-2 ✅ · WS-3a ✅ · WS-3b ✅ · **WS-3c ✅ (this)** — keystone complete. Remaining: **WS-4** (palette over the control-plane registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)