### PR TITLE
feat(canvas): WS-P2a — routes.d/ wiring layer + control-plane API (ADR-0008 P2)

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -292,3 +292,21 @@ export const updateMcpServer = (name: string, def: unknown) =>
 /** Remove an MCP server (→ disconnected + unregistered live). */
 export const deleteMcpServer = (name: string) =>
   adminFetch(`/api/mcp-servers/${encodeURIComponent(name)}`, "DELETE");
+
+// ── Routes (wiring) — ADR-0008 P2 ───────────────────────────────────────────
+/** A declarative wiring route: "when when.topic fires, dispatch then.skill (to then.agent)." */
+export interface RouteSummary {
+  name: string;
+  description?: string;
+  when: { topic: string };
+  then: { skill: string; agent?: string };
+  enabled?: boolean;
+}
+/** GET /api/routes — live wiring routes, rendered as canvas edges. */
+export const getRoutes = (force = false) =>
+  apiFetch<{ routes: RouteSummary[] }>("/api/routes", { ttl: 10_000, force });
+/** Author a route (persisted to routes.d/; live via hot-reload). */
+export const createRoute = (def: unknown) => adminFetch("/api/routes", "POST", def);
+/** Remove a route by name (→ unsubscribed live). */
+export const deleteRoute = (name: string) =>
+  adminFetch(`/api/routes/${encodeURIComponent(name)}`, "DELETE");

--- a/src/api/__tests__/routes-crud.test.ts
+++ b/src/api/__tests__/routes-crud.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Routes control-plane API (ADR-0008 P2) — POST/DELETE publish command.route.*
+ * to the registrar (the sole writer); the registrar persists routes.d/; GET
+ * reads it back. End-to-end with a real bus + registrar + temp workspace.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, existsSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import { ExecutorRegistry } from "../../executor/executor-registry.ts";
+import { ControlPlaneRegistrarPlugin } from "../../plugins/control-plane-registrar-plugin.ts";
+import { createRoutes } from "../routes-crud.ts";
+import type { ApiContext, Route } from "../types.ts";
+
+const ROUTE = { name: "triage", when: { topic: "message.inbound.github.#" }, then: { skill: "bug_triage", agent: "quinn" } };
+
+describe("routes-crud API", () => {
+  let root: string;
+  let bus: InMemoryEventBus;
+  let ctx: ApiContext;
+  let routes: Route[];
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "routes-crud-"));
+    bus = new InMemoryEventBus();
+    new ControlPlaneRegistrarPlugin(root).install(bus);
+    ctx = { workspaceDir: root, bus, plugins: [], executorRegistry: new ExecutorRegistry() };
+    routes = createRoutes(ctx);
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  const route = (method: string, path: string) => {
+    const r = routes.find((x) => x.method === method && x.path === path);
+    if (!r) throw new Error(`no route ${method} ${path}`);
+    return r;
+  };
+  const post = (body: unknown) => new Request("http://localhost/api/routes", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+
+  test("POST creates routes.d/<name>.yaml via the registrar", async () => {
+    const res = await route("POST", "/api/routes").handler(post(ROUTE), {});
+    expect(res.status).toBe(201);
+    const file = join(root, "routes.d", "triage.yaml");
+    expect(existsSync(file)).toBe(true);
+    const written = parseYaml(readFileSync(file, "utf8"));
+    expect(written.name).toBe("triage");
+    expect(written.then.skill).toBe("bug_triage");
+  });
+
+  test("POST an invalid route → 400 (and writes nothing)", async () => {
+    const res = await route("POST", "/api/routes").handler(post({ name: "bad", then: { skill: "s" } }), {});
+    expect(res.status).toBe(400);
+    expect(existsSync(join(root, "routes.d", "bad.yaml"))).toBe(false);
+  });
+
+  test("GET lists persisted routes", async () => {
+    await route("POST", "/api/routes").handler(post(ROUTE), {});
+    const res = await route("GET", "/api/routes").handler(new Request("http://localhost/api/routes"), {});
+    const body = (await res.json()) as { success: boolean; data: { routes: Array<{ name: string }> } };
+    expect(body.success).toBe(true);
+    expect(body.data.routes.map((r) => r.name)).toEqual(["triage"]);
+  });
+
+  test("DELETE removes the route file", async () => {
+    await route("POST", "/api/routes").handler(post(ROUTE), {});
+    const file = join(root, "routes.d", "triage.yaml");
+    expect(existsSync(file)).toBe(true);
+    const res = await route("DELETE", "/api/routes/:name").handler(new Request("http://localhost/api/routes/triage", { method: "DELETE" }), { name: "triage" });
+    expect(res.status).toBe(200);
+    expect(existsSync(file)).toBe(false);
+  });
+
+  test("admin key gates writes when configured", async () => {
+    ctx.apiKey = "secret";
+    const denied = await route("POST", "/api/routes").handler(post(ROUTE), {});
+    expect(denied.status).toBe(401);
+    const ok = await route("POST", "/api/routes").handler(
+      new Request("http://localhost/api/routes", { method: "POST", headers: { "content-type": "application/json", "x-api-key": "secret" }, body: JSON.stringify(ROUTE) }),
+      {},
+    );
+    expect(ok.status).toBe(201);
+  });
+});

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -31,6 +31,7 @@ import { createRoutes as busHistoryRoutes } from "./bus-history.ts";
 import { createRoutes as flowRoutes } from "./flows.ts";
 import { createRoutes as humanInputRoutes } from "./human-input.ts";
 import { createRoutes as agentsCrudRoutes } from "./agents-crud.ts";
