### PR TITLE
feat(canvas): P2 hardening — bound route cascades with a per-correlation hop guard

### DIFF
--- a/src/plugins/__tests__/routes-plugin.test.ts
+++ b/src/plugins/__tests__/routes-plugin.test.ts
@@ -11,6 +11,7 @@ import { join } from "node:path";
 import { InMemoryEventBus } from "../../../lib/bus.ts";
 import type { BusMessage } from "../../../lib/types.ts";
 import { RoutesPlugin } from "../routes-plugin.ts";
+import { RouteHopGuard } from "../../routes/route-hop-guard.ts";
 
 function trigger(topic: string, payload: Record<string, unknown>, correlationId = "corr-1"): BusMessage {
   return { id: "m1", correlationId, topic, timestamp: 1, payload };
@@ -36,8 +37,8 @@ describe("RoutesPlugin", () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  function install() {
-    plugin = new RoutesPlugin(root);
+  function install(hopGuard?: RouteHopGuard) {
+    plugin = new RoutesPlugin(root, hopGuard);
     plugin.install(bus);
   }
 
@@ -85,5 +86,16 @@ describe("RoutesPlugin", () => {
     plugin.uninstall();
     bus.publish("test.trigger", trigger("test.trigger", {}));
     expect(dispatched).toHaveLength(0);
+  });
+
+  test("caps a cascade: same correlation chain stops dispatching past the hop limit", () => {
+    writeFileSync(join(routesd, "triage.yaml"), "name: triage\nwhen: { topic: test.trigger }\nthen: { skill: s }\n");
+    install(new RouteHopGuard({ max: 3, windowMs: 10_000 }));
+    // Re-fire the same correlation chain 6×; the guard allows only the first 3.
+    for (let i = 0; i < 6; i++) bus.publish("test.trigger", trigger("test.trigger", { i }, "chain-1"));
+    expect(dispatched).toHaveLength(3);
+    // A fresh correlation chain is unaffected.
+    bus.publish("test.trigger", trigger("test.trigger", {}, "chain-2"));
+    expect(dispatched).toHaveLength(4);
   });
 });

--- a/src/plugins/routes-plugin.ts
+++ b/src/plugins/routes-plugin.ts
@@ -18,6 +18,7 @@ import { resolve } from "node:path";
 import type { EventBus, BusMessage, Plugin } from "../../lib/types.ts";
 import { WorkspaceWatcher } from "../../lib/workspace-watcher.ts";
 import { loadRouteEntries, type RouteDefinition } from "../routes/route-definition.ts";
+import { RouteHopGuard } from "../routes/route-hop-guard.ts";
 import { logger } from "../../lib/log.ts";
 
 const log = logger("routes");
@@ -34,9 +35,12 @@ export class RoutesPlugin implements Plugin {
   /** Subscription ids for the live routes — torn down + rebuilt on every reload. */
   private routeSubs: string[] = [];
   private watcher?: WorkspaceWatcher;
+  /** Bounds indirect multi-hop route cascades per correlation chain (ADR-0008 P2 hardening). */
+  private readonly hopGuard: RouteHopGuard;
 
-  constructor(workspaceDir: string) {
+  constructor(workspaceDir: string, hopGuard: RouteHopGuard = new RouteHopGuard()) {
     this.routesdDir = resolve(workspaceDir, "routes.d");
+    this.hopGuard = hopGuard;
   }
 
   install(bus: EventBus): void {
@@ -82,6 +86,13 @@ export class RoutesPlugin implements Plugin {
     const triggerPayload = (msg.payload ?? {}) as Record<string, unknown>;
     // Reuse the trigger's correlationId so the trace stitches end-to-end.
     const correlationId = msg.correlationId ?? crypto.randomUUID();
+    // Cascade guard: bound route dispatches per correlation chain so an
+    // indirect cross-route cycle (agent side-effect → another route → …) can't
+    // run away. Drops loudly past the cap rather than flooding the bus.
+    if (!this.hopGuard.allow(correlationId, Date.now())) {
+      log.warn(`route "${route.name}" dropped — correlation ${correlationId} exceeded the route-hop cap (cascade guard)`);
+      return;
+    }
     this.bus.publish("agent.skill.request", {
       id: crypto.randomUUID(),
       correlationId,

--- a/src/routes/__tests__/route-hop-guard.test.ts
+++ b/src/routes/__tests__/route-hop-guard.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from "bun:test";
+import { RouteHopGuard } from "../route-hop-guard.ts";
+
+describe("RouteHopGuard", () => {
+  test("allows up to max hops per correlation, then drops", () => {
+    const g = new RouteHopGuard({ max: 3, windowMs: 1000 });
+    expect(g.allow("c1", 0)).toBe(true);  // 1
+    expect(g.allow("c1", 1)).toBe(true);  // 2
+    expect(g.allow("c1", 2)).toBe(true);  // 3
+    expect(g.allow("c1", 3)).toBe(false); // capped
+    expect(g.allow("c1", 4)).toBe(false); // stays capped within the window
+  });
+
+  test("a chain that goes quiet past the window resets", () => {
+    const g = new RouteHopGuard({ max: 2, windowMs: 100 });
+    expect(g.allow("c1", 0)).toBe(true);
+    expect(g.allow("c1", 10)).toBe(true);
+    expect(g.allow("c1", 20)).toBe(false);   // capped
+    expect(g.allow("c1", 200)).toBe(true);   // window elapsed (expiresAt was 120) → reset
+  });
+
+  test("distinct correlations are tracked independently", () => {
+    const g = new RouteHopGuard({ max: 1, windowMs: 1000 });
+    expect(g.allow("a", 0)).toBe(true);
+    expect(g.allow("b", 0)).toBe(true);   // different chain, not affected by a
+    expect(g.allow("a", 1)).toBe(false);  // a is capped
+    expect(g.allow("b", 1)).toBe(false);  // b is capped
+  });
+
+  test("expired entries are swept once the soft cap is reached (bounded memory)", () => {
+    const g = new RouteHopGuard({ max: 5, windowMs: 100, pruneAt: 3 });
+    g.allow("a", 0);
+    g.allow("b", 0);
+    g.allow("c", 0);           // size now 3 (== pruneAt)
+    // Next call sees size >= pruneAt, sweeps the now-expired a/b/c, then adds d.
+    g.allow("d", 500);
+    expect(g.size).toBe(1);    // only "d" survives
+  });
+});

--- a/src/routes/route-hop-guard.ts
+++ b/src/routes/route-hop-guard.ts
@@ -1,0 +1,66 @@
+/**
+ * RouteHopGuard — bounds route cascades (ADR-0008 P2 hardening).
+ *
+ * A route always emits `agent.skill.request`, never an arbitrary topic, so it
+ * cannot *directly* re-trigger its own `when.topic` (the loader also rejects
+ * `#`/`agent.skill.request` triggers). But a route's dispatch can *indirectly*
+ * cause its trigger to fire again — agent → side-effect topic → another route →
+ * … — an unbounded cross-route cycle. The dispatcher's cooldown is per-`(skill,
+ * target)` rate-limiting, not a cycle breaker; `activeExecutions` is
+ * correlation-keyed, not a hop counter. So routing needs its own bound.
+ *
+ * Routes that share a cause share a `correlationId` (each route reuses its
+ * trigger's). This guard caps the number of route dispatches permitted per
+ * correlation chain inside a time window — breaking the cascade while leaving
+ * normal fan-out (one cause → a few routes) untouched. Pure + clock-injected so
+ * it's deterministically testable.
+ */
+
+export interface RouteHopGuardOptions {
+  /** Max route dispatches allowed per correlation chain within the window. */
+  max?: number;
+  /** Sliding window (ms): a correlation that goes quiet this long resets. */
+  windowMs?: number;
+  /** Soft cap on tracked correlations before an expired-entry sweep runs. */
+  pruneAt?: number;
+}
+
+export class RouteHopGuard {
+  private readonly max: number;
+  private readonly windowMs: number;
+  private readonly pruneAt: number;
+  private readonly seen = new Map<string, { count: number; expiresAt: number }>();
+
+  constructor(opts: RouteHopGuardOptions = {}) {
+    this.max = opts.max ?? 12;
+    this.windowMs = opts.windowMs ?? 30_000;
+    this.pruneAt = opts.pruneAt ?? 1000;
+  }
+
+  /**
+   * Record a route hop for `correlationId` and report whether it is allowed.
+   * Returns false once the chain has hit `max` within the window — the caller
+   * drops the dispatch. An expired (quiet > windowMs) chain resets to 1.
+   */
+  allow(correlationId: string, now: number): boolean {
+    if (this.seen.size >= this.pruneAt) this._prune(now);
+    const e = this.seen.get(correlationId);
+    if (!e || e.expiresAt <= now) {
+      this.seen.set(correlationId, { count: 1, expiresAt: now + this.windowMs });
+      return true;
+    }
+    if (e.count >= this.max) return false; // capped — do NOT extend the window (let it drain)
+    e.count += 1;
+    e.expiresAt = now + this.windowMs;
+    return true;
+  }
+
+  /** Tracked-correlation count (for tests / diagnostics). */
+  get size(): number {
+    return this.seen.size;
+  }
+
+  private _prune(now: number): void {
+    for (const [k, v] of this.seen) if (v.expiresAt <= now) this.seen.delete(k);
+  }
+}


### PR DESCRIPTION
## What

Follow-up to #883, closing the real gap **CodeRabbit raised on #882**: the P2 routing engine had **no bound on indirect multi-hop cascades**.

A route only ever emits `agent.skill.request` (and the loader rejects `#`/`agent.skill.request` triggers), so it can't *directly* self-loop. But its dispatch can *indirectly* re-trigger — agent → side-effect topic → another route → … — an unbounded **cross-route cycle**. The dispatcher's per-`(skill, target)` cooldown is not a cycle breaker, and `activeExecutions` is correlation-keyed, not a hop counter. So routing needs its own bound.

## How

**`RouteHopGuard`** (pure, clock-injected) caps route dispatches **per correlation chain** within a sliding window (default **12 / 30s**). Routes reuse their trigger's `correlationId`, so an indirect cascade shares one chain and gets bounded — while normal fan-out (one cause → a few routes) is untouched. `RoutesPlugin._dispatch` drops loudly (`log.warn`) past the cap. Memory is bounded by a lazy expired-entry sweep once a soft cap is reached.

## Tests

- `RouteHopGuard`: cap, window-reset, per-correlation isolation, bounded-memory prune.
- `RoutesPlugin`: same chain stops dispatching at the limit; a fresh chain is unaffected.

`tsc` + `biome` clean; 28 route tests green.

The P2 plan doc (#882) was updated to describe exactly this as the cascade protection (the static loader guard only catches the trivial case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)