### PR TITLE
feat(canvas): WS-P2b2 — render routes as canvas edges + drag-to-wire (ADR-0008 P2 complete)

### DIFF
--- a/dashboard/src/components/SystemGraph.tsx
+++ b/dashboard/src/components/SystemGraph.tsx
@@ -35,6 +35,8 @@ import QuinnVerdictCounters from "./QuinnVerdictCounters.tsx";
 import LatencyHistogram from "./LatencyHistogram.tsx";
 import { architecturalLayout } from "../lib/layout.ts";
 import { applyFlowDispatch, type FlowDispatchItem } from "../lib/flow-dispatch.ts";
+import { getRoutes, createRoute, type RouteSummary } from "../lib/api";
+import WireRouteDialog from "./WireRouteDialog.tsx";
 
 /** Ring-buffer cap for per-topic history shown in the edge drawer. */
 const TOPIC_HISTORY_CAP = 20;
@@ -130,9 +132,11 @@ interface BuildArgs {
   activeEdges: Set<string>;
   /** Agent names with a live dispatch, folded from flow.item.* (WS-3b). */
   inFlight: Set<string>;
+  /** Authored wiring routes, rendered as edges into their target agent (P2-b2). */
+  routes: RouteSummary[];
 }
 
-function buildGraph({ plugins, agents, agentActivity, activeEdges, inFlight }: BuildArgs): { nodes: Node[]; edges: Edge[] } {
+function buildGraph({ plugins, agents, agentActivity, activeEdges, inFlight, routes }: BuildArgs): { nodes: Node[]; edges: Edge[] } {
   const nodes: Node[] = [];
   const edges: Edge[] = [];
 
@@ -301,6 +305,58 @@ function buildGraph({ plugins, agents, agentActivity, activeEdges, inFlight }: B
     }
   }
 
+  // 8. Wiring routes (ADR-0008 P2). Each authored route — "when when.topic
+  // fires, dispatch then.skill to then.agent" — renders as an edge INTO its
+  // target agent, sourced from the plugin most plausibly publishing the trigger
+  // topic (reusing topicMatches), or a shared synthetic `wiring-triggers` anchor
+  // when no publisher matches. Distinct dashed-lavender "wire" style + the
+  // topic→skill on the label. Routes with no resolvable agent node are skipped.
+  const agentIds = new Set(agents.map((a) => `agent-${a.name}`));
+  let triggersNodeAdded = false;
+  for (const route of routes) {
+    if (!route.then.agent) continue; // skill-resolved routes have no fixed node target
+    const targetId = `agent-${route.then.agent}`;
+    if (!agentIds.has(targetId)) continue;
+    const publisher = plugins.find((p) => (p.publishes ?? []).some((pub) => topicMatches(route.when.topic, pub)));
+    let sourceId: string;
+    if (publisher) {
+      sourceId = `plugin-${publisher.name}`;
+    } else {
+      sourceId = "wiring-triggers";
+      if (!triggersNodeAdded) {
+        triggersNodeAdded = true;
+        nodes.push({
+          id: sourceId,
+          position: PLACEHOLDER_POS,
+          data: { label: "triggers" },
+          style: {
+            background: "var(--bg-default)",
+            color: "var(--accent-fg)",
+            border: "1px dashed var(--accent-fg)",
+            borderRadius: 6,
+            padding: "6px 10px",
+            fontSize: 11,
+            fontFamily: "ui-monospace, SFMono-Regular, monospace",
+          },
+        });
+      }
+    }
+    edges.push({
+      id: `route-${route.name}`,
+      source: sourceId,
+      target: targetId,
+      label: `${route.when.topic} → ${route.then.skill}`,
+      animated: false,
+      style: {
+        stroke: route.enabled === false ? "var(--border-muted)" : "var(--accent-fg)",
+        strokeWidth: 1.5,
+        strokeDasharray: "6 3",
+        opacity: route.enabled === false ? 0.4 : 0.9,
+      },
+      labelStyle: { fill: "var(--accent-fg)", fontSize: 9, fontFamily: "ui-monospace, monospace" },
+    });
+  }
+
   return architecturalLayout(nodes, edges);
 }
 