+import { createRoutes as routesCrudRoutes } from "./routes-crud.ts";
 import { createRoutes as controlPlaneRoutes } from "./control-plane.ts";
 import { createRoutes as mcpCrudRoutes } from "./mcp-crud.ts";
 import { createRoutes as researchRoutes } from "./research.ts";
@@ -65,6 +66,7 @@ export function createAllRoutes(ctx: ApiContext): Route[] {
     ...flowRoutes(ctx),
     ...humanInputRoutes(ctx),
     ...agentsCrudRoutes(ctx),
+    ...routesCrudRoutes(ctx),
     ...controlPlaneRoutes(ctx),
     ...mcpCrudRoutes(ctx),
   ];

--- a/src/api/routes-crud.ts
+++ b/src/api/routes-crud.ts
@@ -1,0 +1,85 @@
+/**
+ * Routes control-plane API (ADR-0008 P2 — wiring authoring).
+ *
+ * The canvas's draw-edge writes a route here:
+ *   GET    /api/routes          list live routes (render as canvas edges)
+ *   POST   /api/routes          validate + persist a route (admin-keyed)
+ *   DELETE /api/routes/:name    remove a route (admin-keyed)
+ *
+ * Writes publish `command.route.{upsert,remove}`; ControlPlaneRegistrar is the
+ * sole writer of `workspace/routes.d/`. RoutesPlugin hot-reloads the change.
+ * Mirrors agents-crud — same auth, same registrar handoff, no new write path.
+ */
+
+import { join, resolve } from "node:path";
+import type { Route, ApiContext } from "./types.ts";
+import { loadRouteEntries, parseRouteDefinition, routeToYaml } from "../routes/route-definition.ts";
+
+function safeFileName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9-]/g, "-").replace(/^-+|-+$/g, "");
+}
+
+export function createRoutes(ctx: ApiContext): Route[] {
+  const routesdDir = join(ctx.workspaceDir, "routes.d");
+
+  const authorized = (req: Request): boolean => {
+    if (!ctx.apiKey) return true;
+    if (req.headers.get("x-api-key") === ctx.apiKey) return true;
+    return req.headers.get("authorization") === `Bearer ${ctx.apiKey}`;
+  };
+  const unauthorized = () => Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  const badJson = () => Response.json({ success: false, error: "Invalid JSON" }, { status: 400 });
+
+  function command(topic: string, name: string, payload: Record<string, unknown>): void {
+    ctx.bus.publish(topic, {
+      id: crypto.randomUUID(),
+      correlationId: crypto.randomUUID(),
+      topic,
+      timestamp: Date.now(),
+      payload: { name, ...payload },
+      source: { interface: "api" },
+    });
+  }
+
+  return [
+    {
+      // List live routes — the canvas renders these as wiring edges.
+      method: "GET",
+      path: "/api/routes",
+      handler: () => Response.json({ success: true, data: { routes: loadRouteEntries(routesdDir) } }),
+    },
+    {
+      // Author a route: validate, then hand to the registrar (→ routes.d/, hot-reloaded).
+      method: "POST",
+      path: "/api/routes",
+      handler: async (req) => {
+        if (!authorized(req)) return unauthorized();
+        let body: unknown;
+        try { body = await req.json(); } catch { return badJson(); }
+        let def;
+        try { def = parseRouteDefinition(body, "(request body)"); } catch (err) {
+          return Response.json({ success: false, error: err instanceof Error ? err.message : String(err) }, { status: 400 });
+        }
+        const safe = safeFileName(def.name);
+        if (!safe) return Response.json({ success: false, error: "name produced an empty filename" }, { status: 400 });
+        const file = resolve(join(routesdDir, `${safe}.yaml`));
+        command("command.route.upsert", def.name, { file, yaml: routeToYaml(def) });
+        return Response.json({ success: true, data: { name: def.name } }, { status: 201 });
+      },
+    },
+    {
+      // Remove a route by name.
+      method: "DELETE",
+      path: "/api/routes/:name",
+      handler: (req, p) => {
+        if (!authorized(req)) return unauthorized();
+        const name = p.name;
+        const safe = safeFileName(name);
+        if (!safe) return Response.json({ success: false, error: "invalid name" }, { status: 400 });
+        const file = resolve(join(routesdDir, `${safe}.yaml`));
+        command("command.route.remove", name, { file });
+        return Response.json({ success: true, data: { name } });
+      },
+    },
+  ];
+}

--- a/src/event-bus/all-topics.ts
+++ b/src/event-bus/all-topics.ts
@@ -107,6 +107,16 @@ export const ACTION_TOPICS = {
   COMMAND_MCP_UPSERT: "command.mcp.upsert",
   COMMAND_MCP_REMOVE: "command.mcp.remove",
 
+  /**
+   * Route (wiring) mutations (ADR-0008 P2). The registrar persists the route to
+   * workspace/routes.d/<name>.yaml; RoutesPlugin hot-reloads and (un)subscribes
+   * its trigger topic live (no restart).
+   *   command.route.upsert — { name, file, yaml }
+   *   command.route.remove — { name, file }
+   */
+  COMMAND_ROUTE_UPSERT: "command.route.upsert",
+  COMMAND_ROUTE_REMOVE: "command.route.remove",
+
   /** Wildcard subscription pattern — matches all cron events from SchedulerPlugin. */
   CRON_ALL: "cron.#",
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { SignalPlugin } from "../lib/plugins/signal";
 import { SchedulerPlugin } from "../lib/plugins/scheduler";
 import { A2ADeliveryPlugin } from "../lib/plugins/a2a-delivery";
 import { ControlPlaneRegistrarPlugin } from "./plugins/control-plane-registrar-plugin.ts";
+import { RoutesPlugin } from "./plugins/routes-plugin.ts";
 import { RegistrationStore } from "./storage/registration-store.ts";
 import type { Plugin, } from "../lib/types";
 import { parseEnv } from "./config/env.ts";
@@ -165,6 +166,9 @@ const corePlugins: Plugin[] = [
   // Backed by a durable RegistrationStore so API-driven a2a registrations
   // survive a redeploy (the agents.d/ clone is ephemeral) — #850.
   new ControlPlaneRegistrarPlugin(workspaceDir, new RegistrationStore(`${dataDir}/registrations.db`)),
+  // ADR-0008 P2: loads workspace/routes.d/ and dispatches agent.skill.request
+  // on each route's trigger topic. Funnels into the same dispatcher chokepoint.
+  new RoutesPlugin(workspaceDir),
 ];
 
 for (const plugin of corePlugins) {

--- a/src/plugins/__tests__/routes-plugin.test.ts
+++ b/src/plugins/__tests__/routes-plugin.test.ts
@@ -1,0 +1,89 @@
+/**
+ * RoutesPlugin (ADR-0008 P2) — a route's trigger topic fires → it republishes
+ * agent.skill.request with the route's skill + target, passing the trigger
+ * payload through untouched. Real in-memory bus, no mocks.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { InMemoryEventBus } from "../../../lib/bus.ts";
+import type { BusMessage } from "../../../lib/types.ts";
+import { RoutesPlugin } from "../routes-plugin.ts";
+
+function trigger(topic: string, payload: Record<string, unknown>, correlationId = "corr-1"): BusMessage {
+  return { id: "m1", correlationId, topic, timestamp: 1, payload };
+}
+
+describe("RoutesPlugin", () => {
+  let root: string;
+  let routesd: string;
+  let bus: InMemoryEventBus;
+  let plugin: RoutesPlugin;
+  let dispatched: BusMessage[];
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "routes-plugin-"));
+    routesd = join(root, "routes.d");
+    mkdirSync(routesd);
+    bus = new InMemoryEventBus();
+    dispatched = [];
+    bus.subscribe("agent.skill.request", "capture", (msg) => { dispatched.push(msg); });
+  });
+  afterEach(() => {
+    plugin?.uninstall();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function install() {
+    plugin = new RoutesPlugin(root);
+    plugin.install(bus);
+  }
+
+  test("fires the route's skill + target on the trigger topic, passing payload through", () => {
+    writeFileSync(join(routesd, "triage.yaml"), "name: triage\nwhen: { topic: test.trigger }\nthen: { skill: bug_triage, agent: quinn }\n");
+    install();
+
+    bus.publish("test.trigger", trigger("test.trigger", { content: "hello", contextId: "c9" }));
+
+    expect(dispatched).toHaveLength(1);
+    const p = dispatched[0].payload as Record<string, unknown>;
+    expect(p.skill).toBe("bug_triage");
+    expect(p.targets).toEqual(["quinn"]);
+    expect(p.content).toBe("hello");      // passthrough
+    expect(p.contextId).toBe("c9");       // passthrough
+    expect(p.routedBy).toBe("triage");
+    expect(dispatched[0].correlationId).toBe("corr-1"); // trace stitches
+  });
+
+  test("a disabled route does not subscribe", () => {
+    writeFileSync(join(routesd, "off.yaml"), "name: off\nwhen: { topic: test.trigger }\nthen: { skill: s }\nenabled: false\n");
+    install();
+    bus.publish("test.trigger", trigger("test.trigger", {}));
+    expect(dispatched).toHaveLength(0);
+  });
+
+  test("agent-less route carries no target (skill-resolved downstream)", () => {
+    writeFileSync(join(routesd, "noagent.yaml"), "name: noagent\nwhen: { topic: test.trigger }\nthen: { skill: s }\n");
+    install();
+    bus.publish("test.trigger", trigger("test.trigger", {}));
+    expect((dispatched[0].payload as Record<string, unknown>).targets).toEqual([]);
+  });
+
+  test("a wildcard trigger matches the bus pattern", () => {
+    writeFileSync(join(routesd, "wild.yaml"), "name: wild\nwhen: { topic: message.inbound.github.# }\nthen: { skill: bug_triage, agent: quinn }\n");
+    install();
+    bus.publish("message.inbound.github.issue.opened", trigger("message.inbound.github.issue.opened", { n: 1 }));
+    expect(dispatched).toHaveLength(1);
+    expect((dispatched[0].payload as Record<string, unknown>).skill).toBe("bug_triage");
+  });
+
+  test("uninstall tears down the route subscriptions", () => {
+    writeFileSync(join(routesd, "triage.yaml"), "name: triage\nwhen: { topic: test.trigger }\nthen: { skill: s }\n");
+    install();
+    plugin.uninstall();
+    bus.publish("test.trigger", trigger("test.trigger", {}));
+    expect(dispatched).toHaveLength(0);
+  });
+});

--- a/src/plugins/control-plane-registrar-plugin.ts
+++ b/src/plugins/control-plane-registrar-plugin.ts
@@ -34,6 +34,7 @@ export class ControlPlaneRegistrarPlugin implements Plugin {
   private readonly agentsRoot: string;     // workspace/agents/        — in-process DeepAgents (P2)
   private readonly agentsdRoot: string;    // workspace/agents.d/      — A2A endpoints (P3)
   private readonly mcpServersRoot: string; // workspace/mcp-servers.d/ — MCP servers (P4, ADR-0005)
+  private readonly routesdRoot: string;    // workspace/routes.d/      — wiring routes (ADR-0008 P2)
   private subscriptionIds: string[] = [];
 
   /**
@@ -48,6 +49,7 @@ export class ControlPlaneRegistrarPlugin implements Plugin {
     this.agentsRoot = resolve(workspaceDir, "agents");
     this.agentsdRoot = resolve(workspaceDir, "agents.d");
     this.mcpServersRoot = resolve(workspaceDir, "mcp-servers.d");
+    this.routesdRoot = resolve(workspaceDir, "routes.d");
     this.store = store;
   }
 
@@ -64,6 +66,8 @@ export class ControlPlaneRegistrarPlugin implements Plugin {
       bus.subscribe("command.a2a.remove", this.name, (msg) => this._delete(this.agentsdRoot, msg)),
       bus.subscribe("command.mcp.upsert", this.name, (msg) => this._write(this.mcpServersRoot, msg)),
       bus.subscribe("command.mcp.remove", this.name, (msg) => this._delete(this.mcpServersRoot, msg)),
+      bus.subscribe("command.route.upsert", this.name, (msg) => this._write(this.routesdRoot, msg)),
+      bus.subscribe("command.route.remove", this.name, (msg) => this._delete(this.routesdRoot, msg)),
     );
   }
 

--- a/src/plugins/routes-plugin.ts
+++ b/src/plugins/routes-plugin.ts
@@ -1,0 +1,101 @@
+/**
+ * RoutesPlugin — the runtime for ADR-0008 P2 wiring authoring.
+ *
+ * Loads `workspace/routes.d/` and, for each enabled route, subscribes to the
+ * route's `when.topic` and republishes `agent.skill.request` with the route's
+ * `then.skill`/`agent` when that topic fires. Hot-reloads on file change (a
+ * canvas draw-edge writes a file via the registrar; this plugin picks it up
+ * within the watch window — no restart).
+ *
+ * It is a pure bus participant (the Plugin contract): it holds no reference to
+ * another plugin. Routes funnel into the *existing* `agent.skill.request`
+ * chokepoint, so every dispatcher invariant (cooldown, target-registry guard,
+ * synthetic-actor filter, destructive-verdict guard) still applies — no new
+ * dispatch path. A route is one hop; multi-step logic is a P3 workflow.
+ */
+
+import { resolve } from "node:path";
+import type { EventBus, BusMessage, Plugin } from "../../lib/types.ts";
+import { WorkspaceWatcher } from "../../lib/workspace-watcher.ts";
+import { loadRouteEntries, type RouteDefinition } from "../routes/route-definition.ts";
+import { logger } from "../../lib/log.ts";
+
+const log = logger("routes");
+
+export class RoutesPlugin implements Plugin {
+  name = "routes";
+  description = "Loads workspace/routes.d/ and dispatches agent.skill.request on each route's trigger topic (ADR-0008 P2 wiring).";
+  capabilities = ["wiring", "routing"];
+  subscribes = ["routes.d/* trigger topics (dynamic)"];
+  publishes = ["agent.skill.request"];
+
+  private bus?: EventBus;
+  private readonly routesdDir: string;
+  /** Subscription ids for the live routes — torn down + rebuilt on every reload. */
+  private routeSubs: string[] = [];
+  private watcher?: WorkspaceWatcher;
+
+  constructor(workspaceDir: string) {
+    this.routesdDir = resolve(workspaceDir, "routes.d");
+  }
+
+  install(bus: EventBus): void {
+    this.bus = bus;
+    this._loadAndSubscribe();
+    // Hot-reload: re-derive subscriptions whenever routes.d/ changes.
+    this.watcher = new WorkspaceWatcher({
+      dirs: [this.routesdDir],
+      onChange: () => this._loadAndSubscribe(),
+    });
+    this.watcher.prime();
+    this.watcher.start();
+  }
+
+  uninstall(): void {
+    this.watcher?.stop();
+    this._unsubscribeAll();
+    this.bus = undefined;
+  }
+
+  private _unsubscribeAll(): void {
+    if (this.bus) for (const id of this.routeSubs) this.bus.unsubscribe(id);
+    this.routeSubs = [];
+  }
+
+  /** Tear down the live route subscriptions and rebuild them from routes.d/. */
+  private _loadAndSubscribe(): void {
+    if (!this.bus) return;
+    this._unsubscribeAll();
+    const routes = loadRouteEntries(this.routesdDir, (file, err) =>
+      log.warn(`skipped malformed route "${file}": ${err instanceof Error ? err.message : String(err)}`),
+    ).filter((r) => r.enabled !== false);
+    for (const route of routes) {
+      const id = this.bus.subscribe(route.when.topic, `routes:${route.name}`, (msg) => this._dispatch(route, msg));
+      this.routeSubs.push(id);
+    }
+    log.info(`loaded ${routes.length} route(s) from routes.d/`);
+  }
+
+  /** A route fired: forward the trigger into agent.skill.request, wiring only. */
+  private _dispatch(route: RouteDefinition, msg: BusMessage): void {
+    if (!this.bus) return;
+    const triggerPayload = (msg.payload ?? {}) as Record<string, unknown>;
+    // Reuse the trigger's correlationId so the trace stitches end-to-end.
+    const correlationId = msg.correlationId ?? crypto.randomUUID();
+    this.bus.publish("agent.skill.request", {
+      id: crypto.randomUUID(),
+      correlationId,
+      topic: "agent.skill.request",
+      timestamp: Date.now(),
+      // Passthrough: the agent sees the original message; the route only sets
+      // the skill + target. No transform (the D1/D5 boundary).
+      payload: {
+        ...triggerPayload,
+        skill: route.then.skill,
+        targets: route.then.agent ? [route.then.agent] : (triggerPayload.targets ?? []),
+        routedBy: route.name,
+      },
+      source: { interface: "routes" },
+    });
+  }
+}

--- a/src/routes/__tests__/route-definition.test.ts
+++ b/src/routes/__tests__/route-definition.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { parseRouteDefinition, routeToYaml, loadRouteEntries } from "../route-definition.ts";
+
+describe("parseRouteDefinition", () => {
+  test("accepts a minimal valid route", () => {
+    const def = parseRouteDefinition({ name: "triage", when: { topic: "message.inbound.github.#" }, then: { skill: "bug_triage", agent: "quinn" } });
+    expect(def.name).toBe("triage");
+    expect(def.when.topic).toBe("message.inbound.github.#");
+    expect(def.then).toEqual({ skill: "bug_triage", agent: "quinn" });
+  });
+
+  test("agent is optional (skill-resolved target)", () => {
+    const def = parseRouteDefinition({ name: "r", when: { topic: "x.y" }, then: { skill: "s" } });
+    expect(def.then.agent).toBeUndefined();
+  });
+
+  test.each([
+    ["missing name", { when: { topic: "x.y" }, then: { skill: "s" } }],
+    ["bad name", { name: "no spaces", when: { topic: "x.y" }, then: { skill: "s" } }],
+    ["missing when.topic", { name: "r", when: {}, then: { skill: "s" } }],
+    ["missing then.skill", { name: "r", when: { topic: "x.y" }, then: {} }],
+    ["empty agent", { name: "r", when: { topic: "x.y" }, then: { skill: "s", agent: "" } }],
+    ["non-boolean enabled", { name: "r", when: { topic: "x.y" }, then: { skill: "s" }, enabled: "yes" }],
+  ])("rejects %s", (_label, raw) => {
+    expect(() => parseRouteDefinition(raw)).toThrow();
+  });
+
+  test.each(["#", "agent.skill.request"])("rejects self-looping trigger %s", (topic) => {
+    expect(() => parseRouteDefinition({ name: "loop", when: { topic }, then: { skill: "s" } })).toThrow(/loop/);
+  });
+
+  test("round-trips through YAML", () => {
+    const def = parseRouteDefinition({ name: "r", description: "d", when: { topic: "x.y" }, then: { skill: "s", agent: "a" }, enabled: false });
+    const reparsed = parseRouteDefinition(parseYaml(routeToYaml(def)));
+    expect(reparsed).toEqual(def);
+  });
+});
+
+describe("loadRouteEntries", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "routes-"));
+    mkdirSync(join(dir, "routes.d"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("loads valid routes, sorted by name, skipping malformed", () => {
+    const rd = join(dir, "routes.d");
+    writeFileSync(join(rd, "b.yaml"), "name: bravo\nwhen: { topic: x.y }\nthen: { skill: s }\n");
+    writeFileSync(join(rd, "a.yaml"), "name: alpha\nwhen: { topic: x.z }\nthen: { skill: t }\n");
+    writeFileSync(join(rd, "bad.yaml"), "name: nope\nthen: { skill: s }\n"); // missing when.topic
+    const skips: string[] = [];
+    const routes = loadRouteEntries(rd, (file) => skips.push(file));
+    expect(routes.map((r) => r.name)).toEqual(["alpha", "bravo"]);
+    expect(skips).toEqual(["bad.yaml"]);
+  });
+
+  test("absent directory → empty", () => {
+    expect(loadRouteEntries(join(dir, "nope.d"))).toEqual([]);
+  });
+});

--- a/src/routes/route-definition.ts
+++ b/src/routes/route-definition.ts
@@ -1,0 +1,90 @@
+/**
+ * Route definitions (ADR-0008 P2 — wiring authoring).
+ *
+ * A route is the canvas's authorable unit of WIRING: "when this bus topic
+ * fires, dispatch this skill to this agent." One file per route in
+ * `workspace/routes.d/<name>.yaml`, hot-reloaded like agents.d/. A route is a
+ * single pub/sub hop — it carries NO payload transform, NO conditionals, NO
+ * `output→input` logic (that boundary is ADR-0008 D1/D5). The triggering
+ * payload passes through untouched; the agent decides what to do.
+ *
+ * This module is pure (parse / validate / load / serialize) so the loader and
+ * the control-plane API share one definition of "a valid route".
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+
+export interface RouteDefinition {
+  /** Unique, filename-safe (kebab). Names the routes.d/<name>.yaml file. */
+  name: string;
+  description?: string;
+  /** The trigger: a bus topic pattern (the bus's `#`/`*` matcher). */
+  when: { topic: string };
+  /** The reaction: dispatch `skill` (optionally to a specific `agent`). */
+  then: { skill: string; agent?: string };
+  /** Absence = enabled. `false` greys the route on the canvas without deleting it. */
+  enabled?: boolean;
+}
+
+const NAME_RE = /^[a-z0-9][a-z0-9._-]*$/i;
+
+/**
+ * Topics a route may NOT trigger on — they would re-enter the dispatch the
+ * route itself produces and loop. `agent.skill.request` is the dispatch topic;
+ * `#` matches everything (including it). Narrower self-loops are still bounded
+ * by the dispatcher's cooldown + self-cascade guard.
+ */
+const FORBIDDEN_TRIGGERS = new Set(["#", "agent.skill.request"]);
+
+/**
+ * Validate a raw object into a RouteDefinition. Throws on invalid input — the
+ * control-plane API turns the throw into a 400; the loader catches + skips.
+ */
+export function parseRouteDefinition(raw: unknown, source = "(route)"): RouteDefinition {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  const fail = (msg: string): never => { throw new Error(`${source}: ${msg}`); };
+
+  if (typeof r.name !== "string" || !NAME_RE.test(r.name)) fail("name is required and must be filename-safe (a-z, 0-9, . _ -)");
+  const when = (r.when ?? {}) as Record<string, unknown>;
+  if (typeof when.topic !== "string" || when.topic.trim() === "") fail("when.topic (a bus topic pattern) is required");
+  if (FORBIDDEN_TRIGGERS.has((when.topic as string).trim())) fail(`when.topic "${when.topic}" would loop the dispatch — pick a narrower trigger`);
+  const then = (r.then ?? {}) as Record<string, unknown>;
+  if (typeof then.skill !== "string" || then.skill.trim() === "") fail("then.skill is required");
+  if (then.agent !== undefined && (typeof then.agent !== "string" || then.agent.trim() === "")) fail("then.agent, when set, must be a non-empty string");
+  if (r.enabled !== undefined && typeof r.enabled !== "boolean") fail("enabled, when set, must be a boolean");
+
+  const def: RouteDefinition = {
+    name: (r.name as string).trim(),
+    when: { topic: (when.topic as string).trim() },
+    then: { skill: (then.skill as string).trim(), ...(then.agent ? { agent: (then.agent as string).trim() } : {}) },
+  };
+  if (typeof r.description === "string" && r.description.trim()) def.description = r.description.trim();
+  if (r.enabled !== undefined) def.enabled = r.enabled as boolean;
+  return def;
+}
+
+/** Serialize a route to its canonical YAML file contents. */
+export function routeToYaml(def: RouteDefinition): string {
+  return stringifyYaml(def);
+}
+
+/**
+ * Load every route in `routesdDir`. Tolerant: a malformed file is skipped (and
+ * surfaced via onSkip) rather than failing the whole load — one bad route must
+ * never take down routing. Returns [] if the directory is absent.
+ */
+export function loadRouteEntries(routesdDir: string, onSkip?: (file: string, err: unknown) => void): RouteDefinition[] {
+  if (!existsSync(routesdDir)) return [];
+  const out: RouteDefinition[] = [];
+  for (const file of readdirSync(routesdDir)) {
+    if (!/\.ya?ml$/.test(file) || file.endsWith(".example")) continue;
+    try {
+      out.push(parseRouteDefinition(parseYaml(readFileSync(join(routesdDir, file), "utf8")), file));
+    } catch (err) {
+      onSkip?.(file, err);
+    }
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name));
+}