@@ -362,6 +418,10 @@ export default function SystemGraph() {
   // Agent name whose inspector is open (WS-3c). Mutually exclusive with the
   // edge MessageDrawer.
   const [openNode, setOpenNode] = useState<string | null>(null);
+  // Authored wiring routes, rendered as edges (P2-b2). `wireTarget` holds the
+  // agent a drag-to-connect gesture is wiring into → opens the route dialog.
+  const [routes, setRoutes] = useState<RouteSummary[]>([]);
+  const [wireTarget, setWireTarget] = useState<string | null>(null);
   // Per-topic ring buffer of recent WS-observed messages. Lives in a ref
   // (not state) because every WS frame would otherwise re-trigger the
   // whole graph rebuild — we only need to re-render when the operator
@@ -385,9 +445,10 @@ export default function SystemGraph() {
     let cancelled = false;
     (async () => {
       try {
-        const [topoR, agentsR] = await Promise.all([
+        const [topoR, agentsR, routesR] = await Promise.all([
           fetch("/api/bus/topology").then((r) => r.json()),
           fetch("/api/agents/runtime").then((r) => r.json()),
+          getRoutes(true).catch(() => ({ routes: [] as RouteSummary[] })),
         ]);
         if (cancelled) return;
         if (!topoR.success) {
@@ -396,6 +457,7 @@ export default function SystemGraph() {
         }
         setTopology(topoR.data.plugins);
         setAgents(agentsR.success ? agentsR.data.agents : []);
+        setRoutes(routesR.routes ?? []);
       } catch (err) {
         if (!cancelled) setError(err instanceof Error ? err.message : String(err));
       }
@@ -491,9 +553,9 @@ export default function SystemGraph() {
 
   const { nodes, edges } = useMemo(
     () => topology
-      ? buildGraph({ plugins: topology, agents, agentActivity, activeEdges, inFlight })
+      ? buildGraph({ plugins: topology, agents, agentActivity, activeEdges, inFlight, routes })
       : { nodes: [], edges: [] },
-    [topology, agents, agentActivity, activeEdges, inFlight],
+    [topology, agents, agentActivity, activeEdges, inFlight, routes],
   );
 
   // ALL hooks must run before any conditional return (Rules of Hooks). This
@@ -538,7 +600,17 @@ export default function SystemGraph() {
             setOpenTopic(null); // inspector + edge drawer are mutually exclusive
           }
         }}
+        onConnect={(conn: { target: string | null }) => {
+          // Drag-to-wire (P2-b2): dropping a connection on an agent node opens
+          // the route dialog prefilled with that agent as the target.
+          if (typeof conn.target === "string" && conn.target.startsWith("agent-")) {
+            setWireTarget(conn.target.slice("agent-".length));
+          }
+        }}
         onEdgeClick={(_evt: unknown, edge: Edge) => {
+          // Route edges (id `route-*`) carry a "topic → skill" label, not a real
+          // topic — they don't open the message drawer.
+          if (typeof edge.id === "string" && edge.id.startsWith("route-")) return;
           // Edges built from publisher → subscriber carry their topic as the
           // edge label. Static plugin → service edges have no topic — those
           // skip the drawer.
@@ -563,6 +635,20 @@ export default function SystemGraph() {
       )}
       {inspectorNode && (
         <NodeInspector node={inspectorNode} onClose={() => setOpenNode(null)} />
+      )}
+      {wireTarget && (
+        <WireRouteDialog
+          agent={wireTarget}
+          onClose={() => setWireTarget(null)}
+          onCreate={async (def) => {
+            const r = await createRoute(def);
+            if (r.ok) {
+              const fresh = await getRoutes(true).catch(() => ({ routes }));
+              setRoutes(fresh.routes ?? routes);
+            }
+            return r;
+          }}
+        />
       )}
     </div>
   );

--- a/dashboard/src/components/WireRouteDialog.tsx
+++ b/dashboard/src/components/WireRouteDialog.tsx
@@ -55,13 +55,18 @@ export default function WireRouteDialog({ agent, onClose, onCreate }: Props) {
       return;
     }
     setBusy(true);
-    const r = await onCreate({ name: name.trim(), when: { topic: topic.trim() }, then: { skill: skill.trim(), agent } });
-    setBusy(false);
-    if (r.ok) {
-      setResult({ ok: true, msg: "Wired — live within the hot-reload window." });
-      setTimeout(onClose, 900);
-    } else {
-      setResult({ ok: false, msg: `${r.status}: ${(r.body?.error as string) ?? "create failed"}` });
+    try {
+      const r = await onCreate({ name: name.trim(), when: { topic: topic.trim() }, then: { skill: skill.trim(), agent } });
+      if (r.ok) {
+        setResult({ ok: true, msg: "Wired — live within the hot-reload window." });
+        setTimeout(onClose, 900);
+      } else {
+        setResult({ ok: false, msg: `${r.status}: ${(r.body?.error as string) ?? "create failed"}` });
+      }
+    } catch (err) {
+      setResult({ ok: false, msg: `Request failed: ${err instanceof Error ? err.message : String(err)}` });
+    } finally {
+      setBusy(false);
     }
   }
 

--- a/dashboard/src/components/WireRouteDialog.tsx
+++ b/dashboard/src/components/WireRouteDialog.tsx
@@ -1,0 +1,122 @@
+/**
+ * WireRouteDialog — the drag-to-wire form (ADR-0008 P2-b2).
+ *
+ * Opened when an operator drags a connection onto an agent node on the canvas.
+ * The target agent is fixed (what you dropped on); the operator supplies the
+ * trigger topic + skill, and we POST a route via the control-plane API (the
+ * same path the Wiring panel uses). A route is one hop, no logic (D1/D5).
+ */
+
+import { useEffect, useState } from "react";
+import { getAdminKey, setAdminKey, type WriteResult } from "../lib/api";
+
+interface Props {
+  /** The target agent (then.agent) — fixed by the drop. */
+  agent: string;
+  onClose: () => void;
+  onCreate: (def: unknown) => Promise<WriteResult>;
+}
+
+const inputStyle = {
+  background: "var(--bg-default)",
+  color: "var(--text-primary)",
+  border: "1px solid var(--border-default)",
+  borderRadius: "6px",
+  padding: "8px 10px",
+  fontSize: "13px",
+  width: "100%",
+  fontFamily: "var(--pl-font-mono)",
+} as const;
+
+const kebab = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+
+export default function WireRouteDialog({ agent, onClose, onCreate }: Props) {
+  const [key, setKey] = useState(getAdminKey());
+  const [topic, setTopic] = useState("");
+  const [skill, setSkill] = useState("");
+  const [name, setName] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<{ ok: boolean; msg: string } | null>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  function onSkill(v: string) {
+    setSkill(v);
+    if (!name || name === kebab(skill)) setName(kebab(v));
+  }
+
+  async function submit() {
+    if (!topic.trim() || !skill.trim() || !name.trim()) {
+      setResult({ ok: false, msg: "topic, skill and name are required." });
+      return;
+    }
+    setBusy(true);
+    const r = await onCreate({ name: name.trim(), when: { topic: topic.trim() }, then: { skill: skill.trim(), agent } });
+    setBusy(false);
+    if (r.ok) {
+      setResult({ ok: true, msg: "Wired — live within the hot-reload window." });
+      setTimeout(onClose, 900);
+    } else {
+      setResult({ ok: false, msg: `${r.status}: ${(r.body?.error as string) ?? "create failed"}` });
+    }
+  }
+
+  return (
+    <>
+      <div onClick={onClose} style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.45)", zIndex: 200 }} />
+      <div
+        role="dialog"
+        aria-label={`Wire a route to ${agent}`}
+        style={{
+          position: "fixed", top: "50%", left: "50%", transform: "translate(-50%, -50%)",
+          width: 420, maxWidth: "92vw", background: "var(--bg-canvas)", border: "1px solid var(--border-default)",
+          borderRadius: 10, boxShadow: "0 12px 40px rgba(0,0,0,0.5)", zIndex: 201, padding: 18,
+          fontFamily: "ui-monospace, SFMono-Regular, monospace", color: "var(--text-primary)",
+        }}
+      >
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
+          <strong style={{ fontSize: 14 }}>Wire a route → <span style={{ color: "var(--accent-fg)" }}>{agent}</span></strong>
+          <button onClick={onClose} aria-label="Close" style={{ background: "transparent", border: "none", color: "var(--text-secondary)", fontSize: 20, cursor: "pointer" }}>×</button>
+        </div>
+        <p style={{ fontSize: 12, color: "var(--text-secondary)", margin: "0 0 12px" }}>
+          When a bus topic fires, dispatch a skill to {agent}. One hop, no logic.
+        </p>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          <label style={{ fontSize: 12, color: "var(--text-secondary)", display: "flex", flexDirection: "column", gap: 4 }}>
+            admin key
+            <input type="password" value={key} placeholder="WORKSTACEAN_API_KEY" onChange={(e) => { setKey(e.currentTarget.value); setAdminKey(e.currentTarget.value); }} style={{ ...inputStyle, fontFamily: "inherit" }} />
+          </label>
+          <label style={{ fontSize: 12, color: "var(--text-secondary)", display: "flex", flexDirection: "column", gap: 4 }}>
+            when.topic
+            <input value={topic} placeholder="message.inbound.github.#" onChange={(e) => setTopic(e.currentTarget.value)} style={inputStyle} />
+          </label>
+          <label style={{ fontSize: 12, color: "var(--text-secondary)", display: "flex", flexDirection: "column", gap: 4 }}>
+            then.skill
+            <input value={skill} placeholder="bug_triage" onChange={(e) => onSkill(e.currentTarget.value)} style={inputStyle} />
+          </label>
+          <label style={{ fontSize: 12, color: "var(--text-secondary)", display: "flex", flexDirection: "column", gap: 4 }}>
+            name
+            <input value={name} placeholder="triage-github-issues" onChange={(e) => setName(e.currentTarget.value)} style={{ ...inputStyle, fontFamily: "inherit" }} />
+          </label>
+        </div>
+
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 14 }}>
+          <button
+            onClick={() => void submit()}
+            disabled={busy || !topic.trim() || !skill.trim() || !name.trim()}
+            style={{ background: "var(--accent-emphasis)", color: "#fff", border: "none", borderRadius: 6, padding: "7px 14px", fontSize: 13, cursor: "pointer", opacity: busy ? 0.6 : 1 }}
+          >
+            Wire
+          </button>
+          <button onClick={onClose} style={{ background: "transparent", color: "var(--text-secondary)", border: "1px solid var(--border-default)", borderRadius: 6, padding: "7px 14px", fontSize: 13, cursor: "pointer" }}>Cancel</button>
+          {result && <span style={{ fontSize: 12, color: result.ok ? "var(--text-success)" : "var(--text-danger)" }}>{result.ok ? "✓ " : "✗ "}{result.msg}</span>}
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## What

Completes **P2**. `SystemGraph` reads the authored routes (`/api/routes`) and brings wiring onto the canvas:

- **Renders each route as a dashed-lavender "wire" edge** *into* its target agent, sourced from the plugin most plausibly publishing `when.topic` (reusing `topicMatches`), or a shared synthetic **`triggers`** anchor when none matches. The label carries `when.topic → then.skill`; disabled routes render greyed. Route edges are inert to the message-drawer (they're not topics).
- **Drag-to-connect** — dropping a connection on an agent node opens **`WireRouteDialog`** (target agent prefilled). It `POST`s a route through the **same control-plane API the Wiring panel uses** (`createRoute`) and refreshes the edges live.

No new mutation path; a route stays **one hop, no logic** (D1/D5).

## P2 — complete

| Slice | PR |
|---|---|
| Plan | #882 |
| P2-a routes.d/ engine + API | #883 |
| Hardening — cascade hop guard | #884 |
| P2-b1 Wiring panel | #885 |
| **P2-b2 canvas edges + drag-to-wire** | this |

## Verification

- `tsc` + `vite build` clean · `bun test` 27/27 · `WireRouteDialog` biome-clean (the lone warning is the pre-existing `topicMatches` ternary).
- ⚠️ The **drag-to-connect gesture + edge layout** want a human glance on the deployed `/system` — interaction/visual, not headlessly verifiable. The route-edge *data* (which edge, which agent, label) and the create path are logic-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)