### PR DESCRIPTION
## What

The **backend for P2 wiring authoring** ([plan #882](https://github.com/protoLabsAI/protoWorkstacean/pull/882)). Introduces the declarative **route** primitive — *"when `when.topic` fires, dispatch `then.skill` (to `then.agent`)"* — the authorable unit a canvas edge will write. One pub/sub hop: **no payload transform, no conditionals, no data-flow** (the ADR-0008 D1/D5 boundary).

## Pieces

- **`route-definition.ts`** (pure) — parse / validate / load / serialize `routes.d/*.yaml`. Rejects self-looping triggers (`#`, `agent.skill.request`); tolerant loader skips malformed files.
- **`RoutesPlugin`** — loads `routes.d/`, subscribes each route's `when.topic`, republishes `agent.skill.request` (trigger payload **passed through**, plus `skill`/`targets`/`routedBy`), hot-reloads via `WorkspaceWatcher`, unsubscribes on `uninstall`. A pure bus participant (no plugin refs). **Funnels into the existing dispatcher chokepoint** — every invariant (cooldown, target guard, …) still applies; no new dispatch path.
- **`ControlPlaneRegistrar`** — `command.route.upsert/remove` → write/delete `routes.d/<name>.yaml` (sole writer, mirrors `agents.d/`).
- **`routes-crud` API** — `GET /api/routes` (the canvas edges), `POST` + `DELETE` (admin-keyed), mirroring `agents-crud`. `command.route.*` declared in `all-topics`.
- **dashboard api helpers** — `getRoutes` / `createRoute` / `deleteRoute` (for P2-b).

## Tests

- `route-definition`: parse/validate (incl. loop-trigger + malformed-skip), load/sort.
- `RoutesPlugin`: trigger → `agent.skill.request` with skill+target+passthrough; disabled route inert; wildcard trigger; `uninstall` tears down.
- `routes-crud`: POST writes `routes.d/` **through a real registrar + bus**; 400 on invalid; GET lists; DELETE removes; admin-key gate.

**23 new** tests; **233** registrar/dispatcher/api regression tests green; `tsc` + dashboard `vite build` clean. (No mocks — real in-memory bus, per CLAUDE.md.)

## Next

**P2-b** — canvas draw-to-wire: render routes as edges on `/system`, draw edge → route form → `POST /api/routes`, delete-edge → `DELETE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)